### PR TITLE
Brief: tell the agent the orchestrator owns publish

### DIFF
--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -208,9 +208,14 @@ def render(brief: SessionBrief) -> str:
         "",
         "# Ground rules",
         "Work only within the contract's allowed paths. One hypothesis, one "
-        "change-set. When done (or blocked), write a short research report: "
-        "hypothesis, what you did, outcome with numbers, takeaways, and the "
-        "most promising next step. A negative result reported clearly is a "
+        "change-set. Do NOT commit, push, or open PRs: when your session "
+        "ends, the orchestrator scope-checks your working tree, re-measures "
+        "the benchmark itself, and publishes the branch, PR, and progress "
+        "records (BENCHMARKS.md and the leader ledger — never edit those; "
+        "they update after your session from orchestrator measurements). "
+        "When done (or blocked), write a short research report: hypothesis, "
+        "what you did, outcome with numbers, takeaways, and the most "
+        "promising next step. A negative result reported clearly is a "
         "success.",
     ]
     return "\n".join(parts)

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -226,8 +226,9 @@ def live_climb(
             # orchestrator-written progress files are the only exemption.
             ws.commit_all(
                 f"agent: improve {config.benchmark} "
-                f"({_title_pair(result.baseline, result.candidate)})",
-                author=config.agent_id,
+                f"({_title_pair(result.baseline, result.candidate)})"
+                f"\n\nAgent: {config.agent_id}",
+                author=config.bot_login,
                 forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
             )
             ws.push(branch)

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -310,8 +310,9 @@ def _respond(
                     write_progress(workspace, entries, record.target)
                     branch = _current_branch(ws)
                     ws.commit_all(
-                        f"agent: address review feedback ({bench.metric}={candidate:.6g})",
-                        author=record.agent_id,
+                        f"agent: address review feedback ({bench.metric}={candidate:.6g})"
+                        f"\n\nAgent: {record.agent_id}",
+                        author=bot_login,
                         forbidden=lambda p: (
                             p not in PROGRESS_PATHS and bool(out_of_scope([p], contract))
                         ),

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -186,6 +186,10 @@ class ClimbConfig:
     benchmark: str  # the ONE benchmark this loop works on
     branch_prefix: str = "feat/auto/agent-01"
     agent_id: str = "agent-01"
+    # Commits are AUTHORED as the bot account (a real GitHub identity):
+    # a bare "agent-01" noreply address links to whoever owns that login.
+    # The agent id lives in a commit trailer instead.
+    bot_login: str = "agentic-learning-bot"
     # relative improvement below this is noise, not a PR (ε is contract-
     # configurable later; this is the loop-side floor)
     min_relative_improvement: float = 0.005

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -514,7 +514,19 @@ def main() -> int:
         except Exception as exc:
             log.warning("in-review servicing disabled: %s", exc)
     else:
-        log.info("in-review servicing disabled (missing env/creds/image)")
+        absent = [
+            name
+            for name, value in [
+                ("AUTORESEARCH_PAT_FILE", pat_file),
+                ("AUTORESEARCH_ACCOUNT", account),
+                ("AUTORESEARCH_PARTITION", partition),
+                ("AUTORESEARCH_HOME", home),
+            ]
+            if not value
+        ]
+        if not Path(image).is_file():
+            absent.append(f"image:{image}")
+        log.info("in-review servicing disabled (missing: %s)", ", ".join(absent))
 
     report = tick(
         args.root,


### PR DESCRIPTION
The sokoban run's report spent its close hedging ('the change is uncommitted — tell me if you want a PR'; 'BENCHMARKS.md still lists 0.25, outside my scope') — both correct behaviors it didn't know were by design. The ground rules now state: never commit/push/PR (the orchestrator publishes after scope-check + re-measurement) and progress files update post-session from orchestrator measurements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)