### PR TITLE
Deployment hardening for the advisory reviewer + OSS-facing README

### DIFF
--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -32,6 +32,12 @@ on:
     secrets:
       reviewer_api_key:
         required: true
+      checkout_ssh_key:
+        description: >-
+          Read-only deploy key for the reviewer repo. Only needed while that
+          repo is PRIVATE (the caller's token cannot read another private
+          repo); omit entirely once it is public.
+        required: false
 
 permissions:
   contents: read
@@ -54,13 +60,19 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       # Checks out the REVIEWER, never the pull request's code. Nothing from
-      # the PR is executed at any point.
+      # the PR is executed at any point. An empty ssh-key is ignored by
+      # actions/checkout (token auth, enough for a public or same-repo
+      # reviewer); a private reviewer repo needs the read-only deploy key.
+      # (`secrets` is not a valid context in step-level `if:` — do not split
+      # this into conditional steps.)
       - name: Check out the reviewer
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.reviewer_repo }}
           ref: ${{ inputs.reviewer_ref }}
+          ssh-key: ${{ secrets.checkout_ssh_key }}
           path: .autoresearch
+          persist-credentials: false
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Deployment hardening for the reviewer: operational LLM errors map to
+  `CompleterError` (an expected failure — never reds a target repo's CI),
+  missing API key skips cleanly, and the reusable workflow accepts a read-only
+  deploy key so private self-hosted copies work. README rewritten for external
+  adopters.
 - `autoresearch.contract_cli`: validate a `.autoresearch.yaml` locally and print
   what the agent would be allowed to do.
 - `autoresearch.review` + reusable advisory-review workflow: constrained PR

--- a/README.md
+++ b/README.md
@@ -2,24 +2,65 @@
 
 [![ci](https://github.com/agentic-learning-ai-lab/autoresearch/actions/workflows/ci.yml/badge.svg)](https://github.com/agentic-learning-ai-lab/autoresearch/actions/workflows/ci.yml)
 
-Autonomous research agent that co-develops the lab's benchmark-bearing repos:
-picks work, implements, runs GPU experiments, opens PRs when metrics improve,
-reviews PRs, reports weekly. Humans keep the merge button.
-[Agentic Learning AI Lab](https://agenticlearning.ai), New York University.
+An autonomous research agent you point at your own repos. It reviews pull
+requests, implements ideas, runs experiments on your compute, and opens a PR
+when a benchmark actually improves — with a readable research report, not just
+numbers. **Humans keep the merge button.**
 
-> **Private — internal infrastructure.** Handles bot credentials and unpublished
-> lab code. Confidential until released.
+Built and dogfooded by the [Agentic Learning AI Lab](https://agenticlearning.ai)
+at NYU, where it co-develops our research codebases. Designed from the start to
+be **self-hosted by anyone**: your credentials, your compute, your repos.
+Nothing reports back to us.
 
-## How a repo opts in
+> Currently private while we harden it in production on our own lab. All
+> history is written to be public.
 
-1. Grant the lab bot account write access.
-2. Add `.autoresearch.yaml` at the repo root (benchmarks, budgets, scope — see
-   [docs/design/architecture.md](docs/design/architecture.md)).
+## What it does
 
-Target repos never import this repo; the agent's PRs go through their normal
-review gates.
+- **Advisory PR reviews** — comments on pull requests with concrete findings.
+  It never approves, never blocks, and never fails your CI. This works today
+  and takes about five minutes to set up.
+- **Benchmark climbing** *(arriving — see the [roadmap](docs/roadmap.md))* —
+  given a contract (`.autoresearch.yaml`) declaring what "better" means, the
+  agent will propose changes, evaluate them on your infrastructure, and open a
+  PR only when the metric moves. Claims stay re-verifiable by your own CI
+  because benchmark commands are deterministic. The contract format and
+  validator exist today.
+- **Research reports** *(arriving)* — every run will end with a readable
+  report (hypothesis, outcome, takeaways, next steps), feeding task selection
+  for future runs.
 
-## Quickstart
+## Getting started
+
+See **[docs/install.md](docs/install.md)**. Level 1 (advisory reviews) needs
+only an LLM API key and one workflow file. Level 2 (the climber) adds a bot
+account and a contract.
+
+```bash
+# validate your contract before you push it
+uv run python -m autoresearch.contract_cli .autoresearch.yaml
+```
+
+## Design principles
+
+- **Opt-in and contract-bound.** A repo participates by granting the bot access
+  and committing a contract. The contract, your roadmap, and `.github/` are
+  never writable by the agent, whatever the contract says.
+- **Your gates apply.** The agent is an ordinary contributor: branch
+  protection, required checks, and code owners bind it like anyone else.
+- **Untrusted by default.** PR text and diffs are data, never instructions.
+  Agent sessions run without credentials in their environment. Budgets are
+  enforced in code.
+- **Nothing leaves your infrastructure.** Experiments run where you say
+  (Slurm is the first backend; the compute interface is small and pluggable).
+- **No model lock-in.** LLM calls sit behind small interfaces (`Completer` for
+  reviews, the harness layer for coding sessions) so backends can diversify;
+  Anthropic is the pilot backend.
+
+Full design: [docs/design/architecture.md](docs/design/architecture.md) ·
+Roadmap: [docs/roadmap.md](docs/roadmap.md)
+
+## Developing
 
 ```bash
 uv sync
@@ -27,15 +68,13 @@ uv run pre-commit install
 uv run pytest
 ```
 
-## Layout
-
 | Path | Purpose |
 | --- | --- |
-| `src/autoresearch/` | The library: contract, harness, orchestrator, compute, github, budget, report (arriving per [roadmap](docs/roadmap.md)) |
+| `src/autoresearch/` | The library: contract, review, github, llm; harness, orchestrator, compute arriving per the roadmap |
 | `tests/` | Tiers: unit (default), `slow`, `llm`, `slurm` markers |
-| `scripts/` | Committed operational scripts (protection, tick job) |
-| `docs/` | Architecture and roadmap |
+| `scripts/` | Committed operational scripts |
+| `docs/` | Install guide, architecture, roadmap |
 
-## Status
+## License
 
-Scaffold phase. Design: [docs/design/architecture.md](docs/design/architecture.md).
+MIT.

--- a/docs/install.md
+++ b/docs/install.md
@@ -136,9 +136,10 @@ that can reach GitHub and your LLM provider works.
   2FA.
 - **A VM or workstation**: run it on a timer.
 
-Experiments run wherever your `compute` backend says. Slurm ships today; the
-interface is small (submit a job, poll for completion), so a CI runner, a cloud
-backend, or a hardware rig plugs in the same way.
+Experiments run wherever your `compute` backend says. Slurm is the first
+backend (arriving per the roadmap); the interface is small (submit a job, poll
+for completion), so a CI runner, a cloud backend, or a hardware rig plugs in
+the same way.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dev = [
     "mypy>=1.13",
     "pytest>=8",
     "pre-commit>=4",
+    # so the completer's error mapping is testable without the extra
+    "anthropic>=0.70",
 ]
 
 [tool.hatch.version]

--- a/src/autoresearch/llm.py
+++ b/src/autoresearch/llm.py
@@ -25,6 +25,10 @@ class TruncatedError(RuntimeError):
     """The response hit max_tokens; the JSON body is incomplete."""
 
 
+class CompleterError(RuntimeError):
+    """The completion failed operationally (auth, network, rate limit, overload)."""
+
+
 @dataclass
 class AnthropicCompleter:
     """Calls Claude and returns the raw JSON text of a structured response."""
@@ -42,22 +46,28 @@ class AnthropicCompleter:
     def complete(self, system: str, prompt: str, schema: dict[str, Any]) -> str:
         if self.effort not in EFFORTS:
             raise ValueError(f"effort must be one of {EFFORTS}, got {self.effort!r}")
+        import anthropic  # imported lazily: the `review` extra is optional
+        import httpx  # anthropic's transport; mid-stream failures surface raw
+
         # Streamed: thinking is on by default and shares max_tokens with the
         # response, so a long review can outlive a non-streaming timeout.
-        with self._client().beta.messages.stream(
-            model=self.model,
-            max_tokens=self.max_tokens,
-            system=system,
-            messages=[{"role": "user", "content": prompt}],
-            output_config={
-                "effort": self.effort,
-                "format": {"type": "json_schema", "schema": schema},
-            },
-            # Safety classifiers can decline; route the retry server-side.
-            betas=["server-side-fallback-2026-07-01"],
-            fallbacks="default",
-        ) as stream:
-            response = stream.get_final_message()
+        try:
+            with self._client().beta.messages.stream(
+                model=self.model,
+                max_tokens=self.max_tokens,
+                system=system,
+                messages=[{"role": "user", "content": prompt}],
+                output_config={
+                    "effort": self.effort,
+                    "format": {"type": "json_schema", "schema": schema},
+                },
+                # Safety classifiers can decline; route the retry server-side.
+                betas=["server-side-fallback-2026-07-01"],
+                fallbacks="default",
+            ) as stream:
+                response = stream.get_final_message()
+        except (anthropic.AnthropicError, httpx.HTTPError) as exc:
+            raise CompleterError(f"{type(exc).__name__}: {exc}") from exc
         if response.stop_reason == "refusal":
             category = getattr(response.stop_details, "category", None)
             raise RefusalError(f"model declined the review (category={category})")

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -13,7 +13,7 @@ import os
 import sys
 
 from autoresearch.github import EnvTokenProvider, GitHubClient, GitHubError
-from autoresearch.llm import AnthropicCompleter, RefusalError
+from autoresearch.llm import AnthropicCompleter, CompleterError, RefusalError, TruncatedError
 from autoresearch.review import MARKER, PullRequest, format_comment, review
 
 log = logging.getLogger(__name__)
@@ -21,7 +21,15 @@ log = logging.getLogger(__name__)
 # Failures that mean "this run can't post" — logged, never fatal, because an
 # advisory reviewer must not turn a target repo's CI red. Programming errors
 # (AttributeError, KeyError, TypeError) deliberately propagate.
-EXPECTED_FAILURES = (GitHubError, RefusalError, ValueError, OSError, json.JSONDecodeError)
+EXPECTED_FAILURES = (
+    GitHubError,
+    RefusalError,
+    TruncatedError,
+    CompleterError,
+    ValueError,
+    OSError,
+    json.JSONDecodeError,
+)
 
 
 def main() -> int:
@@ -33,6 +41,11 @@ def main() -> int:
     bot_login = os.environ.get("REVIEW_BOT_LOGIN", "").strip()
     if not bot_login:
         log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot identify bot-authored PRs)")
+        return 0
+    # An unset secret arrives as an empty string; skip cleanly instead of
+    # crashing inside the API client.
+    if not os.environ.get("ANTHROPIC_API_KEY", "").strip():
+        log.warning("ANTHROPIC_API_KEY is unset or empty; skipping review")
         return 0
     client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
 

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -54,6 +54,26 @@ def test_review_cli_never_fails_the_build_on_api_errors(monkeypatch, caplog) -> 
     monkeypatch.setenv("PR_REPO", "org/repo")
     monkeypatch.setenv("PR_NUMBER", "1")
     monkeypatch.setenv("REVIEW_BOT_LOGIN", "some-bot")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)  # -> ValueError from the provider
     assert review_main() == 0
     assert "did not complete" in caplog.text
+
+
+def test_review_cli_skips_without_api_key(monkeypatch, caplog) -> None:
+    """An unset Actions secret arrives as an empty string; skip, don't crash."""
+    monkeypatch.setenv("PR_REPO", "org/repo")
+    monkeypatch.setenv("PR_NUMBER", "1")
+    monkeypatch.setenv("REVIEW_BOT_LOGIN", "some-bot")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+    assert review_main() == 0
+    assert "ANTHROPIC_API_KEY is unset" in caplog.text
+
+
+def test_completer_failures_are_expected_failures() -> None:
+    """Operational LLM errors must never propagate out of the advisory CLI."""
+    from autoresearch.llm import CompleterError, TruncatedError
+    from autoresearch.review_cli import EXPECTED_FAILURES
+
+    assert CompleterError in EXPECTED_FAILURES
+    assert TruncatedError in EXPECTED_FAILURES

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,43 @@
+"""Error mapping in the Anthropic completer (no network, no key)."""
+
+from __future__ import annotations
+
+import pytest
+
+anthropic = pytest.importorskip("anthropic")
+
+from autoresearch.llm import AnthropicCompleter, CompleterError  # noqa: E402
+
+
+def test_api_errors_map_to_completer_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Auth/network/rate-limit failures must surface as an expected failure type,
+    not crash the advisory entry point."""
+
+    class FailingClient:
+        @property
+        def beta(self) -> object:
+            raise anthropic.AnthropicError("boom: connection reset")
+
+    monkeypatch.setattr(AnthropicCompleter, "_client", lambda self: FailingClient())
+    with pytest.raises(CompleterError, match="boom"):
+        AnthropicCompleter(api_key="k").complete("s", "p", {})
+
+
+def test_unknown_effort_is_rejected_before_any_api_call() -> None:
+    with pytest.raises(ValueError, match="effort"):
+        AnthropicCompleter(api_key="k", effort="ultra").complete("s", "p", {})
+
+
+def test_mid_stream_transport_errors_also_map(monkeypatch: pytest.MonkeyPatch) -> None:
+    """httpx errors escape the SDK's own wrapping mid-stream; they must still
+    become an expected failure."""
+    import httpx
+
+    class FailingClient:
+        @property
+        def beta(self) -> object:
+            raise httpx.ReadError("connection reset mid-stream")
+
+    monkeypatch.setattr(AnthropicCompleter, "_client", lambda self: FailingClient())
+    with pytest.raises(CompleterError, match="ReadError"):
+        AnthropicCompleter(api_key="k").complete("s", "p", {})

--- a/uv.lock
+++ b/uv.lock
@@ -103,6 +103,7 @@ review = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anthropic" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -119,6 +120,7 @@ provides-extras = ["review"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anthropic", specifier = ">=0.70" },
     { name = "mypy", specifier = ">=1.13" },
     { name = "pre-commit", specifier = ">=4" },
     { name = "pytest", specifier = ">=8" },


### PR DESCRIPTION
- Operational LLM failures (anthropic SDK errors AND raw httpx mid-stream errors) map to `CompleterError`, an expected failure — the advisory CLI can no longer red a target repo's CI on a rate limit or connection reset.
- Missing/empty `ANTHROPIC_API_KEY` skips cleanly (an unset Actions secret arrives as an empty string), so callers can be deployed before the key exists.
- Reusable workflow accepts an optional read-only deploy key so other private org repos can check out the (currently private) reviewer; single checkout step because `secrets` is not a valid context in step-level `if:`. `persist-credentials: false` keeps the key out of the checkout's git config.
- README rewritten for external adopters: what works today vs. what's arriving is now explicit, and 'no model lock-in' is a stated design principle (Anthropic is the pilot backend behind small interfaces).

🤖 Generated with [Claude Code](https://claude.com/claude-code)