### PR TITLE
Climb crash containment: no path may strand a run in implementing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Crash containment in live climbs: the run record is saved before any
+  network or clone work, the claim block runs inside the contained region,
+  and every ending step (record, report, issue post) degrades independently
+  — a full disk cannot block the GitHub failure report, and a network
+  failure cannot block the record. The tick summary line now reports the
+  intake and self-initiated lanes.
+
 - Self-initiated lane: when the requested lane claims nothing and no run is
   active, the tick launches a climb on the least-recently-attempted contract
   benchmark, within the weekly budget and a per-benchmark cooldown. The

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -12,6 +12,7 @@ has ended; the session sees only its own capped API key inside its container.
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -87,6 +88,23 @@ class LiveClimbOutcome:
     report_path: str = ""
 
 
+def _best_effort(what: str, fn: Callable[[], object], secrets: tuple[str, ...] = ()) -> bool:
+    """One ending step; a failure is logged, never raised.
+
+    The terminal sequence (record, report, issue post) must degrade
+    independently: a full disk must not block the GitHub post, and a network
+    failure must not block the record. The 2026-08-07 quota crisis stranded a
+    run in `implementing` because the ending record itself hit EDQUOT inside
+    the except handler and took the report and issue post down with it.
+    """
+    try:
+        fn()
+        return True
+    except Exception as exc:
+        log.warning("%s failed: %s", what, redact(f"{type(exc).__name__}: {exc}", secrets))
+        return False
+
+
 def live_climb(
     config: ClimbConfig,
     run_root: Path,
@@ -107,23 +125,10 @@ def live_climb(
     run_dir.mkdir(parents=True, exist_ok=True)
     workspace = run_dir / "ws"
 
-    ws = Workspace.clone(f"https://github.com/{config.target}.git", workspace, auth=bot_auth)
-    contract_path = workspace / ".autoresearch.yaml"
-    contract_text = contract_path.read_text()
-    contract = load_contract(contract_text, config.target)
-
-    tree_hashes: list[str] = []
-
-    def changed_paths() -> list[str]:
-        ws.git("add", "-A")
-        paths = ws.staged_paths()
-        # Content fingerprint of the whole tree: the drift check must catch a
-        # file REWRITTEN during eval (same path set, different bytes), not
-        # only files created or deleted.
-        tree_hashes.append(ws.git("write-tree").strip())
-        ws.git("reset")
-        return paths
-
+    # The record exists before any network or clone work: every crash from
+    # here on has a record to end. (A run once stranded in `implementing`
+    # because the region between record creation and the contained call
+    # could still raise.)
     record = RunRecord(
         run_id=run_id,
         target=config.target,
@@ -135,22 +140,38 @@ def live_climb(
         issue_number=issue_number,
     )
     save_record(run_root, record, now)
-    if issue_number:
-        from autoresearch.intake import CLAIM_MARKER
 
-        already = any(
-            CLAIM_MARKER in str(c.get("body", ""))
-            for c in github.list_comments(config.target, issue_number)
-        )
-        if not already:  # manual CLI runs claim here; tick-submitted runs claimed at submit
-            github.comment(
-                config.target,
-                issue_number,
-                f"{CLAIM_MARKER}\nPicked up as run `{run_id}` "
-                f"(benchmark `{config.benchmark}`). A report will follow here.",
-            )
-
+    tree_hashes: list[str] = []
     try:
+        ws = Workspace.clone(f"https://github.com/{config.target}.git", workspace, auth=bot_auth)
+        contract_text = (workspace / ".autoresearch.yaml").read_text()
+        contract = load_contract(contract_text, config.target)
+
+        def changed_paths() -> list[str]:
+            ws.git("add", "-A")
+            paths = ws.staged_paths()
+            # Content fingerprint of the whole tree: the drift check must
+            # catch a file REWRITTEN during eval (same path set, different
+            # bytes), not only files created or deleted.
+            tree_hashes.append(ws.git("write-tree").strip())
+            ws.git("reset")
+            return paths
+
+        if issue_number:
+            from autoresearch.intake import CLAIM_MARKER
+
+            already = any(
+                CLAIM_MARKER in str(c.get("body", ""))
+                for c in github.list_comments(config.target, issue_number)
+            )
+            if not already:  # manual CLI runs claim here; tick runs claimed at submit
+                github.comment(
+                    config.target,
+                    issue_number,
+                    f"{CLAIM_MARKER}\nPicked up as run `{run_id}` "
+                    f"(benchmark `{config.benchmark}`). A report will follow here.",
+                )
+
         result = climb_once(
             config,
             contract_text,
@@ -163,29 +184,42 @@ def live_climb(
             task_hypothesis=task_hypothesis,
         )
     except Exception as exc:
-        log.warning(
-            "climb failed for %s: %s", run_id, redact(f"{type(exc).__name__}: {exc}", secrets)
-        )
+        note = redact(f"{type(exc).__name__}: {exc}", secrets)[:500]
+        log.warning("climb failed for %s: %s", run_id, note)
         failed = RunRecord(
             **{
                 **record.__dict__,
                 "state": ENDED,
                 "ending": ABORTED,
-                "ending_note": redact(f"{type(exc).__name__}: {exc}", secrets)[:500],
+                "ending_note": note,
             }
         )
-        save_record(run_root, failed, now)
         report_path = run_dir / "report.md"
-        report_path.write_text(
-            f"# Run report — {config.target} / {config.benchmark}\n"
-            f"Outcome: **climb-error**\n"
-            f"Note: {redact(f'{type(exc).__name__}: {exc}', secrets)[:500]}\n"
+        _best_effort("ending record", lambda: save_record(run_root, failed, now), secrets)
+        _best_effort(
+            "error report",
+            lambda: report_path.write_text(
+                f"# Run report — {config.target} / {config.benchmark}\n"
+                f"Outcome: **climb-error**\n"
+                f"Note: {note}\n"
+            ),
+            secrets,
         )
+        if issue_number:
+            _best_effort(
+                "issue report",
+                lambda: github.comment(
+                    config.target,
+                    issue_number,
+                    f"Run `{run_id}` finished (climb-error).\n\n{note}",
+                ),
+                secrets,
+            )
         return LiveClimbOutcome(run_id=run_id, outcome="climb-error", report_path=str(report_path))
 
     report = result.report(config, redact_secrets=secrets)
     report_path = run_dir / "report.md"
-    report_path.write_text(report)
+    _best_effort("run report", lambda: report_path.write_text(report), secrets)
 
     pr_url = ""
     outcome_name = result.outcome
@@ -305,18 +339,19 @@ def live_climb(
                 "ending_note": redact(result.note, secrets),
             }
         )
-    save_record(run_root, final, now)
+    _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
     if issue_number:
         summary = redact(result.report(config, redact_secrets=secrets), secrets)[:8000]
         link = f"\n\nPull request: {pr_url}" if pr_url else ""
-        try:
-            github.comment(
+        _best_effort(
+            "issue report",
+            lambda: github.comment(
                 config.target,
                 issue_number,
                 f"Run `{run_id}` finished ({outcome_name}).{link}\n\n{summary}",
-            )
-        except Exception as exc:
-            log.warning("could not report to issue #%s: %s", issue_number, exc)
+            ),
+            secrets,
+        )
     log.info("run %s: %s %s", run_id, outcome_name, pr_url)
     return LiveClimbOutcome(
         run_id=run_id,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -139,7 +139,29 @@ def live_climb(
         deadline=now + 24 * 3600,
         issue_number=issue_number,
     )
-    save_record(run_root, record, now)
+    try:
+        save_record(run_root, record, now)
+    except Exception as exc:
+        # No record could be written, so the run must not proceed invisibly:
+        # nothing would ever end it. Submit-time evidence (the claim comment
+        # or the pending marker) plus this post keep the failure visible.
+        exc_name = type(exc).__name__
+        log.warning(
+            "could not create run record for %s: %s",
+            run_id,
+            redact(f"{exc_name}: {exc}", secrets),
+        )
+        if issue_number:
+            _best_effort(
+                "issue report",
+                lambda: github.comment(
+                    config.target,
+                    issue_number,
+                    f"Run `{run_id}` could not start ({exc_name} while writing its run record).",
+                ),
+                secrets,
+            )
+        return LiveClimbOutcome(run_id=run_id, outcome="climb-error")
 
     tree_hashes: list[str] = []
     try:
@@ -184,7 +206,8 @@ def live_climb(
             task_hypothesis=task_hypothesis,
         )
     except Exception as exc:
-        note = redact(f"{type(exc).__name__}: {exc}", secrets)[:500]
+        exc_name = type(exc).__name__
+        note = redact(f"{exc_name}: {exc}", secrets)[:500]
         log.warning("climb failed for %s: %s", run_id, note)
         failed = RunRecord(
             **{
@@ -196,7 +219,7 @@ def live_climb(
         )
         report_path = run_dir / "report.md"
         _best_effort("ending record", lambda: save_record(run_root, failed, now), secrets)
-        _best_effort(
+        wrote = _best_effort(
             "error report",
             lambda: report_path.write_text(
                 f"# Run report — {config.target} / {config.benchmark}\n"
@@ -206,20 +229,30 @@ def live_climb(
             secrets,
         )
         if issue_number:
+            # Exception detail stays in the local record and report: redact()
+            # only knows the secrets it was handed, and raw messages can carry
+            # paths or tokens the tuple does not cover. The issue gets the
+            # exception TYPE only.
             _best_effort(
                 "issue report",
                 lambda: github.comment(
                     config.target,
                     issue_number,
-                    f"Run `{run_id}` finished (climb-error).\n\n{note}",
+                    f"Run `{run_id}` finished (climb-error): {exc_name}. "
+                    f"Details are in the run's record and report on the orchestrator.",
                 ),
                 secrets,
             )
-        return LiveClimbOutcome(run_id=run_id, outcome="climb-error", report_path=str(report_path))
+        return LiveClimbOutcome(
+            run_id=run_id,
+            outcome="climb-error",
+            # an outcome must never point at a report that was not written
+            report_path=str(report_path) if wrote else "",
+        )
 
     report = result.report(config, redact_secrets=secrets)
     report_path = run_dir / "report.md"
-    _best_effort("run report", lambda: report_path.write_text(report), secrets)
+    wrote_report = _best_effort("run report", lambda: report_path.write_text(report), secrets)
 
     pr_url = ""
     outcome_name = result.outcome
@@ -339,7 +372,25 @@ def live_climb(
                 "ending_note": redact(result.note, secrets),
             }
         )
-    _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
+    if not _best_effort("final record", lambda: save_record(run_root, final, now), secrets):
+        # The on-disk record still says `implementing`, so automated
+        # follow-up servicing will not track this run — and if a PR was
+        # opened, its humans are the only ones who can act. Say so WHERE
+        # they are looking: GitHub is the one store still writable when the
+        # local disk is gone.
+        pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1] if pr_url else ""
+        if pr_number.isdigit():
+            _best_effort(
+                "pr state warning",
+                lambda: github.comment(
+                    config.target,
+                    int(pr_number),
+                    f"State record for run `{run_id}` could not be saved; "
+                    f"automated follow-up servicing is offline for this run. "
+                    f"A maintainer owns any follow-ups on this PR.",
+                ),
+                secrets,
+            )
     if issue_number:
         summary = redact(result.report(config, redact_secrets=secrets), secrets)[:8000]
         link = f"\n\nPull request: {pr_url}" if pr_url else ""
@@ -357,7 +408,7 @@ def live_climb(
         run_id=run_id,
         outcome=outcome_name,
         pr_url=pr_url,
-        report_path=str(report_path),
+        report_path=str(report_path) if wrote_report else "",
     )
 
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -821,7 +821,7 @@ def main() -> int:
     )
     log.info(
         "tick done: paused=%s swept=%d woken=%d deferred=%d reaped=%d stuck=%d "
-        "review_ended=%s followups=%s",
+        "review_ended=%s followups=%s intake=%s self_initiated=%s",
         report.paused,
         report.swept,
         len(report.woken),
@@ -830,6 +830,8 @@ def main() -> int:
         len(report.stuck),
         report.review_ended,
         report.followups_submitted,
+        report.intake,
+        report.self_initiated,
     )
     return 0
 

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -570,6 +570,9 @@ def test_clone_crash_ends_record_and_reports_to_issue(tmp_path, monkeypatch) -> 
     assert record.state == "ended" and record.ending == "aborted"
     assert "quota" in record.ending_note
     assert any("climb-error" in body for _, body in github.issue_comments)
+    # exception DETAIL stays local: redact() only knows the secrets tuple,
+    # so raw messages (paths, embedded tokens) never reach the public issue
+    assert not any("quota" in body for _, body in github.issue_comments)
 
 
 def _save_failing_after_first(monkeypatch):
@@ -611,6 +614,7 @@ def test_ending_steps_degrade_independently(tmp_path, target_repo, monkeypatch) 
     # the record could not be ended (disk dead) — but the failure is VISIBLE:
     assert any("climb-error" in body for _, body in github.issue_comments)
     assert Path(outcome.report_path).exists()
+    assert not any("not in contract" in body for _, body in github.issue_comments)
 
 
 def test_final_record_failure_does_not_lose_pr_or_issue_report(
@@ -635,3 +639,35 @@ def test_final_record_failure_does_not_lose_pr_or_issue_report(
     assert outcome.outcome == "improved"
     assert github.prs and outcome.pr_url.endswith("/pull/1")
     assert any("finished (improved)" in body for _, body in github.issue_comments)
+    # the un-saveable record means follow-up servicing is blind to this PR —
+    # the warning lands where the humans are looking
+    assert any(
+        num == 1 and "follow-up servicing is offline" in body for num, body in github.issue_comments
+    )
+
+
+def test_first_record_write_failure_is_contained(tmp_path, target_repo, monkeypatch) -> None:
+    """If not even the initial record can be written, the run must not
+    proceed invisibly OR crash the caller: climb-error plus an issue post."""
+    from autoresearch import climb as climb_mod
+
+    def always_failing(root, record, now):
+        raise OSError(122, "Disk quota exceeded")
+
+    monkeypatch.setattr(climb_mod, "save_record", always_failing)
+    github = CommentingGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-recfail",
+        harness=ScriptedHarness(edits={}),
+        evaluator=QueueEvaluator(values=[]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+        issue_number=7,
+    )
+    assert outcome.outcome == "climb-error"
+    assert outcome.report_path == ""  # never point at a report that was not written
+    assert any("could not start" in body for _, body in github.issue_comments)

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -100,6 +100,17 @@ class FakeGitHub:
 
 
 @dataclass
+class CommentingGitHub(FakeGitHub):
+    issue_comments: list = field(default_factory=list)
+
+    def comment(self, repo, number, body):
+        self.issue_comments.append((number, body))
+
+    def list_comments(self, repo, number, max_pages=20):
+        return []
+
+
+@dataclass
 class NoAuth:
     def token(self) -> str:
         return "unused"
@@ -508,17 +519,6 @@ def test_title_pair_never_renders_identical() -> None:
 
 def test_issue_run_references_issue_and_reports_back(tmp_path, target_repo) -> None:
     """The requested lane's visible loop: claim → Addresses #N → report."""
-
-    @dataclass
-    class CommentingGitHub(FakeGitHub):
-        issue_comments: list = field(default_factory=list)
-
-        def comment(self, repo, number, body):
-            self.issue_comments.append((number, body))
-
-        def list_comments(self, repo, number, max_pages=20):
-            return []
-
     github = CommentingGitHub()
     outcome = live_climb(
         config=ClimbConfig(target="org/pilot", benchmark="tsp"),
@@ -541,3 +541,97 @@ def test_issue_run_references_issue_and_reports_back(tmp_path, target_repo) -> N
     assert "pull/1" in report[1]
     record = load_record(tmp_path / "state", "tsp-iss")
     assert record.issue_number == 42
+
+
+def test_clone_crash_ends_record_and_reports_to_issue(tmp_path, monkeypatch) -> None:
+    """A crash BEFORE the contained call (clone/contract/claim) must end the
+    record and surface on the issue — not strand `implementing`."""
+    from autoresearch import climb as climb_mod
+
+    def exploding_clone(url, dest, auth=None, dry_run=False):
+        raise OSError(122, "Disk quota exceeded")
+
+    monkeypatch.setattr(climb_mod.Workspace, "clone", staticmethod(exploding_clone))
+    github = CommentingGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-clonefail",
+        harness=ScriptedHarness(edits={}),
+        evaluator=QueueEvaluator(values=[]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+        issue_number=7,
+    )
+    assert outcome.outcome == "climb-error"
+    record = load_record(tmp_path / "state", "tsp-clonefail")
+    assert record.state == "ended" and record.ending == "aborted"
+    assert "quota" in record.ending_note
+    assert any("climb-error" in body for _, body in github.issue_comments)
+
+
+def _save_failing_after_first(monkeypatch):
+    """save_record succeeds once (the implementing record) then raises — the
+    quota-crisis failure mode where the ENDING write is what dies."""
+    from autoresearch import climb as climb_mod
+
+    real_save = climb_mod.save_record
+    calls = {"n": 0}
+
+    def failing(root, record, now):
+        calls["n"] += 1
+        if calls["n"] > 1:
+            raise OSError(122, "Disk quota exceeded")
+        real_save(root, record, now)
+
+    monkeypatch.setattr(climb_mod, "save_record", failing)
+
+
+def test_ending_steps_degrade_independently(tmp_path, target_repo, monkeypatch) -> None:
+    """A full disk must not block the GitHub failure report (the 2026-08-07
+    stranding: the ending record raised EDQUOT inside the handler and took
+    the report and issue post down with it)."""
+    _save_failing_after_first(monkeypatch)
+    github = CommentingGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="chess"),  # not in contract
+        run_root=tmp_path / "state",
+        run_id="chess-disk",
+        harness=ScriptedHarness(edits={}),
+        evaluator=QueueEvaluator(values=[1.0]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+        issue_number=7,
+    )
+    assert outcome.outcome == "climb-error"  # returned, never raised
+    # the record could not be ended (disk dead) — but the failure is VISIBLE:
+    assert any("climb-error" in body for _, body in github.issue_comments)
+    assert Path(outcome.report_path).exists()
+
+
+def test_final_record_failure_does_not_lose_pr_or_issue_report(
+    tmp_path, target_repo, monkeypatch
+) -> None:
+    """An improvement whose FINAL record save dies must still open the PR and
+    report back to the issue."""
+    _save_failing_after_first(monkeypatch)
+    github = CommentingGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-finaldisk",
+        harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "z=1\n"}),
+        evaluator=QueueEvaluator(values=[13.876, 13.1]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="2026-08-07T00:00:00Z",
+        issue_number=9,
+    )
+    assert outcome.outcome == "improved"
+    assert github.prs and outcome.pr_url.endswith("/pull/1")
+    assert any("finished (improved)" in body for _, body in github.issue_comments)


### PR DESCRIPTION
Fixes the stranding that hit `reach-20260807-154540` live (repaired by hand today): during the quota crisis the except handler's own `save_record` raised EDQUOT, so the run stayed `implementing` with no report and no issue post — silently blocking the new self-initiated lane until the 6h stranded-guard.

Layers:
1. **Record first, and contained** — saved before clone/contract/claim so every later crash has a record to end; if even that first write fails, the run refuses to proceed invisibly (could-not-start note on the issue, climb-error to the caller).
2. **Widened containment** — clone, contract load, and the claim block move inside the contained region.
3. **Independent ending steps** — record save, report write, and issue post are each best-effort: a full disk cannot block the GitHub post, a network failure cannot block the record. If the final post-publish record save fails, the record IS still stranded for automated servicing — that is unavoidable with a dead disk — but a warning lands on the PR itself, where the humans who own the follow-ups are looking.
4. **Honest disclosure and contracts** — public issues get the exception type only (raw messages can carry paths or tokens outside the redaction tuple; detail stays in the local record/report), and `report_path` is empty when the report write failed.

Also: the `tick done` log line now includes `intake` and `self_initiated` (their absence made this morning's ticks look silent while diagnosing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)