### PR TITLE
Design: verification agent (bot-PR judgment layer)

### DIFF
--- a/docs/design/scaling.md
+++ b/docs/design/scaling.md
@@ -134,6 +134,43 @@ Rules that fall out:
 Implementation lands with phase 6 (reports); nothing here blocks the live
 climb.
 
+## Part 2d — Verification (decided 2026-08-07)
+
+Three verification regimes, by what the target's metric permits:
+
+1. **Directly verifiable** (the pilot): the frozen eval validates solution
+   structure (invalid output raises, never scores), the metric is
+   deterministic, the orchestrator re-measures, fingerprints pin the tree.
+   No judgment needed.
+2. **Statistically verifiable** (ML targets): protocol replaces proof —
+   frozen held-out evals on frozen config grids, seeds, the noise floor,
+   full-suite reporting, leader-never-regresses, and consolidation runs with
+   leave-one-out ablation, where lucky seeds and flukes die.
+3. **Judgment-verifiable**: a **verification agent** skims the code and the
+   claim for what protocol cannot catch — ruler-gaming inside allowed scope,
+   test-set leakage, seed-fishing, overfitting to frozen instances, claims
+   the diff does not support.
+
+The verification agent is the advisory reviewer's complement, and the two
+never overlap:
+
+| | advisory reviewer | verification agent |
+| --- | --- | --- |
+| runs on | human-authored PRs | **bot-authored PRs only** |
+| hunts | general defects | metric-gaming specifically |
+| inputs | diff + file context | diff + contract + eval code + claimed numbers + run report |
+| output | findings, never approvals | findings, never approvals — and its header states that **absence of findings is not an endorsement** |
+| credential | its own capped key | its own capped key, distinct from both the reviewer's and the harness's |
+
+This stays compatible with the reviewer-influence rule (nothing in the
+pipeline may nudge humans toward merging its own work) because the verifier
+only ever raises suspicions: silence is explicitly meaningless, and its text
+passes the same approval-language sanitization as the reviewer's. It ships
+on the same reusable-workflow chassis (a verifier mode: inverted bot gate,
+gaming-focused prompt) and is **required before the first
+statistically-verifiable target onboards** — judgment is the layer category-2
+targets cannot do without.
+
 ## Part 3 — Multi-agent: identity, isolation, seats
 
 **Why multiple agents at all** (practical, not aesthetic): subscription seats

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -132,6 +132,10 @@ open-ended sweep space.
 
 ## Phase 7 — Research targets & scale-out
 
+- [ ] Verification agent (scaling.md Part 2d): verifier mode on the review
+      chassis — bot-PRs only, metric-gaming prompt, own capped key, silence-is
+      -not-endorsement header. REQUIRED before any statistically-verifiable
+      target onboards
 - [ ] jepa-agent as the first research target: `.autoresearch.yaml` + bot Write
       grant + token scope, once its benchmark harness lands and the pilot's
       PR-quality bar is met

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,8 +133,8 @@ open-ended sweep space.
 ## Phase 7 — Research targets & scale-out
 
 - [ ] Verification agent (scaling.md Part 2d): verifier mode on the review
-      chassis — bot-PRs only, metric-gaming prompt, own capped key, silence-is
-      -not-endorsement header. REQUIRED before any statistically-verifiable
+      chassis — bot-PRs only, metric-gaming prompt, own capped key, and the
+      silence-is-not-endorsement header. REQUIRED before any statistically-verifiable
       target onboards
 - [ ] jepa-agent as the first research target: `.autoresearch.yaml` + bot Write
       grant + token scope, once its benchmark harness lands and the pilot's
@@ -153,7 +153,7 @@ open-ended sweep space.
 - [ ] Create the bot machine user; invite to org (free seat on Team plan); mint
       the fine-grained PAT per the architecture's spec
 - [ ] Subscription seat or lab-managed account for the pilot harness
-- [ ] API billing with hard spend caps + the separate reviewer key
+- [ ] API billing with hard spend caps + the separate reviewer key + a third capped key for the verification agent (before any category-2 target)
 - [ ] Choose the sponsoring Torch account for bot-submitted jobs
 - [ ] Decide transcript retention period and project-space location
 


### PR DESCRIPTION
Per the maintainer's verification taxonomy: directly-verifiable (pilot — frozen ruler validates structure), statistically-verifiable (ML — protocol: held-out grids, noise floor, consolidation ablations), and judgment-verifiable — a verification agent that runs ONLY on bot-authored PRs (the advisory reviewer's exact complement), hunts metric-gaming specifically, carries its own capped credential, and whose silence is explicitly not an endorsement. Required before the first category-2 target onboards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)