### PR TITLE
Wake-prompt supersession contract + checklist consistency

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -206,7 +206,14 @@ what it is waiting for, and ends. The orchestrator watches the experiment job;
 when results land it wakes the agent — native session resume against the
 per-run HOME, so the agent's working context (its plan, its notes, what it
 tried) is restored, plus a bounded wake prompt carrying only what is new:
-results and remaining budget. The cycle repeats — iterate or conclude — until
+results and remaining budget. A resumed agent honors its standing
+instructions (observed live: it refused a wake task that contradicted its
+brief), so a wake prompt must explicitly mark which TASK-level instruction it
+supersedes ("the experiment you were waiting for is done"). Only task-level
+instructions are ever liftable: contract scope, budgets, and the standing
+safety rules are not the wake prompt's to relax, and wake text never embeds
+raw experiment output that could try (results are summarized, data-fenced,
+by the orchestrator). The cycle repeats — iterate or conclude — until
 the run ends in a research report and (when the metric moved) a PR. A run is
 never a one-off launch; it is a persistent agent that hibernates through
 experiments. Wakes are node-independent (state on the shared filesystem) and
@@ -296,7 +303,8 @@ partitions and lets the scheduler place jobs, never nodes.
       Slurm 25.05
 - [x] Login nodes are ephemeral Kubernetes pods — never park a daemon on one;
       the chain lives in the Slurm queue
-- [ ] Headless CLI auth on a compute node (the phase-3 gating spike)
+- [x] Headless CLI auth on a compute node (2026-08-05 spike; production
+      session path incl. cross-node resume re-verified live 2026-08-06)
 - [ ] Bot git push over HTTPS with fine-grained PAT (needs the bot account)
 
 Account names, partitions, and hostnames stay in the lab wiki and untracked ops

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -137,11 +137,19 @@ def render_wake(update: str, budget: BudgetState) -> str:
 
     The resumed session already holds its own working context (plan, code
     understanding, what it launched); the wake carries only what is new:
-    results and the current budget.
+    results and the current budget. It explicitly supersedes the brief's
+    wait-for-results instruction — a resumed agent honors standing
+    instructions, so a wake that silently contradicts one gets refused
+    (observed live on Torch). Task-level instructions only: contract scope,
+    budgets, and safety rules are never the wake's to relax.
     """
     return "\n".join(
         [
             "# Experiment update",
+            "The experiment you launched and were waiting for has finished; "
+            "this update supersedes the brief's instruction to wait. All "
+            "other rules (contract scope, budgets, ground rules) still bind.",
+            "",
             _cap(update, MAX_WAKE_CHARS),
             "",
             "# Budget",


### PR DESCRIPTION
Applies the live reviewer's three findings on #21: the resumed-agent lesson now lives in the architecture's wake-cycle contract and render_wake itself (the wake text explicitly supersedes the wait instruction), liftable instructions are bounded to task-level (scope/budget/safety are never the wake's to relax), and the stale phase-3 checklist item is ticked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)