### PR TITLE
Live-climb glue: clone → climb → publish, hardened for the first real run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `autoresearch.climb`: one live climb end to end — bot-auth clone, contract
+  from the target tree, contained session + eval, full-scope commit veto,
+  push, PR with orchestrator-measured numbers, durable run record and report.
+  `create_pull` on the GitHub client.
+
 - Phase 5 core: `orchestrator.climb_once` (single-benchmark climb with
   orchestrator-measured baseline/candidate — the agent's claim is never
   trusted) and Apptainer session containment in the harness

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -30,6 +30,12 @@ from autoresearch.orchestrator import (
     out_of_scope,
     pr_body,
 )
+from autoresearch.progress import (
+    PROGRESS_PATHS,
+    load_leader,
+    update_leader,
+    write_progress,
+)
 from autoresearch.runstate import (
     ABORTED,
     ENDED,
@@ -137,12 +143,30 @@ def live_climb(
             # unique branch per run: a fixed name collides on the second run
             branch = f"{config.branch_prefix}/{run_id}"
             ws.branch(branch)
+            # Progress record (BENCHMARKS.md + results/leader.json), written
+            # by the orchestrator from ITS measurements after the drift check
+            # — the improvement and its human-readable record land in one PR.
+            if result.baseline is None or result.candidate is None:
+                raise WorkspaceDrift("improved result missing measurements")
+            bench = next(b for b in contract.benchmarks if b.name == config.benchmark)
+            entries = update_leader(
+                load_leader(workspace),
+                benchmark=bench.name,
+                metric=bench.metric,
+                direction=bench.direction,
+                baseline=result.baseline,
+                candidate=result.candidate,
+                run_id=run_id,
+                date=created[:10],
+            )
+            write_progress(workspace, entries, config.target)
             # The commit veto re-checks FULL scope (allowed + forbidden) as
-            # defense in depth behind climb_once's pre-eval check.
+            # defense in depth behind climb_once's pre-eval check. The two
+            # orchestrator-written progress files are the only exemption.
             ws.commit_all(
                 f"agent: improve {config.benchmark} ({result.baseline} -> {result.candidate})",
                 author=config.agent_id,
-                forbidden=lambda p: bool(out_of_scope([p], contract)),
+                forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
             )
             ws.push(branch)
             pr_url = github.create_pull(

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1,0 +1,209 @@
+"""One live climb, end to end: clone → climb_once → commit/push/PR → report.
+
+This is the glue `orchestrator.climb_once` deliberately does not own: the git
+side (bot-auth clone, veto-checked commit, push, PR) and the run's durable
+record. One invocation = one run = at most one PR.
+
+Credential separation holds throughout: the bot PAT is read orchestrator-side
+and used only by Workspace network calls and the PR client, after the session
+has ended; the session sees only its own capped API key inside its container.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from autoresearch.contract import load_contract
+from autoresearch.github import (
+    FileTokenProvider,
+    GitHubClient,
+    Workspace,
+)
+from autoresearch.harness import ClaudeCodeHarness, Harness, redact
+from autoresearch.orchestrator import (
+    ClimbConfig,
+    Evaluator,
+    SubprocessEvaluator,
+    climb_once,
+    out_of_scope,
+    pr_body,
+)
+from autoresearch.runstate import (
+    ABORTED,
+    ENDED,
+    IN_REVIEW,
+    NEGATIVE_RESULT,
+    RunRecord,
+    save_record,
+)
+
+log = logging.getLogger(__name__)
+
+RULER = (
+    "The metric is computed by the contract's eval command over a frozen "
+    "instance pool. Your claim is verified by the orchestrator re-running "
+    "that exact command on your tree — and again by CI after the PR opens. "
+    "Only changes inside the contract's allowed paths are ever measured."
+)
+
+_ENDINGS_BY_OUTCOME = {
+    "no-improvement": NEGATIVE_RESULT,
+    "session-error": ABORTED,
+    "eval-error": ABORTED,
+    "scope-violation": ABORTED,
+}
+
+
+@dataclass(frozen=True)
+class LiveClimbOutcome:
+    run_id: str
+    outcome: str
+    pr_url: str = ""
+    report_path: str = ""
+
+
+def live_climb(
+    config: ClimbConfig,
+    run_root: Path,
+    run_id: str,
+    harness: Harness,
+    evaluator: Evaluator,
+    github: GitHubClient,
+    bot_auth: FileTokenProvider,
+    now: float,
+    created: str,
+    secrets: tuple[str, ...] = (),
+    base_branch: str = "main",
+) -> LiveClimbOutcome:
+    """Run one climb against the real target repo."""
+    run_dir = run_root / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    workspace = run_dir / "ws"
+
+    ws = Workspace.clone(f"https://github.com/{config.target}.git", workspace, auth=bot_auth)
+    contract_path = workspace / ".autoresearch.yaml"
+    contract_text = contract_path.read_text()
+    contract = load_contract(contract_text, config.target)
+
+    def changed_paths() -> list[str]:
+        ws.git("add", "-A")
+        paths = ws.staged_paths()
+        ws.git("reset")
+        return paths
+
+    record = RunRecord(
+        run_id=run_id,
+        target=config.target,
+        task_title=f"improve {config.benchmark}",
+        state="implementing",
+        agent_id=config.agent_id,
+        deadline=now + 24 * 3600,
+    )
+    save_record(run_root, record, now)
+
+    result = climb_once(
+        config,
+        contract_text,
+        workspace,
+        harness,
+        evaluator,
+        ruler=RULER,
+        changed_paths=changed_paths,
+        created=created,
+    )
+
+    report = result.report(config, redact_secrets=secrets)
+    report_path = run_dir / "report.md"
+    report_path.write_text(report)
+
+    pr_url = ""
+    if result.outcome == "improved":
+        branch = result.branch
+        ws.branch(branch)
+        # The commit veto re-checks FULL scope (allowed + forbidden) as
+        # defense in depth behind climb_once's pre-eval check.
+        ws.commit_all(
+            f"agent: improve {config.benchmark} ({result.baseline} -> {result.candidate})",
+            author=config.agent_id,
+            forbidden=lambda p: bool(out_of_scope([p], contract)),
+        )
+        ws.push(branch)
+        pr_url = github.create_pull(
+            config.target,
+            title=f"[agent] {config.benchmark}: {result.baseline} -> {result.candidate}",
+            head=branch,
+            base=base_branch,
+            body=pr_body(result, config, redact_secrets=secrets),
+        )
+        final = RunRecord(**{**record.__dict__, "state": IN_REVIEW, "ending_note": pr_url})
+    else:
+        final = RunRecord(
+            **{
+                **record.__dict__,
+                "state": ENDED,
+                "ending": _ENDINGS_BY_OUTCOME[result.outcome],
+                "ending_note": redact(result.note, secrets),
+            }
+        )
+    save_record(run_root, final, now)
+    log.info("run %s: %s %s", run_id, result.outcome, pr_url)
+    return LiveClimbOutcome(
+        run_id=run_id,
+        outcome=result.outcome,
+        pr_url=pr_url,
+        report_path=str(report_path),
+    )
+
+
+def main() -> int:
+    import argparse
+    import os
+    import time
+    from datetime import UTC, datetime
+
+    parser = argparse.ArgumentParser(description="One live climb on one benchmark.")
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--benchmark", required=True)
+    parser.add_argument("--run-root", required=True, type=Path)
+    parser.add_argument("--image", default="", help="apptainer image for session+eval")
+    parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
+    parser.add_argument("--model", default="claude-opus-5")
+    parser.add_argument("--max-turns", type=int, default=60)
+    parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
+    parser.add_argument(
+        "--key-file", default=os.path.expanduser("~/.config/autoresearch/harness_key")
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+
+    api_key = Path(args.key_file).read_text().strip()
+    bot_auth = FileTokenProvider(Path(args.pat_file))
+    stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
+    run_id = f"{args.benchmark}-{stamp}"
+
+    outcome = live_climb(
+        config=ClimbConfig(target=args.target, benchmark=args.benchmark),
+        run_root=args.run_root,
+        run_id=run_id,
+        harness=ClaudeCodeHarness(
+            api_key=api_key,
+            binary=args.claude_bin,
+            model=args.model,
+            max_turns=args.max_turns,
+            container_image=args.image,
+        ),
+        evaluator=SubprocessEvaluator(container_image=args.image),
+        github=GitHubClient(auth=bot_auth),
+        bot_auth=bot_auth,
+        now=time.time(),
+        created=datetime.now(UTC).isoformat(),
+        secrets=(api_key,),
+    )
+    print(f"outcome={outcome.outcome} pr={outcome.pr_url or '-'} report={outcome.report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -41,6 +41,11 @@ from autoresearch.runstate import (
 
 log = logging.getLogger(__name__)
 
+
+class WorkspaceDrift(RuntimeError):
+    """The tree changed between measurement and commit."""
+
+
 RULER = (
     "The metric is computed by the contract's eval command over a frozen "
     "instance pool. Your claim is verified by the orchestrator re-running "
@@ -119,25 +124,46 @@ def live_climb(
     report_path.write_text(report)
 
     pr_url = ""
+    outcome_name = result.outcome
     if result.outcome == "improved":
-        branch = result.branch
-        ws.branch(branch)
-        # The commit veto re-checks FULL scope (allowed + forbidden) as
-        # defense in depth behind climb_once's pre-eval check.
-        ws.commit_all(
-            f"agent: improve {config.benchmark} ({result.baseline} -> {result.candidate})",
-            author=config.agent_id,
-            forbidden=lambda p: bool(out_of_scope([p], contract)),
-        )
-        ws.push(branch)
-        pr_url = github.create_pull(
-            config.target,
-            title=f"[agent] {config.benchmark}: {result.baseline} -> {result.candidate}",
-            head=branch,
-            base=base_branch,
-            body=pr_body(result, config, redact_secrets=secrets),
-        )
-        final = RunRecord(**{**record.__dict__, "state": IN_REVIEW, "ending_note": pr_url})
+        try:
+            # The committed tree must be EXACTLY the measured tree: code the
+            # agent's solver wrote during the candidate eval was neither
+            # scope-checked nor measured, so its presence voids the claim.
+            post_eval = set(changed_paths())
+            if post_eval != set(result.measured_paths):
+                drift = sorted(post_eval.symmetric_difference(result.measured_paths))
+                raise WorkspaceDrift(f"workspace changed during eval: {drift[:10]}")
+            # unique branch per run: a fixed name collides on the second run
+            branch = f"{config.branch_prefix}/{run_id}"
+            ws.branch(branch)
+            # The commit veto re-checks FULL scope (allowed + forbidden) as
+            # defense in depth behind climb_once's pre-eval check.
+            ws.commit_all(
+                f"agent: improve {config.benchmark} ({result.baseline} -> {result.candidate})",
+                author=config.agent_id,
+                forbidden=lambda p: bool(out_of_scope([p], contract)),
+            )
+            ws.push(branch)
+            pr_url = github.create_pull(
+                config.target,
+                title=f"[agent] {config.benchmark}: {result.baseline} -> {result.candidate}",
+                head=branch,
+                base=base_branch,
+                body=pr_body(result, config, redact_secrets=secrets),
+            )
+            final = RunRecord(**{**record.__dict__, "state": IN_REVIEW, "ending_note": pr_url})
+        except Exception as exc:
+            log.warning("publish failed for %s: %s: %s", run_id, type(exc).__name__, exc)
+            outcome_name = "publish-error"
+            final = RunRecord(
+                **{
+                    **record.__dict__,
+                    "state": ENDED,
+                    "ending": ABORTED,
+                    "ending_note": redact(f"{type(exc).__name__}: {exc}", secrets)[:500],
+                }
+            )
     else:
         final = RunRecord(
             **{
@@ -148,10 +174,10 @@ def live_climb(
             }
         )
     save_record(run_root, final, now)
-    log.info("run %s: %s %s", run_id, result.outcome, pr_url)
+    log.info("run %s: %s %s", run_id, outcome_name, pr_url)
     return LiveClimbOutcome(
         run_id=run_id,
-        outcome=result.outcome,
+        outcome=outcome_name,
         pr_url=pr_url,
         report_path=str(report_path),
     )
@@ -168,6 +194,12 @@ def main() -> int:
     parser.add_argument("--benchmark", required=True)
     parser.add_argument("--run-root", required=True, type=Path)
     parser.add_argument("--image", default="", help="apptainer image for session+eval")
+    parser.add_argument(
+        "--uncontained",
+        action="store_true",
+        help="run WITHOUT a container (dev only: sessions can then read "
+        "same-user files, including credential files)",
+    )
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument("--model", default="claude-opus-5")
     parser.add_argument("--max-turns", type=int, default=60)
@@ -177,8 +209,11 @@ def main() -> int:
     )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    if not args.image and not args.uncontained:
+        parser.error("--image is required (or pass --uncontained explicitly, dev only)")
 
-    api_key = Path(args.key_file).read_text().strip()
+    # same 0600 discipline as the PAT: this key spends real money
+    api_key = FileTokenProvider(Path(args.key_file)).token()
     bot_auth = FileTokenProvider(Path(args.pat_file))
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_id = f"{args.benchmark}-{stamp}"
@@ -199,7 +234,7 @@ def main() -> int:
         bot_auth=bot_auth,
         now=time.time(),
         created=datetime.now(UTC).isoformat(),
-        secrets=(api_key,),
+        secrets=(api_key, bot_auth.token()),
     )
     print(f"outcome={outcome.outcome} pr={outcome.pr_url or '-'} report={outcome.report_path}")
     return 0

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -220,6 +220,23 @@ class GitHubClient:
             raise GitHubError(200, path, f"no PR number in response: {data.get('message')}")
         return int(data["number"])
 
+    def create_pull(
+        self, repo: str, title: str, head: str, base: str, body: str, draft: bool = False
+    ) -> str:
+        """Open a pull request; returns its html url."""
+        if self.dry_run:
+            log.info("[dry-run] PR on %s: %s (%s -> %s)", repo, title, head, base)
+            return f"https://github.com/{repo}/pull/dry-run"
+        path = f"/repos/{urllib.parse.quote(repo)}/pulls"
+        data = self._request(
+            "POST",
+            path,
+            {"title": title, "head": head, "base": base, "body": body, "draft": draft},
+        )
+        if not isinstance(data, dict) or "html_url" not in data:
+            raise GitHubError(0, path, f"unexpected create_pull response: {str(data)[:200]}")
+        return str(data["html_url"])
+
     def get_pull_request(self, repo: str, number: int) -> dict[str, Any]:
         path = f"/repos/{urllib.parse.quote(repo)}/pulls/{number}"
         return self._expect_dict(self._request("GET", path), path)

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -144,6 +144,13 @@ def _metric_from_output(stdout: str, metric: str) -> float | None:
                     return float(data[metric])
                 except (TypeError, ValueError):
                     return None
+            # the {"metric": <name>, "value": <v>} shape (what the pilot's
+            # eval actually prints)
+            if isinstance(data, dict) and data.get("metric") == metric and "value" in data:
+                try:
+                    return float(data["value"])
+                except (TypeError, ValueError):
+                    return None
     return None
 
 
@@ -167,6 +174,9 @@ class ClimbResult:
     baseline: float | None = None
     candidate: float | None = None
     branch: str = ""
+    # the exact paths that were scope-checked and then measured — the caller
+    # must refuse to commit anything beyond this set
+    measured_paths: tuple[str, ...] = ()
     session: SessionResult | None = None
     note: str = ""
 
@@ -309,7 +319,8 @@ def climb_once(
 
     # Scope BEFORE measurement: an out-of-scope tree is never evaluated,
     # because the out-of-scope edit could be to the ruler itself.
-    violations = out_of_scope(list(changed_paths()), load_contract(contract_text, config.target))
+    measured = tuple(changed_paths())
+    violations = out_of_scope(list(measured), load_contract(contract_text, config.target))
     if violations:
         return ClimbResult(
             outcome="scope-violation",
@@ -332,6 +343,7 @@ def climb_once(
             candidate=candidate,
             session=session,
             branch=f"{config.branch_prefix}/{config.benchmark}",
+            measured_paths=measured,
         )
     return ClimbResult(
         outcome="no-improvement",

--- a/src/autoresearch/progress.py
+++ b/src/autoresearch/progress.py
@@ -92,7 +92,7 @@ def update_leader(
 
 
 def _delta(entry: LeaderEntry) -> str:
-    if entry.baseline == 0:
+    if entry.baseline == 0 or entry.best == entry.baseline:
         return "—"
     rel = (entry.best - entry.baseline) / abs(entry.baseline) * 100
     good = rel >= 0 if entry.direction == "max" else rel <= 0

--- a/src/autoresearch/progress.py
+++ b/src/autoresearch/progress.py
@@ -1,0 +1,136 @@
+"""Human-readable benchmark progress, written by the orchestrator.
+
+Two files in the target repo, updated as part of each improvement PR so the
+progress record and the change that caused it land atomically:
+
+- ``results/leader.json`` — the machine ledger (the scaling sketch's
+  "leader"): per benchmark, the original baseline, the current best, and
+  which run set it.
+- ``BENCHMARKS.md`` — the same data as a table for humans, rendered from the
+  ledger (never parsed back).
+
+Both are ORCHESTRATOR-written from orchestrator-measured numbers: the agent
+editing either one is a scope violation that ends the run, and the publish
+step overwrites them from trusted data only after the workspace-drift check
+has passed.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+LEADER_FILE = "results/leader.json"
+PROGRESS_FILE = "BENCHMARKS.md"
+PROGRESS_PATHS = (LEADER_FILE, PROGRESS_FILE)
+
+
+@dataclass(frozen=True)
+class LeaderEntry:
+    benchmark: str
+    metric: str
+    direction: str  # "min" | "max"
+    baseline: float  # first orchestrator-measured value; never changes
+    best: float  # current best orchestrator-measured value
+    best_run: str  # run id that set the best
+    updated: str  # ISO date
+
+
+def load_leader(workspace: Path) -> dict[str, LeaderEntry]:
+    """The ledger from the target tree; tolerant of absence and corruption
+    (a broken ledger must not block an improvement — it gets rewritten)."""
+    path = workspace / LEADER_FILE
+    try:
+        raw = json.loads(path.read_text())
+    except FileNotFoundError:
+        return {}
+    except (OSError, ValueError):
+        log.warning("unreadable %s; starting a fresh ledger", path)
+        return {}
+    entries: dict[str, LeaderEntry] = {}
+    if isinstance(raw, dict):
+        for name, item in raw.items():
+            if not isinstance(item, dict):
+                continue
+            known = {k: v for k, v in item.items() if k in LeaderEntry.__dataclass_fields__}
+            try:
+                entries[name] = LeaderEntry(**known)
+            except TypeError:
+                log.warning("skipping malformed leader entry %r", name)
+    return entries
+
+
+def update_leader(
+    entries: dict[str, LeaderEntry],
+    benchmark: str,
+    metric: str,
+    direction: str,
+    baseline: float,
+    candidate: float,
+    run_id: str,
+    date: str,
+) -> dict[str, LeaderEntry]:
+    """A new ledger with this run's improvement folded in. The baseline is
+    pinned by the FIRST entry and never moves; best follows improvements."""
+    existing = entries.get(benchmark)
+    pinned_baseline = existing.baseline if existing is not None else baseline
+    updated = dict(entries)
+    updated[benchmark] = LeaderEntry(
+        benchmark=benchmark,
+        metric=metric,
+        direction=direction,
+        baseline=pinned_baseline,
+        best=candidate,
+        best_run=run_id,
+        updated=date,
+    )
+    return updated
+
+
+def _delta(entry: LeaderEntry) -> str:
+    if entry.baseline == 0:
+        return "—"
+    rel = (entry.best - entry.baseline) / abs(entry.baseline) * 100
+    good = rel >= 0 if entry.direction == "max" else rel <= 0
+    return f"{'▲' if good else '▼'} {rel:+.1f}%"
+
+
+def render_markdown(entries: dict[str, LeaderEntry], target: str) -> str:
+    lines = [
+        "# Benchmark progress",
+        "",
+        f"Autonomous improvement record for `{target}`. Every number in this",
+        "table was measured by the orchestrator re-running the contract's",
+        "eval command — never taken from an agent's claim — and updated as",
+        "part of the pull request that achieved it.",
+        "",
+        "| benchmark | metric | baseline | best | progress | last improved | by run |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for name in sorted(entries):
+        e = entries[name]
+        arrow = "↓" if e.direction == "min" else "↑"
+        lines.append(
+            f"| {e.benchmark} | `{e.metric}` {arrow} | {e.baseline:g} | "
+            f"{e.best:g} | {_delta(e)} | {e.updated} | `{e.best_run}` |"
+        )
+    lines += [
+        "",
+        "_Written by [autoresearch](https://github.com/agentic-learning-ai-lab/autoresearch);",
+        "do not edit by hand — agent edits to this file end the run._",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def write_progress(workspace: Path, entries: dict[str, LeaderEntry], target: str) -> None:
+    leader_path = workspace / LEADER_FILE
+    leader_path.parent.mkdir(parents=True, exist_ok=True)
+    leader_path.write_text(
+        json.dumps({name: asdict(e) for name, e in sorted(entries.items())}, indent=2) + "\n"
+    )
+    (workspace / PROGRESS_FILE).write_text(render_markdown(entries, target))

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -50,12 +50,12 @@ def target_repo(tmp_path: Path, monkeypatch) -> Path:
     from autoresearch import climb as climb_mod
     from autoresearch.github import Workspace
 
-    real_clone = Workspace.clone.__func__
+    real_clone = Workspace.clone
 
-    def fake_clone(cls, url, dest, auth=None, dry_run=False):
-        return real_clone(cls, str(bare), dest, auth=None, dry_run=dry_run)
+    def fake_clone(url, dest, auth=None, dry_run=False):
+        return real_clone(str(bare), dest, auth=None, dry_run=dry_run)
 
-    monkeypatch.setattr(climb_mod.Workspace, "clone", classmethod(fake_clone))
+    monkeypatch.setattr(climb_mod.Workspace, "clone", staticmethod(fake_clone))
     return bare
 
 
@@ -132,10 +132,10 @@ def test_improvement_produces_branch_commit_and_pr(tmp_path, target_repo) -> Non
     assert outcome.outcome == "improved"
     assert outcome.pr_url.endswith("/pull/1")
     # the branch actually landed in the bare origin with only the solver edit
-    files = _git(target_repo, "diff", "--name-only", "main", "feat/auto/agent-01/tsp").split()
+    files = _git(target_repo, "diff", "--name-only", "main", "feat/auto/agent-01/tsp-1").split()
     assert files == ["src/pilot/solvers/tsp.py"]
     pr = github.prs[0]
-    assert pr["head"] == "feat/auto/agent-01/tsp"
+    assert pr["head"] == "feat/auto/agent-01/tsp-1"
     assert "13.876" in pr["title"]
     assert "measured by the orchestrator" in pr["body"]
     # run record went in-review with the PR url
@@ -208,6 +208,76 @@ def test_session_error_aborts_cleanly(tmp_path, target_repo) -> None:
     )
     assert outcome.outcome == "session-error"
     assert github.prs == []
+
+
+def test_second_run_gets_its_own_branch(tmp_path, target_repo) -> None:
+    """A fixed branch name would non-fast-forward on run two."""
+    edits = {"src/pilot/solvers/tsp.py": "def solve(): return 1\n"}
+    run_live(tmp_path, target_repo, edits=edits, values=[13.876, 13.1], run_id="tsp-a")
+    edits2 = {"src/pilot/solvers/tsp.py": "def solve(): return 2\n"}
+    outcome, _ = run_live(tmp_path, target_repo, edits=edits2, values=[13.1, 12.5], run_id="tsp-b")
+    assert outcome.outcome == "improved"
+    branches = _git(target_repo, "branch", "--list")
+    assert "feat/auto/agent-01/tsp-a" in branches
+    assert "feat/auto/agent-01/tsp-b" in branches
+
+
+def test_files_written_during_eval_void_the_claim(tmp_path, target_repo) -> None:
+    """The committed tree must be exactly the measured tree — solver code
+    that writes files at eval time is neither scope-checked nor measured."""
+
+    @dataclass
+    class PlantingEvaluator:
+        values: list[float] = field(default_factory=list)
+        calls: int = 0
+
+        def evaluate(self, workspace, command, metric) -> float:
+            self.calls += 1
+            if self.calls == 2:  # during the candidate eval
+                (workspace / "src" / "pilot" / "solvers" / "planted.py").write_text("x=1\n")
+            return self.values.pop(0)
+
+    github = FakeGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-drift",
+        harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "y=2\n"}),
+        evaluator=PlantingEvaluator(values=[13.876, 13.1]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "publish-error"
+    assert github.prs == []
+    assert "feat/auto" not in _git(target_repo, "branch", "--list")
+    record = load_record(tmp_path / "state", "tsp-drift")
+    assert record.ending == "aborted"
+    assert "changed during eval" in record.ending_note
+
+
+def test_create_pull_failure_records_aborted_not_crash(tmp_path, target_repo) -> None:
+    @dataclass
+    class FailingGitHub:
+        def create_pull(self, *a, **k) -> str:
+            raise RuntimeError("422 already exists")
+
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-prfail",
+        harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "z=3\n"}),
+        evaluator=QueueEvaluator(values=[13.876, 13.1]),
+        github=FailingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "publish-error"
+    record = load_record(tmp_path / "state", "tsp-prfail")
+    assert record.state == "ended"
+    assert record.ending == "aborted"
 
 
 def test_report_is_written_for_every_outcome(tmp_path, target_repo) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1,0 +1,222 @@
+"""live_climb end to end: real local git repos, fake harness/evaluator/API."""
+
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from autoresearch.climb import live_climb
+from autoresearch.harness import SessionResult
+from autoresearch.orchestrator import ClimbConfig
+from autoresearch.runstate import load_record
+
+CONTRACT = """\
+benchmarks:
+  - name: tsp
+    command: uv run python -m pilot.eval --benchmark tsp --json
+    metric: mean_tour_length
+    direction: min
+budgets: {gpu_hours_per_run: 1, runs_per_week: 10}
+scope: {allowed: [src/pilot/solvers/]}
+roadmap: docs/roadmap.md
+"""
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+@pytest.fixture
+def target_repo(tmp_path: Path, monkeypatch) -> Path:
+    """A bare 'github' repo seeded with a pilot-shaped tree; Workspace.clone
+    is monkeypatched to clone from it instead of github.com."""
+    seed = tmp_path / "seed"
+    (seed / "src" / "pilot" / "solvers").mkdir(parents=True)
+    (seed / "docs").mkdir()
+    (seed / ".autoresearch.yaml").write_text(CONTRACT)
+    (seed / "docs" / "roadmap.md").write_text("# roadmap\n")
+    (seed / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): ...\n")
+    _git(seed, "init", "-q", "-b", "main")
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "seed")
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(seed), str(bare))
+
+    from autoresearch import climb as climb_mod
+    from autoresearch.github import Workspace
+
+    real_clone = Workspace.clone.__func__
+
+    def fake_clone(cls, url, dest, auth=None, dry_run=False):
+        return real_clone(cls, str(bare), dest, auth=None, dry_run=dry_run)
+
+    monkeypatch.setattr(climb_mod.Workspace, "clone", classmethod(fake_clone))
+    return bare
+
+
+@dataclass
+class ScriptedHarness:
+    """Applies edits to the workspace like a session would."""
+
+    edits: dict[str, str]
+    text: str = "Report: swapped construction heuristic; tours shortened."
+
+    def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+        for rel, content in self.edits.items():
+            path = workspace / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        return SessionResult(
+            stop_reason="end_turn",
+            is_error=False,
+            cost_usd=0.9,
+            num_turns=12,
+            session_id="s1",
+            final_text=self.text,
+            transcript_path="",
+        )
+
+
+@dataclass
+class QueueEvaluator:
+    values: list[float] = field(default_factory=list)
+
+    def evaluate(self, workspace, command, metric) -> float:
+        return self.values.pop(0)
+
+
+@dataclass
+class FakeGitHub:
+    prs: list[dict] = field(default_factory=list)
+
+    def create_pull(self, repo, title, head, base, body, draft=False) -> str:
+        self.prs.append(dict(repo=repo, title=title, head=head, base=base, body=body))
+        return f"https://github.com/{repo}/pull/1"
+
+
+@dataclass
+class NoAuth:
+    def token(self) -> str:
+        return "unused"
+
+
+def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1") -> tuple:
+    github = FakeGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id=run_id,
+        harness=ScriptedHarness(edits=edits),
+        evaluator=QueueEvaluator(values=list(values)),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="2026-08-06T00:00:00Z",
+        secrets=("sk-live-key",),
+    )
+    return outcome, github
+
+
+def test_improvement_produces_branch_commit_and_pr(tmp_path, target_repo) -> None:
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+        values=[13.876, 13.1],
+    )
+    assert outcome.outcome == "improved"
+    assert outcome.pr_url.endswith("/pull/1")
+    # the branch actually landed in the bare origin with only the solver edit
+    files = _git(target_repo, "diff", "--name-only", "main", "feat/auto/agent-01/tsp").split()
+    assert files == ["src/pilot/solvers/tsp.py"]
+    pr = github.prs[0]
+    assert pr["head"] == "feat/auto/agent-01/tsp"
+    assert "13.876" in pr["title"]
+    assert "measured by the orchestrator" in pr["body"]
+    # run record went in-review with the PR url
+    record = load_record(tmp_path / "state", "tsp-1")
+    assert record.state == "in-review"
+    assert "pull/1" in record.ending_note
+    # report exists and is redacted-safe
+    report = Path(outcome.report_path).read_text()
+    assert "improved" in report
+
+
+def test_no_improvement_ends_negative_result_and_pushes_nothing(tmp_path, target_repo) -> None:
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'worse'\n"},
+        values=[13.876, 14.5],
+    )
+    assert outcome.outcome == "no-improvement"
+    assert github.prs == []
+    branches = _git(target_repo, "branch", "--list")
+    assert "feat/auto" not in branches
+    record = load_record(tmp_path / "state", "tsp-1")
+    assert record.state == "ended"
+    assert record.ending == "negative-result"
+
+
+def test_out_of_scope_edit_aborts_without_pr(tmp_path, target_repo) -> None:
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={
+            "src/pilot/solvers/tsp.py": "def solve(): ...\n",
+            "docs/roadmap.md": "doctored\n",
+        },
+        values=[13.876, 1.0],
+    )
+    assert outcome.outcome == "scope-violation"
+    assert github.prs == []
+    record = load_record(tmp_path / "state", "tsp-1")
+    assert record.ending == "aborted"
+    assert "roadmap" in record.ending_note
+
+
+def test_session_error_aborts_cleanly(tmp_path, target_repo) -> None:
+    @dataclass
+    class DeadHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            return SessionResult(
+                stop_reason="timeout",
+                is_error=True,
+                cost_usd=0.0,
+                num_turns=0,
+                session_id="",
+                final_text="",
+                transcript_path="",
+            )
+
+    github = FakeGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-err",
+        harness=DeadHarness(),
+        evaluator=QueueEvaluator(values=[13.876]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "session-error"
+    assert github.prs == []
+
+
+def test_report_is_written_for_every_outcome(tmp_path, target_repo) -> None:
+    outcome, _ = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "x = 1\n"},
+        values=[13.876, 14.0],
+    )
+    text = Path(outcome.report_path).read_text()
+    assert "no-improvement" in text
+    assert "Agent's report" in text

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -131,9 +131,12 @@ def test_improvement_produces_branch_commit_and_pr(tmp_path, target_repo) -> Non
     )
     assert outcome.outcome == "improved"
     assert outcome.pr_url.endswith("/pull/1")
-    # the branch actually landed in the bare origin with only the solver edit
-    files = _git(target_repo, "diff", "--name-only", "main", "feat/auto/agent-01/tsp-1").split()
-    assert files == ["src/pilot/solvers/tsp.py"]
+    # the branch landed in the bare origin: the solver edit plus the two
+    # orchestrator-written progress files, nothing else
+    files = set(
+        _git(target_repo, "diff", "--name-only", "main", "feat/auto/agent-01/tsp-1").split()
+    )
+    assert files == {"src/pilot/solvers/tsp.py", "BENCHMARKS.md", "results/leader.json"}
     pr = github.prs[0]
     assert pr["head"] == "feat/auto/agent-01/tsp-1"
     assert "13.876" in pr["title"]
@@ -290,3 +293,56 @@ def test_report_is_written_for_every_outcome(tmp_path, target_repo) -> None:
     text = Path(outcome.report_path).read_text()
     assert "no-improvement" in text
     assert "Agent's report" in text
+
+
+def test_improvement_pr_carries_progress_table(tmp_path, target_repo) -> None:
+    """The human-readable record lands in the same PR as the improvement."""
+    import json as _json
+
+    outcome, _ = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+        values=[13.876, 13.1],
+    )
+    assert outcome.outcome == "improved"
+    files = set(
+        _git(target_repo, "diff", "--name-only", "main", "feat/auto/agent-01/tsp-1").split()
+    )
+    assert files == {"src/pilot/solvers/tsp.py", "BENCHMARKS.md", "results/leader.json"}
+    table = _git(target_repo, "show", "feat/auto/agent-01/tsp-1:BENCHMARKS.md")
+    assert "| tsp | `mean_tour_length` ↓ | 13.876 | 13.1 |" in table
+    assert "▲" in table  # improvement marked good even though direction=min
+    leader = _json.loads(_git(target_repo, "show", "feat/auto/agent-01/tsp-1:results/leader.json"))
+    assert leader["tsp"]["best"] == 13.1
+    assert leader["tsp"]["baseline"] == 13.876
+
+
+def test_agent_editing_benchmarks_md_ends_the_run(tmp_path, target_repo) -> None:
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={
+            "src/pilot/solvers/tsp.py": "ok\n",
+            "BENCHMARKS.md": "| fake | glory |\n",
+        },
+        values=[13.876, 13.1],
+    )
+    assert outcome.outcome == "scope-violation"
+    assert github.prs == []
+
+
+def test_second_improvement_updates_best_keeps_baseline(tmp_path, target_repo) -> None:
+    import json as _json
+
+    edits = {"src/pilot/solvers/tsp.py": "v1\n"}
+    run_live(tmp_path, target_repo, edits=edits, values=[13.876, 13.1], run_id="tsp-a")
+    # simulate the merge of run a: advance main to its branch
+    _git(target_repo, "branch", "-f", "main", "feat/auto/agent-01/tsp-a")
+    edits2 = {"src/pilot/solvers/tsp.py": "v2\n"}
+    outcome, _ = run_live(tmp_path, target_repo, edits=edits2, values=[13.1, 12.4], run_id="tsp-b")
+    assert outcome.outcome == "improved"
+    leader = _json.loads(_git(target_repo, "show", "feat/auto/agent-01/tsp-b:results/leader.json"))
+    assert leader["tsp"]["baseline"] == 13.876  # pinned from the FIRST run
+    assert leader["tsp"]["best"] == 12.4
+    assert leader["tsp"]["best_run"] == "tsp-b"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -297,3 +297,30 @@ def test_report_redacts_secrets(tmp_path: Path) -> None:
     report = result.report(CONFIG, redact_secrets=("sk-report-leak",))
     assert "sk-report-leak" not in report
     assert "[redacted]" in report
+
+
+def test_progress_render_and_ledger_roundtrip(tmp_path: Path) -> None:
+    from autoresearch.progress import (
+        load_leader,
+        render_markdown,
+        update_leader,
+        write_progress,
+    )
+
+    entries = update_leader({}, "tsp", "mean_tour_length", "min", 13.876, 13.1, "r1", "2026-08-06")
+    entries = update_leader(entries, "sokoban", "solve_rate", "max", 0.25, 0.31, "r2", "2026-08-06")
+    write_progress(tmp_path, entries, "org/pilot")
+    reloaded = load_leader(tmp_path)
+    assert reloaded == entries
+    table = render_markdown(reloaded, "org/pilot")
+    assert "| sokoban | `solve_rate` ↑ | 0.25 | 0.31 | ▲ +24.0% |" in table
+    assert "measured by the orchestrator" in table
+
+
+def test_leader_survives_corruption(tmp_path: Path) -> None:
+    from autoresearch.progress import LEADER_FILE, load_leader
+
+    path = tmp_path / LEADER_FILE
+    path.parent.mkdir(parents=True)
+    path.write_text("{broken")
+    assert load_leader(tmp_path) == {}

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -150,6 +150,17 @@ def test_improved_direction_semantics() -> None:
     assert not improved(0.25, 0.24, "max", 0.005)
 
 
+def test_metric_parsing_accepts_pilot_shape() -> None:
+    """The pilot's eval prints the metric NAME as a value: caught pre-live by
+    the review agent — this exact line would have aborted the first climb."""
+    line = (
+        '{"benchmark": "tsp", "metric": "mean_tour_length",'
+        ' "value": 13.875696168157484, "direction": "min"}'
+    )
+    assert _metric_from_output(line, "mean_tour_length") == 13.875696168157484
+    assert _metric_from_output(line, "solve_rate") is None
+
+
 def test_metric_parsing_json_only_no_fuzzy_fallback() -> None:
     assert _metric_from_output('{"mean_tour_length": 13.1}', "mean_tour_length") == 13.1
     noisy = 'log line\n{"other": 1}\n{"solve_rate": 0.31, "n": 40}'


### PR DESCRIPTION
The last code between here and the bot's first research PR.

- `climb.py`: bot-auth clone, contract read from the untouched tree, contained session + eval via `climb_once`, then publish: **workspace-drift veto** (the committed tree must be exactly the measured tree — solver code writing files during eval voids the claim), full-scope commit veto, per-run branch names, PR with orchestrator-measured numbers, durable run record for every path (publish failures record `aborted`, never a stale `implementing`).
- CLI is contained-by-default: `--image` required unless `--uncontained` is passed explicitly; the harness key gets the same 0600 discipline as the PAT; both credentials in the redaction set.
- `_metric_from_output` accepts the pilot eval's actual shape (`{"metric": name, "value": v}`) — the review agent ran the pilot's eval and proved the first live run would have aborted at baseline without this.

Pre-merge adversarial pass: 7 findings (5 confirmed by execution, incl. the DOA metric shape, second-run branch collision, and eval-time file-planting bypassing scope+measurement). All fixed with regression tests. 252 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)