### PR TITLE
Actions economy: single ci job + on-demand advisory review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
-# Job names (lint, types, test, lock, gitleaks) are required-check contexts in
-# branch protection — renaming a job requires updating scripts/setup_branch_protection.sh.
+# ONE job: GitHub bills per job rounded UP to a full minute, so five 15-second
+# jobs cost five minutes. The job name `ci` is the sole required-check context
+# in branch protection (scripts/setup_branch_protection.sh).
 name: ci
 
 on:
@@ -16,55 +17,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
+  ci:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history: gitleaks scans it (this repo handles credentials).
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       - run: uv sync --locked
+      - run: uv lock --check
       - run: uv run ruff check .
       - run: uv run ruff format --check .
-
-  types:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-      - run: uv sync --locked
       - run: uv run mypy
-
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-      - run: uv sync --locked
-      # addopts in pyproject.toml already excludes the slow/llm/slurm tiers
       - run: uv run pytest
-
-  lock:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
-      - run: uv lock --check
-
-  gitleaks:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          # Scan full history — this repo handles bot and API credentials.
-          fetch-depth: 0
-      # Pinned CLI binary instead of gitleaks/gitleaks-action: the action requires a
-      # paid GITLEAKS_LICENSE for organization repos; the CLI is free (MIT).
-      - name: Run gitleaks over full history
+      # Pinned CLI binary instead of gitleaks/gitleaks-action: the action
+      # requires a paid GITLEAKS_LICENSE for org repos; the CLI is free (MIT).
+      - name: gitleaks over full history
         run: |
           curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.24.3/gitleaks_8.24.3_linux_x64.tar.gz | tar -xz gitleaks
           ./gitleaks git --no-banner --redact --exit-code 1 .

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,12 +1,17 @@
 name: advisory-review
+# Advisory review runs on OPEN and on demand (label), not on every push —
+# a 2-3 minute model review per synchronize was the minutes burner.
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened, labeled]
 permissions:
   contents: read
   pull-requests: write
 jobs:
   advisory:
+    # label events only run the review for the explicit re-request label
+    if: github.event.action != 'labeled' || github.event.label.name == 'autoresearch:review'
+
     uses: agentic-learning-ai-lab/autoresearch/.github/workflows/advisory-review.yml@main
     with:
       bot_login: agentic-learning-bot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- CI consolidated to one job (`ci`) — GitHub bills per job rounded up to a
+  minute, so five short jobs cost 5x. The advisory review now runs on PR open
+  and on the `autoresearch:review` label, not on every push.
+
 - **Breaking**: the review CLI reads `ANTHROPIC_REVIEWER_KEY`, no longer
   `ANTHROPIC_API_KEY` (role-named credentials; the harness gets its own key).
   Reusable-workflow callers are unaffected. Direct invokers must export the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -152,3 +152,13 @@ open-ended sweep space.
 - [ ] API billing with hard spend caps + the separate reviewer key
 - [ ] Choose the sponsoring Torch account for bot-submitted jobs
 - [ ] Decide transcript retention period and project-space location
+
+
+## Actions economy (decided 2026-08-07)
+
+- [x] Single `ci` job (job-minute rounding was 5x the real usage); advisory
+      review on open + `autoresearch:review` label, never per push
+- [ ] Same consolidation on the target repos' workflows
+- [ ] Mid-term: self-hosted runner on the lab workstation (outbound-only
+      polling; frees private-repo minutes entirely). When repos go public,
+      hosted minutes become free anyway

--- a/scripts/setup_branch_protection.sh
+++ b/scripts/setup_branch_protection.sh
@@ -28,11 +28,7 @@ gh api --method PUT -H "Accept: application/vnd.github+json" \
   "required_status_checks": {
     "strict": false,
     "checks": [
-      {"context": "lint"},
-      {"context": "types"},
-      {"context": "test"},
-      {"context": "lock"},
-      {"context": "gitleaks"}
+      {"context": "ci"}
     ]
   },
   "enforce_admins": ${ENFORCE_ADMINS},


### PR DESCRIPTION
644/3000 org minutes burned in two days, mostly job-rounding (five ~15s jobs bill five minutes) and opus reviews on every push. This consolidates CI into one `ci` job (same steps, same coverage) and triggers the advisory review on `opened`/`reopened`/`autoresearch:review`-label only. Branch protection must switch its required contexts to `ci` BEFORE this merges (script updated; live PATCH is a maintainer action).

🤖 Generated with [Claude Code](https://claude.com/claude-code)