### PR TITLE
Automatic in-review servicing from the tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- The tick now services in-review runs automatically: PR merge/close ends the
+  run; new qualifying review comments submit a follow-up job that wakes the
+  authoring session (lease-guarded; `followup_job_id` prevents duplicate
+  queueing). The chain passes the PAT path to the tick for GitHub reads;
+  agent sessions remain scrubbed by the harness allowlist.
+
 - `autoresearch.followup`: the in-review path — PR merge/close ends the run;
   qualifying maintainer comments (author-association gate) resume the
   authoring session in its retained workspace, and the reply lands on the

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -97,4 +97,7 @@ fi
 # --- 3. the tick itself (scrubbed of the PAT path; sessions are scrubbed
 #        further down in the harness) ---
 cd "$AUTORESEARCH_HOME"
-exec env -u AUTORESEARCH_PAT_FILE uv run python -m autoresearch.tick --root "$AUTORESEARCH_ROOT"
+# The tick keeps AUTORESEARCH_PAT_FILE: it reads GitHub (PR states, review
+# comments) and submits follow-up jobs. Agent sessions remain scrubbed by the
+# harness env allowlist regardless.
+exec uv run python -m autoresearch.tick --root "$AUTORESEARCH_ROOT"

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -85,6 +85,41 @@ def qualifying_comments(
     return picked
 
 
+def close_if_done(run_root: Path, record: RunRecord, github: GitHubClient, now: float) -> str:
+    """End the run if its PR is merged/closed. Returns the ending or ""."""
+    number = _pr_number(record.pr_url)
+    pr = github.get_pull_request(record.target, number)
+    if pr.get("merged") or pr.get("merged_at"):
+        save_record(run_root, replace(record, state=ENDED, ending=MERGED), now)
+        return MERGED
+    if pr.get("state") == "closed":
+        save_record(
+            run_root,
+            replace(record, state=ENDED, ending=REJECTED, ending_note="PR closed unmerged"),
+            now,
+        )
+        return REJECTED
+    return ""
+
+
+def has_new_comments(record: RunRecord, github: GitHubClient, bot_login: str) -> bool:
+    """Cheap read-only check the tick can afford every cycle."""
+    number = _pr_number(record.pr_url)
+    return bool(
+        qualifying_comments(
+            github.list_comments(record.target, number), bot_login, record.last_comment_id
+        )
+        or qualifying_comments(
+            github.list_pr_reviews(record.target, number), bot_login, record.last_review_id
+        )
+        or qualifying_comments(
+            github.list_pr_review_comments(record.target, number),
+            bot_login,
+            record.last_review_comment_id,
+        )
+    )
+
+
 def respond_once(
     run_root: Path,
     run_id: str,

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -339,6 +339,7 @@ def _respond(
             last_review_id=cursors["review"],
             last_review_comment_id=cursors["review_comment"],
             resume_session_id=session.session_id or record.resume_session_id,
+            wake_attempts=0,  # progress: the retry cap starts fresh
         ),
         now,
     )

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -68,6 +68,7 @@ class RunRecord:
     last_comment_id: int = 0
     last_review_id: int = 0
     last_review_comment_id: int = 0
+    followup_job_id: str = ""  # slurm job servicing this run's review comments
     wake_attempts: int = 0
     deadline: float = 0.0  # unix; submit+walltime+slack, re-based on start
     terminal_seen: float = 0.0  # when the sweep first saw the experiment terminal

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -41,6 +41,7 @@ from autoresearch.runstate import (
     acquire_lease,
     lease_is_stale,
     list_runs,
+    load_record,
     read_lease,
     reap_lease,
     release_lease,
@@ -110,6 +111,8 @@ class FollowupSpec:
     home: Path  # AUTORESEARCH_HOME: cwd for the submitted job
     bot_login: str = "agentic-learning-bot"
     time_minutes: int = 60
+    pat_file: str = ""  # forwarded to the job; "" = the followup CLI default
+    key_file: str = ""
 
 
 def service_in_review(
@@ -148,38 +151,61 @@ def service_in_review(
                         continue  # a follow-up job is already queued/running
                 except SlurmQueryError:
                     continue  # unknown — do not stack another job
+            # the wake-attempt counter caps follow-up retries too: a responder
+            # that cannot advance its cursors must not burn a session per tick
+            if record.wake_attempts >= MAX_WAKE_ATTEMPTS:
+                log.warning(
+                    "run %s: %d follow-up attempts without progress; not resubmitting",
+                    record.run_id,
+                    record.wake_attempts,
+                )
+                continue
             if dry_run:
                 submitted.append((record.run_id, "dry-run"))
                 continue
-            command = quote_command(
-                [
-                    "uv",
-                    "run",
-                    "python",
-                    "-m",
-                    "autoresearch.followup",
-                    "--run-root",
-                    str(spec.run_root),
-                    "--run-id",
-                    record.run_id,
-                    "--image",
-                    spec.image,
-                    "--bot-login",
-                    spec.bot_login,
-                ]
-            )
+            argv = [
+                "uv",
+                "run",
+                "python",
+                "-m",
+                "autoresearch.followup",
+                "--run-root",
+                str(spec.run_root),
+                "--run-id",
+                record.run_id,
+                "--image",
+                spec.image,
+                "--bot-login",
+                spec.bot_login,
+            ]
+            if spec.pat_file:
+                argv += ["--pat-file", spec.pat_file]
+            if spec.key_file:
+                argv += ["--key-file", spec.key_file]
+            command = quote_command(argv)
             job_id = compute.submit(
                 JobSpec(
                     job_name=f"followup-{record.run_id}"[:60],
                     account=spec.account,
                     partition=spec.partition,
                     time_minutes=spec.time_minutes,
-                    command=f"cd {spec.home} && {command}",
+                    command=f"cd {quote_command([str(spec.home)])} && {command}",
                     cpus=4,
                     mem="8G",
                 )
             )
-            save_record(root, replace(record, followup_job_id=job_id), now)
+            # read-modify-write on the FRESH record: the submitted job may
+            # already be saving its own fields
+            latest = load_record(root, record.run_id)
+            save_record(
+                root,
+                replace(
+                    latest,
+                    followup_job_id=job_id,
+                    wake_attempts=latest.wake_attempts + 1,
+                ),
+                now,
+            )
             submitted.append((record.run_id, job_id))
         except (SlurmError, Exception) as exc:
             log.warning("in-review service failed for %s: %s", record.run_id, exc)
@@ -482,6 +508,8 @@ def main() -> int:
                 run_root=args.root,
                 image=image,
                 home=Path(home),
+                pat_file=pat_file,
+                key_file=os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE", ""),
             )
         except Exception as exc:
             log.warning("in-review servicing disabled: %s", exc)

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -19,11 +19,21 @@ import os
 import socket
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
-from autoresearch.compute import GONE, SlurmCompute, SlurmQueryError, is_pending, is_terminal
+from autoresearch.compute import (
+    GONE,
+    JobSpec,
+    SlurmCompute,
+    SlurmError,
+    SlurmQueryError,
+    is_pending,
+    is_terminal,
+    quote_command,
+)
 from autoresearch.runstate import (
     ENDED,
+    IN_REVIEW,
     MAX_WAKE_ATTEMPTS,
     STUCK,
     WAITING,
@@ -85,6 +95,95 @@ class TickReport:
     deferred: tuple[str, ...] = ()  # runs skipped on "Slurm unknown"
     reaped_leases: tuple[str, ...] = ()
     stuck: tuple[str, ...] = ()
+    review_ended: tuple[tuple[str, str], ...] = ()  # (run_id, ending)
+    followups_submitted: tuple[tuple[str, str], ...] = ()  # (run_id, job_id)
+
+
+@dataclass(frozen=True)
+class FollowupSpec:
+    """How the tick launches follow-up jobs for in-review runs."""
+
+    account: str
+    partition: str
+    run_root: Path
+    image: str
+    home: Path  # AUTORESEARCH_HOME: cwd for the submitted job
+    bot_login: str = "agentic-learning-bot"
+    time_minutes: int = 60
+
+
+def service_in_review(
+    root: Path,
+    github: Any,  # GitHubClient (Any keeps tick importable without github deps)
+    compute: SlurmCompute,
+    spec: FollowupSpec,
+    now: float,
+    dry_run: bool = False,
+) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
+    """PR-state transitions + follow-up job submission for in-review runs.
+
+    The tick only READS GitHub here (cheap, every cycle); the session-running
+    work happens in a submitted job, which takes the run lease itself — a
+    duplicate submission no-ops on the lease, and `followup_job_id` keeps the
+    tick from queueing duplicates in the first place.
+    """
+    from autoresearch.followup import close_if_done, has_new_comments
+
+    ended: list[tuple[str, str]] = []
+    submitted: list[tuple[str, str]] = []
+    for record in list_runs(root):
+        if record.state != IN_REVIEW or not record.pr_url:
+            continue
+        try:
+            ending = close_if_done(root, record, github, now)
+            if ending:
+                ended.append((record.run_id, ending))
+                continue
+            if not has_new_comments(record, github, spec.bot_login):
+                continue
+            if record.followup_job_id:
+                try:
+                    state = compute.status(record.followup_job_id)
+                    if not (is_terminal(state) or state == GONE):
+                        continue  # a follow-up job is already queued/running
+                except SlurmQueryError:
+                    continue  # unknown — do not stack another job
+            if dry_run:
+                submitted.append((record.run_id, "dry-run"))
+                continue
+            command = quote_command(
+                [
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "autoresearch.followup",
+                    "--run-root",
+                    str(spec.run_root),
+                    "--run-id",
+                    record.run_id,
+                    "--image",
+                    spec.image,
+                    "--bot-login",
+                    spec.bot_login,
+                ]
+            )
+            job_id = compute.submit(
+                JobSpec(
+                    job_name=f"followup-{record.run_id}"[:60],
+                    account=spec.account,
+                    partition=spec.partition,
+                    time_minutes=spec.time_minutes,
+                    command=f"cd {spec.home} && {command}",
+                    cpus=4,
+                    mem="8G",
+                )
+            )
+            save_record(root, replace(record, followup_job_id=job_id), now)
+            submitted.append((record.run_id, job_id))
+        except (SlurmError, Exception) as exc:
+            log.warning("in-review service failed for %s: %s", record.run_id, exc)
+    return ended, submitted
 
 
 def write_heartbeat(root: Path, now: float) -> None:
@@ -307,6 +406,9 @@ def tick(
     grace_s: float = DEFAULT_GRACE_S,
     lease_ttl_s: float = DEFAULT_LEASE_TTL_S,
     dry_run: bool = False,
+    github: Any = None,
+    followup_spec: FollowupSpec | None = None,
+    followup_dry_run: bool = False,
 ) -> TickReport:
     """One full tick. Pause sentinel wins over everything: a paused loop
     heartbeats (so the watchdog stays quiet) but touches nothing."""
@@ -314,7 +416,21 @@ def tick(
     if (root / PAUSE_SENTINEL).exists():
         log.info("pause sentinel present; tick is a no-op")
         return TickReport(paused=True)
-    return sweep(root, compute, dispatcher, now, grace_s, lease_ttl_s, dry_run=dry_run)
+    report = sweep(root, compute, dispatcher, now, grace_s, lease_ttl_s, dry_run=dry_run)
+    if github is not None and followup_spec is not None:
+        ended, submitted = service_in_review(
+            root, github, compute, followup_spec, now, dry_run=followup_dry_run
+        )
+        report = replace_report(report, ended, submitted)
+    return report
+
+
+def replace_report(
+    report: TickReport, ended: list[tuple[str, str]], submitted: list[tuple[str, str]]
+) -> TickReport:
+    from dataclasses import replace as dc_replace
+
+    return dc_replace(report, review_ended=tuple(ended), followups_submitted=tuple(submitted))
 
 
 @dataclass
@@ -340,8 +456,38 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     args.root.mkdir(parents=True, exist_ok=True)
-    # dry_run until the phase-5 dispatcher exists: the live loop must not
-    # mutate run state it cannot follow through on.
+    # The waiting-run sweep stays dry until the experiment dispatcher lands;
+    # in-review servicing is LIVE when credentials + image are available in
+    # the chain environment.
+    import os
+
+    github = None
+    followup_spec = None
+    pat_file = os.environ.get("AUTORESEARCH_PAT_FILE", "")
+    account = os.environ.get("AUTORESEARCH_ACCOUNT", "")
+    partition = os.environ.get("AUTORESEARCH_PARTITION", "")
+    image = os.environ.get(
+        "AUTORESEARCH_IMAGE",
+        os.path.expanduser("~/autoresearch-images/agent-py312.sif"),
+    )
+    home = os.environ.get("AUTORESEARCH_HOME", "")
+    if pat_file and account and partition and home and Path(image).is_file():
+        from autoresearch.github import FileTokenProvider, GitHubClient
+
+        try:
+            github = GitHubClient(auth=FileTokenProvider(Path(pat_file)))
+            followup_spec = FollowupSpec(
+                account=account,
+                partition=partition,
+                run_root=args.root,
+                image=image,
+                home=Path(home),
+            )
+        except Exception as exc:
+            log.warning("in-review servicing disabled: %s", exc)
+    else:
+        log.info("in-review servicing disabled (missing env/creds/image)")
+
     report = tick(
         args.root,
         SlurmCompute(),
@@ -350,15 +496,21 @@ def main() -> int:
         grace_s=args.grace_s,
         lease_ttl_s=args.lease_ttl_s,
         dry_run=True,
+        github=github,
+        followup_spec=followup_spec,
+        followup_dry_run=False,
     )
     log.info(
-        "tick done: paused=%s swept=%d woken=%d deferred=%d reaped=%d stuck=%d",
+        "tick done: paused=%s swept=%d woken=%d deferred=%d reaped=%d stuck=%d "
+        "review_ended=%s followups=%s",
         report.paused,
         report.swept,
         len(report.woken),
         len(report.deferred),
         len(report.reaped_leases),
         len(report.stuck),
+        report.review_ended,
+        report.followups_submitted,
     )
     return 0
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -402,7 +402,7 @@ def test_cli_grace_flag_reaches_the_sweep(tmp_path: Path, monkeypatch) -> None:
 
     real_tick = tick_mod.tick
 
-    def spy(root, compute, dispatcher, now, grace_s=0, lease_ttl_s=0, dry_run=False):
+    def spy(root, compute, dispatcher, now, grace_s=0, lease_ttl_s=0, dry_run=False, **kw):
         captured["grace_s"] = grace_s
         return real_tick(root, compute, dispatcher, now, grace_s, lease_ttl_s, dry_run)
 
@@ -411,3 +411,101 @@ def test_cli_grace_flag_reaches_the_sweep(tmp_path: Path, monkeypatch) -> None:
     monkeypatch.setattr(sys, "argv", ["tick", "--root", str(tmp_path), "--grace-s", "1"])
     assert tick_mod.main() == 0
     assert captured["grace_s"] == 1.0
+
+
+def test_service_in_review_submits_followup_once(tmp_path: Path) -> None:
+    """Comment present → one job submitted, recorded; second tick skips while
+    that job is queued/running."""
+    from autoresearch.compute import CommandResult
+    from autoresearch.runstate import IN_REVIEW, RunRecord, save_record
+    from autoresearch.tick import FollowupSpec, service_in_review
+
+    record = RunRecord(
+        run_id="r-rev",
+        target="org/pilot",
+        task_title="improve tsp",
+        benchmark="tsp",
+        state=IN_REVIEW,
+        pr_url="https://github.com/org/pilot/pull/6",
+    )
+    save_record(tmp_path, record, now=NOW)
+
+    class G:
+        def get_pull_request(self, repo, number):
+            return {"state": "open", "merged": False}
+
+        def list_comments(self, repo, number, max_pages=20):
+            return [
+                {
+                    "id": 9,
+                    "body": "explain",
+                    "user": {"login": "renmengye"},
+                    "author_association": "MEMBER",
+                }
+            ]
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return []
+
+    submits = []
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            submits.append(list(argv))
+            return CommandResult(0, "4242\n", "")
+        if argv[0] == "sacct":
+            return CommandResult(0, "RUNNING\n", "")
+        raise AssertionError(argv)
+
+    compute = SlurmCompute(runner=runner)
+    spec = FollowupSpec(
+        account="acct",
+        partition="cpu_short",
+        run_root=tmp_path,
+        image="/img/a.sif",
+        home=Path("/home/x/autoresearch"),
+    )
+    _ended, submitted = service_in_review(tmp_path, G(), compute, spec, NOW)
+    assert submitted == [("r-rev", "4242")]
+    assert any("autoresearch.followup" in a for a in submits[0])
+    from autoresearch.runstate import load_record as lr
+
+    assert lr(tmp_path, "r-rev").followup_job_id == "4242"
+    # second pass: job RUNNING → no duplicate
+    _ended2, submitted2 = service_in_review(tmp_path, G(), compute, spec, NOW + 60)
+    assert submitted2 == []
+
+
+def test_service_in_review_ends_merged_runs(tmp_path: Path) -> None:
+    from autoresearch.runstate import IN_REVIEW, RunRecord, load_record, save_record
+    from autoresearch.tick import FollowupSpec, service_in_review
+
+    record = RunRecord(
+        run_id="r-m",
+        target="org/pilot",
+        task_title="improve tsp",
+        benchmark="tsp",
+        state=IN_REVIEW,
+        pr_url="https://github.com/org/pilot/pull/7",
+    )
+    save_record(tmp_path, record, now=NOW)
+
+    class G:
+        def get_pull_request(self, repo, number):
+            return {"state": "closed", "merged": True}
+
+    spec = FollowupSpec(
+        account="a", partition="p", run_root=tmp_path, image="/i.sif", home=Path("/h")
+    )
+
+    def unused_runner(argv, timeout_s):
+        raise AssertionError("no slurm calls expected")
+
+    ended, _submitted = service_in_review(
+        tmp_path, G(), SlurmCompute(runner=unused_runner), spec, NOW
+    )
+    assert ended == [("r-m", "merged")]
+    assert load_record(tmp_path, "r-m").ending == "merged"


### PR DESCRIPTION
Closes the manual gap for the live comment test: each tick cheaply reads every in-review run's PR (state + all three comment surfaces); merge/close ends the run, and new qualifying comments submit a cpu_short follow-up job running `autoresearch.followup`. Duplicate protection is two-layer: `followup_job_id` keeps the tick from stacking jobs, and the responder's run lease no-ops any concurrent invocation. The chain script now passes AUTORESEARCH_PAT_FILE through to the tick (GitHub reads + job submission happen orchestrator-side; sessions remain scrubbed by the harness env allowlist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)