### PR TITLE
GitHub module: token-provider seam, REST + workspace, dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `autoresearch.github`: REST client + git workspace behind a token-provider
+  seam (GitHub App-ready), env-injected git auth, dry-run mode (phase 1).
 - `autoresearch.contract`: schema + loader for `.autoresearch.yaml` with suite
   aggregates and hard-coded safety invariants (phase 1).
 - Repository scaffold: package skeleton, CI gates (lint/types/test/lock/gitleaks),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,8 +12,8 @@ Package skeleton, CI gates, governance docs, architecture (ops+safety reviewed).
 
 - [x] `contract`: pydantic schema + loader, including the hard-coded invariants
       (no self-targeting; contract/roadmap/`.github/` always forbidden)
-- [ ] `github`: bot auth, clone/branch/push, PR + issue operations
-- [ ] Dry-run mode: everything logs, nothing posts
+- [x] `github`: bot auth, clone/branch/push, PR + issue operations
+- [x] Dry-run mode: everything logs, nothing posts
 
 ## Phase 2 — Advisory reviewer
 

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -1,0 +1,172 @@
+"""GitHub operations for the orchestrator: REST and git, behind a token provider.
+
+Auth flows through :class:`TokenProvider` so a GitHub App installation-token
+provider can replace the PAT file without touching callers
+(docs/design/external.md). Every mutating operation respects ``dry_run``: log
+the intent, touch nothing. Tokens never appear in process arguments or in
+``.git/config`` — git auth is injected per-invocation via ``GIT_CONFIG_*``
+environment variables.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import subprocess
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+log = logging.getLogger(__name__)
+
+API = "https://api.github.com"
+Transport = Callable[[urllib.request.Request], Any]
+
+
+class TokenProvider(Protocol):
+    def token(self) -> str: ...
+
+
+@dataclass(frozen=True)
+class FileTokenProvider:
+    """Reads a 0600 credential file (the bot PAT on the orchestrator host)."""
+
+    path: Path
+
+    def token(self) -> str:
+        return self.path.read_text().strip()
+
+
+def _default_transport(request: urllib.request.Request) -> Any:
+    with urllib.request.urlopen(request, timeout=30) as response:
+        payload = response.read()
+    return json.loads(payload) if payload else None
+
+
+@dataclass
+class GitHubClient:
+    """Minimal REST surface the orchestrator needs. Mutations honor dry_run."""
+
+    auth: TokenProvider
+    transport: Transport = field(default=_default_transport)
+    dry_run: bool = False
+
+    def _request(self, method: str, path: str, body: dict[str, Any] | None = None) -> Any:
+        request = urllib.request.Request(
+            f"{API}{path}",
+            method=method,
+            data=json.dumps(body).encode() if body is not None else None,
+            headers={
+                "Authorization": f"Bearer {self.auth.token()}",
+                "Accept": "application/vnd.github+json",
+                "Content-Type": "application/json",
+            },
+        )
+        return self.transport(request)
+
+    def default_branch(self, repo: str) -> str:
+        return str(self._request("GET", f"/repos/{repo}")["default_branch"])
+
+    def get_file(self, repo: str, path: str, ref: str) -> str:
+        """Fetch a file's text at a ref — used to read contracts from the
+        default branch, never from PR branches."""
+        data = self._request("GET", f"/repos/{repo}/contents/{path}?ref={ref}")
+        if data.get("encoding") != "base64":
+            raise ValueError(f"unexpected encoding for {repo}:{path}")
+        return base64.b64decode(data["content"]).decode()
+
+    def create_pr(self, repo: str, head: str, base: str, title: str, body: str) -> int | None:
+        if self.dry_run:
+            log.info("[dry-run] create PR %s: %s <- %s (%r)", repo, base, head, title)
+            return None
+        data = self._request(
+            "POST",
+            f"/repos/{repo}/pulls",
+            {"title": title, "head": head, "base": base, "body": body},
+        )
+        return int(data["number"])
+
+    def comment(self, repo: str, issue_number: int, body: str) -> None:
+        if self.dry_run:
+            log.info("[dry-run] comment on %s#%s (%d chars)", repo, issue_number, len(body))
+            return
+        self._request("POST", f"/repos/{repo}/issues/{issue_number}/comments", {"body": body})
+
+
+def _git_auth_env(token: str | None) -> dict[str, str]:
+    """Per-invocation git auth that never lands in argv or .git/config."""
+    env = dict(os.environ)
+    if token is not None:
+        basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+        env |= {
+            "GIT_CONFIG_COUNT": "1",
+            "GIT_CONFIG_KEY_0": "http.https://github.com/.extraheader",
+            "GIT_CONFIG_VALUE_0": f"Authorization: Basic {basic}",
+        }
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    return env
+
+
+@dataclass
+class Workspace:
+    """A working clone the agent session edits; pushes happen orchestrator-side."""
+
+    root: Path
+    auth: TokenProvider | None = None
+    dry_run: bool = False
+
+    def _token(self) -> str | None:
+        return self.auth.token() if self.auth is not None else None
+
+    def git(self, *args: str) -> str:
+        result = subprocess.run(
+            ["git", "-C", str(self.root), *args],
+            capture_output=True,
+            text=True,
+            env=_git_auth_env(self._token()),
+            check=True,
+        )
+        return result.stdout.strip()
+
+    @classmethod
+    def clone(
+        cls,
+        url: str,
+        dest: Path,
+        auth: TokenProvider | None = None,
+        dry_run: bool = False,
+    ) -> Workspace:
+        token = auth.token() if auth is not None else None
+        subprocess.run(
+            ["git", "clone", "--quiet", url, str(dest)],
+            capture_output=True,
+            text=True,
+            env=_git_auth_env(token),
+            check=True,
+        )
+        return cls(root=dest, auth=auth, dry_run=dry_run)
+
+    def branch(self, name: str) -> None:
+        self.git("switch", "-c", name)
+
+    def commit_all(self, message: str, author: str) -> None:
+        self.git("add", "-A")
+        self.git(
+            "-c",
+            f"user.name={author}",
+            "-c",
+            f"user.email={author}@users.noreply.github.com",
+            "commit",
+            "-m",
+            message,
+        )
+
+    def push(self, branch: str) -> None:
+        if self.dry_run:
+            log.info("[dry-run] push %s from %s", branch, self.root)
+            return
+        self.git("push", "-u", "origin", branch)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -1,0 +1,114 @@
+import base64
+import json
+import subprocess
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from autoresearch.github import FileTokenProvider, GitHubClient, Workspace
+
+
+class FakeTransport:
+    def __init__(self, responses: list[object]) -> None:
+        self.responses = responses
+        self.requests: list[urllib.request.Request] = []
+
+    def __call__(self, request: urllib.request.Request) -> object:
+        self.requests.append(request)
+        return self.responses.pop(0)
+
+
+@pytest.fixture
+def provider(tmp_path: Path) -> FileTokenProvider:
+    pat = tmp_path / "pat"
+    pat.write_text("github_pat_test123\n")
+    return FileTokenProvider(pat)
+
+
+def test_token_provider_strips(provider: FileTokenProvider) -> None:
+    assert provider.token() == "github_pat_test123"
+
+
+def test_default_branch_and_headers(provider: FileTokenProvider) -> None:
+    transport = FakeTransport([{"default_branch": "main"}])
+    client = GitHubClient(auth=provider, transport=transport)
+    assert client.default_branch("org/repo") == "main"
+    request = transport.requests[0]
+    assert request.full_url == "https://api.github.com/repos/org/repo"
+    assert request.get_header("Authorization") == "Bearer github_pat_test123"
+
+
+def test_get_file_decodes_base64(provider: FileTokenProvider) -> None:
+    content = base64.b64encode(b"benchmarks: []\n").decode()
+    transport = FakeTransport([{"encoding": "base64", "content": content}])
+    client = GitHubClient(auth=provider, transport=transport)
+    assert client.get_file("org/repo", ".autoresearch.yaml", "main") == "benchmarks: []\n"
+    assert "ref=main" in transport.requests[0].full_url
+
+
+def test_create_pr_posts_body(provider: FileTokenProvider) -> None:
+    transport = FakeTransport([{"number": 7}])
+    client = GitHubClient(auth=provider, transport=transport)
+    assert client.create_pr("org/repo", "feat/x", "main", "Title", "Body") == 7
+    request = transport.requests[0]
+    assert request.get_method() == "POST"
+    assert isinstance(request.data, bytes)
+    assert json.loads(request.data.decode()) == {
+        "title": "Title",
+        "head": "feat/x",
+        "base": "main",
+        "body": "Body",
+    }
+
+
+def test_dry_run_mutations_touch_nothing(provider: FileTokenProvider) -> None:
+    transport = FakeTransport([])
+    client = GitHubClient(auth=provider, transport=transport, dry_run=True)
+    assert client.create_pr("org/repo", "h", "b", "t", "b") is None
+    client.comment("org/repo", 1, "hello")
+    assert transport.requests == []
+
+
+def _make_origin(tmp_path: Path) -> Path:
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "clone", "-q", str(origin), str(seed)], check=True)
+    (seed / "README.md").write_text("seed\n")
+    for cmd in (
+        ["add", "-A"],
+        ["-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "seed"],
+        ["push", "-q", "origin", "main"],
+    ):
+        subprocess.run(["git", "-C", str(seed), *cmd], check=True)
+    return origin
+
+
+def test_workspace_clone_branch_commit_push(tmp_path: Path) -> None:
+    origin = _make_origin(tmp_path)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work")
+    ws.branch("feat/auto/test")
+    (ws.root / "new.txt").write_text("x\n")
+    ws.commit_all("Test commit", author="agentic-learning-bot")
+    ws.push("feat/auto/test")
+    log = subprocess.run(
+        ["git", "-C", str(origin), "log", "feat/auto/test", "--format=%s <%ae>"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    assert "Test commit <agentic-learning-bot@users.noreply.github.com>" in log
+
+
+def test_workspace_dry_run_push_stays_local(tmp_path: Path) -> None:
+    origin = _make_origin(tmp_path)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work", dry_run=True)
+    ws.branch("feat/auto/nope")
+    (ws.root / "new.txt").write_text("x\n")
+    ws.commit_all("Local only", author="bot")
+    ws.push("feat/auto/nope")
+    branches = subprocess.run(
+        ["git", "-C", str(origin), "branch"], capture_output=True, text=True, check=True
+    ).stdout
+    assert "feat/auto/nope" not in branches


### PR DESCRIPTION
## Summary
Completes phase 1 alongside the contract module:
- `TokenProvider` protocol + `FileTokenProvider` — the seam that makes the future GitHub App an implementation swap (docs/design/external.md).
- `GitHubClient`: minimal REST surface (default branch, contract fetch pinned to a ref, create PR, comment) with injectable transport; every mutation honors `dry_run`.
- `Workspace`: clone/branch/commit/push where git auth is injected per-invocation via `GIT_CONFIG_*` env — tokens never in argv, shell history, or `.git/config` (multi-user cluster hygiene).

## Test plan
25 tests total: fake-transport unit tests (headers, bodies, base64 contract fetch, dry-run posts nothing) and real-git tests against local `file://` bare repos (round-trip push with bot authorship; dry-run push stays local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)