### PR TITLE
Eval dependency cache on node-local scratch

### DIFF
--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -70,6 +70,7 @@ class SubprocessEvaluator:
         # climb died at baseline on a full tmpfs).
         # Fresh per-EVAL home (never reused): baseline and candidate cannot
         # see each other's writes, and nothing survives to any later run.
+        import os
         import tempfile
 
         try:
@@ -80,20 +81,35 @@ class SubprocessEvaluator:
             )
         except OSError as exc:
             raise EvalError(f"could not create eval home: {exc}") from exc
+        # per-EVAL cache on node-local scratch: local IO (NFS caches flake),
+        # no state crossing evals (agent code runs during the candidate eval
+        # and must not poison later baselines), and only THIS directory is
+        # bound into the container — never the whole host /tmp.
         try:
-            return self._measure(workspace, command, metric, eval_home)
-        finally:
-            # bounded disk: each eval's cache dies with it (re-downloading
-            # wheels per eval is the accepted cost of eval isolation)
+            cache_dir = Path(
+                tempfile.mkdtemp(prefix="uv-cache-", dir=os.environ.get("TMPDIR", "/tmp"))
+            )
+        except OSError as exc:
             import shutil
 
             shutil.rmtree(eval_home, ignore_errors=True)
+            raise EvalError(f"could not create eval cache dir: {exc}") from exc
+        try:
+            return self._measure(workspace, command, metric, eval_home, cache_dir)
+        finally:
+            # bounded disk: each eval's home AND cache die with it
+            # (re-downloading wheels per eval is the accepted isolation cost)
+            import shutil
 
-    def _measure(self, workspace: Path, command: str, metric: str, eval_home: Path) -> float:
+            shutil.rmtree(eval_home, ignore_errors=True)
+            shutil.rmtree(cache_dir, ignore_errors=True)
+
+    def _measure(
+        self, workspace: Path, command: str, metric: str, eval_home: Path, cache_dir: Path
+    ) -> float:
         import os
         import signal
 
-        host_tmp = os.environ.get("TMPDIR", "/tmp")
         if self.container_image:
             argv = [
                 self.apptainer_binary,
@@ -107,7 +123,7 @@ class SubprocessEvaluator:
                 # node-local scratch for uv's cache: the container's own /tmp
                 # is a size-capped tmpfs, and shared-FS caches flake (NFS)
                 "--bind",
-                f"{host_tmp}:{host_tmp}",
+                f"{cache_dir}:{cache_dir}",
                 "--pwd",
                 str(workspace),
                 self.container_image,
@@ -121,7 +137,7 @@ class SubprocessEvaluator:
         # uv's cache does heavy small-file IO; on shared filesystems (NFS)
         # that flakes with stale-handle/copy errors (seen live twice). Keep
         # the cache on node-local scratch and copy across filesystems.
-        env["UV_CACHE_DIR"] = os.path.join(host_tmp, "uv-cache")
+        env["UV_CACHE_DIR"] = str(cache_dir)
         env["UV_LINK_MODE"] = "copy"
         if self.container_image:
             # --cleanenv drops the host env; APPTAINERENV_* survives it

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -93,6 +93,7 @@ class SubprocessEvaluator:
         import os
         import signal
 
+        host_tmp = os.environ.get("TMPDIR", "/tmp")
         if self.container_image:
             argv = [
                 self.apptainer_binary,
@@ -103,6 +104,10 @@ class SubprocessEvaluator:
                 f"{workspace}:{workspace}",
                 "--home",
                 f"{eval_home}:{eval_home}",
+                # node-local scratch for uv's cache: the container's own /tmp
+                # is a size-capped tmpfs, and shared-FS caches flake (NFS)
+                "--bind",
+                f"{host_tmp}:{host_tmp}",
                 "--pwd",
                 str(workspace),
                 self.container_image,
@@ -113,6 +118,15 @@ class SubprocessEvaluator:
         else:
             argv = ["sh", "-c", command]
         env = {k: os.environ[k] for k in ("PATH", "LANG", "TMPDIR") if k in os.environ}
+        # uv's cache does heavy small-file IO; on shared filesystems (NFS)
+        # that flakes with stale-handle/copy errors (seen live twice). Keep
+        # the cache on node-local scratch and copy across filesystems.
+        env["UV_CACHE_DIR"] = os.path.join(host_tmp, "uv-cache")
+        env["UV_LINK_MODE"] = "copy"
+        if self.container_image:
+            # --cleanenv drops the host env; APPTAINERENV_* survives it
+            env["APPTAINERENV_UV_CACHE_DIR"] = env["UV_CACHE_DIR"]
+            env["APPTAINERENV_UV_LINK_MODE"] = "copy"
         env["HOME"] = str(eval_home)
         try:
             # process group, like the harness: a timed-out eval must not

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -340,3 +340,35 @@ def test_leader_best_never_regresses() -> None:
     # a genuinely better run still advances it
     entries = update_leader(entries, "tsp", "m", "min", 13.1, 12.9, "r3", "d3")
     assert entries["tsp"].best == 12.9
+
+
+def test_eval_cache_is_bound_alone_and_cleaned(tmp_path: Path, monkeypatch) -> None:
+    """Only the per-eval cache dir is bound into the container — never the
+    whole host tmp — and it dies with the eval."""
+    import stat as stat_mod
+
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    monkeypatch.setenv("TMPDIR", str(scratch))
+    fake = tmp_path / "apptainer"
+    fake.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s " "$@" > {tmp_path}/eval_argv\n'
+        f"env > {tmp_path}/eval_env\n"
+        "printf '{\"m\": 3.5}\\n'\n"
+    )
+    fake.chmod(fake.stat().st_mode | stat_mod.S_IEXEC)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    evaluator = SubprocessEvaluator(
+        timeout_s=30, container_image="/img/pilot.sif", apptainer_binary=str(fake)
+    )
+    assert evaluator.evaluate(ws, "run", "m") == 3.5
+    argv = (tmp_path / "eval_argv").read_text()
+    assert f"--bind {scratch}/uv-cache-" in argv  # the cache dir, specifically
+    assert f"--bind {scratch}:{scratch}" not in argv  # never the whole tmp
+    seen_env = (tmp_path / "eval_env").read_text()
+    assert "APPTAINERENV_UV_CACHE_DIR=" in seen_env
+    assert list(scratch.glob("uv-cache-*")) == []  # cleaned up after


### PR DESCRIPTION
Issue #7's requested-lane run died at baseline on NFS stale-handle errors during uv wheel extraction in the shared-FS eval home — the same failure class that hit deploys. The uv cache now lives on node-local $TMPDIR (bound into the eval container, since --containall's /tmp is the size-capped tmpfs and --cleanenv drops host vars; APPTAINERENV_ carries them through).

🤖 Generated with [Claude Code](https://claude.com/claude-code)