### PR TITLE
Self-initiated lane: the loop picks its own next climb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Self-initiated lane: when the requested lane claims nothing and no run is
+  active, the tick launches a climb on the least-recently-attempted contract
+  benchmark, within the weekly budget and a per-benchmark cooldown. The
+  planning agent later replaces this picker with motivated, vetoable plans.
+
 - The requested lane: maintainer issues on the target repo become runs. The
   tick claims at most one qualifying issue per cycle (standing-gated,
   single-benchmark-named, claim-marker deduped); the issue text enters the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -104,8 +104,11 @@ the research repos' porting timelines; mistakes are free; adversarial testing
       run contained (Apptainer --containall, workspace + run-home binds only,
       key via APPTAINERENV_ env). Git glue (clone/push/PR wiring) + live
       pilot climb next
-- [ ] Full loop live on the pilot: bounded iterations; PR with results
-      table, one human code-owner approval per merge
+- [x] Full loop live on the pilot (2026-08-07): requested lane (issue #7 →
+      PR #8), in-review follow-up (comment → resumed-author reply), and
+      self-initiated selection (least-recently-attempted, budget + cooldown
+      bounded, one active run per target) all exercised; auto-merge armed by
+      approval for bot PRs
 - [ ] Every run ends with a research report — hypothesis, outcome, takeaways,
       next steps — posted to the PR or the ledger (negative results included)
 - [x] `in-review` follow-up (followup.respond_once + CLI): merge/close →

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -99,6 +99,7 @@ class TickReport:
     review_ended: tuple[tuple[str, str], ...] = ()  # (run_id, ending)
     followups_submitted: tuple[tuple[str, str], ...] = ()  # (run_id, job_id)
     intake: tuple[str, str] = ("", "")  # (issue tag, job_id) when one was claimed
+    self_initiated: tuple[str, str] = ("", "")  # (benchmark, job_id) when one launched
 
 
 @dataclass(frozen=True)
@@ -452,7 +453,24 @@ def tick(
         intake_job = service_intake(
             root, github, compute, followup_spec, now, dry_run=followup_dry_run
         )
-        report = replace_report(report, ended, submitted, intake_job)
+        self_job = None
+        if intake_job is None and followup_spec.target:
+            try:
+                from autoresearch.contract import load_contract
+
+                raw = github.get_file_content(followup_spec.target, ".autoresearch.yaml", "main")
+                if raw is not None:
+                    self_job = service_self_initiated(
+                        root,
+                        compute,
+                        followup_spec,
+                        load_contract(raw, followup_spec.target),
+                        now,
+                        dry_run=followup_dry_run,
+                    )
+            except Exception as exc:
+                log.warning("self-initiated selection failed: %s", exc)
+        report = replace_report(report, ended, submitted, intake_job, self_job)
     return report
 
 
@@ -461,6 +479,7 @@ def replace_report(
     ended: list[tuple[str, str]],
     submitted: list[tuple[str, str]],
     intake_job: tuple[str, str] | None = None,
+    self_job: tuple[str, str] | None = None,
 ) -> TickReport:
     from dataclasses import replace as dc_replace
 
@@ -469,7 +488,93 @@ def replace_report(
         review_ended=tuple(ended),
         followups_submitted=tuple(submitted),
         intake=intake_job or ("", ""),
+        self_initiated=self_job or ("", ""),
     )
+
+
+MAX_ACTIVE_RUNS_PER_TARGET = 1
+SELF_INITIATED_COOLDOWN_S = 6 * 3600
+
+
+def pick_self_initiated(records: list[RunRecord], contract: Any, now: float) -> str | None:
+    """The benchmark to climb next, or None.
+
+    Deliberately boring (the planning agent upgrades this later): serialize
+    to one active run per target, respect the contract's weekly budget and a
+    per-benchmark cooldown, then choose the benchmark least recently
+    attempted — untouched ones first.
+    """
+    active = [r for r in records if r.state != ENDED]
+    if len(active) >= MAX_ACTIVE_RUNS_PER_TARGET:
+        return None
+    week_ago = now - 7 * 24 * 3600
+    if sum(1 for r in records if r.created >= week_ago) >= contract.budgets.runs_per_week:
+        return None
+    last_attempt: dict[str, float] = {}
+    for r in records:
+        if r.benchmark:
+            last_attempt[r.benchmark] = max(last_attempt.get(r.benchmark, 0.0), r.created)
+    candidates = sorted(
+        contract.benchmarks,
+        key=lambda b: (last_attempt.get(b.name, 0.0), b.name),
+    )
+    for bench in candidates:
+        if now - last_attempt.get(bench.name, 0.0) >= SELF_INITIATED_COOLDOWN_S:
+            return str(bench.name)
+    return None
+
+
+def service_self_initiated(
+    root: Path,
+    compute: SlurmCompute,
+    spec: FollowupSpec,
+    contract: Any,
+    now: float,
+    dry_run: bool = False,
+) -> tuple[str, str] | None:
+    """The default background mode: when nothing else needs doing, climb the
+    least-recently-attempted benchmark."""
+    try:
+        benchmark = pick_self_initiated(list_runs(root), contract, now)
+        if benchmark is None:
+            return None
+        if dry_run:
+            return (benchmark, "dry-run")
+        argv = [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "autoresearch.climb",
+            "--target",
+            spec.target,
+            "--benchmark",
+            benchmark,
+            "--run-root",
+            str(spec.run_root),
+            "--image",
+            spec.image,
+        ]
+        if spec.pat_file:
+            argv += ["--pat-file", spec.pat_file]
+        if spec.key_file:
+            argv += ["--key-file", spec.key_file]
+        job_id = compute.submit(
+            JobSpec(
+                job_name=f"climb-{benchmark}"[:60],
+                account=spec.account,
+                partition=spec.partition,
+                time_minutes=90,
+                command=f"cd {quote_command([str(spec.home)])} && {quote_command(argv)}",
+                cpus=4,
+                mem="8G",
+            )
+        )
+        log.info("self-initiated climb on %s: job %s", benchmark, job_id)
+        return (benchmark, job_id)
+    except Exception as exc:  # one bad pass must not break the tick
+        log.warning("self-initiated pass failed: %s", exc)
+        return None
 
 
 def service_intake(

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -33,6 +33,7 @@ from autoresearch.compute import (
 )
 from autoresearch.runstate import (
     ENDED,
+    IMPLEMENTING,
     IN_REVIEW,
     MAX_WAKE_ATTEMPTS,
     STUCK,
@@ -494,26 +495,49 @@ def replace_report(
 
 MAX_ACTIVE_RUNS_PER_TARGET = 1
 SELF_INITIATED_COOLDOWN_S = 6 * 3600
+# An implementing run untouched for this long is a crashed climb job (their
+# walltime is 90 min); it must not block the lane forever. Its cooldown
+# entry still applies, so the crashed benchmark isn't immediately retried.
+STRANDED_IMPLEMENTING_S = 6 * 3600
+# A pending marker older than this is dead even if squeue can't be read.
+PENDING_TTL_S = 4 * 3600
 
 
-def pick_self_initiated(records: list[RunRecord], contract: Any, now: float) -> str | None:
-    """The benchmark to climb next, or None.
+def pick_self_initiated(
+    records: list[RunRecord],
+    contract: Any,
+    target: str,
+    now: float,
+    pending_attempt: tuple[str, float] | None = None,
+) -> str | None:
+    """The benchmark to climb next on `target`, or None.
 
     Deliberately boring (the planning agent upgrades this later): serialize
     to one active run per target, respect the contract's weekly budget and a
     per-benchmark cooldown, then choose the benchmark least recently
-    attempted — untouched ones first.
+    attempted — untouched ones first. Only this target's runs count toward
+    any of it. `pending_attempt` is a (benchmark, submitted_at) from a climb
+    job that died before writing a run record — it counts toward cooldown so
+    a crash loop can't resubmit every tick.
     """
-    active = [r for r in records if r.state != ENDED]
+    mine = [r for r in records if r.target == target]
+
+    def stranded(r: RunRecord) -> bool:
+        return r.state == IMPLEMENTING and now - max(r.updated, r.created) > STRANDED_IMPLEMENTING_S
+
+    active = [r for r in mine if r.state != ENDED and not stranded(r)]
     if len(active) >= MAX_ACTIVE_RUNS_PER_TARGET:
         return None
     week_ago = now - 7 * 24 * 3600
-    if sum(1 for r in records if r.created >= week_ago) >= contract.budgets.runs_per_week:
+    if sum(1 for r in mine if r.created >= week_ago) >= contract.budgets.runs_per_week:
         return None
     last_attempt: dict[str, float] = {}
-    for r in records:
+    for r in mine:
         if r.benchmark:
             last_attempt[r.benchmark] = max(last_attempt.get(r.benchmark, 0.0), r.created)
+    if pending_attempt is not None and pending_attempt[0]:
+        bench_name, submitted_at = pending_attempt
+        last_attempt[bench_name] = max(last_attempt.get(bench_name, 0.0), submitted_at)
     candidates = sorted(
         contract.benchmarks,
         key=lambda b: (last_attempt.get(b.name, 0.0), b.name),
@@ -522,6 +546,32 @@ def pick_self_initiated(records: list[RunRecord], contract: Any, now: float) -> 
         if now - last_attempt.get(bench.name, 0.0) >= SELF_INITIATED_COOLDOWN_S:
             return str(bench.name)
     return None
+
+
+def _pending_path(root: Path, target: str) -> Path:
+    return root / "pending" / (target.replace("/", "__") + ".json")
+
+
+def read_pending(root: Path, target: str) -> dict[str, Any] | None:
+    """The submit-time marker for a climb whose run record may not exist yet."""
+    path = _pending_path(root, target)
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) and "submitted_at" in data else None
+
+
+def write_pending(root: Path, target: str, benchmark: str, job_id: str, now: float) -> None:
+    path = _pending_path(root, target)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps({"benchmark": benchmark, "job_id": job_id, "submitted_at": now}))
+    os.replace(tmp, path)
+
+
+def clear_pending(root: Path, target: str) -> None:
+    _pending_path(root, target).unlink(missing_ok=True)
 
 
 def service_self_initiated(
@@ -533,9 +583,34 @@ def service_self_initiated(
     dry_run: bool = False,
 ) -> tuple[str, str] | None:
     """The default background mode: when nothing else needs doing, climb the
-    least-recently-attempted benchmark."""
+    least-recently-attempted benchmark.
+
+    A pending marker written at submit time bridges the gap between
+    `compute.submit` and the climb job writing its run record — without it,
+    every tick during Slurm queue latency would launch a duplicate climb.
+    """
     try:
-        benchmark = pick_self_initiated(list_runs(root), contract, now)
+        records = list_runs(root)
+        pending = read_pending(root, spec.target)
+        pending_attempt: tuple[str, float] | None = None
+        if pending is not None:
+            submitted_at = float(pending["submitted_at"])
+            landed = any(
+                r.target == spec.target and r.created >= submitted_at - 60 for r in records
+            )
+            expired = now - submitted_at > PENDING_TTL_S
+            if landed:
+                clear_pending(root, spec.target)  # the run record carries it now
+            elif (
+                not expired and _holder_alive(compute, str(pending.get("job_id", ""))) is not False
+            ):
+                return None  # climb queued or starting; its record isn't written yet
+            else:
+                # Died before writing a record. Keep its cooldown so a
+                # crash-at-startup loop can't resubmit every tick.
+                clear_pending(root, spec.target)
+                pending_attempt = (str(pending.get("benchmark", "")), submitted_at)
+        benchmark = pick_self_initiated(records, contract, spec.target, now, pending_attempt)
         if benchmark is None:
             return None
         if dry_run:
@@ -570,6 +645,7 @@ def service_self_initiated(
                 mem="8G",
             )
         )
+        write_pending(root, spec.target, benchmark, job_id, now)
         log.info("self-initiated climb on %s: job %s", benchmark, job_id)
         return (benchmark, job_id)
     except Exception as exc:  # one bad pass must not break the tick

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -509,3 +509,87 @@ def test_service_in_review_ends_merged_runs(tmp_path: Path) -> None:
     )
     assert ended == [("r-m", "merged")]
     assert load_record(tmp_path, "r-m").ending == "merged"
+
+
+def test_self_initiated_selection_rules(tmp_path: Path) -> None:
+    from autoresearch.contract import load_contract
+    from autoresearch.runstate import ENDED, RunRecord, save_record
+    from autoresearch.tick import pick_self_initiated
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+  - {name: denoise, command: c, metric: m, direction: min}
+  - {name: reach, command: c, metric: m, direction: max}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+
+    def rec(run_id, benchmark, created, state=ENDED, ending="negative-result"):
+        r = RunRecord(
+            run_id=run_id,
+            target="org/pilot",
+            task_title="t",
+            benchmark=benchmark,
+            state=state,
+            ending=ending if state == ENDED else "",
+        )
+        save_record(tmp_path, r, now=created)
+        return r
+
+    # empty history → alphabetically-first untouched benchmark
+    assert pick_self_initiated([], contract, now=NOW) == "denoise"
+    # an ACTIVE run serializes: nothing new
+    rec("r1", "tsp", NOW - 100, state="waiting")
+    # waiting run needs deadline etc — build directly instead
+    records = [
+        RunRecord(
+            run_id="a",
+            target="o/p",
+            task_title="t",
+            benchmark="tsp",
+            state="implementing",
+            created=NOW - 100,
+        ),
+    ]
+    assert pick_self_initiated(records, contract, now=NOW) is None
+    # cooldown: recently-attempted benchmark skipped, next-oldest picked
+    records = [
+        RunRecord(
+            run_id="a",
+            target="o/p",
+            task_title="t",
+            benchmark="denoise",
+            state=ENDED,
+            ending="negative-result",
+            created=NOW - 60,
+        ),
+        RunRecord(
+            run_id="b",
+            target="o/p",
+            task_title="t",
+            benchmark="reach",
+            state=ENDED,
+            ending="merged",
+            created=NOW - 8 * 3600,
+        ),
+    ]
+    assert pick_self_initiated(records, contract, now=NOW) == "tsp"
+    # weekly budget: 3 runs in the window → None
+    records = [
+        RunRecord(
+            run_id=f"r{i}",
+            target="o/p",
+            task_title="t",
+            benchmark="tsp",
+            state=ENDED,
+            ending="negative-result",
+            created=NOW - i * 3600,
+        )
+        for i in range(3)
+    ]
+    assert pick_self_initiated(records, contract, now=NOW) is None

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -511,12 +511,10 @@ def test_service_in_review_ends_merged_runs(tmp_path: Path) -> None:
     assert load_record(tmp_path, "r-m").ending == "merged"
 
 
-def test_self_initiated_selection_rules(tmp_path: Path) -> None:
+def _self_contract():
     from autoresearch.contract import load_contract
-    from autoresearch.runstate import ENDED, RunRecord, save_record
-    from autoresearch.tick import pick_self_initiated
 
-    contract = load_contract(
+    return load_contract(
         """
 benchmarks:
   - {name: tsp, command: c, metric: m, direction: min}
@@ -529,67 +527,109 @@ roadmap: docs/roadmap.md
         "org/pilot",
     )
 
-    def rec(run_id, benchmark, created, state=ENDED, ending="negative-result"):
-        r = RunRecord(
-            run_id=run_id,
-            target="org/pilot",
-            task_title="t",
-            benchmark=benchmark,
-            state=state,
-            ending=ending if state == ENDED else "",
-        )
-        save_record(tmp_path, r, now=created)
-        return r
 
-    # empty history → alphabetically-first untouched benchmark
-    assert pick_self_initiated([], contract, now=NOW) == "denoise"
+def _run(run_id, benchmark, created, state=ENDED, ending="negative-result", target="org/pilot"):
+    return RunRecord(
+        run_id=run_id,
+        target=target,
+        task_title="t",
+        benchmark=benchmark,
+        state=state,
+        ending=ending if state == ENDED else "",
+        created=created,
+        updated=created,
+    )
+
+
+def test_self_initiated_selection_rules() -> None:
+    from autoresearch.tick import pick_self_initiated
+
+    contract = _self_contract()
+    pick = lambda records, **kw: pick_self_initiated(records, contract, "org/pilot", now=NOW, **kw)
+
+    # empty history -> alphabetically-first untouched benchmark
+    assert pick([]) == "denoise"
     # an ACTIVE run serializes: nothing new
-    rec("r1", "tsp", NOW - 100, state="waiting")
-    # waiting run needs deadline etc — build directly instead
+    assert pick([_run("a", "tsp", NOW - 100, state="implementing", ending="")]) is None
+    # cooldown: recently-attempted benchmarks skipped, oldest eligible picked
     records = [
-        RunRecord(
-            run_id="a",
-            target="o/p",
-            task_title="t",
-            benchmark="tsp",
-            state="implementing",
-            created=NOW - 100,
-        ),
+        _run("a", "denoise", NOW - 60),
+        _run("b", "reach", NOW - 8 * 3600),
     ]
-    assert pick_self_initiated(records, contract, now=NOW) is None
-    # cooldown: recently-attempted benchmark skipped, next-oldest picked
-    records = [
-        RunRecord(
-            run_id="a",
-            target="o/p",
-            task_title="t",
-            benchmark="denoise",
-            state=ENDED,
-            ending="negative-result",
-            created=NOW - 60,
-        ),
-        RunRecord(
-            run_id="b",
-            target="o/p",
-            task_title="t",
-            benchmark="reach",
-            state=ENDED,
-            ending="merged",
-            created=NOW - 8 * 3600,
-        ),
-    ]
-    assert pick_self_initiated(records, contract, now=NOW) == "tsp"
-    # weekly budget: 3 runs in the window → None
-    records = [
-        RunRecord(
-            run_id=f"r{i}",
-            target="o/p",
-            task_title="t",
-            benchmark="tsp",
-            state=ENDED,
-            ending="negative-result",
-            created=NOW - i * 3600,
-        )
-        for i in range(3)
-    ]
-    assert pick_self_initiated(records, contract, now=NOW) is None
+    assert pick(records) == "tsp"
+    # weekly budget: 3 runs in the window -> None
+    records = [_run(f"r{i}", "tsp", NOW - i * 3600) for i in range(3)]
+    assert pick(records) is None
+    # a pending attempt that died pre-record still counts toward cooldown
+    assert pick([], pending_attempt=("denoise", NOW - 60)) == "reach"
+
+
+def test_self_initiated_scoped_to_target() -> None:
+    from autoresearch.tick import pick_self_initiated
+
+    contract = _self_contract()
+    # active run + full budget on ANOTHER target: neither blocks org/pilot
+    other = [_run(f"o{i}", "tsp", NOW - i * 60, target="org/other") for i in range(3)]
+    other.append(_run("oa", "tsp", NOW - 30, state="implementing", ending="", target="org/other"))
+    assert pick_self_initiated(other, contract, "org/pilot", now=NOW) == "denoise"
+    # while org/other itself is both serialized and over budget
+    assert pick_self_initiated(other, contract, "org/other", now=NOW) is None
+
+
+def test_self_initiated_stranded_implementing_unblocks() -> None:
+    from autoresearch.tick import STRANDED_IMPLEMENTING_S, pick_self_initiated
+
+    contract = _self_contract()
+    stale = STRANDED_IMPLEMENTING_S + 3600
+    dead = _run("d", "tsp", NOW - stale, state="implementing", ending="")
+    # a crashed climb job's record stops counting as active after the window,
+    # but its benchmark keeps its cooldown slot: another one is picked
+    assert pick_self_initiated([dead], contract, "org/pilot", now=NOW) == "denoise"
+    # a FRESH implementing run still serializes
+    fresh = _run("f", "tsp", NOW - 60, state="implementing", ending="")
+    assert pick_self_initiated([fresh], contract, "org/pilot", now=NOW) is None
+
+
+def test_self_initiated_pending_marker_blocks_duplicates(tmp_path: Path) -> None:
+    from autoresearch.tick import (
+        FollowupSpec,
+        read_pending,
+        service_self_initiated,
+    )
+
+    contract = _self_contract()
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="acct",
+        partition="part",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+        bot_login="bot",
+    )
+    submitted: list[str] = []
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            submitted.append(" ".join(argv))
+            return CommandResult(0, "123\n", "")
+        return CommandResult(0, "RUNNING\n", "")  # sacct liveness probe
+
+    compute = SlurmCompute(runner=runner)
+    out = service_self_initiated(tmp_path, compute, spec, contract, NOW)
+    assert out == ("denoise", "123")
+    marker = read_pending(tmp_path, "org/pilot")
+    assert marker is not None and marker["benchmark"] == "denoise"
+    # next tick, record not yet written, job alive -> NO duplicate submit
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 1800) is None
+    assert len(submitted) == 1
+    # once the climb writes its run record, the marker clears and the
+    # active-run serialization (not the marker) is what blocks
+    save_record(
+        tmp_path,
+        _run("r-live", "denoise", NOW + 1900, state="implementing", ending=""),
+        now=NOW + 1900,
+    )
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 3600) is None
+    assert read_pending(tmp_path, "org/pilot") is None
+    assert len(submitted) == 1


### PR DESCRIPTION
The last non-automatic lane. When the requested lane claims nothing this tick and no run is active for the target, the tick launches a climb on the least-recently-attempted contract benchmark — bounded by the contract's runs_per_week, a 6h per-benchmark cooldown, and one-active-run-per-target serialization. Deliberately boring by design: the planning agent (scaling.md Part 1) later replaces this picker with hypothesis-motivated, vetoable plans; this gives it the run history to plan from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)