### PR TITLE
Harden phase-1 modules after adversarial review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Hardening from the first adversarial review pass: local git runs without
+  credentials and with hooks disabled (planted hooks can no longer read the
+  PAT), scope paths are normalized component-wise, self-target matching accepts
+  any repo spelling, contract YAML rejects aliases/duplicate keys/oversized
+  input, commits are vetoed against the contract's forbidden paths, and API
+  errors/response shapes are typed instead of crashing.
+
 ### Added
 
 - `autoresearch.github`: REST client + git workspace behind a token-provider

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -5,25 +5,54 @@ enforces invariants no YAML can override (see the threat model in
 docs/design/architecture.md): autoresearch is never a target of itself, and the
 contract file, the target's roadmap, and `.github/` are always forbidden write
 paths, regardless of what `scope.allowed` says.
+
+Contracts live in target repos and are therefore untrusted input: parsing
+rejects aliases, duplicate keys, and oversized documents.
 """
 
 from __future__ import annotations
 
-from typing import Literal
+import posixpath
+from pathlib import PurePosixPath
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field
 
 SELF_REPO = "agentic-learning-ai-lab/autoresearch"
-ALWAYS_FORBIDDEN: tuple[str, ...] = (".github/", ".autoresearch.yaml")
+ALWAYS_FORBIDDEN: tuple[str, ...] = (".github", ".autoresearch.yaml")
+MAX_CONTRACT_BYTES = 64 * 1024
+_GLOB_CHARS = set("*?[]!")
 
 
-class SelfTargetError(ValueError):
+class ContractError(ValueError):
+    """Base class for contract rejections."""
+
+
+class SelfTargetError(ContractError):
     """Raised when a contract names autoresearch itself as the target."""
 
 
-class ScopeError(ValueError):
-    """Raised when an allowed path overlaps an always-forbidden path."""
+class ScopeError(ContractError):
+    """Raised when an allowed path is unsafe or overlaps a forbidden path."""
+
+
+class _SafeLoader(yaml.SafeLoader):
+    """SafeLoader that refuses alias expansion and duplicate mapping keys."""
+
+    def compose_node(self, parent: Any, index: Any) -> Any:
+        if self.check_event(yaml.events.AliasEvent):
+            raise ContractError("YAML aliases are not allowed in contracts")
+        return super().compose_node(parent, index)
+
+    def construct_mapping(self, node: Any, deep: bool = False) -> dict[Any, Any]:
+        seen = set()
+        for key_node, _ in node.value:
+            key = self.construct_object(key_node, deep=deep)
+            if key in seen:
+                raise ContractError(f"duplicate key in contract: {key!r}")
+            seen.add(key)
+        return super().construct_mapping(node, deep=deep)
 
 
 class _StrictModel(BaseModel):
@@ -63,30 +92,79 @@ class Contract(_StrictModel):
     suite: SuiteAggregate | None = None
 
 
+def normalize_repo(target_repo: str) -> str:
+    """Reduce a repo reference to `owner/name`, casefolded.
+
+    Accepts bare `owner/name`, trailing `/` or `.git`, and https/ssh URLs, so
+    the self-target check can't be dodged by spelling.
+    """
+    ref = target_repo.strip().casefold()
+    for prefix in ("https://github.com/", "http://github.com/", "git@github.com:", "ssh://"):
+        if ref.startswith(prefix):
+            ref = ref[len(prefix) :]
+    ref = ref.rstrip("/")
+    if ref.endswith(".git"):
+        ref = ref[: -len(".git")]
+    return ref
+
+
+def normalize_path(entry: str) -> PurePosixPath:
+    """Normalize a scope entry, rejecting anything that can escape the repo."""
+    raw = entry.strip()
+    if not raw or raw in {".", "./"}:
+        raise ScopeError("allowing the repository root is never permitted")
+    if raw.startswith("/") or ":" in raw or "\\" in raw:
+        raise ScopeError(f"path must be repo-relative and POSIX: {entry!r}")
+    if _GLOB_CHARS & set(raw):
+        raise ScopeError(f"glob patterns are not allowed in scope: {entry!r}")
+    normalized = posixpath.normpath(raw)
+    path = PurePosixPath(normalized)
+    if normalized in {".", ""} or any(part == ".." for part in path.parts):
+        raise ScopeError(f"path escapes the repository: {entry!r}")
+    return path
+
+
 def forbidden_paths(contract: Contract) -> tuple[str, ...]:
-    """The write paths forbidden for this contract — the hard-coded set plus
-    the target's roadmap."""
-    return (*ALWAYS_FORBIDDEN, contract.roadmap)
+    """Write paths forbidden for this contract: the hard-coded set plus the
+    target's roadmap."""
+    return (*ALWAYS_FORBIDDEN, str(normalize_path(contract.roadmap)))
 
 
-def _overlaps(allowed: str, forbidden: str) -> bool:
-    a = allowed.strip().lstrip("./")
-    f = forbidden.strip().lstrip("./")
-    if a == "":
-        return True  # allowing the repo root allows everything
-    return a == f or a.startswith(f) or f.startswith(a)
+def path_is_forbidden(candidate: str, contract: Contract) -> bool:
+    """True if `candidate` (a repo-relative file path) may not be written.
+
+    Component-wise, so `README.mdx` is not shadowed by roadmap `README.md`.
+    Anything unnormalizable counts as forbidden.
+    """
+    try:
+        path = normalize_path(candidate)
+    except ScopeError:
+        return True
+    for forbidden in forbidden_paths(contract):
+        f = PurePosixPath(forbidden)
+        if path == f or f in path.parents:
+            return True
+    return False
+
+
+def _overlaps(allowed: PurePosixPath, forbidden: PurePosixPath) -> bool:
+    return allowed == forbidden or forbidden in allowed.parents or allowed in forbidden.parents
 
 
 def load_contract(text: str, target_repo: str) -> Contract:
-    """Parse and validate a contract for `target_repo` (owner/name)."""
-    if target_repo.strip().lower() == SELF_REPO:
+    """Parse and validate a contract for `target_repo`."""
+    if normalize_repo(target_repo) == SELF_REPO:
         raise SelfTargetError("autoresearch is never a valid target of itself")
-    data = yaml.safe_load(text)
+    if len(text.encode()) > MAX_CONTRACT_BYTES:
+        raise ContractError(f"contract exceeds {MAX_CONTRACT_BYTES} bytes")
+    data = yaml.load(text, Loader=_SafeLoader)
     if not isinstance(data, dict):
-        raise ValueError("contract must be a YAML mapping")
+        raise ContractError("contract must be a YAML mapping")
     contract = Contract.model_validate(data)
-    for allowed in contract.scope.allowed:
-        for forbidden in forbidden_paths(contract):
-            if _overlaps(allowed, forbidden):
-                raise ScopeError(f"allowed path {allowed!r} overlaps forbidden {forbidden!r}")
+    forbidden = [PurePosixPath(p) for p in forbidden_paths(contract)]
+    for entry in contract.scope.allowed:
+        allowed = normalize_path(entry)
+        for path in forbidden:
+            if _overlaps(allowed, path):
+                raise ScopeError(f"allowed path {entry!r} overlaps forbidden {str(path)!r}")
     return contract

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -13,6 +13,7 @@ rejects aliases, duplicate keys, and oversized documents.
 from __future__ import annotations
 
 import posixpath
+import re
 from pathlib import PurePosixPath
 from typing import Any, Literal
 
@@ -92,17 +93,18 @@ class Contract(_StrictModel):
     suite: SuiteAggregate | None = None
 
 
+_HOST_PREFIX = re.compile(r"^(?:[a-z+]+://)?(?:[^@/]*@)?(?:www\.)?github\.com[:/]+")
+
+
 def normalize_repo(target_repo: str) -> str:
     """Reduce a repo reference to `owner/name`, casefolded.
 
-    Accepts bare `owner/name`, trailing `/` or `.git`, and https/ssh URLs, so
-    the self-target check can't be dodged by spelling.
+    Accepts bare `owner/name`, trailing `/` or `.git`, and any scheme/userinfo
+    URL spelling, so the self-target check can't be dodged by spelling.
     """
     ref = target_repo.strip().casefold()
-    for prefix in ("https://github.com/", "http://github.com/", "git@github.com:", "ssh://"):
-        if ref.startswith(prefix):
-            ref = ref[len(prefix) :]
-    ref = ref.rstrip("/")
+    ref = _HOST_PREFIX.sub("", ref)
+    ref = re.sub(r"/{2,}", "/", ref).strip("/")
     if ref.endswith(".git"):
         ref = ref[: -len(".git")]
     return ref
@@ -121,6 +123,8 @@ def normalize_path(entry: str) -> PurePosixPath:
     path = PurePosixPath(normalized)
     if normalized in {".", ""} or any(part == ".." for part in path.parts):
         raise ScopeError(f"path escapes the repository: {entry!r}")
+    if any(part.casefold() == ".git" for part in path.parts):
+        raise ScopeError(f"the git directory is never writable: {entry!r}")
     return path
 
 
@@ -130,25 +134,34 @@ def forbidden_paths(contract: Contract) -> tuple[str, ...]:
     return (*ALWAYS_FORBIDDEN, str(normalize_path(contract.roadmap)))
 
 
+def _fold(path: PurePosixPath) -> PurePosixPath:
+    """Casefold components: `.GITHUB/x` must be as forbidden as `.github/x`."""
+    return PurePosixPath(*[part.casefold() for part in path.parts])
+
+
 def path_is_forbidden(candidate: str, contract: Contract) -> bool:
     """True if `candidate` (a repo-relative file path) may not be written.
 
-    Component-wise, so `README.mdx` is not shadowed by roadmap `README.md`.
-    Anything unnormalizable counts as forbidden.
+    Component-wise and case-insensitive, so `README.mdx` is not shadowed by
+    roadmap `README.md` but `.GITHUB/` is still blocked. Anything
+    unnormalizable counts as forbidden.
     """
     try:
-        path = normalize_path(candidate)
+        path = _fold(normalize_path(candidate))
     except ScopeError:
         return True
+    if any(part == ".git" for part in path.parts):
+        return True  # never write into the git directory itself
     for forbidden in forbidden_paths(contract):
-        f = PurePosixPath(forbidden)
+        f = _fold(PurePosixPath(forbidden))
         if path == f or f in path.parents:
             return True
     return False
 
 
 def _overlaps(allowed: PurePosixPath, forbidden: PurePosixPath) -> bool:
-    return allowed == forbidden or forbidden in allowed.parents or allowed in forbidden.parents
+    a, f = _fold(allowed), _fold(forbidden)
+    return a == f or f in a.parents or a in f.parents
 
 
 def load_contract(text: str, target_repo: str) -> Contract:
@@ -157,7 +170,12 @@ def load_contract(text: str, target_repo: str) -> Contract:
         raise SelfTargetError("autoresearch is never a valid target of itself")
     if len(text.encode()) > MAX_CONTRACT_BYTES:
         raise ContractError(f"contract exceeds {MAX_CONTRACT_BYTES} bytes")
-    data = yaml.load(text, Loader=_SafeLoader)
+    try:
+        data = yaml.load(text, Loader=_SafeLoader)
+    except ContractError:
+        raise
+    except (yaml.YAMLError, TypeError, ValueError) as exc:
+        raise ContractError(f"unparseable contract: {type(exc).__name__}") from None
     if not isinstance(data, dict):
         raise ContractError("contract must be a YAML mapping")
     contract = Contract.model_validate(data)

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -3,9 +3,14 @@
 Auth flows through :class:`TokenProvider` so a GitHub App installation-token
 provider can replace the PAT file without touching callers
 (docs/design/external.md). Every mutating operation respects ``dry_run``: log
-the intent, touch nothing. Tokens never appear in process arguments or in
-``.git/config`` — git auth is injected per-invocation via ``GIT_CONFIG_*``
-environment variables.
+the intent, touch nothing.
+
+Credential rules enforced here:
+- Tokens never appear in process arguments or in ``.git/config``; git auth is
+  injected per-invocation via ``GIT_CONFIG_*`` environment variables.
+- Only network git subcommands get that environment. Local subcommands run
+  token-free with hooks disabled, so repo content written by an agent session
+  (hooks, filters) can never read the credential.
 """
 
 from __future__ import annotations
@@ -15,6 +20,8 @@ import json
 import logging
 import os
 import subprocess
+import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -24,7 +31,29 @@ from typing import Any, Protocol
 log = logging.getLogger(__name__)
 
 API = "https://api.github.com"
+NETWORK_GIT_COMMANDS = frozenset({"clone", "fetch", "pull", "push", "ls-remote"})
 Transport = Callable[[urllib.request.Request], Any]
+
+
+class GitHubError(RuntimeError):
+    """A GitHub API call failed."""
+
+    def __init__(self, status: int, path: str, message: str) -> None:
+        super().__init__(f"{status} on {path}: {message}")
+        self.status = status
+        self.path = path
+
+
+class GitError(RuntimeError):
+    """A git subcommand failed; carries git's own explanation."""
+
+
+class NothingToCommit(GitError):
+    """Nothing staged — an ordinary outcome, not a crash."""
+
+
+class ForbiddenPathError(GitError):
+    """A commit tried to stage a path the contract forbids."""
 
 
 class TokenProvider(Protocol):
@@ -33,17 +62,47 @@ class TokenProvider(Protocol):
 
 @dataclass(frozen=True)
 class FileTokenProvider:
-    """Reads a 0600 credential file (the bot PAT on the orchestrator host)."""
+    """Reads a credential file (the bot PAT on the orchestrator host)."""
 
     path: Path
 
     def token(self) -> str:
-        return self.path.read_text().strip()
+        mode = self.path.stat().st_mode & 0o077
+        if mode:
+            raise PermissionError(f"{self.path} is group/world accessible; chmod 600 it")
+        token = self.path.read_text().strip()
+        if not token:
+            raise ValueError(f"{self.path} is empty")
+        return token
+
+
+class _NoAuthRedirect(urllib.request.HTTPRedirectHandler):
+    """Drop the Authorization header when a redirect changes host."""
+
+    def redirect_request(
+        self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str
+    ) -> Any:
+        new = super().redirect_request(req, fp, code, msg, headers, newurl)
+        if (
+            new is not None
+            and urllib.parse.urlparse(newurl).netloc != urllib.parse.urlparse(req.full_url).netloc
+        ):
+            for header in ("Authorization", "authorization"):
+                new.headers.pop(header, None)
+                new.unredirected_hdrs.pop(header, None)
+        return new
+
+
+_opener = urllib.request.build_opener(_NoAuthRedirect)
 
 
 def _default_transport(request: urllib.request.Request) -> Any:
-    with urllib.request.urlopen(request, timeout=30) as response:
-        payload = response.read()
+    try:
+        with _opener.open(request, timeout=30) as response:
+            payload = response.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")[:500]
+        raise GitHubError(exc.code, urllib.parse.urlparse(request.full_url).path, body) from None
     return json.loads(payload) if payload else None
 
 
@@ -68,47 +127,72 @@ class GitHubClient:
         )
         return self.transport(request)
 
+    @staticmethod
+    def _expect_dict(data: Any, path: str) -> dict[str, Any]:
+        if not isinstance(data, dict):
+            raise GitHubError(200, path, f"expected an object, got {type(data).__name__}")
+        return data
+
     def default_branch(self, repo: str) -> str:
-        return str(self._request("GET", f"/repos/{repo}")["default_branch"])
+        path = f"/repos/{urllib.parse.quote(repo)}"
+        return str(self._expect_dict(self._request("GET", path), path)["default_branch"])
 
     def get_file(self, repo: str, path: str, ref: str) -> str:
         """Fetch a file's text at a ref — used to read contracts from the
         default branch, never from PR branches."""
-        data = self._request("GET", f"/repos/{repo}/contents/{path}?ref={ref}")
+        query = urllib.parse.urlencode({"ref": ref})
+        api_path = f"/repos/{urllib.parse.quote(repo)}/contents/{urllib.parse.quote(path)}?{query}"
+        data = self._expect_dict(self._request("GET", api_path), api_path)
+        if data.get("type") != "file":
+            raise GitHubError(200, api_path, f"not a file (type={data.get('type')!r})")
         if data.get("encoding") != "base64":
-            raise ValueError(f"unexpected encoding for {repo}:{path}")
+            raise GitHubError(200, api_path, f"unreadable encoding {data.get('encoding')!r}")
         return base64.b64decode(data["content"]).decode()
 
     def create_pr(self, repo: str, head: str, base: str, title: str, body: str) -> int | None:
         if self.dry_run:
             log.info("[dry-run] create PR %s: %s <- %s (%r)", repo, base, head, title)
             return None
-        data = self._request(
-            "POST",
-            f"/repos/{repo}/pulls",
-            {"title": title, "head": head, "base": base, "body": body},
+        path = f"/repos/{urllib.parse.quote(repo)}/pulls"
+        data = self._expect_dict(
+            self._request("POST", path, {"title": title, "head": head, "base": base, "body": body}),
+            path,
         )
+        if "number" not in data:
+            raise GitHubError(200, path, f"no PR number in response: {data.get('message')}")
         return int(data["number"])
 
     def comment(self, repo: str, issue_number: int, body: str) -> None:
         if self.dry_run:
             log.info("[dry-run] comment on %s#%s (%d chars)", repo, issue_number, len(body))
             return
-        self._request("POST", f"/repos/{repo}/issues/{issue_number}/comments", {"body": body})
+        path = f"/repos/{urllib.parse.quote(repo)}/issues/{issue_number}/comments"
+        self._request("POST", path, {"body": body})
 
 
-def _git_auth_env(token: str | None) -> dict[str, str]:
-    """Per-invocation git auth that never lands in argv or .git/config."""
+def _git_env(token: str | None) -> dict[str, str]:
+    """Environment for a git invocation. The token is present only for network
+    subcommands; local ones also get hooks disabled."""
     env = dict(os.environ)
-    if token is not None:
-        basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
-        env |= {
-            "GIT_CONFIG_COUNT": "1",
-            "GIT_CONFIG_KEY_0": "http.https://github.com/.extraheader",
-            "GIT_CONFIG_VALUE_0": f"Authorization: Basic {basic}",
-        }
     env["GIT_TERMINAL_PROMPT"] = "0"
+    if token is None:
+        env["GIT_CONFIG_COUNT"] = "0"
+        return env
+    basic = base64.b64encode(f"x-access-token:{token}".encode()).decode()
+    env |= {
+        "GIT_CONFIG_COUNT": "1",
+        "GIT_CONFIG_KEY_0": "http.https://github.com/.extraheader",
+        "GIT_CONFIG_VALUE_0": f"Authorization: Basic {basic}",
+    }
     return env
+
+
+def _run_git(args: list[str], env: dict[str, str]) -> str:
+    result = subprocess.run(args, capture_output=True, text=True, env=env, check=False)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise GitError(f"git {' '.join(args[1:3])} failed: {detail}")
+    return result.stdout.strip()
 
 
 @dataclass
@@ -119,18 +203,22 @@ class Workspace:
     auth: TokenProvider | None = None
     dry_run: bool = False
 
-    def _token(self) -> str | None:
-        return self.auth.token() if self.auth is not None else None
-
     def git(self, *args: str) -> str:
-        result = subprocess.run(
-            ["git", "-C", str(self.root), *args],
-            capture_output=True,
-            text=True,
-            env=_git_auth_env(self._token()),
-            check=True,
+        """Run a local git subcommand: no credential, hooks disabled."""
+        return _run_git(
+            ["git", "-C", str(self.root), "-c", "core.hooksPath=/dev/null", *args],
+            _git_env(None),
         )
-        return result.stdout.strip()
+
+    def git_network(self, *args: str) -> str:
+        """Run a git subcommand that talks to the remote, with credentials."""
+        if args and args[0] not in NETWORK_GIT_COMMANDS:
+            raise ValueError(f"{args[0]!r} is not a network git command")
+        token = self.auth.token() if self.auth is not None else None
+        return _run_git(
+            ["git", "-C", str(self.root), "-c", "core.hooksPath=/dev/null", *args],
+            _git_env(token),
+        )
 
     @classmethod
     def clone(
@@ -141,20 +229,41 @@ class Workspace:
         dry_run: bool = False,
     ) -> Workspace:
         token = auth.token() if auth is not None else None
-        subprocess.run(
-            ["git", "clone", "--quiet", url, str(dest)],
-            capture_output=True,
-            text=True,
-            env=_git_auth_env(token),
-            check=True,
+        _run_git(
+            ["git", "clone", "--quiet", "-c", "core.hooksPath=/dev/null", url, str(dest)],
+            _git_env(token),
         )
         return cls(root=dest, auth=auth, dry_run=dry_run)
 
     def branch(self, name: str) -> None:
         self.git("switch", "-c", name)
 
-    def commit_all(self, message: str, author: str) -> None:
+    def staged_paths(self) -> list[str]:
+        output = self.git("diff", "--cached", "--name-only")
+        return [line for line in output.splitlines() if line]
+
+    def commit_all(
+        self,
+        message: str,
+        author: str,
+        forbidden: Callable[[str], bool] | None = None,
+    ) -> None:
+        """Stage everything and commit.
+
+        `forbidden(path)` — normally `partial(path_is_forbidden, contract=...)`
+        — vetoes the commit if the session touched a path the contract puts
+        off-limits, so the invariant is enforced against the diff, not only
+        against the contract's own scope list.
+        """
         self.git("add", "-A")
+        staged = self.staged_paths()
+        if not staged:
+            raise NothingToCommit("nothing to commit; working tree clean")
+        if forbidden is not None:
+            violations = [p for p in staged if forbidden(p)]
+            if violations:
+                self.git("reset")
+                raise ForbiddenPathError(f"commit touches forbidden paths: {sorted(violations)}")
         self.git(
             "-c",
             f"user.name={author}",
@@ -169,4 +278,4 @@ class Workspace:
         if self.dry_run:
             log.info("[dry-run] push %s from %s", branch, self.root)
             return
-        self.git("push", "-u", "origin", branch)
+        self.git_network("push", "-u", "origin", "--", branch)

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -11,6 +11,9 @@ Credential rules enforced here:
 - Only network git subcommands get that environment. Local subcommands run
   token-free with hooks disabled, so repo content written by an agent session
   (hooks, filters) can never read the credential.
+- Credentialed invocations additionally neutralize every git setting that can
+  spawn a child process (ssh command, credential helpers, alternate
+  protocols), because the session owns the clone's ``.git/config``.
 """
 
 from __future__ import annotations
@@ -32,6 +35,26 @@ log = logging.getLogger(__name__)
 
 API = "https://api.github.com"
 NETWORK_GIT_COMMANDS = frozenset({"clone", "fetch", "pull", "push", "ls-remote"})
+# Settings a session could add to .git/config that make git spawn a child
+# process; neutralized on every credentialed invocation.
+SAFE_GIT_FLAGS = (
+    "-c",
+    "core.hooksPath=/dev/null",
+    "-c",
+    "core.sshCommand=false",
+    "-c",
+    "credential.helper=",
+    "-c",
+    "protocol.allow=never",
+    "-c",
+    "protocol.https.allow=always",
+    "-c",
+    "protocol.file.allow=always",
+    "-c",
+    "core.fsmonitor=",
+    "-c",
+    "core.quotePath=false",
+)
 Transport = Callable[[urllib.request.Request], Any]
 
 
@@ -67,6 +90,8 @@ class FileTokenProvider:
     path: Path
 
     def token(self) -> str:
+        if not self.path.is_file():
+            raise ValueError(f"{self.path} is not a readable credential file")
         mode = self.path.stat().st_mode & 0o077
         if mode:
             raise PermissionError(f"{self.path} is group/world accessible; chmod 600 it")
@@ -83,9 +108,10 @@ class _NoAuthRedirect(urllib.request.HTTPRedirectHandler):
         self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str
     ) -> Any:
         new = super().redirect_request(req, fp, code, msg, headers, newurl)
-        if (
-            new is not None
-            and urllib.parse.urlparse(newurl).netloc != urllib.parse.urlparse(req.full_url).netloc
+        old_parts = urllib.parse.urlparse(req.full_url)
+        new_parts = urllib.parse.urlparse(newurl)
+        if new is not None and (
+            new_parts.netloc != old_parts.netloc or new_parts.scheme != old_parts.scheme
         ):
             for header in ("Authorization", "authorization"):
                 new.headers.pop(header, None)
@@ -103,6 +129,10 @@ def _default_transport(request: urllib.request.Request) -> Any:
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")[:500]
         raise GitHubError(exc.code, urllib.parse.urlparse(request.full_url).path, body) from None
+    except urllib.error.URLError as exc:
+        raise GitHubError(
+            0, urllib.parse.urlparse(request.full_url).path, str(exc.reason)
+        ) from None
     return json.loads(payload) if payload else None
 
 
@@ -191,7 +221,12 @@ def _run_git(args: list[str], env: dict[str, str]) -> str:
     result = subprocess.run(args, capture_output=True, text=True, env=env, check=False)
     if result.returncode != 0:
         detail = (result.stderr or result.stdout or "").strip()
-        raise GitError(f"git {' '.join(args[1:3])} failed: {detail}")
+        skip = {"-C", "-c"}
+        subcommand = next(
+            (a for i, a in enumerate(args[1:], 1) if a not in skip and args[i - 1] not in skip),
+            "?",
+        )
+        raise GitError(f"git {subcommand} failed: {detail}")
     return result.stdout.strip()
 
 
@@ -202,23 +237,22 @@ class Workspace:
     root: Path
     auth: TokenProvider | None = None
     dry_run: bool = False
+    url: str | None = None
 
     def git(self, *args: str) -> str:
-        """Run a local git subcommand: no credential, hooks disabled."""
-        return _run_git(
-            ["git", "-C", str(self.root), "-c", "core.hooksPath=/dev/null", *args],
-            _git_env(None),
-        )
+        """Run a local git subcommand: no credential, no child-spawning config."""
+        return _run_git(["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(None))
 
     def git_network(self, *args: str) -> str:
         """Run a git subcommand that talks to the remote, with credentials."""
         if args and args[0] not in NETWORK_GIT_COMMANDS:
             raise ValueError(f"{args[0]!r} is not a network git command")
         token = self.auth.token() if self.auth is not None else None
-        return _run_git(
-            ["git", "-C", str(self.root), "-c", "core.hooksPath=/dev/null", *args],
-            _git_env(token),
-        )
+        return _run_git(["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(token))
+
+    def remote_url(self) -> str:
+        """The remote URL as recorded at clone time, read token-free."""
+        return self.git("config", "--get", "remote.origin.url")
 
     @classmethod
     def clone(
@@ -229,18 +263,16 @@ class Workspace:
         dry_run: bool = False,
     ) -> Workspace:
         token = auth.token() if auth is not None else None
-        _run_git(
-            ["git", "clone", "--quiet", "-c", "core.hooksPath=/dev/null", url, str(dest)],
-            _git_env(token),
-        )
-        return cls(root=dest, auth=auth, dry_run=dry_run)
+        _run_git(["git", "clone", "--quiet", *SAFE_GIT_FLAGS, url, str(dest)], _git_env(token))
+        return cls(root=dest, auth=auth, dry_run=dry_run, url=url)
 
     def branch(self, name: str) -> None:
         self.git("switch", "-c", name)
 
     def staged_paths(self) -> list[str]:
-        output = self.git("diff", "--cached", "--name-only")
-        return [line for line in output.splitlines() if line]
+        """Staged paths, NUL-delimited so unicode/space/newline names survive."""
+        output = self.git("diff", "--cached", "--name-only", "-z")
+        return [entry for entry in output.split("\0") if entry]
 
     def commit_all(
         self,
@@ -278,4 +310,7 @@ class Workspace:
         if self.dry_run:
             log.info("[dry-run] push %s from %s", branch, self.root)
             return
-        self.git_network("push", "-u", "origin", "--", branch)
+        # Push to the URL captured at clone time: the session can rewrite
+        # remote.origin.url, and "origin" would follow it.
+        target = self.url or self.remote_url()
+        self.git_network("push", target, "--", f"{branch}:{branch}")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -70,12 +70,12 @@ def test_self_target_refused_case_insensitive() -> None:
 
 def test_forbidden_paths_include_roadmap() -> None:
     contract = load_contract(PILOT_CONTRACT, "x/y")
-    assert set(forbidden_paths(contract)) == {".github/", ".autoresearch.yaml", "README.md"}
+    assert set(forbidden_paths(contract)) == {".github", ".autoresearch.yaml", "README.md"}
 
 
 @pytest.mark.parametrize(
     "allowed",
-    [".github/workflows/", ".autoresearch.yaml", "README.md", ".", "", "./"],
+    [".github/workflows/", ".autoresearch.yaml", "README.md", ".", "./"],
 )
 def test_scope_overlap_refused(allowed: str) -> None:
     text = PILOT_CONTRACT.replace("allowed: [src/pilot/solvers/]", f"allowed: ['{allowed}']")

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -23,6 +23,7 @@ class FakeTransport:
 def provider(tmp_path: Path) -> FileTokenProvider:
     pat = tmp_path / "pat"
     pat.write_text("github_pat_test123\n")
+    pat.chmod(0o600)
     return FileTokenProvider(pat)
 
 
@@ -41,7 +42,7 @@ def test_default_branch_and_headers(provider: FileTokenProvider) -> None:
 
 def test_get_file_decodes_base64(provider: FileTokenProvider) -> None:
     content = base64.b64encode(b"benchmarks: []\n").decode()
-    transport = FakeTransport([{"encoding": "base64", "content": content}])
+    transport = FakeTransport([{"type": "file", "encoding": "base64", "content": content}])
     client = GitHubClient(auth=provider, transport=transport)
     assert client.get_file("org/repo", ".autoresearch.yaml", "main") == "benchmarks: []\n"
     assert "ref=main" in transport.requests[0].full_url

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import base64
 import subprocess
+import threading
 import urllib.error
 import urllib.request
 from functools import partial
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 
 import pytest
@@ -25,6 +28,7 @@ from autoresearch.github import (
     GitHubError,
     NothingToCommit,
     Workspace,
+    _default_transport,
 )
 from test_contract import PILOT_CONTRACT
 
@@ -121,27 +125,82 @@ def provider(tmp_path: Path) -> FileTokenProvider:
     return FileTokenProvider(pat)
 
 
-def test_session_planted_hook_cannot_read_token(
+def _plant_hook(ws: Workspace, name: str, sink: Path) -> None:
+    """Plant a hook the way a compromised session would, defeating the
+    clone-time core.hooksPath so the per-invocation flag is what's tested."""
+    subprocess.run(["git", "-C", str(ws.root), "config", "--unset", "core.hooksPath"], check=False)
+    hooks = ws.root / ".git" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    hook = hooks / name
+    hook.write_text(f'#!/bin/sh\nenv > "{sink}"\nexit 0\n')
+    hook.chmod(0o755)
+
+
+def _basic_header(token: str) -> str:
+    return base64.b64encode(f"x-access-token:{token}".encode()).decode()
+
+
+def test_session_planted_commit_hook_cannot_read_token(
     tmp_path: Path, provider: FileTokenProvider
 ) -> None:
     origin = _origin(tmp_path)
     ws = Workspace.clone(f"file://{origin}", tmp_path / "work", auth=provider)
-    hooks = ws.root / ".git" / "hooks"
-    hooks.mkdir(parents=True, exist_ok=True)
-    stolen = tmp_path / "stolen.txt"
-    hook = hooks / "pre-commit"
-    hook.write_text(f'#!/bin/sh\nenv > "{stolen}"\n')
-    hook.chmod(0o755)
+    stolen = tmp_path / "stolen_commit.txt"
+    _plant_hook(ws, "pre-commit", stolen)
     ws.branch("feat/auto/x")
     (ws.root / "f.txt").write_text("x\n")
     ws.commit_all("msg", author="bot")
-    assert not stolen.exists(), "hook ran despite core.hooksPath=/dev/null"
+    assert not stolen.exists(), "hook ran during commit"
+
+
+def test_session_planted_push_hook_cannot_read_token(
+    tmp_path: Path, provider: FileTokenProvider
+) -> None:
+    """The push path carries the credential — hooks must be dead there too."""
+    origin = _origin(tmp_path)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work", auth=provider)
+    ws.branch("feat/auto/x")
+    (ws.root / "f.txt").write_text("x\n")
+    ws.commit_all("msg", author="bot")
+    stolen = tmp_path / "stolen_push.txt"
+    _plant_hook(ws, "pre-push", stolen)
+    ws.push("feat/auto/x")
+    assert not stolen.exists(), "pre-push hook ran with the credential in env"
+    if stolen.exists():  # pragma: no cover - defensive
+        assert _basic_header(provider.token()) not in stolen.read_text()
+
+
+def test_session_cannot_redirect_push_to_its_own_remote(
+    tmp_path: Path, provider: FileTokenProvider
+) -> None:
+    """A session rewriting remote.origin.url must not capture the token."""
+    origin = _origin(tmp_path)
+    evil = tmp_path / "evil.git"
+    subprocess.run(["git", "init", "--bare", "-q", str(evil)], check=True)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work", auth=provider)
+    ws.branch("feat/auto/x")
+    (ws.root / "f.txt").write_text("x\n")
+    ws.commit_all("msg", author="bot")
+    subprocess.run(
+        ["git", "-C", str(ws.root), "config", "remote.origin.url", f"file://{evil}"], check=True
+    )
+    ws.push("feat/auto/x")
+    landed = subprocess.run(
+        ["git", "-C", str(origin), "branch"], capture_output=True, text=True, check=True
+    ).stdout
+    hijacked = subprocess.run(
+        ["git", "-C", str(evil), "branch"], capture_output=True, text=True, check=True
+    ).stdout
+    assert "feat/auto/x" in landed, "push did not reach the real origin"
+    assert "feat/auto/x" not in hijacked, "push followed the session's rewritten remote"
 
 
 def test_local_git_env_has_no_credential(tmp_path: Path, provider: FileTokenProvider) -> None:
     origin = _origin(tmp_path)
     ws = Workspace.clone(f"file://{origin}", tmp_path / "work", auth=provider)
-    assert "SUPERSECRET" not in ws.git("config", "--list")
+    config = ws.git("config", "--list")
+    assert "extraheader" not in config.lower()
+    assert _basic_header(provider.token()) not in config
 
 
 def test_file_token_provider_rejects_loose_permissions(tmp_path: Path) -> None:
@@ -182,13 +241,72 @@ def test_commit_all_refuses_forbidden_paths(tmp_path: Path) -> None:
 
 
 # --- findings 6 and 7: HTTP errors and response shapes ------------------------------
-def test_http_error_becomes_typed_without_url_token(provider: FileTokenProvider) -> None:
-    def transport(request: urllib.request.Request) -> object:
-        raise urllib.error.HTTPError(request.full_url, 404, "Not Found", {}, None)  # type: ignore[arg-type]
+def test_default_transport_types_http_errors(provider: FileTokenProvider) -> None:
+    """Exercise the real transport, not a stub: 404 must become GitHubError."""
 
-    client = GitHubClient(auth=provider, transport=transport)
-    with pytest.raises(urllib.error.HTTPError):
-        client.default_branch("org/repo")  # raw transport passes through; wrapper is in default
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b'{"message": "Not Found"}')
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{server.server_port}/x",
+            headers={"Authorization": "Bearer github_pat_SUPERSECRET"},
+        )
+        with pytest.raises(GitHubError) as excinfo:
+            _default_transport(request)
+        assert excinfo.value.status == 404
+        assert "SUPERSECRET" not in str(excinfo.value)
+    finally:
+        server.shutdown()
+
+
+def test_cross_host_redirect_drops_authorization() -> None:
+    """The PAT must not follow a redirect to another host."""
+    seen: list[str | None] = []
+
+    class Final(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            seen.append(self.headers.get("Authorization"))
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"{}")
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    final = HTTPServer(("127.0.0.1", 0), Final)
+    threading.Thread(target=final.serve_forever, daemon=True).start()
+    final_url = f"http://localhost:{final.server_port}/dest"
+
+    class Redirector(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(302)
+            self.send_header("Location", final_url)
+            self.end_headers()
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    hop = HTTPServer(("127.0.0.1", 0), Redirector)
+    threading.Thread(target=hop.serve_forever, daemon=True).start()
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{hop.server_port}/start",
+            headers={"Authorization": "Bearer github_pat_SUPERSECRET"},
+        )
+        _default_transport(request)
+        assert seen == [None], f"credential followed the redirect: {seen}"
+    finally:
+        hop.shutdown()
+        final.shutdown()
 
 
 def test_get_file_on_directory_listing_errors(provider: FileTokenProvider) -> None:
@@ -220,3 +338,58 @@ def test_ref_is_url_encoded(provider: FileTokenProvider) -> None:
 
     GitHubClient(auth=provider, transport=transport).get_file("org/repo", "a.yaml", "we#ird")
     assert "we%23ird" in seen[0]
+
+
+# --- verification round: remaining bypasses -----------------------------------------
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "ssh://git@github.com/agentic-learning-ai-lab/autoresearch.git",
+        "github.com/agentic-learning-ai-lab/autoresearch",
+        "www.github.com/agentic-learning-ai-lab/autoresearch",
+        "git://github.com/agentic-learning-ai-lab/autoresearch",
+        "https://x-access-token:tok@github.com/agentic-learning-ai-lab/autoresearch",
+        "https://github.com//agentic-learning-ai-lab/autoresearch",
+        "  agentic-learning-ai-lab/autoresearch\n",
+    ],
+)
+def test_self_target_url_spellings_refused(spelling: str) -> None:
+    with pytest.raises(SelfTargetError):
+        load_contract(PILOT_CONTRACT, spelling)
+
+
+@pytest.mark.parametrize(
+    "candidate", [".GITHUB/workflows/evil.yml", ".GitHub/x", ".Autoresearch.YAML"]
+)
+def test_forbidden_paths_are_case_insensitive(candidate: str) -> None:
+    contract = load_contract(PILOT_CONTRACT, "x/y")
+    assert path_is_forbidden(candidate, contract)
+
+
+def test_git_directory_never_writable() -> None:
+    contract = load_contract(PILOT_CONTRACT, "x/y")
+    assert path_is_forbidden(".git/config", contract)
+    text = PILOT_CONTRACT.replace("allowed: [src/pilot/solvers/]", "allowed: ['.git/hooks']")
+    with pytest.raises(ScopeError):
+        load_contract(text, "x/y")
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    ["benchmarks: [", "\tbad: indent", "? {a: 1}\n: v", "x: !!python/object/apply:os.system ['x']"],
+)
+def test_hostile_yaml_raises_contract_error(hostile: str) -> None:
+    with pytest.raises(ContractError):
+        load_contract(hostile, "x/y")
+
+
+def test_unicode_filenames_do_not_trip_the_forbidden_check(tmp_path: Path) -> None:
+    """git C-quotes exotic names; the veto must see real paths, not quoted ones."""
+    origin = _origin(tmp_path)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work")
+    ws.branch("feat/auto/x")
+    (ws.root / "café.txt").write_text("x\n")
+    (ws.root / "a b.txt").write_text("x\n")
+    contract = load_contract(PILOT_CONTRACT, "x/y")
+    ws.commit_all("unicode", author="bot", forbidden=partial(path_is_forbidden, contract=contract))
+    assert "café.txt" in ws.git("show", "--stat", "--name-only", "HEAD")

--- a/tests/test_hardening.py
+++ b/tests/test_hardening.py
@@ -1,0 +1,222 @@
+"""Regression tests for the findings of the 2026-08-05 adversarial review."""
+
+from __future__ import annotations
+
+import subprocess
+import urllib.error
+import urllib.request
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from autoresearch.contract import (
+    ContractError,
+    ScopeError,
+    SelfTargetError,
+    load_contract,
+    normalize_repo,
+    path_is_forbidden,
+)
+from autoresearch.github import (
+    FileTokenProvider,
+    ForbiddenPathError,
+    GitHubClient,
+    GitHubError,
+    NothingToCommit,
+    Workspace,
+)
+from test_contract import PILOT_CONTRACT
+
+
+# --- finding 2: path normalization -------------------------------------------------
+@pytest.mark.parametrize(
+    "allowed",
+    ["src/../.github/", "src//../.github", "../../etc", "/etc/passwd", "*", "src/**", ".", "./"],
+)
+def test_unsafe_scope_entries_refused(allowed: str) -> None:
+    text = PILOT_CONTRACT.replace("allowed: [src/pilot/solvers/]", f"allowed: ['{allowed}']")
+    with pytest.raises(ScopeError):
+        load_contract(text, "x/y")
+
+
+def test_sibling_name_not_shadowed_by_roadmap() -> None:
+    # roadmap README.md must not forbid README.mdx (prefix vs component match)
+    text = PILOT_CONTRACT.replace("allowed: [src/pilot/solvers/]", "allowed: [README.mdx]")
+    contract = load_contract(text, "x/y")
+    assert not path_is_forbidden("README.mdx", contract)
+    assert path_is_forbidden("README.md", contract)
+
+
+def test_forbidden_matches_are_component_wise() -> None:
+    contract = load_contract(PILOT_CONTRACT, "x/y")
+    assert path_is_forbidden(".github/workflows/ci.yml", contract)
+    assert path_is_forbidden(".autoresearch.yaml", contract)
+    assert path_is_forbidden("src/../.github/x.yml", contract)  # unnormalizable → forbidden
+    assert not path_is_forbidden("src/pilot/solvers/tsp.py", contract)
+
+
+# --- finding 3: self-target spellings ----------------------------------------------
+@pytest.mark.parametrize(
+    "spelling",
+    [
+        "agentic-learning-ai-lab/autoresearch",
+        "Agentic-Learning-AI-Lab/AutoResearch",
+        "agentic-learning-ai-lab/autoresearch.git",
+        "agentic-learning-ai-lab/autoresearch/",
+        "https://github.com/agentic-learning-ai-lab/autoresearch",
+        "git@github.com:agentic-learning-ai-lab/autoresearch.git",
+    ],
+)
+def test_self_target_spellings_refused(spelling: str) -> None:
+    with pytest.raises(SelfTargetError):
+        load_contract(PILOT_CONTRACT, spelling)
+
+
+def test_normalize_repo_keeps_other_repos() -> None:
+    assert normalize_repo("https://github.com/org/Other.git") == "org/other"
+
+
+# --- finding 4: untrusted YAML ------------------------------------------------------
+def test_alias_bomb_refused_fast() -> None:
+    bomb = "a: &a [x, x, x, x, x, x, x, x, x]\n"
+    for i in range(1, 10):
+        bomb += f"{'b' * i}: &{'b' * i} [*{'b' * (i - 1) if i > 1 else 'a'}] * 9\n"
+    with pytest.raises(ContractError, match="alias"):
+        load_contract("benchmarks: []\n" + bomb, "x/y")
+
+
+def test_duplicate_keys_refused() -> None:
+    text = PILOT_CONTRACT + "\nbudgets:\n  gpu_hours_per_run: 999\n  runs_per_week: 999\n"
+    with pytest.raises(ContractError, match="duplicate"):
+        load_contract(text, "x/y")
+
+
+def test_oversized_contract_refused() -> None:
+    with pytest.raises(ContractError, match="exceeds"):
+        load_contract("x: 1\n" * 20_000, "x/y")
+
+
+# --- finding 1: no credential for local git -----------------------------------------
+def _origin(tmp_path: Path) -> Path:
+    origin = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-b", "main", str(origin)], check=True)
+    seed = tmp_path / "seed"
+    subprocess.run(["git", "clone", "-q", str(origin), str(seed)], check=True)
+    (seed / "README.md").write_text("seed\n")
+    for cmd in (
+        ["add", "-A"],
+        ["-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "seed"],
+        ["push", "-q", "origin", "main"],
+    ):
+        subprocess.run(["git", "-C", str(seed), *cmd], check=True)
+    return origin
+
+
+@pytest.fixture
+def provider(tmp_path: Path) -> FileTokenProvider:
+    pat = tmp_path / "pat"
+    pat.write_text("github_pat_SUPERSECRET\n")
+    pat.chmod(0o600)
+    return FileTokenProvider(pat)
+
+
+def test_session_planted_hook_cannot_read_token(
+    tmp_path: Path, provider: FileTokenProvider
+) -> None:
+    origin = _origin(tmp_path)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work", auth=provider)
+    hooks = ws.root / ".git" / "hooks"
+    hooks.mkdir(parents=True, exist_ok=True)
+    stolen = tmp_path / "stolen.txt"
+    hook = hooks / "pre-commit"
+    hook.write_text(f'#!/bin/sh\nenv > "{stolen}"\n')
+    hook.chmod(0o755)
+    ws.branch("feat/auto/x")
+    (ws.root / "f.txt").write_text("x\n")
+    ws.commit_all("msg", author="bot")
+    assert not stolen.exists(), "hook ran despite core.hooksPath=/dev/null"
+
+
+def test_local_git_env_has_no_credential(tmp_path: Path, provider: FileTokenProvider) -> None:
+    origin = _origin(tmp_path)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work", auth=provider)
+    assert "SUPERSECRET" not in ws.git("config", "--list")
+
+
+def test_file_token_provider_rejects_loose_permissions(tmp_path: Path) -> None:
+    pat = tmp_path / "loose"
+    pat.write_text("tok\n")
+    pat.chmod(0o644)
+    with pytest.raises(PermissionError):
+        FileTokenProvider(pat).token()
+
+
+def test_file_token_provider_rejects_empty(tmp_path: Path) -> None:
+    pat = tmp_path / "empty"
+    pat.write_text("\n")
+    pat.chmod(0o600)
+    with pytest.raises(ValueError, match="empty"):
+        FileTokenProvider(pat).token()
+
+
+# --- findings 5 and 8: commit semantics ---------------------------------------------
+def test_commit_all_on_clean_tree_raises_typed(tmp_path: Path) -> None:
+    origin = _origin(tmp_path)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work")
+    ws.branch("feat/auto/x")
+    with pytest.raises(NothingToCommit):
+        ws.commit_all("nothing", author="bot")
+
+
+def test_commit_all_refuses_forbidden_paths(tmp_path: Path) -> None:
+    origin = _origin(tmp_path)
+    ws = Workspace.clone(f"file://{origin}", tmp_path / "work")
+    ws.branch("feat/auto/x")
+    (ws.root / ".github" / "workflows").mkdir(parents=True)
+    (ws.root / ".github" / "workflows" / "evil.yml").write_text("on: push\n")
+    contract = load_contract(PILOT_CONTRACT, "x/y")
+    with pytest.raises(ForbiddenPathError, match=r"\.github"):
+        ws.commit_all("evil", author="bot", forbidden=partial(path_is_forbidden, contract=contract))
+    assert ws.git("log", "--oneline").count("\n") == 0  # nothing new committed
+
+
+# --- findings 6 and 7: HTTP errors and response shapes ------------------------------
+def test_http_error_becomes_typed_without_url_token(provider: FileTokenProvider) -> None:
+    def transport(request: urllib.request.Request) -> object:
+        raise urllib.error.HTTPError(request.full_url, 404, "Not Found", {}, None)  # type: ignore[arg-type]
+
+    client = GitHubClient(auth=provider, transport=transport)
+    with pytest.raises(urllib.error.HTTPError):
+        client.default_branch("org/repo")  # raw transport passes through; wrapper is in default
+
+
+def test_get_file_on_directory_listing_errors(provider: FileTokenProvider) -> None:
+    client = GitHubClient(auth=provider, transport=lambda _r: [{"type": "file"}])
+    with pytest.raises(GitHubError, match="expected an object"):
+        client.get_file("org/repo", "src", "main")
+
+
+def test_get_file_on_large_file_errors(provider: FileTokenProvider) -> None:
+    client = GitHubClient(
+        auth=provider, transport=lambda _r: {"type": "file", "encoding": "none", "content": ""}
+    )
+    with pytest.raises(GitHubError, match="encoding"):
+        client.get_file("org/repo", "big.bin", "main")
+
+
+def test_create_pr_without_number_errors(provider: FileTokenProvider) -> None:
+    client = GitHubClient(auth=provider, transport=lambda _r: {"message": "Validation Failed"})
+    with pytest.raises(GitHubError, match="no PR number"):
+        client.create_pr("org/repo", "h", "main", "t", "b")
+
+
+def test_ref_is_url_encoded(provider: FileTokenProvider) -> None:
+    seen: list[str] = []
+
+    def transport(request: urllib.request.Request) -> object:
+        seen.append(request.full_url)
+        return {"type": "file", "encoding": "base64", "content": "eA=="}
+
+    GitHubClient(auth=provider, transport=transport).get_file("org/repo", "a.yaml", "we#ird")
+    assert "we%23ird" in seen[0]


### PR DESCRIPTION
First application of the new pre-merge review practice — a review agent found 8 confirmed defects in the just-merged phase-1 code. All fixed, each with a regression test.

**Security (worst first)**
1. **Credential leak via planted git hooks** — the PAT env was passed to *every* git subprocess, so a session-written `.git/hooks/pre-commit` (never staged, invisible in any diff) could read it during orchestrator-side commit. The reviewer reproduced the theft. Now: only network subcommands (clone/fetch/push) get credentials; local git runs token-free with `core.hooksPath=/dev/null`.
2. **Scope invariant bypass** — `src/../.github/`, absolute paths, and `*` all passed. Now normalized and compared component-wise; `..`, absolute, and glob entries are refused, and `README.mdx` is no longer shadowed by roadmap `README.md`.
3. **Self-target bypass** — `…/autoresearch.git` and URL forms passed the equality check. Now normalized (scheme/host/`.git`/trailing slash, casefolded).
4. **Contract YAML is untrusted input** — a 513-byte alias bomb cost 3s/567MB; duplicate keys silently last-win. Now aliases and duplicate keys are refused and input is size-capped.
5. **Invariants weren't wired to commits** — `forbidden_paths` had no callers; `git add -A` staged anything. `commit_all` now vetoes forbidden paths in the staged diff.

**Robustness**: typed `GitHubError`/`GitError`/`NothingToCommit`, cross-host redirects drop the Authorization header, URL components quoted (a `#` in a ref silently fetched the default branch), response shapes validated, token file checked for 0600 + non-empty.

## Test plan
55 tests (was 25). `tests/test_hardening.py` has one regression test per finding, including a real planted-hook theft attempt asserting the credential never reaches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)