### PR TITLE
Design: results layers (telemetry / ledger / headline)

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -354,7 +354,7 @@ Scheduler etiquette learned live: `--exclude` is disallowed on Torch and node
 pinning (`-w`) queues behind reservations — the orchestrator requests
 partitions and lets the scheduler place jobs, never nodes.
 
-## Environments and containers (decided with Mengye, 2026-08-06)
+## Environments and containers (decided 2026-08-06)
 
 Torch supports exactly one container runtime — Apptainer (Singularity); no
 Docker daemon exists ([cluster docs](https://services.rt.nyu.edu/docs/hpc/containers/intro/)).
@@ -363,7 +363,7 @@ Containers are applied where they pay, not uniformly:
 | What | Environment | Why |
 | --- | --- | --- |
 | Orchestrator tick | host `uv` venv, deliberately NOT containerized | it exists to drive the host's `sbatch`/`sacct`/`squeue`; binding Slurm binaries, config, and the munge socket into a container is well-known friction, bought for a four-dependency pure-Python loop that needs none of it |
-| Experiments | **per-target Apptainer image, declared in the target's contract** (Mengye's call) | each researched repo owns its dependency world; a pinned image makes the contract's "deterministic and re-runnable" promise stronger (same digest at claim time and at CI re-verification), and GPU runs use the supported `apptainer exec --nv` path. Targets without an image declare none and run in their own uv-managed env |
+| Experiments | **per-target Apptainer image, declared in the target's contract** | each researched repo owns its dependency world; a pinned image makes the contract's "deterministic and re-runnable" promise stronger (same digest at claim time and at CI re-verification), and GPU runs use the supported `apptainer exec --nv` path. Targets without an image declare none and run in their own uv-managed env |
 | Agent sessions | host binary today; Apptainer `--no-home --bind <workspace>` is the designated hardening step | this is the named mechanism for the threat model's accepted residual risk: a contained session cannot read same-user absolute paths (key files, other runs), closing the gap the per-run HOME redirect only narrows |
 
 The contract grows an optional `environment` block (phase 5):
@@ -445,7 +445,7 @@ Planned search around a per-benchmark leader config, an experiment ladder
 (smoke → small proof-of-idea → periodic large consolidation runs with
 ablations), and multi-agent sharding by repo assignment with per-agent
 identity, chains, and credentials (seats or API keys): see
-[design/scaling.md](scaling.md) — a v1 sketch under iteration with Mengye,
+[design/scaling.md](scaling.md) — a sketch under iteration with the maintainers,
 not yet build-gating.
 
 ## Deferred by default

--- a/docs/design/scaling.md
+++ b/docs/design/scaling.md
@@ -1,6 +1,6 @@
 # Research planning and multi-agent scaling
 
-**Status: design sketch, v2 — iterating with Mengye (started 2026-08-06;
+**Status: design sketch, v2 — iterating with the maintainers (started 2026-08-06;
 round-1 decisions folded in 2026-08-06). Nothing here gates the phase-4
 build; decided pieces get promoted into architecture.md as they firm up.**
 
@@ -26,7 +26,7 @@ explicitly:
 - *experiment economics* — expected information per GPU-hour; what this
   eliminates from the search space if the answer is negative.
 
-**Where plans live: GitHub Issues** (Mengye's call, for visibility), one
+**Where plans live: GitHub Issues** (maintainer decision, for visibility), one
 issue per search line on the target repo, plus a machine-readable copy in the
 notebook's `plans/<target>/`. Bot-authored plan issues do NOT pass the
 requested-lane gate (that would let the pipeline feed itself privileged
@@ -75,7 +75,7 @@ defensible headline number — and where interactions between improvements
 consolidation line carries its own ceiling (a minimum interval and a per-run
 GPU-hour cap), so a burst of merges cannot trigger unbounded large runs.
 
-## Part 2b — Maintenance work and the vision (added from Mengye's round 1)
+## Part 2b — Maintenance work and the vision (added in round 1)
 
 Not every valuable merge moves a benchmark. **Maintenance work** — refactors,
 test coverage, tooling, documentation, dependency health — is a first-class
@@ -99,14 +99,14 @@ a human PR to the target repo: governed, visible, versioned — the same forum
 mechanism as everything else. Agents may *propose* vision changes in reports
 or issues; they cannot enact them.
 
-## Part 2c — Results: three layers, one blur resolved (Mengye + round 3)
+## Part 2c — Results: three layers, one blur resolved (round 3)
 
 A codebase, a leaderboard, and an experiment server are different things;
 results tracking keeps them separate instead of blurring them:
 
 | Layer | Lives | Written by | Contains |
 | --- | --- | --- | --- |
-| **Telemetry** | W&B (`nyu-mengye-group`, the lab's existing standard) | experiment jobs, via the target repo's own config-driven logging | curves, configs, artifacts — the deep-dive surface; agent runs tagged with agent + run id, filterable next to human runs |
+| **Telemetry** | the experiment tracker your org already uses (W&B, in our case) | experiment jobs, via the target repo's own config-driven logging | curves, configs, artifacts — the deep-dive surface; agent runs tagged with agent + run id, filterable next to human runs |
 | **Ledger** | a `results` branch in the target repo — append-only `ledger.jsonl` + a full rendered history table | the orchestrator after every measured run (improvements, negative results, aborted); humans via one command that evals + appends | EVERY measured number with provenance: benchmark, value, sha, who (agent id or human), date, W&B link. Intermediate baselines and lab members' numbers live here — attributable, in-repo, zero PRs |
 | **Headline** | `BENCHMARKS.md` + `results/leader.json` on main | the orchestrator only, riding inside improvement PRs | current best per benchmark + milestones (rows where the leader changed) |
 
@@ -180,7 +180,7 @@ agents:
 testing is ready; round-1 decision 3).** Claude Code supports
 headless auth two ways: an API key (today's path, works), or a long-lived
 OAuth token minted by `claude setup-token` from a subscription seat —
-designed for CI, no browser on the cluster needed. Proposed flow: Mengye runs
+designed for CI, no browser on the cluster needed. Proposed flow: a maintainer runs
 `setup-token` locally once per seat, the token lands in
 `~/.config/autoresearch/agents/<agent-id>/credential` (0600) on Torch, and
 the harness's existing env-injection seam passes it as
@@ -201,7 +201,7 @@ not a technical one. Confirm against current terms before the seat path
 becomes default; needs a live spike regardless (token lifetime, refresh,
 concurrent seats).
 
-## Round-1 decisions (Mengye, 2026-08-06)
+## Round-1 decisions (maintainers, 2026-08-06)
 
 1. **Veto**: `autoresearch:stop` label; default start one day after the plan
    issue posts; a maintainer's `autoresearch:approved` label starts it

--- a/docs/design/scaling.md
+++ b/docs/design/scaling.md
@@ -99,6 +99,41 @@ a human PR to the target repo: governed, visible, versioned — the same forum
 mechanism as everything else. Agents may *propose* vision changes in reports
 or issues; they cannot enact them.
 
+## Part 2c — Results: three layers, one blur resolved (Mengye + round 3)
+
+A codebase, a leaderboard, and an experiment server are different things;
+results tracking keeps them separate instead of blurring them:
+
+| Layer | Lives | Written by | Contains |
+| --- | --- | --- | --- |
+| **Telemetry** | W&B (`nyu-mengye-group`, the lab's existing standard) | experiment jobs, via the target repo's own config-driven logging | curves, configs, artifacts — the deep-dive surface; agent runs tagged with agent + run id, filterable next to human runs |
+| **Ledger** | a `results` branch in the target repo — append-only `ledger.jsonl` + a full rendered history table | the orchestrator after every measured run (improvements, negative results, aborted); humans via one command that evals + appends | EVERY measured number with provenance: benchmark, value, sha, who (agent id or human), date, W&B link. Intermediate baselines and lab members' numbers live here — attributable, in-repo, zero PRs |
+| **Headline** | `BENCHMARKS.md` + `results/leader.json` on main | the orchestrator only, riding inside improvement PRs | current best per benchmark + milestones (rows where the leader changed) |
+
+Rules that fall out:
+
+- **No result ever creates its own main-branch PR.** Headline updates ride
+  inside improvement PRs that merge on their own merits; everything else goes
+  to the ledger branch (a push, not a PR — data, not code, same reasoning as
+  the notebook's auto-merge) or to W&B. Public research repos' main history
+  stays exactly as clean as their science.
+- **Humans share baselines through the ledger**, one command: run the eval,
+  append the JSON row with your name, push to the results branch. No W&B
+  account needed to be counted; no PR needed to be seen.
+- **History is the ledger, not the leader.** `leader.json` is a snapshot;
+  "what was the best before X" and every intermediate baseline is a ledger
+  query. The rendered history table on the results branch shows leader
+  transitions per benchmark.
+- **W&B credentials never enter agent sessions** (credential-free sessions
+  are an invariant); experiment jobs may log with the target repo's own
+  config. Whether agent experiments get a scoped W&B service account or log
+  anonymously-tagged is a phase-6 decision.
+- The pilot keeps its simpler shape (headline-on-main only): every merge
+  there is important by construction, and it has no W&B.
+
+Implementation lands with phase 6 (reports); nothing here blocks the live
+climb.
+
 ## Part 3 — Multi-agent: identity, isolation, seats
 
 **Why multiple agents at all** (practical, not aesthetic): subscription seats

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -75,7 +75,7 @@ standing instruction they supersede — a resumed agent honors stale constraints
 - [x] Deploy shim (same script): pull main with the bot PAT → `uv sync
       --locked` → exec tick; every step best-effort (bad merges crash ticks,
       never the chain). Bot PAT on Torch + repo in the token's selection
-      still owed by Mengye before live deploy
+      still owed by the maintainer before live deploy
 - [ ] Pause sentinel + lease (compare-and-swap on the state branch); heartbeat at
       tick start; stale-lease reaping
 - [ ] `compute`: sbatch submit / squeue poll, jobs tagged + `--nice`, GPU-hour caps
@@ -97,7 +97,7 @@ the research repos' porting timelines; mistakes are free; adversarial testing
 - [ ] Task pinning: target SHA + contract hash at task start, re-validated each
       poll; baseline re-run at merge-base
 - [x] `orchestrator.climb_once` (2026-08-06): one implement→evaluate→verify
-      cycle on ONE configured benchmark (Mengye: start with one, tsp, not
+      cycle on ONE configured benchmark (maintainer decision: start with one, tsp, not
       everything); baseline re-measured from the pre-session tree, candidate
       re-measured by the orchestrator (never the agent's claim), direction-
       aware threshold, PR body with results table + agent report. Sessions
@@ -114,14 +114,12 @@ the research repos' porting timelines; mistakes are free; adversarial testing
       workspace GC after PR close
 - [ ] Staged injection tests against the pilot before any research target
 
-Candidate second target (Mengye, 2026-08-06): **yolo-jepa** — clean toy JEPA
-experiments on synthetic dynamical systems (`run_sweep.py`, held-out probes).
-Attractive because it is real research code at toy scale: CPU-runnable,
-seeded, single-command evals. Two things to settle before opting it in: it is
-paper-bearing (unpublished results — needs the same private-history care as
-the research repos, and no injection testing), and a contract needs one
-deterministic headline metric (held-out probe error on a frozen config grid)
-rather than the open-ended sweep space.
+Candidate second target (2026-08-06): a private toy-scale research repo —
+real research code, CPU-runnable, seeded, single-command evals. Two things
+to settle before opting it in: it is paper-bearing (needs research-repo
+confidentiality care, and no injection testing), and its contract needs one
+deterministic headline metric over a frozen config grid rather than an
+open-ended sweep space.
 
 ## Phase 6 — Reporting & research memory
 
@@ -146,7 +144,7 @@ rather than the open-ended sweep space.
 - [ ] Storage interface: notebook-repo backend → walled multi-tenant store
 - [ ] Experiment-backend interface: consumer-side runners, verifiable rewards
 
-## Manual prerequisites (Mengye)
+## Manual prerequisites (maintainer)
 
 - [ ] Create the bot machine user; invite to org (free seat on Team plan); mint
       the fine-grained PAT per the architecture's spec


### PR DESCRIPTION
Resolves the codebase-vs-leaderboard-vs-experiment-server blur from Mengye's round 3: W&B (existing lab standard) for deep-dive telemetry; an append-only ledger on a results branch for EVERY measured number incl. intermediate baselines and human-contributed numbers (attributable, in-repo, zero PRs); BENCHMARKS.md/leader.json on main as headline only, riding inside improvement PRs. No result ever creates its own main-branch PR — public research repos stay as clean as their science.

🤖 Generated with [Claude Code](https://claude.com/claude-code)