### PR TITLE
Short metric precision in PR titles

### DIFF
--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -53,6 +53,17 @@ class WorkspaceDrift(RuntimeError):
     """The tree changed between measurement and commit."""
 
 
+def _title_pair(a: float, b: float) -> str:
+    """Compact but never ambiguous: widen precision until the two numbers
+    render differently (a title reading '10.00 -> 10.00' looks like no
+    change even when the improvement is real)."""
+    for precision in range(4, 12):
+        fa, fb = f"{a:.{precision}g}", f"{b:.{precision}g}"
+        if fa != fb:
+            return f"{fa} -> {fb}"
+    return f"{a} -> {b}"
+
+
 RULER = (
     "The metric is computed by the contract's eval command over a frozen "
     "instance pool. Your claim is verified by the orchestrator re-running "
@@ -214,7 +225,7 @@ def live_climb(
             # orchestrator-written progress files are the only exemption.
             ws.commit_all(
                 f"agent: improve {config.benchmark} "
-                f"({result.baseline:.4g} -> {result.candidate:.4g})",
+                f"({_title_pair(result.baseline, result.candidate)})",
                 author=config.agent_id,
                 forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
             )
@@ -225,7 +236,7 @@ def live_climb(
                 # short precision in the title; full precision lives in the
                 # PR body table and the ledger
                 title=f"[agent] {config.benchmark}: "
-                f"{result.baseline:.4g} -> {result.candidate:.4g}",
+                f"{_title_pair(result.baseline, result.candidate)}",
                 head=branch,
                 base=base_branch,
                 body=pr_body(result, config, redact_secrets=secrets),

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -213,7 +213,8 @@ def live_climb(
             # defense in depth behind climb_once's pre-eval check. The two
             # orchestrator-written progress files are the only exemption.
             ws.commit_all(
-                f"agent: improve {config.benchmark} ({result.baseline} -> {result.candidate})",
+                f"agent: improve {config.benchmark} "
+                f"({result.baseline:.4g} -> {result.candidate:.4g})",
                 author=config.agent_id,
                 forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
             )
@@ -221,7 +222,10 @@ def live_climb(
             pushed = True
             pr_url = github.create_pull(
                 config.target,
-                title=f"[agent] {config.benchmark}: {result.baseline} -> {result.candidate}",
+                # short precision in the title; full precision lives in the
+                # PR body table and the ledger
+                title=f"[agent] {config.benchmark}: "
+                f"{result.baseline:.4g} -> {result.candidate:.4g}",
                 head=branch,
                 base=base_branch,
                 body=pr_body(result, config, redact_secrets=secrets),

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -139,7 +139,7 @@ def test_improvement_produces_branch_commit_and_pr(tmp_path, target_repo) -> Non
     assert files == {"src/pilot/solvers/tsp.py", "BENCHMARKS.md", "results/leader.json"}
     pr = github.prs[0]
     assert pr["head"] == "feat/auto/agent-01/tsp-1"
-    assert "13.876" in pr["title"]
+    assert pr["title"] == "[agent] tsp: 13.88 -> 13.1"  # 4 sig figs, not full floats
     assert "measured by the orchestrator" in pr["body"]
     # run record went in-review with the PR url
     record = load_record(tmp_path / "state", "tsp-1")

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -496,3 +496,11 @@ def test_climb_error_still_writes_a_report(tmp_path, target_repo) -> None:
     )
     assert outcome.outcome == "climb-error"
     assert Path(outcome.report_path).read_text().startswith("# Run report")
+
+
+def test_title_pair_never_renders_identical() -> None:
+    from autoresearch.climb import _title_pair
+
+    assert _title_pair(13.875696168157484, 10.844662077277105) == "13.88 -> 10.84"
+    assert _title_pair(10.00001, 10.00002) == "10.00001 -> 10.00002"
+    assert " -> " in _title_pair(1e-7, 2e-7)


### PR DESCRIPTION
Per maintainer feedback on the first climb PR: titles like '[agent] tsp: 13.875696168157484 -> 10.844662077277105' become '[agent] tsp: 13.88 -> 10.84'. Full precision remains in the PR body results table, the run report, and results/leader.json.

🤖 Generated with [Claude Code](https://claude.com/claude-code)