### PR TITLE
Phase 5 core: contained sessions + single-benchmark climb (tsp first)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Phase 5 core: `orchestrator.climb_once` (single-benchmark climb with
+  orchestrator-measured baseline/candidate — the agent's claim is never
+  trusted) and Apptainer session containment in the harness
+  (`container_image`: --containall with workspace + per-run-HOME binds only;
+  the API key travels via APPTAINERENV_, never argv).
+
 - Phase 4 loop plumbing: `compute` (Slurm submit/status/cancel behind an
   injectable runner; afterany wake jobs; query-failure ≠ job-gone),
   `runstate` (atomic run records, six endings, expiring wake leases with

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -96,7 +96,15 @@ the research repos' porting timelines; mistakes are free; adversarial testing
       architecture "Environments and containers") wired into experiment launch
 - [ ] Task pinning: target SHA + contract hash at task start, re-validated each
       poll; baseline re-run at merge-base
-- [ ] Full loop on the pilot benchmarks; bounded iterations; PR with results
+- [x] `orchestrator.climb_once` (2026-08-06): one implement→evaluate→verify
+      cycle on ONE configured benchmark (Mengye: start with one, tsp, not
+      everything); baseline re-measured from the pre-session tree, candidate
+      re-measured by the orchestrator (never the agent's claim), direction-
+      aware threshold, PR body with results table + agent report. Sessions
+      run contained (Apptainer --containall, workspace + run-home binds only,
+      key via APPTAINERENV_ env). Git glue (clone/push/PR wiring) + live
+      pilot climb next
+- [ ] Full loop live on the pilot: bounded iterations; PR with results
       table, one human code-owner approval per merge
 - [ ] Every run ends with a research report — hypothesis, outcome, takeaways,
       next steps — posted to the PR or the ledger (negative results included)

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -159,6 +159,16 @@ class ClaudeCodeHarness:
     # passes the task-source gate upstream.
     allowed_tools: tuple[str, ...] = ("Write", "Edit", "Read", "Glob", "Grep", "Bash")
     extra_args: tuple[str, ...] = field(default_factory=tuple)
+    # Apptainer image for session containment (decided 2026-08-06). When set,
+    # the session runs under `apptainer exec --containall --cleanenv`: no host
+    # $HOME, no host env, no same-user absolute paths — the session sees only
+    # the workspace, its per-run HOME, and the read-only claude binary. This
+    # closes the threat model's shared-filesystem residual risk. Images stay
+    # generic (python + uv + git); the binary is bind-mounted in.
+    container_image: str = ""
+    apptainer_binary: str = "apptainer"
+
+    CONTAINER_CLAUDE = "/opt/agent/claude"
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
@@ -178,8 +188,8 @@ class ClaudeCodeHarness:
         except OSError as exc:
             log.warning("could not create session home %s: %s", session_home, exc)
             return _error_result("workspace-error")
-        command = [
-            self.binary,
+        claude_argv = [
+            self.CONTAINER_CLAUDE if self.container_image else self.binary,
             "-p",
             # The brief travels on stdin: argv is world-readable via /proc on
             # shared nodes, and briefs carry private research text.
@@ -197,16 +207,46 @@ class ClaudeCodeHarness:
             *self.extra_args,
         ]
         if resume_session_id:
-            command += ["--resume", resume_session_id]
+            claude_argv += ["--resume", resume_session_id]
+        if self.container_image:
+            command = [
+                self.apptainer_binary,
+                "exec",
+                "--containall",
+                "--cleanenv",
+                "--bind",
+                f"{workspace}:{workspace}",
+                "--bind",
+                f"{session_home}:{session_home}",
+                "--bind",
+                f"{self.binary}:{self.CONTAINER_CLAUDE}:ro",
+                # HOME inside the container is the same per-run path, so
+                # native resume state survives contained/uncontained flips.
+                "--env",
+                f"HOME={session_home}",
+                "--pwd",
+                str(workspace),
+                self.container_image,
+                *claude_argv,
+            ]
+        else:
+            command = claude_argv
         try:
             # start_new_session puts the CLI and every descendant (Bash-tool
             # children included) in one process group we can kill as a unit —
             # a timed-out session must not leave orphans holding the API key
             # and writing into the clone.
+            env = session_env(self.api_key, "ANTHROPIC_API_KEY", session_home)
+            if self.container_image:
+                # --cleanenv drops the host environment inside the container
+                # EXCEPT APPTAINERENV_* variables, which apptainer injects
+                # with the prefix stripped — the key travels via the
+                # environment, never argv (argv is world-readable in /proc).
+                env["APPTAINERENV_ANTHROPIC_API_KEY"] = self.api_key
             process = subprocess.Popen(
                 command,
                 cwd=workspace,
-                env=session_env(self.api_key, "ANTHROPIC_API_KEY", session_home),
+                env=env,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -209,6 +209,9 @@ class ClaudeCodeHarness:
         if resume_session_id:
             claude_argv += ["--resume", resume_session_id]
         if self.container_image:
+            # bind sources must be absolute or apptainer fails at mount time
+            workspace = workspace.resolve()
+            session_home = session_home.resolve()
             if not os.path.isabs(self.binary):
                 # a relative bind source fails at mount time deep inside
                 # apptainer; catch the misconfiguration here instead

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -209,6 +209,11 @@ class ClaudeCodeHarness:
         if resume_session_id:
             claude_argv += ["--resume", resume_session_id]
         if self.container_image:
+            if not os.path.isabs(self.binary):
+                # a relative bind source fails at mount time deep inside
+                # apptainer; catch the misconfiguration here instead
+                log.warning("container sessions need an absolute claude path")
+                return _error_result("config-error")
             command = [
                 self.apptainer_binary,
                 "exec",
@@ -216,14 +221,15 @@ class ClaudeCodeHarness:
                 "--cleanenv",
                 "--bind",
                 f"{workspace}:{workspace}",
-                "--bind",
+                # --home (NOT --env HOME=..., which apptainer silently
+                # refuses): mounts the per-run home at the same path inside
+                # and sets $HOME to it — native resume state survives
+                # contained/uncontained flips and lands on the shared FS,
+                # not a tmpfs that evaporates at session end.
+                "--home",
                 f"{session_home}:{session_home}",
                 "--bind",
                 f"{self.binary}:{self.CONTAINER_CLAUDE}:ro",
-                # HOME inside the container is the same per-run path, so
-                # native resume state survives contained/uncontained flips.
-                "--env",
-                f"HOME={session_home}",
                 "--pwd",
                 str(workspace),
                 self.container_image,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -16,14 +16,15 @@ from __future__ import annotations
 
 import json
 import logging
-import re
+import math
 import subprocess
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 
 from autoresearch.brief import BriefInputs, BudgetState, Task, build_brief, render
-from autoresearch.contract import Contract, load_contract
+from autoresearch.contract import Contract, load_contract, normalize_path, path_is_forbidden
 from autoresearch.harness import Harness, SessionResult, redact
 
 log = logging.getLogger(__name__)
@@ -47,39 +48,81 @@ class SubprocessEvaluator:
     """Runs the contract's benchmark command and reads `metric` from its
     JSON output (the contract requires commands to print their metrics).
 
-    The command executes agent-written code: no network access is assumed to
-    be needed, the environment is scrubbed, and the run is bounded.
-    """
+    The command executes AGENT-WRITTEN code — it is session-grade untrusted
+    execution and gets session-grade containment: with `container_image` set
+    (the production configuration), the command runs under `apptainer exec
+    --containall` seeing only the workspace, a throwaway tmpfs HOME, and no
+    host environment. Uncontained mode exists for tests and non-cluster dev,
+    with a scrubbed env that NEVER includes the real HOME (the orchestrator
+    account holds the bot PAT under it)."""
 
     timeout_s: int = EVAL_TIMEOUT_S
+    container_image: str = ""
+    apptainer_binary: str = "apptainer"
 
     def evaluate(self, workspace: Path, command: str, metric: str) -> float:
         import os
+        import signal
 
-        env = {k: os.environ[k] for k in ("PATH", "HOME", "LANG", "TMPDIR") if k in os.environ}
-        try:
-            completed = subprocess.run(
+        if self.container_image:
+            argv = [
+                self.apptainer_binary,
+                "exec",
+                "--containall",
+                "--cleanenv",
+                "--bind",
+                f"{workspace}:{workspace}",
+                "--pwd",
+                str(workspace),
+                self.container_image,
+                "sh",
+                "-c",
                 command,
-                shell=True,
+            ]
+        else:
+            argv = ["sh", "-c", command]
+        env = {k: os.environ[k] for k in ("PATH", "LANG", "TMPDIR") if k in os.environ}
+        env["HOME"] = str(workspace)  # never the orchestrator's real home
+        try:
+            # process group, like the harness: a timed-out eval must not
+            # leave orphans mutating a workspace that later gets committed
+            process = subprocess.Popen(
+                argv,
                 cwd=workspace,
                 env=env,
-                capture_output=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 text=True,
-                timeout=self.timeout_s,
+                start_new_session=True,
             )
+        except OSError as exc:
+            raise EvalError(f"eval could not start: {exc}") from exc
+        try:
+            stdout, stderr = process.communicate(timeout=self.timeout_s)
         except subprocess.TimeoutExpired as exc:
+            import contextlib
+
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(process.pid, signal.SIGKILL)
+            with contextlib.suppress(subprocess.TimeoutExpired):
+                process.communicate(timeout=10)
             raise EvalError(f"eval timed out after {self.timeout_s}s") from exc
-        if completed.returncode != 0:
-            raise EvalError(f"eval failed ({completed.returncode}): {completed.stderr[-500:]}")
-        value = _metric_from_output(completed.stdout, metric)
+        if process.returncode != 0:
+            raise EvalError(f"eval failed ({process.returncode}): {stderr[-500:]}")
+        value = _metric_from_output(stdout, metric)
         if value is None:
             raise EvalError(f"metric {metric!r} not found in eval output")
+        if not math.isfinite(value):
+            raise EvalError(f"metric {metric!r} is not finite: {value}")
         return value
 
 
 def _metric_from_output(stdout: str, metric: str) -> float | None:
-    """Find `metric` in the command's output: last JSON object wins, with a
-    `metric: value` line-scan fallback."""
+    """The metric from the LAST single-line JSON object that carries it.
+
+    No regex fallback: a fuzzy match that reads the wrong number (a progress
+    line, a prefixed metric name) is worse than a clean failure — the
+    contract requires eval commands to print their metrics as JSON."""
     for line in reversed(stdout.strip().splitlines()):
         line = line.strip()
         if line.startswith("{"):
@@ -92,8 +135,7 @@ def _metric_from_output(stdout: str, metric: str) -> float | None:
                     return float(data[metric])
                 except (TypeError, ValueError):
                     return None
-    match = re.search(rf"{re.escape(metric)}[\s:=]+(-?\d+(?:\.\d+)?)", stdout)
-    return float(match.group(1)) if match else None
+    return None
 
 
 @dataclass(frozen=True)
@@ -112,7 +154,7 @@ class ClimbConfig:
 class ClimbResult:
     """What one attempt produced — the raw material of the run report."""
 
-    outcome: str  # "improved" | "no-improvement" | "session-error" | "eval-error"
+    outcome: str  # improved | no-improvement | session-error | eval-error | scope-violation
     baseline: float | None = None
     candidate: float | None = None
     branch: str = ""
@@ -150,10 +192,36 @@ def _benchmark(contract: Contract, name: str):
     )
 
 
+def out_of_scope(paths: Sequence[str], contract: Contract) -> list[str]:
+    """Changed paths the contract does not allow the agent to touch.
+
+    Checked BEFORE the candidate eval: an out-of-scope edit could be to the
+    eval harness itself, and measuring a doctored ruler would turn "CI
+    re-verifies independently" into re-running the fraud."""
+    allowed = [normalize_path(entry) for entry in contract.scope.allowed]
+    violations = []
+    for path in paths:
+        if path_is_forbidden(path, contract):
+            violations.append(path)
+            continue
+        try:
+            candidate = normalize_path(path)
+        except Exception:
+            violations.append(path)
+            continue
+        if not any(candidate == a or a in candidate.parents for a in allowed):
+            violations.append(path)
+    return violations
+
+
 def improved(baseline: float, candidate: float, direction: str, min_rel: float) -> bool:
-    """Direction-aware, threshold-clearing improvement."""
+    """Direction-aware, threshold-clearing improvement. Non-finite values
+    never count (the evaluator rejects them; this is defense in depth)."""
+    if not (math.isfinite(baseline) and math.isfinite(candidate)):
+        return False
     if baseline == 0:
-        return (candidate > 0) if direction == "max" else (candidate < 0)
+        # no relative scale exists: apply the threshold absolutely
+        return candidate >= min_rel if direction == "max" else candidate <= -min_rel
     rel = (candidate - baseline) / abs(baseline)
     return rel >= min_rel if direction == "max" else rel <= -min_rel
 
@@ -183,6 +251,7 @@ def climb_once(
     harness: Harness,
     evaluator: Evaluator,
     ruler: str,
+    changed_paths: Callable[[], Sequence[str]],
     lessons: str = "",
     recent_reports: tuple[str, ...] = (),
     created: str = "",
@@ -191,6 +260,9 @@ def climb_once(
 
     The caller owns the git side (clone before, diff/commit/push/PR after) —
     same split as the harness: this function owns the science loop only.
+    `changed_paths` reports every path the session touched (the caller wires
+    it to `git add -A` + staged paths); scope is enforced on it BEFORE the
+    candidate eval runs.
     """
     contract = load_contract(contract_text, config.target)
     bench = _benchmark(contract, config.benchmark)
@@ -224,6 +296,17 @@ def climb_once(
             note=session.stop_reason,
         )
 
+    # Scope BEFORE measurement: an out-of-scope tree is never evaluated,
+    # because the out-of-scope edit could be to the ruler itself.
+    violations = out_of_scope(list(changed_paths()), load_contract(contract_text, config.target))
+    if violations:
+        return ClimbResult(
+            outcome="scope-violation",
+            baseline=baseline,
+            session=session,
+            note=f"out-of-scope paths: {', '.join(sorted(violations)[:10])}",
+        )
+
     try:
         candidate = evaluator.evaluate(workspace, bench.command, bench.metric)
     except EvalError as exc:
@@ -250,7 +333,8 @@ def climb_once(
 
 def pr_body(result: ClimbResult, config: ClimbConfig, redact_secrets: tuple[str, ...]) -> str:
     """The PR body for an improved run: results table + the agent's report."""
-    assert result.baseline is not None and result.candidate is not None
+    if result.outcome != "improved" or result.baseline is None or result.candidate is None:
+        raise ValueError("pr_body requires an improved result with both measurements")
     body = "\n".join(
         [
             f"Automated improvement attempt on `{config.benchmark}` "

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -82,7 +82,12 @@ class SubprocessEvaluator:
         else:
             argv = ["sh", "-c", command]
         env = {k: os.environ[k] for k in ("PATH", "LANG", "TMPDIR") if k in os.environ}
-        env["HOME"] = str(workspace)  # never the orchestrator's real home
+        # Throwaway HOME OUTSIDE the clone: never the orchestrator's real home
+        # (it shelters the PAT), and never the workspace — eval cache/state
+        # artifacts must not masquerade as agent edits in the diff.
+        eval_home = workspace.resolve().parent / f"{workspace.name}-eval-home"
+        eval_home.mkdir(parents=True, exist_ok=True)
+        env["HOME"] = str(eval_home)
         try:
             # process group, like the harness: a timed-out eval must not
             # leave orphans mutating a workspace that later gets committed
@@ -104,8 +109,12 @@ class SubprocessEvaluator:
 
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(process.pid, signal.SIGKILL)
-            with contextlib.suppress(subprocess.TimeoutExpired):
+            try:
                 process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    process.communicate(timeout=5)
             raise EvalError(f"eval timed out after {self.timeout_s}s") from exc
         if process.returncode != 0:
             raise EvalError(f"eval failed ({process.returncode}): {stderr[-500:]}")
@@ -161,7 +170,7 @@ class ClimbResult:
     session: SessionResult | None = None
     note: str = ""
 
-    def report(self, config: ClimbConfig) -> str:
+    def report(self, config: ClimbConfig, redact_secrets: tuple[str, ...] = ()) -> str:
         lines = [
             f"# Run report — {config.target} / {config.benchmark}",
             f"Outcome: **{self.outcome}**",
@@ -178,9 +187,11 @@ class ClimbResult:
                 f"turns={self.session.num_turns}, stop={self.session.stop_reason}",
                 "",
                 "## Agent's report",
-                self.session.final_text[:MAX_REPORT_BODY],
+                # redact BEFORE truncating: a secret straddling the cut would
+                # otherwise survive as an unmatchable prefix
+                redact(self.session.final_text, redact_secrets)[:MAX_REPORT_BODY],
             ]
-        return "\n".join(lines)
+        return redact("\n".join(lines), redact_secrets)
 
 
 def _benchmark(contract: Contract, name: str):
@@ -351,7 +362,11 @@ def pr_body(result: ClimbResult, config: ClimbConfig, redact_secrets: tuple[str,
             "",
             "## Research report",
             "",
-            (result.session.final_text[:MAX_REPORT_BODY] if result.session else ""),
+            (
+                redact(result.session.final_text, redact_secrets)[:MAX_REPORT_BODY]
+                if result.session
+                else ""
+            ),
         ]
     )
     return redact(body, redact_secrets)

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1,0 +1,273 @@
+"""Orchestrator v1: one climb attempt on one benchmark of one target.
+
+Deliberately narrow (Mengye, 2026-08-06: "choose one benchmark on pilot
+instead of launching everything"): `climb_once` runs a single
+implement→evaluate→verify→PR cycle for the configured benchmark. Task
+selection across benchmarks, the planner, experiment sbatch + wakes, and
+notebook reports grow from here — each behind a seam that already exists.
+
+The verification stance is the architecture's: the agent's claim is never
+trusted. The orchestrator re-runs the benchmark command itself — baseline at
+the pre-session tree, candidate after — and only a direction-consistent,
+threshold-clearing delta opens a PR.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Protocol
+
+from autoresearch.brief import BriefInputs, BudgetState, Task, build_brief, render
+from autoresearch.contract import Contract, load_contract
+from autoresearch.harness import Harness, SessionResult, redact
+
+log = logging.getLogger(__name__)
+
+EVAL_TIMEOUT_S = 1800
+MAX_REPORT_BODY = 20_000
+
+
+class EvalError(RuntimeError):
+    """The benchmark command failed or produced no readable metric."""
+
+
+class Evaluator(Protocol):
+    """Runs a benchmark command in a workspace, returns the metric value."""
+
+    def evaluate(self, workspace: Path, command: str, metric: str) -> float: ...
+
+
+@dataclass
+class SubprocessEvaluator:
+    """Runs the contract's benchmark command and reads `metric` from its
+    JSON output (the contract requires commands to print their metrics).
+
+    The command executes agent-written code: no network access is assumed to
+    be needed, the environment is scrubbed, and the run is bounded.
+    """
+
+    timeout_s: int = EVAL_TIMEOUT_S
+
+    def evaluate(self, workspace: Path, command: str, metric: str) -> float:
+        import os
+
+        env = {k: os.environ[k] for k in ("PATH", "HOME", "LANG", "TMPDIR") if k in os.environ}
+        try:
+            completed = subprocess.run(
+                command,
+                shell=True,
+                cwd=workspace,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=self.timeout_s,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise EvalError(f"eval timed out after {self.timeout_s}s") from exc
+        if completed.returncode != 0:
+            raise EvalError(f"eval failed ({completed.returncode}): {completed.stderr[-500:]}")
+        value = _metric_from_output(completed.stdout, metric)
+        if value is None:
+            raise EvalError(f"metric {metric!r} not found in eval output")
+        return value
+
+
+def _metric_from_output(stdout: str, metric: str) -> float | None:
+    """Find `metric` in the command's output: last JSON object wins, with a
+    `metric: value` line-scan fallback."""
+    for line in reversed(stdout.strip().splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict) and metric in data:
+                try:
+                    return float(data[metric])
+                except (TypeError, ValueError):
+                    return None
+    match = re.search(rf"{re.escape(metric)}[\s:=]+(-?\d+(?:\.\d+)?)", stdout)
+    return float(match.group(1)) if match else None
+
+
+@dataclass(frozen=True)
+class ClimbConfig:
+    target: str  # owner/repo
+    benchmark: str  # the ONE benchmark this loop works on
+    branch_prefix: str = "feat/auto/agent-01"
+    agent_id: str = "agent-01"
+    # relative improvement below this is noise, not a PR (ε is contract-
+    # configurable later; this is the loop-side floor)
+    min_relative_improvement: float = 0.005
+    budget: BudgetState = field(default_factory=lambda: BudgetState(0.0, 1))
+
+
+@dataclass(frozen=True)
+class ClimbResult:
+    """What one attempt produced — the raw material of the run report."""
+
+    outcome: str  # "improved" | "no-improvement" | "session-error" | "eval-error"
+    baseline: float | None = None
+    candidate: float | None = None
+    branch: str = ""
+    session: SessionResult | None = None
+    note: str = ""
+
+    def report(self, config: ClimbConfig) -> str:
+        lines = [
+            f"# Run report — {config.target} / {config.benchmark}",
+            f"Outcome: **{self.outcome}**",
+        ]
+        if self.baseline is not None:
+            lines.append(f"Baseline: {self.baseline}")
+        if self.candidate is not None:
+            lines.append(f"Candidate: {self.candidate}")
+        if self.note:
+            lines.append(f"Note: {self.note}")
+        if self.session is not None:
+            lines += [
+                f"Session: cost=${self.session.cost_usd:.2f}, "
+                f"turns={self.session.num_turns}, stop={self.session.stop_reason}",
+                "",
+                "## Agent's report",
+                self.session.final_text[:MAX_REPORT_BODY],
+            ]
+        return "\n".join(lines)
+
+
+def _benchmark(contract: Contract, name: str):
+    for bench in contract.benchmarks:
+        if bench.name == name:
+            return bench
+    raise ValueError(
+        f"benchmark {name!r} not in contract ({[b.name for b in contract.benchmarks]})"
+    )
+
+
+def improved(baseline: float, candidate: float, direction: str, min_rel: float) -> bool:
+    """Direction-aware, threshold-clearing improvement."""
+    if baseline == 0:
+        return (candidate > 0) if direction == "max" else (candidate < 0)
+    rel = (candidate - baseline) / abs(baseline)
+    return rel >= min_rel if direction == "max" else rel <= -min_rel
+
+
+def make_task(contract: Contract, benchmark_name: str, baseline: float) -> Task:
+    bench = _benchmark(contract, benchmark_name)
+    better = "up" if bench.direction == "max" else "down"
+    return Task(
+        hypothesis=(
+            f"The {bench.name} solver can be improved: study the current "
+            f"implementation and the evaluation, form ONE concrete hypothesis "
+            f"for why it underperforms, and implement it."
+        ),
+        benchmark=bench.name,
+        expected_effect=f"{bench.metric} {better} from {baseline}",
+        done_criteria=(
+            f"`{bench.command}` runs clean and {bench.metric} moves {better} "
+            f"versus {baseline}; repository tests pass"
+        ),
+    )
+
+
+def climb_once(
+    config: ClimbConfig,
+    contract_text: str,
+    workspace: Path,
+    harness: Harness,
+    evaluator: Evaluator,
+    ruler: str,
+    lessons: str = "",
+    recent_reports: tuple[str, ...] = (),
+    created: str = "",
+) -> ClimbResult:
+    """One implement→evaluate→verify cycle in an existing clean workspace.
+
+    The caller owns the git side (clone before, diff/commit/push/PR after) —
+    same split as the harness: this function owns the science loop only.
+    """
+    contract = load_contract(contract_text, config.target)
+    bench = _benchmark(contract, config.benchmark)
+
+    # Baseline from the PRE-session tree — never from a stored number
+    # (architecture: "baseline re-run at the merge-base, not a trusted
+    # static file").
+    try:
+        baseline = evaluator.evaluate(workspace, bench.command, bench.metric)
+    except EvalError as exc:
+        return ClimbResult(outcome="eval-error", note=f"baseline: {exc}")
+
+    task = make_task(contract, config.benchmark, baseline)
+    brief = build_brief(
+        BriefInputs(
+            task=task,
+            contract_text=contract_text,
+            ruler=ruler,
+            lessons=lessons,
+            recent_reports=recent_reports,
+            budget=config.budget,
+        ),
+        created=created,
+    )
+    session = harness.run(render(brief), workspace)
+    if session.is_error:
+        return ClimbResult(
+            outcome="session-error",
+            baseline=baseline,
+            session=session,
+            note=session.stop_reason,
+        )
+
+    try:
+        candidate = evaluator.evaluate(workspace, bench.command, bench.metric)
+    except EvalError as exc:
+        return ClimbResult(
+            outcome="eval-error", baseline=baseline, session=session, note=f"candidate: {exc}"
+        )
+
+    if improved(baseline, candidate, bench.direction, config.min_relative_improvement):
+        return ClimbResult(
+            outcome="improved",
+            baseline=baseline,
+            candidate=candidate,
+            session=session,
+            branch=f"{config.branch_prefix}/{config.benchmark}",
+        )
+    return ClimbResult(
+        outcome="no-improvement",
+        baseline=baseline,
+        candidate=candidate,
+        session=session,
+        note="a negative result reported clearly is a success",
+    )
+
+
+def pr_body(result: ClimbResult, config: ClimbConfig, redact_secrets: tuple[str, ...]) -> str:
+    """The PR body for an improved run: results table + the agent's report."""
+    assert result.baseline is not None and result.candidate is not None
+    body = "\n".join(
+        [
+            f"Automated improvement attempt on `{config.benchmark}` "
+            f"(agent `{config.agent_id}`, one hypothesis per PR).",
+            "",
+            "| | value |",
+            "| --- | --- |",
+            f"| baseline ({config.benchmark}) | {result.baseline} |",
+            f"| candidate | {result.candidate} |",
+            "",
+            "Both numbers were measured by the orchestrator re-running the "
+            "contract's eval command — not taken from the session. CI "
+            "re-verifies independently.",
+            "",
+            "## Research report",
+            "",
+            (result.session.final_text[:MAX_REPORT_BODY] if result.session else ""),
+        ]
+    )
+    return redact(body, redact_secrets)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -350,3 +350,39 @@ def test_transcripts_accumulate_per_session_not_clobber(tmp_path: Path) -> None:
     assert first.transcript_path != second.transcript_path
     assert Path(first.transcript_path).exists()
     assert Path(second.transcript_path).exists()
+
+
+def test_container_image_wraps_in_apptainer(tmp_path: Path) -> None:
+    """Containment: --containall/--cleanenv, only workspace + run-home bound,
+    binary bind-mounted, key via APPTAINERENV_ (env, never argv)."""
+    binary = fake_claude(tmp_path, json.dumps(CANNED))
+    # the fake stands in for apptainer itself; it records argv + env
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    harness = ClaudeCodeHarness(
+        api_key="sk-c",
+        binary="/real/claude",
+        container_image="/img/agent.sif",
+        apptainer_binary=binary,
+    )
+    result = harness.run("task", ws)
+    assert not result.is_error
+    argv = (tmp_path / "seen_argv").read_text()
+    assert argv.startswith("exec --containall --cleanenv")
+    assert f"--bind {ws}:{ws}" in argv
+    assert f"--bind {tmp_path / 'ws-home'}:{tmp_path / 'ws-home'}" in argv
+    assert "--bind /real/claude:/opt/agent/claude:ro" in argv
+    assert "/img/agent.sif /opt/agent/claude -p" in argv
+    assert "sk-c" not in argv  # the key travels via env, never argv
+    seen_env = (tmp_path / "seen_env").read_text()
+    assert "APPTAINERENV_ANTHROPIC_API_KEY=sk-c" in seen_env
+
+
+def test_no_container_means_no_apptainer(tmp_path: Path) -> None:
+    binary = fake_claude(tmp_path, json.dumps(CANNED))
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
+    argv = (tmp_path / "seen_argv").read_text()
+    assert "apptainer" not in argv and "--containall" not in argv
+    assert "APPTAINERENV_" not in (tmp_path / "seen_env").read_text()

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -370,12 +370,26 @@ def test_container_image_wraps_in_apptainer(tmp_path: Path) -> None:
     argv = (tmp_path / "seen_argv").read_text()
     assert argv.startswith("exec --containall --cleanenv")
     assert f"--bind {ws}:{ws}" in argv
-    assert f"--bind {tmp_path / 'ws-home'}:{tmp_path / 'ws-home'}" in argv
+    # --home, NOT --env HOME (apptainer silently refuses HOME via --env) and
+    # NOT a plain --bind (per-run state must be $HOME inside the container)
+    assert f"--home {tmp_path / 'ws-home'}:{tmp_path / 'ws-home'}" in argv
+    assert "--env" not in argv
     assert "--bind /real/claude:/opt/agent/claude:ro" in argv
     assert "/img/agent.sif /opt/agent/claude -p" in argv
     assert "sk-c" not in argv  # the key travels via env, never argv
     seen_env = (tmp_path / "seen_env").read_text()
     assert "APPTAINERENV_ANTHROPIC_API_KEY=sk-c" in seen_env
+
+
+def test_container_requires_absolute_binary(tmp_path: Path) -> None:
+    """A relative bind source fails at mount time deep inside apptainer —
+    catch the misconfiguration before any money is spent."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    harness = ClaudeCodeHarness(api_key="k", binary="claude", container_image="/img/agent.sif")
+    result = harness.run("task", ws)
+    assert result.is_error
+    assert result.stop_reason == "config-error"
 
 
 def test_no_container_means_no_apptainer(tmp_path: Path) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -265,3 +265,24 @@ def test_report_covers_failure_outcomes(tmp_path: Path) -> None:
     assert "no-improvement" in report
     assert "13.876" in report
     assert "Agent's report" in report
+
+
+def test_eval_home_is_outside_the_clone(tmp_path: Path) -> None:
+    """Eval cache/state must not masquerade as agent edits in the diff."""
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    SubprocessEvaluator(timeout_s=30).evaluate(
+        ws, """touch "$HOME/marker" && printf '{"m": 1}\\n'""", "m"
+    )
+    assert not (ws / "marker").exists()
+    assert (tmp_path / "ws-eval-home" / "marker").exists()
+
+
+def test_report_redacts_secrets(tmp_path: Path) -> None:
+    session = ok_session(text="oops the key is sk-report-leak")
+    result, _, _ = run_climb(tmp_path, [13.876, 14.5], session=session)
+    report = result.report(CONFIG, redact_secrets=("sk-report-leak",))
+    assert "sk-report-leak" not in report
+    assert "[redacted]" in report

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,176 @@
+"""The single-benchmark climb, against fakes for every seam."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from autoresearch.harness import FakeHarness, SessionResult
+from autoresearch.orchestrator import (
+    ClimbConfig,
+    EvalError,
+    _metric_from_output,
+    climb_once,
+    improved,
+    pr_body,
+)
+
+CONTRACT = """
+benchmarks:
+  - name: tsp
+    command: uv run python -m pilot.eval --benchmark tsp --json
+    metric: mean_tour_length
+    direction: min
+  - name: sokoban
+    command: uv run python -m pilot.eval --benchmark sokoban --json
+    metric: solve_rate
+    direction: max
+budgets: {gpu_hours_per_run: 1, runs_per_week: 10}
+scope: {allowed: [src/pilot/solvers/]}
+roadmap: docs/roadmap.md
+"""
+
+CONFIG = ClimbConfig(target="org/pilot", benchmark="tsp")
+
+
+def ok_session(text: str = "Report: replaced NN with NN+2-opt.") -> SessionResult:
+    return SessionResult(
+        stop_reason="end_turn",
+        is_error=False,
+        cost_usd=1.25,
+        num_turns=20,
+        session_id="s1",
+        final_text=text,
+        transcript_path="",
+    )
+
+
+@dataclass
+class FakeEvaluator:
+    """Returns queued metric values; records calls."""
+
+    values: list[float] = field(default_factory=list)
+    calls: list[tuple[str, str]] = field(default_factory=list)
+
+    def evaluate(self, workspace: Path, command: str, metric: str) -> float:
+        self.calls.append((command, metric))
+        value = self.values.pop(0)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+
+def run_climb(tmp_path, values, session=None, config=CONFIG, **kw):
+    harness = FakeHarness(result=session or ok_session())
+    evaluator = FakeEvaluator(values=list(values))
+    result = climb_once(
+        config,
+        CONTRACT,
+        tmp_path,
+        harness,
+        evaluator,
+        ruler="mean tour length over the frozen pool",
+        created="2026-08-06T00:00:00Z",
+        **kw,
+    )
+    return result, harness, evaluator
+
+
+def test_improvement_end_to_end(tmp_path: Path) -> None:
+    result, harness, evaluator = run_climb(tmp_path, [13.876, 13.10])
+    assert result.outcome == "improved"
+    assert result.baseline == 13.876
+    assert result.candidate == 13.10
+    assert result.branch == "feat/auto/agent-01/tsp"
+    # the brief carried the real baseline and the contract verbatim
+    brief_text = harness.calls[0][0]
+    assert "13.876" in brief_text
+    assert "mean_tour_length down from 13.876" in brief_text
+    assert "src/pilot/solvers/" in brief_text
+    # eval ran twice with the contract's command
+    assert (
+        evaluator.calls
+        == [("uv run python -m pilot.eval --benchmark tsp --json", "mean_tour_length")] * 2
+    )
+
+
+def test_direction_min_regression_is_no_improvement(tmp_path: Path) -> None:
+    result, _, _ = run_climb(tmp_path, [13.876, 14.5])
+    assert result.outcome == "no-improvement"
+    assert "negative result" in result.note
+
+
+def test_noise_below_threshold_is_no_improvement(tmp_path: Path) -> None:
+    result, _, _ = run_climb(tmp_path, [100.0, 99.9])  # 0.1% < 0.5% floor
+    assert result.outcome == "no-improvement"
+
+
+def test_session_error_short_circuits_before_second_eval(tmp_path: Path) -> None:
+    bad = SessionResult(
+        stop_reason="timeout",
+        is_error=True,
+        cost_usd=0.0,
+        num_turns=0,
+        session_id="",
+        final_text="",
+        transcript_path="",
+    )
+    result, _, evaluator = run_climb(tmp_path, [13.876, 999.0], session=bad)
+    assert result.outcome == "session-error"
+    assert len(evaluator.calls) == 1  # baseline only
+    assert result.baseline == 13.876
+
+
+def test_baseline_eval_failure_never_starts_a_session(tmp_path: Path) -> None:
+    result, harness, _ = run_climb(tmp_path, [EvalError("boom")])
+    assert result.outcome == "eval-error"
+    assert harness.calls == []  # no session was paid for
+
+
+def test_candidate_eval_failure_is_eval_error_with_session(tmp_path: Path) -> None:
+    """The agent broke the eval — that's a failed run, not an improvement."""
+    result, _, _ = run_climb(tmp_path, [13.876, EvalError("crashed")])
+    assert result.outcome == "eval-error"
+    assert result.session is not None
+
+
+def test_unknown_benchmark_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="not in contract"):
+        run_climb(tmp_path, [1.0], config=ClimbConfig(target="org/pilot", benchmark="chess"))
+
+
+def test_improved_direction_semantics() -> None:
+    assert improved(0.25, 0.31, "max", 0.005)
+    assert not improved(0.25, 0.2501, "max", 0.005)
+    assert improved(13.876, 13.0, "min", 0.005)
+    assert not improved(13.876, 14.0, "min", 0.005)
+    assert not improved(0.25, 0.24, "max", 0.005)
+
+
+def test_metric_parsing_json_and_fallback() -> None:
+    assert _metric_from_output('{"mean_tour_length": 13.1}', "mean_tour_length") == 13.1
+    noisy = 'log line\n{"other": 1}\n{"solve_rate": 0.31, "n": 40}'
+    assert _metric_from_output(noisy, "solve_rate") == 0.31
+    assert _metric_from_output("solve_rate: 0.28", "solve_rate") == 0.28
+    assert _metric_from_output("nothing here", "solve_rate") is None
+    assert _metric_from_output('{"solve_rate": "high"}', "solve_rate") is None
+
+
+def test_pr_body_carries_table_and_redacts(tmp_path: Path) -> None:
+    session = ok_session(text="did the thing; key sk-secret-1 leaked")
+    result, _, _ = run_climb(tmp_path, [13.876, 13.1], session=session)
+    body = pr_body(result, CONFIG, redact_secrets=("sk-secret-1",))
+    assert "| baseline (tsp) | 13.876 |" in body
+    assert "sk-secret-1" not in body
+    assert "[redacted]" in body
+    assert "measured by the orchestrator" in body
+
+
+def test_report_covers_failure_outcomes(tmp_path: Path) -> None:
+    result, _, _ = run_climb(tmp_path, [13.876, 14.5])
+    report = result.report(CONFIG)
+    assert "no-improvement" in report
+    assert "13.876" in report
+    assert "Agent's report" in report

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -62,7 +62,7 @@ class FakeEvaluator:
         return value
 
 
-def run_climb(tmp_path, values, session=None, config=CONFIG, **kw):
+def run_climb(tmp_path, values, session=None, config=CONFIG, changed=None, **kw):
     harness = FakeHarness(result=session or ok_session())
     evaluator = FakeEvaluator(values=list(values))
     result = climb_once(
@@ -72,6 +72,7 @@ def run_climb(tmp_path, values, session=None, config=CONFIG, **kw):
         harness,
         evaluator,
         ruler="mean tour length over the frozen pool",
+        changed_paths=lambda: changed if changed is not None else ["src/pilot/solvers/tsp.py"],
         created="2026-08-06T00:00:00Z",
         **kw,
     )
@@ -149,13 +150,103 @@ def test_improved_direction_semantics() -> None:
     assert not improved(0.25, 0.24, "max", 0.005)
 
 
-def test_metric_parsing_json_and_fallback() -> None:
+def test_metric_parsing_json_only_no_fuzzy_fallback() -> None:
     assert _metric_from_output('{"mean_tour_length": 13.1}', "mean_tour_length") == 13.1
     noisy = 'log line\n{"other": 1}\n{"solve_rate": 0.31, "n": 40}'
     assert _metric_from_output(noisy, "solve_rate") == 0.31
-    assert _metric_from_output("solve_rate: 0.28", "solve_rate") == 0.28
     assert _metric_from_output("nothing here", "solve_rate") is None
     assert _metric_from_output('{"solve_rate": "high"}', "solve_rate") is None
+    # NO regex fallback: a fuzzy match that reads a progress line or a
+    # prefixed metric name is worse than a clean failure
+    assert _metric_from_output("solve_rate: 0.28", "solve_rate") is None
+    assert _metric_from_output('{"mean_solve_rate": 0.99}', "solve_rate") is None
+
+
+def test_scope_violation_blocks_before_candidate_eval(tmp_path: Path) -> None:
+    """An out-of-scope edit could be to the ruler itself — the tree is never
+    measured."""
+    result, _, evaluator = run_climb(
+        tmp_path, [13.876, 1.0], changed=["src/pilot/solvers/tsp.py", "src/pilot/eval.py"]
+    )
+    assert result.outcome == "scope-violation"
+    assert "src/pilot/eval.py" in result.note
+    assert len(evaluator.calls) == 1  # baseline only; doctored tree unmeasured
+
+
+def test_forbidden_paths_are_scope_violations(tmp_path: Path) -> None:
+    result, _, _ = run_climb(tmp_path, [13.876, 1.0], changed=[".github/workflows/ci.yml"])
+    assert result.outcome == "scope-violation"
+
+
+def test_improved_rejects_nonfinite_and_zero_baseline_uses_absolute() -> None:
+    assert not improved(float("nan"), 1.0, "max", 0.005)
+    assert not improved(1.0, float("inf"), "max", 0.005)
+    assert not improved(0.0, 1e-12, "max", 0.005)  # absolute threshold at 0
+    assert improved(0.0, 0.01, "max", 0.005)
+
+
+def test_subprocess_evaluator_real_run(tmp_path: Path) -> None:
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    value = SubprocessEvaluator(timeout_s=30).evaluate(tmp_path, """printf '{"m": 0.5}\n'""", "m")
+    assert value == 0.5
+
+
+def test_subprocess_evaluator_scrubs_home(tmp_path: Path) -> None:
+    """The eval runs agent-written code; the orchestrator's real HOME (which
+    shelters the bot PAT) must never be visible to it."""
+    import os
+
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    real_home = os.environ.get("HOME", "")
+    value = SubprocessEvaluator(timeout_s=30).evaluate(
+        tmp_path, f'[ "$HOME" = "{real_home}" ] && echo \'{{"m": 1}}\' || echo \'{{"m": 0}}\'', "m"
+    )
+    assert value == 0.0
+
+
+def test_subprocess_evaluator_nonzero_exit_is_eval_error(tmp_path: Path) -> None:
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    with pytest.raises(EvalError, match="eval failed"):
+        SubprocessEvaluator(timeout_s=30).evaluate(tmp_path, "exit 3", "m")
+
+
+def test_subprocess_evaluator_rejects_nonfinite(tmp_path: Path) -> None:
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    with pytest.raises(EvalError, match="not finite"):
+        SubprocessEvaluator(timeout_s=30).evaluate(tmp_path, """printf '{"m": Infinity}\n'""", "m")
+
+
+def test_subprocess_evaluator_container_wrapping(tmp_path: Path) -> None:
+    """With an image set, the eval command runs inside apptainer."""
+    import stat as stat_mod
+
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    fake = tmp_path / "apptainer"
+    fake.write_text(
+        f'#!/bin/sh\nprintf "%s " "$@" > {tmp_path}/eval_argv\nprintf \'{{"m": 2.5}}\n\'\n'
+    )
+    fake.chmod(fake.stat().st_mode | stat_mod.S_IEXEC)
+    evaluator = SubprocessEvaluator(
+        timeout_s=30, container_image="/img/pilot.sif", apptainer_binary=str(fake)
+    )
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    assert evaluator.evaluate(ws, "run-the-eval", "m") == 2.5
+    argv = (tmp_path / "eval_argv").read_text()
+    assert "exec --containall --cleanenv" in argv
+    assert f"--bind {ws}:{ws}" in argv
+    assert "/img/pilot.sif sh -c run-the-eval" in argv
+
+
+def test_pr_body_refuses_non_improved_results(tmp_path: Path) -> None:
+    result, _, _ = run_climb(tmp_path, [13.876, 14.5])
+    with pytest.raises(ValueError, match="requires an improved result"):
+        pr_body(result, CONFIG, redact_secrets=())
 
 
 def test_pr_body_carries_table_and_redacts(tmp_path: Path) -> None:


### PR DESCRIPTION
The first real climb machinery, scoped to ONE benchmark per Mengye's direction.

- **Session containment (decided)**: `container_image` on the harness wraps sessions in `apptainer exec --containall --cleanenv` — the session sees only the workspace, its per-run HOME (via `--home`, since apptainer silently refuses `--env HOME` — review-agent catch, verified against apptainer source), and the read-only claude binary. Key travels via `APPTAINERENV_`, never argv.
- **`orchestrator.climb_once`**: baseline measured from the pre-session tree, session, **scope check before candidate eval** (an out-of-scope edit could be to the ruler itself — the doctored tree is never measured), candidate re-measured by the orchestrator, direction-aware threshold with finiteness guards. The agent's claim is never trusted.
- **Contained evaluator**: the benchmark command executes agent-written code, so it gets session-grade containment (same apptainer wrapper); uncontained mode never sees the real HOME (the PAT-holding account) and process-group-kills its orphans on timeout.
- Metric parsing is JSON-only — the fuzzy regex fallback read progress lines and prefixed metric names (review catch, demonstrated live) and is gone.

Pre-merge adversarial pass: 8 confirmed findings, all fixed with regression tests. The top three were live-run blockers: uncontained candidate eval = agent-code execution on the PAT account; `--env HOME` silently ignored = resume state on an evaporating tmpfs; no scope enforcement before eval = metric fraud via a doctored eval harness. 241 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)