### PR TITLE
Dogfood: advisory review on our own PRs

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,0 +1,14 @@
+name: advisory-review
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  advisory:
+    uses: agentic-learning-ai-lab/autoresearch/.github/workflows/advisory-review.yml@main
+    with:
+      bot_login: agentic-learning-bot
+    secrets:
+      reviewer_api_key: ${{ secrets.REVIEWER_API_KEY }}


### PR DESCRIPTION
Enables the advisory reviewer (agentic-learning-ai-lab/autoresearch) on this repo's PRs. Advisory only — comments with findings, never approves, never blocks a merge, never fails CI. Bot-authored and fork PRs are skipped; per-PR opt-out via the `autoresearch:no-review` label. Needs the `REVIEWER_API_KEY` secret to actually post (deploying ahead of the key is safe — it skips cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)