### PR TITLE
Placement: which agent lives where on Torch

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -222,6 +222,26 @@ accounting) live inside the adapter; context policy lives in the brief builder,
 shared by all backends. This is also what makes backend comparisons honest:
 same brief, same task pool, different backend, diff the outcomes.
 
+## Placement on the cluster (Torch facts, verified 2026-08-06)
+
+Slurm bounds every job: `cpu_short` = 6h wall, `cpu48`/`gpu48` = 48h,
+`cpu168`/`gpu168` = 7d. GPU partitions carry a utilization floor. Nothing
+about the agent may therefore depend on a long-lived process — and nothing
+does: **the agent is state on the shared filesystem** (per-run HOME, the
+workspace, run reports), never a process. Job death loses at most one bounded
+step, never the research.
+
+| What | Where | Lifetime | Why |
+| --- | --- | --- | --- |
+| Orchestrator tick | `cpu_short` | minutes | Self-resubmitting sbatch chain (verified live: a compute-node job can sbatch its successor with `--begin`); two queued successors + the GH-Actions watchdog cover a lost link |
+| Agent session | `cpu_short` | ≤ 1h (harness timeout) | A session must NEVER hold a GPU: it thinks, edits, and submits — idling a GPU under the utilization floor gets jobs killed and wastes allocation |
+| Experiment | `gpu48` (`gpu168` only by exception) | ≤ 48h and ≤ the contract's `gpu_hours_per_run` | Actually uses the GPU, so the floor is satisfied; results land on the shared filesystem |
+| The agent itself | shared filesystem | unbounded | Run state + session state + reports; any node can wake it (verified live: a session resumed on a different node recalled its context verbatim) |
+
+Scheduler etiquette learned live: `--exclude` is disallowed on Torch and node
+pinning (`-w`) queues behind reservations — the orchestrator requests
+partitions and lets the scheduler place jobs, never nodes.
+
 ## Threat model
 
 - **Untrusted text.** Task sources are attacker-writable once target repos are

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,6 +50,15 @@ Package skeleton, CI gates, governance docs, architecture (ops+safety reviewed).
 - [ ] `budget`: per-run and weekly caps; session/token proxy metering for the
       subscription backend
 
+Torch pilot findings (2026-08-06, live on compute nodes): the full production
+session path works — redirected per-run HOME with env-key auth, brief on
+stdin, tool use, per-session cost/id in JSON out. Resume restores context
+across sessions AND across nodes (shared-FS state); a 3-tick self-resubmitting
+sbatch chain ran unattended. Two lessons encoded above: sessions never touch
+GPU partitions (utilization floor), and wake prompts must explicitly lift any
+standing instruction they supersede — a resumed agent honors stale constraints
+(observed: it refused a wake task that contradicted its brief).
+
 ## Phase 4 — Torch tick + compute
 
 - [ ] The chain: two queued successors, `--dependency=singleton`, absolute


### PR DESCRIPTION
Answers the 48h-max-job-life question: the agent is state on the shared filesystem, never a process. Ticks and sessions on cpu_short (6h wall, minutes/≤1h actual); experiments on gpu48 within contract budgets; sessions never hold GPUs (utilization floor). All verified live: production session path, cross-node resume, 3-tick self-resubmitting chain. Plus two etiquette findings: --exclude disallowed / node-pinning queues forever, and wake prompts must lift standing instructions they supersede.

🤖 Generated with [Claude Code](https://claude.com/claude-code)