### PR TITLE
Deployment model: pull at tick start

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -76,6 +76,17 @@ needs inbound access is a human with the runbook.
   the lease makes restarts safe, the runbook makes them fast.
 - **GPU jobs**: submitted `--nice`/requeueable so humans always win the queue at
   deadlines; the pause sentinel doubles as a deadline blackout switch.
+- **Deployment = pull at tick start.** The batch script is a minimal, stable
+  shim ordered so updates can never kill the chain: submit successors first
+  (with the already-queued shim), then `git reset --hard origin/main` +
+  `uv sync --locked` in the deploy clone (Torch home dir), then exec the
+  orchestrator from the fresh checkout. Merges to main are live at the next
+  tick; a bad merge crashes the tick but not the chain — heartbeat records it,
+  the fix is a revert PR. Slurm spools batch scripts at submission, so shim
+  changes propagate one tick-generation later. The pull authenticates with a
+  separate read-only fine-grained PAT (contents: read, this repo only) from the
+  sponsor account — the bot has no access here by design. Deploying from a
+  pinned tag instead of main: deferred unless bad merges reach the loop.
 
 ## Task granularity
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -37,6 +37,8 @@ Package skeleton, CI gates, governance docs, architecture (ops+safety reviewed).
 
 - [ ] The chain: two queued successors, `--dependency=singleton`, absolute
       `--begin` cadence grid, sbatch retry/backoff
+- [ ] Deploy shim: submit-successors → pull main → `uv sync --locked` → exec;
+      read-only deploy PAT (sponsor account, contents: read, this repo only)
 - [ ] Pause sentinel + lease (compare-and-swap on the state branch); heartbeat at
       tick start; stale-lease reaping
 - [ ] `compute`: sbatch submit / squeue poll, jobs tagged + `--nice`, GPU-hour caps


### PR DESCRIPTION
Answers 'how does the Torch copy stay up to date?': the tick shim submits successors first, then hard-resets the deploy clone to origin/main + uv sync, then execs the orchestrator — merges are live next tick, bad merges crash a tick but never the chain, shim changes lag one generation (Slurm spools scripts). Pull auth = separate read-only fine-grained PAT from the sponsor account; the bot has no autoresearch access by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)