### PR TITLE
Requested lane: issue intake → climb → report back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- The requested lane: maintainer issues on the target repo become runs. The
+  tick claims at most one qualifying issue per cycle (standing-gated,
+  single-benchmark-named, claim-marker deduped); the issue text enters the
+  brief data-fenced, the PR says "Addresses #N", and the run report lands
+  back on the issue thread.
+
 - The tick now services in-review runs automatically: PR merge/close ends the
   run; new qualifying review comments submit a follow-up job that wakes the
   authoring session (lease-guarded; `followup_job_id` prevents duplicate

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -138,12 +138,17 @@ def live_climb(
     if issue_number:
         from autoresearch.intake import CLAIM_MARKER
 
-        github.comment(
-            config.target,
-            issue_number,
-            f"{CLAIM_MARKER}\nPicked up as run `{run_id}` "
-            f"(benchmark `{config.benchmark}`). A report will follow here.",
+        already = any(
+            CLAIM_MARKER in str(c.get("body", ""))
+            for c in github.list_comments(config.target, issue_number)
         )
+        if not already:  # manual CLI runs claim here; tick-submitted runs claimed at submit
+            github.comment(
+                config.target,
+                issue_number,
+                f"{CLAIM_MARKER}\nPicked up as run `{run_id}` "
+                f"(benchmark `{config.benchmark}`). A report will follow here.",
+            )
 
     try:
         result = climb_once(
@@ -246,6 +251,9 @@ def live_climb(
             )
             ws.push(branch)
             pushed = True
+            body = pr_body(result, config, redact_secrets=secrets)
+            if issue_number:
+                body = f"Addresses #{issue_number}.\n\n{body}"
             pr_url = github.create_pull(
                 config.target,
                 # short precision in the title; full precision lives in the
@@ -254,7 +262,7 @@ def live_climb(
                 f"{_title_pair(result.baseline, result.candidate)}",
                 head=branch,
                 base=base_branch,
-                body=pr_body(result, config, redact_secrets=secrets),
+                body=body,
             )
             final = RunRecord(
                 **{
@@ -298,6 +306,17 @@ def live_climb(
             }
         )
     save_record(run_root, final, now)
+    if issue_number:
+        summary = redact(result.report(config, redact_secrets=secrets), secrets)[:8000]
+        link = f"\n\nPull request: {pr_url}" if pr_url else ""
+        try:
+            github.comment(
+                config.target,
+                issue_number,
+                f"Run `{run_id}` finished ({outcome_name}).{link}\n\n{summary}",
+            )
+        except Exception as exc:
+            log.warning("could not report to issue #%s: %s", issue_number, exc)
     log.info("run %s: %s %s", run_id, outcome_name, pr_url)
     return LiveClimbOutcome(
         run_id=run_id,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -99,6 +99,8 @@ def live_climb(
     created: str,
     secrets: tuple[str, ...] = (),
     base_branch: str = "main",
+    issue_number: int = 0,
+    task_hypothesis: str = "",
 ) -> LiveClimbOutcome:
     """Run one climb against the real target repo."""
     run_dir = run_root / "runs" / run_id
@@ -130,8 +132,18 @@ def live_climb(
         state="implementing",
         agent_id=config.agent_id,
         deadline=now + 24 * 3600,
+        issue_number=issue_number,
     )
     save_record(run_root, record, now)
+    if issue_number:
+        from autoresearch.intake import CLAIM_MARKER
+
+        github.comment(
+            config.target,
+            issue_number,
+            f"{CLAIM_MARKER}\nPicked up as run `{run_id}` "
+            f"(benchmark `{config.benchmark}`). A report will follow here.",
+        )
 
     try:
         result = climb_once(
@@ -143,6 +155,7 @@ def live_climb(
             ruler=RULER,
             changed_paths=changed_paths,
             created=created,
+            task_hypothesis=task_hypothesis,
         )
     except Exception as exc:
         log.warning(
@@ -318,6 +331,10 @@ def main() -> int:
     parser.add_argument(
         "--key-file", default=os.path.expanduser("~/.config/autoresearch/harness_key")
     )
+    parser.add_argument("--issue", type=int, default=0)
+    parser.add_argument(
+        "--hypothesis-b64", default="", help="base64 task hypothesis (issue text, fenced)"
+    )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     if not args.image and not args.uncontained:
@@ -346,6 +363,12 @@ def main() -> int:
         now=time.time(),
         created=datetime.now(UTC).isoformat(),
         secrets=(api_key, bot_auth.token()),
+        issue_number=args.issue,
+        task_hypothesis=(
+            __import__("base64").b64decode(args.hypothesis_b64).decode()
+            if args.hypothesis_b64
+            else ""
+        ),
     )
     print(f"outcome={outcome.outcome} pr={outcome.pr_url or '-'} report={outcome.report_path}")
     return 0

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -220,6 +220,15 @@ class GitHubClient:
             raise GitHubError(200, path, f"no PR number in response: {data.get('message')}")
         return int(data["number"])
 
+    def get_issue(self, repo: str, number: int) -> dict[str, Any]:
+        path = f"/repos/{urllib.parse.quote(repo)}/issues/{number}"
+        return self._expect_dict(self._request("GET", path), path)
+
+    def list_open_issues(self, repo: str, max_pages: int = 3) -> list[dict[str, Any]]:
+        """Open issues (PRs excluded — the issues API mixes them in)."""
+        items = self._paginate(f"/repos/{urllib.parse.quote(repo)}/issues", max_pages)
+        return [i for i in items if "pull_request" not in i]
+
     def create_pull(
         self, repo: str, title: str, head: str, base: str, body: str, draft: bool = False
     ) -> str:

--- a/src/autoresearch/intake.py
+++ b/src/autoresearch/intake.py
@@ -1,0 +1,89 @@
+"""The requested lane: maintainer issues become runs.
+
+An open issue on the target repo qualifies when its author carries repo
+standing (same association gate as review comments). The tick claims at most
+one per cycle by commenting a claim marker, then submits a climb job whose
+task carries the issue text data-fenced; the resulting PR references the
+issue, and the run's report lands back on the issue thread — the loop closes
+with whoever asked (docs/design/architecture.md, "The life of a run").
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from autoresearch.brief import MAX_TASK_CHARS, _cap, _fence
+from autoresearch.contract import Contract
+from autoresearch.followup import QUALIFYING_ASSOCIATIONS
+
+log = logging.getLogger(__name__)
+
+CLAIM_MARKER = "<!-- autoresearch:claimed -->"
+
+
+@dataclass(frozen=True)
+class IssueTask:
+    number: int
+    title: str
+    body: str
+    author: str
+    benchmark: str  # inferred from the issue text against the contract
+
+
+def infer_benchmark(text: str, contract: Contract) -> str:
+    """The single contract benchmark the issue names, or "" if not exactly
+    one — ambiguity is a human problem, not a guess."""
+    lowered = text.casefold()
+    named = [b.name for b in contract.benchmarks if b.name.casefold() in lowered]
+    return named[0] if len(named) == 1 else ""
+
+
+def qualifying_issue(issue: dict, bot_login: str) -> bool:
+    author = str((issue.get("user") or {}).get("login", ""))
+    if author.casefold() == bot_login.casefold():
+        return False
+    if str(issue.get("author_association", "")) not in QUALIFYING_ASSOCIATIONS:
+        return False
+    return bool(str(issue.get("title") or "").strip())
+
+
+def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTask | None:
+    """The oldest qualifying, unclaimed issue that names exactly one
+    benchmark. At most one — intake is deliberately slow."""
+    issues = sorted(github.list_open_issues(repo), key=lambda i: i.get("number", 0))
+    for issue in issues:
+        if not qualifying_issue(issue, bot_login):
+            continue
+        number = int(issue["number"])
+        if any(CLAIM_MARKER in str(c.get("body", "")) for c in github.list_comments(repo, number)):
+            continue  # already claimed by a run
+        text = f"{issue.get('title', '')}\n{issue.get('body') or ''}"
+        benchmark = infer_benchmark(text, contract)
+        if not benchmark:
+            log.info("issue #%s names zero or several benchmarks; skipping", number)
+            continue
+        return IssueTask(
+            number=number,
+            title=str(issue.get("title") or ""),
+            body=str(issue.get("body") or ""),
+            author=str((issue.get("user") or {}).get("login", "")),
+            benchmark=benchmark,
+        )
+    return None
+
+
+def issue_hypothesis(task: IssueTask) -> str:
+    """The task text for the brief: the maintainer's ask, data-fenced.
+
+    The author passed the standing gate, so the REQUEST is legitimate; the
+    fence marks where quoted text ends and the harness's authority resumes.
+    """
+    quoted = _cap(f"{task.title}\n\n{task.body}".strip(), MAX_TASK_CHARS - 400)
+    fence = _fence(quoted)
+    return (
+        f"A maintainer (@{task.author}) opened issue #{task.number} requesting "
+        f"work on the `{task.benchmark}` benchmark. Their request:\n"
+        f"{fence}\n{quoted}\n{fence}\n"
+        "Address the request's substance within the contract's rules."
+    )

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -277,11 +277,14 @@ def improved(baseline: float, candidate: float, direction: str, min_rel: float) 
     return rel >= min_rel if direction == "max" else rel <= -min_rel
 
 
-def make_task(contract: Contract, benchmark_name: str, baseline: float) -> Task:
+def make_task(
+    contract: Contract, benchmark_name: str, baseline: float, hypothesis: str = ""
+) -> Task:
     bench = _benchmark(contract, benchmark_name)
     better = "up" if bench.direction == "max" else "down"
     return Task(
-        hypothesis=(
+        hypothesis=hypothesis
+        or (
             f"The {bench.name} solver can be improved: study the current "
             f"implementation and the evaluation, form ONE concrete hypothesis "
             f"for why it underperforms, and implement it."
@@ -306,6 +309,7 @@ def climb_once(
     lessons: str = "",
     recent_reports: tuple[str, ...] = (),
     created: str = "",
+    task_hypothesis: str = "",
 ) -> ClimbResult:
     """One implement→evaluate→verify cycle in an existing clean workspace.
 
@@ -326,7 +330,7 @@ def climb_once(
     except EvalError as exc:
         return ClimbResult(outcome="eval-error", note=f"baseline: {exc}")
 
-    task = make_task(contract, config.benchmark, baseline)
+    task = make_task(contract, config.benchmark, baseline, hypothesis=task_hypothesis)
     brief = build_brief(
         BriefInputs(
             task=task,

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -69,6 +69,7 @@ class RunRecord:
     last_review_id: int = 0
     last_review_comment_id: int = 0
     followup_job_id: str = ""  # slurm job servicing this run's review comments
+    issue_number: int = 0  # the requesting issue, when the requested lane started this run
     wake_attempts: int = 0
     deadline: float = 0.0  # unix; submit+walltime+slack, re-based on start
     terminal_seen: float = 0.0  # when the sweep first saw the experiment terminal

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -500,6 +500,16 @@ def service_intake(
             return None
         if dry_run:
             return (f"issue-{task.number}", "dry-run")
+        # claim BEFORE submit: Slurm queueing can take minutes, and the next
+        # tick must not re-claim the same issue in that window
+        from autoresearch.intake import CLAIM_MARKER
+
+        github.comment(
+            target,
+            task.number,
+            f"{CLAIM_MARKER}\nClaimed for benchmark `{task.benchmark}`; a run "
+            "is queued and a report will follow here.",
+        )
         import base64 as _b64
 
         hypothesis_b64 = _b64.b64encode(issue_hypothesis(task).encode()).decode()

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -98,6 +98,7 @@ class TickReport:
     stuck: tuple[str, ...] = ()
     review_ended: tuple[tuple[str, str], ...] = ()  # (run_id, ending)
     followups_submitted: tuple[tuple[str, str], ...] = ()  # (run_id, job_id)
+    intake: tuple[str, str] = ("", "")  # (issue tag, job_id) when one was claimed
 
 
 @dataclass(frozen=True)
@@ -113,6 +114,7 @@ class FollowupSpec:
     time_minutes: int = 60
     pat_file: str = ""  # forwarded to the job; "" = the followup CLI default
     key_file: str = ""
+    target: str = ""  # the repo the intake pass scans for requested-lane issues
 
 
 def service_in_review(
@@ -447,16 +449,99 @@ def tick(
         ended, submitted = service_in_review(
             root, github, compute, followup_spec, now, dry_run=followup_dry_run
         )
-        report = replace_report(report, ended, submitted)
+        intake_job = service_intake(
+            root, github, compute, followup_spec, now, dry_run=followup_dry_run
+        )
+        report = replace_report(report, ended, submitted, intake_job)
     return report
 
 
 def replace_report(
-    report: TickReport, ended: list[tuple[str, str]], submitted: list[tuple[str, str]]
+    report: TickReport,
+    ended: list[tuple[str, str]],
+    submitted: list[tuple[str, str]],
+    intake_job: tuple[str, str] | None = None,
 ) -> TickReport:
     from dataclasses import replace as dc_replace
 
-    return dc_replace(report, review_ended=tuple(ended), followups_submitted=tuple(submitted))
+    return dc_replace(
+        report,
+        review_ended=tuple(ended),
+        followups_submitted=tuple(submitted),
+        intake=intake_job or ("", ""),
+    )
+
+
+def service_intake(
+    root: Path,
+    github: Any,
+    compute: SlurmCompute,
+    spec: FollowupSpec,
+    now: float,
+    dry_run: bool = False,
+) -> tuple[str, str] | None:
+    """The requested lane: claim at most ONE qualifying issue per tick and
+    submit a climb job for it. The claim comment (posted by the climb job
+    before its session) marks an issue taken; one-per-tick keeps a burst of
+    issues from bursting the budget."""
+    from autoresearch.contract import load_contract
+    from autoresearch.intake import issue_hypothesis, pick_issue
+
+    target = spec.target
+    if not target:
+        return None
+    try:
+        contract_raw = github.get_file_content(target, ".autoresearch.yaml", "main")
+        if contract_raw is None:
+            return None
+        contract = load_contract(contract_raw, target)
+        task = pick_issue(github, target, contract, spec.bot_login)
+        if task is None:
+            return None
+        if dry_run:
+            return (f"issue-{task.number}", "dry-run")
+        import base64 as _b64
+
+        hypothesis_b64 = _b64.b64encode(issue_hypothesis(task).encode()).decode()
+        argv = [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "autoresearch.climb",
+            "--target",
+            target,
+            "--benchmark",
+            task.benchmark,
+            "--run-root",
+            str(spec.run_root),
+            "--image",
+            spec.image,
+            "--issue",
+            str(task.number),
+            "--hypothesis-b64",
+            hypothesis_b64,
+        ]
+        if spec.pat_file:
+            argv += ["--pat-file", spec.pat_file]
+        if spec.key_file:
+            argv += ["--key-file", spec.key_file]
+        job_id = compute.submit(
+            JobSpec(
+                job_name=f"climb-issue-{task.number}",
+                account=spec.account,
+                partition=spec.partition,
+                time_minutes=90,
+                command=f"cd {quote_command([str(spec.home)])} && {quote_command(argv)}",
+                cpus=4,
+                mem="8G",
+            )
+        )
+        log.info("issue #%s claimed for climb job %s", task.number, job_id)
+        return (f"issue-{task.number}", job_id)
+    except Exception as exc:  # intake must not break the tick
+        log.warning("intake pass failed: %s", exc)
+        return None
 
 
 @dataclass
@@ -510,6 +595,9 @@ def main() -> int:
                 home=Path(home),
                 pat_file=pat_file,
                 key_file=os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE", ""),
+                target=os.environ.get(
+                    "AUTORESEARCH_TARGET", "agentic-learning-ai-lab/autoresearch-pilot"
+                ),
             )
         except Exception as exc:
             log.warning("in-review servicing disabled: %s", exc)

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -504,3 +504,40 @@ def test_title_pair_never_renders_identical() -> None:
     assert _title_pair(13.875696168157484, 10.844662077277105) == "13.88 -> 10.84"
     assert _title_pair(10.00001, 10.00002) == "10.00001 -> 10.00002"
     assert " -> " in _title_pair(1e-7, 2e-7)
+
+
+def test_issue_run_references_issue_and_reports_back(tmp_path, target_repo) -> None:
+    """The requested lane's visible loop: claim → Addresses #N → report."""
+
+    @dataclass
+    class CommentingGitHub(FakeGitHub):
+        issue_comments: list = field(default_factory=list)
+
+        def comment(self, repo, number, body):
+            self.issue_comments.append((number, body))
+
+        def list_comments(self, repo, number, max_pages=20):
+            return []
+
+    github = CommentingGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-iss",
+        harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "i=1\n"}),
+        evaluator=QueueEvaluator(values=[13.876, 13.1]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="2026-08-07T00:00:00Z",
+        issue_number=42,
+        task_hypothesis="A maintainer asked: make tsp faster (fenced text here)",
+    )
+    assert outcome.outcome == "improved"
+    assert "Addresses #42." in github.prs[0]["body"]
+    claim, report = github.issue_comments[0], github.issue_comments[-1]
+    assert claim[0] == 42 and "autoresearch:claimed" in claim[1]
+    assert report[0] == 42 and "finished (improved)" in report[1]
+    assert "pull/1" in report[1]
+    record = load_record(tmp_path / "state", "tsp-iss")
+    assert record.issue_number == 42

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -1,0 +1,90 @@
+"""The requested lane: issues become runs, gated and claimed."""
+
+from __future__ import annotations
+
+from autoresearch.contract import load_contract
+from autoresearch.intake import (
+    CLAIM_MARKER,
+    infer_benchmark,
+    issue_hypothesis,
+    pick_issue,
+    qualifying_issue,
+)
+
+CONTRACT = load_contract(
+    """
+benchmarks:
+  - name: tsp
+    command: c1
+    metric: m1
+    direction: min
+  - name: reach
+    command: c2
+    metric: m2
+    direction: max
+budgets: {gpu_hours_per_run: 1, runs_per_week: 10}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+    "org/pilot",
+)
+
+
+def issue(n, title, body="", assoc="MEMBER", author="renmengye"):
+    return {
+        "number": n,
+        "title": title,
+        "body": body,
+        "author_association": assoc,
+        "user": {"login": author},
+    }
+
+
+class G:
+    def __init__(self, issues, claimed=()):
+        self.issues = issues
+        self.claimed = set(claimed)
+
+    def list_open_issues(self, repo, max_pages=3):
+        return self.issues
+
+    def list_comments(self, repo, number, max_pages=20):
+        if number in self.claimed:
+            return [{"body": f"{CLAIM_MARKER}\nPicked up"}]
+        return []
+
+
+def test_gate_and_benchmark_inference() -> None:
+    assert qualifying_issue(issue(1, "improve reach"), "bot")
+    assert not qualifying_issue(issue(2, "drive-by", assoc="NONE"), "bot")
+    assert not qualifying_issue(issue(3, "self", author="bot"), "bot")
+    assert infer_benchmark("the reach solver stalls", CONTRACT) == "reach"
+    assert infer_benchmark("tsp and reach both bad", CONTRACT) == ""  # ambiguous
+    assert infer_benchmark("nothing named", CONTRACT) == ""
+
+
+def test_pick_oldest_unclaimed_with_one_benchmark() -> None:
+    issues = [
+        issue(5, "reach is weak"),
+        issue(3, "improve tsp", assoc="NONE"),  # unqualified
+        issue(4, "fix reach please"),  # oldest qualified... but claimed
+    ]
+    task = pick_issue(G(issues, claimed={4}), "org/pilot", CONTRACT, "bot")
+    assert task is not None
+    assert task.number == 5
+    assert task.benchmark == "reach"
+
+
+def test_hypothesis_fences_issue_text() -> None:
+    task = pick_issue(
+        G([issue(7, "reach: try a better local planner", "the PD controller ```breaks```")]),
+        "org/pilot",
+        CONTRACT,
+        "bot",
+    )
+    assert task is not None
+    text = issue_hypothesis(task)
+    assert "#7" in text
+    assert "@renmengye" in text
+    assert "````" in text  # fence outruns the backticks in the body
+    assert "better local planner" in text


### PR DESCRIPTION
A maintainer issue on the pilot now starts a run automatically: the tick's intake pass picks the oldest qualifying issue (author-standing gate, must name exactly one contract benchmark — ambiguity is a human problem, not a guess), a claim comment marks it taken, the climb runs with the issue text data-fenced as the task, the PR opens with 'Addresses #N', and the run report posts back on the issue thread win or lose. One intake per tick bounds burst spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)