### PR TITLE
Disk preflight: never launch work onto storage that cannot hold it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Disk preflight (`disk` module): quota exhaustion is invisible on some
+  clusters until a write fails, so the tick and the climb now write-probe
+  their storage (plus a statvfs early-warning threshold, `--min-free-gb`)
+  before launching new work. A failed preflight turns the launch lanes off
+  for the tick, surfaces in the heartbeat and the tick summary, and never
+  kills the chain; the climb refuses to start and tells the issue. The
+  chain script defaults `UV_CACHE_DIR` and `APPTAINER_CACHEDIR` under the
+  state root so host-side caches never land in a constrained $HOME.
+
 - Crash containment in live climbs: the run record is saved before any
   network or clone work, the claim block runs inside the contained region,
   and every ending step (record, report, issue post) degrades independently

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -92,6 +92,14 @@ if [ -n "${AUTORESEARCH_PAT_FILE:-}" ] && [ -r "$AUTORESEARCH_PAT_FILE" ]; then
     fi
     rm -f "$ASKPASS"
 fi
+# Host-side caches must never land in $HOME: home quotas are tiny on many
+# clusters and invisible until EDQUOT (verified on Torch — a full home took
+# down a live run). Default them under the state root (scratch-class
+# storage); explicit env wins. Submitted jobs inherit these via sbatch.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-$AUTORESEARCH_ROOT/cache/uv}"
+export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-$AUTORESEARCH_ROOT/cache/apptainer}"
+mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
+
 (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet) || echo "deploy: uv sync failed"
 
 # --- 3. the tick itself (scrubbed of the PAT path; sessions are scrubbed

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -472,7 +472,9 @@ def main() -> int:
                     args.target,
                     args.issue,
                     "A run for this issue could not start: the orchestrator's "
-                    "storage failed its disk preflight. It will be retried.",
+                    "storage failed its disk preflight. The claim on this issue "
+                    "stays until a maintainer removes the claim comment "
+                    "(automated claim release is on the roadmap).",
                 ),
             )
         return 3

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -438,6 +438,12 @@ def main() -> int:
     )
     parser.add_argument("--issue", type=int, default=0)
     parser.add_argument(
+        "--min-free-gb",
+        type=float,
+        default=10.0,
+        help="refuse to start when the run root has less free space",
+    )
+    parser.add_argument(
         "--hypothesis-b64", default="", help="base64 task hypothesis (issue text, fenced)"
     )
     args = parser.parse_args()
@@ -450,6 +456,26 @@ def main() -> int:
     bot_auth = FileTokenProvider(Path(args.pat_file))
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_id = f"{args.benchmark}-{stamp}"
+
+    # Disk preflight BEFORE any run state exists: a session started on a
+    # full filesystem dies mid-flight in ways that lose its own evidence
+    # (quota errors are invisible until a write fails on some clusters).
+    from autoresearch.disk import check_mount
+
+    health = check_mount(args.run_root, min_free_bytes=int(args.min_free_gb * 1024**3))
+    if not health.ok():
+        log.error("disk preflight failed: %s — refusing to start a run", health.describe())
+        if args.issue:
+            _best_effort(
+                "issue report",
+                lambda: GitHubClient(auth=bot_auth).comment(
+                    args.target,
+                    args.issue,
+                    "A run for this issue could not start: the orchestrator's "
+                    "storage failed its disk preflight. It will be retried.",
+                ),
+            )
+        return 3
 
     outcome = live_climb(
         config=ClimbConfig(target=args.target, benchmark=args.benchmark),

--- a/src/autoresearch/disk.py
+++ b/src/autoresearch/disk.py
@@ -27,6 +27,7 @@ import contextlib
 import errno
 import logging
 import os
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -66,14 +67,25 @@ def probe_writable(path: Path) -> tuple[bool, str]:
 
     fsync is deliberate: quota errors on networked filesystems can be
     deferred until the data is forced out, and a probe that skips the flush
-    reports healthy right up to the crash.
+    reports healthy right up to the crash. mkstemp (random name) rather than
+    a PID-derived one: a stale probe left by a SIGKILLed process must never
+    alias a later PID and read as BLOCKED on healthy storage. Short writes
+    are treated as full: ENOSPC can surface as a short count before the
+    error, and a probe that ignores the count reports healthy on a full
+    mount.
     """
-    probe = path / f"{PROBE_NAME}.{os.getpid()}"
+    probe = ""
     try:
         path.mkdir(parents=True, exist_ok=True)
-        fd = os.open(probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        fd, probe = tempfile.mkstemp(dir=path, prefix=f"{PROBE_NAME}.")
         try:
-            os.write(fd, b"autoresearch disk probe\n" * 32)
+            payload = b"autoresearch disk probe\n" * 32
+            written = 0
+            while written < len(payload):
+                count = os.write(fd, payload[written:])
+                if count <= 0:
+                    return False, "short write: filesystem refused data without an error"
+                written += count
             os.fsync(fd)
         finally:
             os.close(fd)
@@ -82,8 +94,9 @@ def probe_writable(path: Path) -> tuple[bool, str]:
         name = errno.errorcode.get(exc.errno, "") if exc.errno else ""
         return False, f"{name or type(exc).__name__}: {exc}"
     finally:
-        with contextlib.suppress(OSError):
-            probe.unlink(missing_ok=True)
+        if probe:
+            with contextlib.suppress(OSError):
+                os.unlink(probe)
 
 
 def free_bytes(path: Path) -> int:

--- a/src/autoresearch/disk.py
+++ b/src/autoresearch/disk.py
@@ -1,0 +1,151 @@
+"""Disk preflight: refuse to launch work onto storage that cannot hold it.
+
+Quota exhaustion is INVISIBLE on some clusters until a write fails: user
+quotas on VAST/NFS homes are not exposed through statvfs (df reports the
+whole filesystem), and rquota RPCs may be administratively blocked — the
+first symptom is EDQUOT from a write that already lost data. (Verified on
+Torch 2026-08-07, the day a full home quota crashed a live climb and its
+error handling with it.)
+
+So the preflight is built on two honest signals:
+
+- a WRITE PROBE — create, fsync, and remove a small file; this surfaces
+  EDQUOT/ENOSPC/EROFS exactly the way real work would hit them, and is the
+  only quota check that works everywhere;
+- statvfs free space — meaningful for cluster-level exhaustion (a shared
+  scratch filesystem filling up), used as an early-warning threshold where
+  the numbers are real.
+
+The tick probes before launching sessions; the climb probes before touching
+its run directory. A failed probe skips NEW work and surfaces in the
+heartbeat — it never kills the tick chain.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+PROBE_NAME = ".disk-probe"
+# Enough for a clone + venv + eval scratch with margin; overridable per call.
+DEFAULT_MIN_FREE_BYTES = 10 * 1024**3
+
+
+@dataclass(frozen=True)
+class MountHealth:
+    path: str
+    writable: bool
+    error: str = ""  # why the probe failed, when it did
+    free_bytes: int = -1  # statvfs; -1 when the query itself failed
+    min_free_bytes: int = 0
+
+    def ok(self) -> bool:
+        if not self.writable:
+            return False
+        # Unknown free space is not a failure: the write probe is the
+        # authoritative check, the threshold is early warning on top.
+        if self.free_bytes >= 0 and self.min_free_bytes > 0:
+            return self.free_bytes >= self.min_free_bytes
+        return True
+
+    def describe(self) -> str:
+        state = "ok" if self.ok() else "BLOCKED"
+        free = f"{self.free_bytes / 1024**3:.1f}G free" if self.free_bytes >= 0 else "free=?"
+        detail = f" ({self.error})" if self.error else ""
+        return f"{self.path}: {state}, {free}{detail}"
+
+
+def probe_writable(path: Path) -> tuple[bool, str]:
+    """Try to actually write in `path` the way real work would.
+
+    fsync is deliberate: quota errors on networked filesystems can be
+    deferred until the data is forced out, and a probe that skips the flush
+    reports healthy right up to the crash.
+    """
+    probe = path / f"{PROBE_NAME}.{os.getpid()}"
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+        fd = os.open(probe, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            os.write(fd, b"autoresearch disk probe\n" * 32)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        return True, ""
+    except OSError as exc:
+        name = errno.errorcode.get(exc.errno, "") if exc.errno else ""
+        return False, f"{name or type(exc).__name__}: {exc}"
+    finally:
+        with contextlib.suppress(OSError):
+            probe.unlink(missing_ok=True)
+
+
+def free_bytes(path: Path) -> int:
+    """Free bytes from statvfs, or -1 when the query fails. Honest for
+    cluster-level fullness; blind to per-user quotas on some filesystems —
+    that is what the write probe is for."""
+    try:
+        st = os.statvfs(path)
+        return st.f_bavail * st.f_frsize
+    except OSError:
+        return -1
+
+
+def check_mount(path: Path, min_free_bytes: int = 0) -> MountHealth:
+    writable, error = probe_writable(path)
+    return MountHealth(
+        path=str(path),
+        writable=writable,
+        error=error,
+        free_bytes=free_bytes(path),
+        min_free_bytes=min_free_bytes,
+    )
+
+
+@dataclass(frozen=True)
+class DiskHealth:
+    """What the tick needs: may new work launch, and what should humans see."""
+
+    state_root: MountHealth
+    home: MountHealth | None = None  # warn-only: the agent barely writes there
+
+    def launch_ok(self) -> bool:
+        return self.state_root.ok()
+
+    def warnings(self) -> list[str]:
+        out = []
+        if not self.state_root.ok():
+            out.append(self.state_root.describe())
+        if self.home is not None and not self.home.ok():
+            out.append(f"home {self.home.describe()} (warn-only)")
+        return out
+
+    def as_dict(self) -> dict[str, object]:
+        d: dict[str, object] = {
+            "launch_ok": self.launch_ok(),
+            "state_root": self.state_root.__dict__,
+        }
+        if self.home is not None:
+            d["home"] = self.home.__dict__
+        return d
+
+
+def check_disk(
+    root: Path,
+    min_free_bytes: int = DEFAULT_MIN_FREE_BYTES,
+    home: Path | None = None,
+) -> DiskHealth:
+    """Preflight for one tick: the state root gates launches; the home probe
+    (default: the real home) is a warn-only signal for humans, because a
+    full home breaks logins and tooling long before it breaks the agent."""
+    home_path = Path.home() if home is None else home
+    return DiskHealth(
+        state_root=check_mount(root, min_free_bytes),
+        home=check_mount(home_path, 0),
+    )

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -31,6 +31,7 @@ from autoresearch.compute import (
     is_terminal,
     quote_command,
 )
+from autoresearch.disk import DEFAULT_MIN_FREE_BYTES, check_disk
 from autoresearch.runstate import (
     ENDED,
     IMPLEMENTING,
@@ -101,6 +102,7 @@ class TickReport:
     followups_submitted: tuple[tuple[str, str], ...] = ()  # (run_id, job_id)
     intake: tuple[str, str] = ("", "")  # (issue tag, job_id) when one was claimed
     self_initiated: tuple[str, str] = ("", "")  # (benchmark, job_id) when one launched
+    disk: tuple[str, ...] = ()  # preflight warnings; non-empty gated the launch lanes
 
 
 @dataclass(frozen=True)
@@ -126,8 +128,13 @@ def service_in_review(
     spec: FollowupSpec,
     now: float,
     dry_run: bool = False,
+    allow_submit: bool = True,
 ) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
     """PR-state transitions + follow-up job submission for in-review runs.
+
+    allow_submit=False (disk preflight failed) keeps the cheap state
+    transitions — ending merged/closed runs still matters — but submits no
+    new session jobs.
 
     The tick only READS GitHub here (cheap, every cycle); the session-running
     work happens in a submitted job, which takes the run lease itself — a
@@ -163,6 +170,9 @@ def service_in_review(
                     record.run_id,
                     record.wake_attempts,
                 )
+                continue
+            if not allow_submit:
+                log.warning("run %s has new comments but disk preflight failed", record.run_id)
                 continue
             if dry_run:
                 submitted.append((record.run_id, "dry-run"))
@@ -216,11 +226,18 @@ def service_in_review(
     return ended, submitted
 
 
-def write_heartbeat(root: Path, now: float) -> None:
-    payload = json.dumps({"ts": now, "host": socket.gethostname(), "pid": os.getpid()})
-    tmp = root / f".{HEARTBEAT_NAME}.tmp"
-    tmp.write_text(payload)
-    os.replace(tmp, root / HEARTBEAT_NAME)
+def write_heartbeat(root: Path, now: float, disk: dict[str, object] | None = None) -> None:
+    """Best-effort: a heartbeat that cannot be written (full disk) must not
+    kill the tick — the tick can still end runs and post to GitHub."""
+    payload: dict[str, object] = {"ts": now, "host": socket.gethostname(), "pid": os.getpid()}
+    if disk is not None:
+        payload["disk"] = disk
+    try:
+        tmp = root / f".{HEARTBEAT_NAME}.tmp"
+        tmp.write_text(json.dumps(payload))
+        os.replace(tmp, root / HEARTBEAT_NAME)
+    except OSError as exc:
+        log.warning("heartbeat write failed: %s", exc)
 
 
 def _holder_alive(compute: SlurmCompute, lease_job_id: str) -> bool | None:
@@ -439,23 +456,45 @@ def tick(
     github: Any = None,
     followup_spec: FollowupSpec | None = None,
     followup_dry_run: bool = False,
+    min_free_bytes: int = DEFAULT_MIN_FREE_BYTES,
 ) -> TickReport:
     """One full tick. Pause sentinel wins over everything: a paused loop
-    heartbeats (so the watchdog stays quiet) but touches nothing."""
-    write_heartbeat(root, now)
+    heartbeats (so the watchdog stays quiet) but touches nothing.
+
+    Disk preflight gates every lane that LAUNCHES new work (follow-up jobs,
+    intake claims, self-initiated climbs): a session started on a full or
+    nearly-full filesystem dies mid-flight in ways that lose data. The sweep
+    still runs — its writes are small, per-record contained, and ending runs
+    matters more when storage is failing, not less.
+    """
+    disk_health = check_disk(root, min_free_bytes=min_free_bytes)
+    write_heartbeat(root, now, disk=disk_health.as_dict())
+    for warning in disk_health.warnings():
+        log.warning("disk: %s", warning)
     if (root / PAUSE_SENTINEL).exists():
         log.info("pause sentinel present; tick is a no-op")
         return TickReport(paused=True)
     report = sweep(root, compute, dispatcher, now, grace_s, lease_ttl_s, dry_run=dry_run)
+    launch_ok = disk_health.launch_ok()
+    if not launch_ok:
+        log.warning("disk preflight failed; launch lanes are OFF this tick")
     if github is not None and followup_spec is not None:
         ended, submitted = service_in_review(
-            root, github, compute, followup_spec, now, dry_run=followup_dry_run
+            root,
+            github,
+            compute,
+            followup_spec,
+            now,
+            dry_run=followup_dry_run,
+            allow_submit=launch_ok,
         )
-        intake_job = service_intake(
-            root, github, compute, followup_spec, now, dry_run=followup_dry_run
+        intake_job = (
+            service_intake(root, github, compute, followup_spec, now, dry_run=followup_dry_run)
+            if launch_ok
+            else None
         )
         self_job = None
-        if intake_job is None and followup_spec.target:
+        if launch_ok and intake_job is None and followup_spec.target:
             try:
                 from autoresearch.contract import load_contract
 
@@ -471,7 +510,9 @@ def tick(
                     )
             except Exception as exc:
                 log.warning("self-initiated selection failed: %s", exc)
-        report = replace_report(report, ended, submitted, intake_job, self_job)
+        report = replace_report(
+            report, ended, submitted, intake_job, self_job, disk_health.warnings()
+        )
     return report
 
 
@@ -481,6 +522,7 @@ def replace_report(
     submitted: list[tuple[str, str]],
     intake_job: tuple[str, str] | None = None,
     self_job: tuple[str, str] | None = None,
+    disk_warnings: list[str] | None = None,
 ) -> TickReport:
     from dataclasses import replace as dc_replace
 
@@ -490,6 +532,7 @@ def replace_report(
         followups_submitted=tuple(submitted),
         intake=intake_job or ("", ""),
         self_initiated=self_job or ("", ""),
+        disk=tuple(disk_warnings or ()),
     )
 
 
@@ -754,6 +797,12 @@ def main() -> int:
     parser.add_argument("--root", required=True, type=Path, help="state root on the shared FS")
     parser.add_argument("--grace-s", type=float, default=DEFAULT_GRACE_S)
     parser.add_argument("--lease-ttl-s", type=float, default=DEFAULT_LEASE_TTL_S)
+    parser.add_argument(
+        "--min-free-gb",
+        type=float,
+        default=DEFAULT_MIN_FREE_BYTES / 1024**3,
+        help="skip launching new work when the state filesystem has less free",
+    )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
@@ -818,10 +867,11 @@ def main() -> int:
         github=github,
         followup_spec=followup_spec,
         followup_dry_run=False,
+        min_free_bytes=int(args.min_free_gb * 1024**3),
     )
     log.info(
         "tick done: paused=%s swept=%d woken=%d deferred=%d reaped=%d stuck=%d "
-        "review_ended=%s followups=%s intake=%s self_initiated=%s",
+        "review_ended=%s followups=%s intake=%s self_initiated=%s disk=%s",
         report.paused,
         report.swept,
         len(report.woken),
@@ -832,6 +882,7 @@ def main() -> int:
         report.followups_submitted,
         report.intake,
         report.self_initiated,
+        report.disk or "ok",
     )
     return 0
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -102,7 +102,8 @@ class TickReport:
     followups_submitted: tuple[tuple[str, str], ...] = ()  # (run_id, job_id)
     intake: tuple[str, str] = ("", "")  # (issue tag, job_id) when one was claimed
     self_initiated: tuple[str, str] = ("", "")  # (benchmark, job_id) when one launched
-    disk: tuple[str, ...] = ()  # preflight warnings; non-empty gated the launch lanes
+    disk: tuple[str, ...] = ()  # preflight warnings (home entries are warn-only)
+    launch_blocked: bool = False  # True when the preflight turned launch lanes off
 
 
 @dataclass(frozen=True)
@@ -467,6 +468,10 @@ def tick(
     still runs — its writes are small, per-record contained, and ending runs
     matters more when storage is failing, not less.
     """
+    # Heartbeat FIRST, before any probe: check_disk touches $HOME (a
+    # different filesystem), and a hung mount there must not starve the
+    # watchdog signal. The disk-annotated heartbeat follows once known.
+    write_heartbeat(root, now)
     disk_health = check_disk(root, min_free_bytes=min_free_bytes)
     write_heartbeat(root, now, disk=disk_health.as_dict())
     for warning in disk_health.warnings():
@@ -511,7 +516,7 @@ def tick(
             except Exception as exc:
                 log.warning("self-initiated selection failed: %s", exc)
         report = replace_report(
-            report, ended, submitted, intake_job, self_job, disk_health.warnings()
+            report, ended, submitted, intake_job, self_job, disk_health.warnings(), not launch_ok
         )
     return report
 
@@ -523,6 +528,7 @@ def replace_report(
     intake_job: tuple[str, str] | None = None,
     self_job: tuple[str, str] | None = None,
     disk_warnings: list[str] | None = None,
+    launch_blocked: bool = False,
 ) -> TickReport:
     from dataclasses import replace as dc_replace
 
@@ -533,6 +539,7 @@ def replace_report(
         intake=intake_job or ("", ""),
         self_initiated=self_job or ("", ""),
         disk=tuple(disk_warnings or ()),
+        launch_blocked=launch_blocked,
     )
 
 
@@ -871,7 +878,7 @@ def main() -> int:
     )
     log.info(
         "tick done: paused=%s swept=%d woken=%d deferred=%d reaped=%d stuck=%d "
-        "review_ended=%s followups=%s intake=%s self_initiated=%s disk=%s",
+        "review_ended=%s followups=%s intake=%s self_initiated=%s disk=%s launch_blocked=%s",
         report.paused,
         report.swept,
         len(report.woken),
@@ -883,6 +890,7 @@ def main() -> int:
         report.intake,
         report.self_initiated,
         report.disk or "ok",
+        report.launch_blocked,
     )
     return 0
 

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -1,0 +1,79 @@
+"""Disk preflight: write probes, thresholds, and launch gating."""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+from autoresearch.disk import (
+    DiskHealth,
+    MountHealth,
+    check_disk,
+    check_mount,
+    free_bytes,
+    probe_writable,
+)
+
+
+def test_probe_writable_on_a_real_directory(tmp_path: Path) -> None:
+    ok, error = probe_writable(tmp_path)
+    assert ok and error == ""
+    assert list(tmp_path.iterdir()) == []  # probe cleaned up after itself
+
+
+def test_probe_fails_on_unwritable_directory(tmp_path: Path) -> None:
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    locked.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        if os.access(locked, os.W_OK):  # running as root: probe cannot fail
+            return
+        ok, error = probe_writable(locked)
+        assert not ok
+        assert "ACCES" in error or "Permission" in error
+    finally:
+        locked.chmod(stat.S_IRWXU)
+
+
+def test_free_bytes_is_positive_for_tmp(tmp_path: Path) -> None:
+    assert free_bytes(tmp_path) > 0
+    assert free_bytes(tmp_path / "does-not-exist") == -1
+
+
+def test_mount_threshold_blocks_but_probe_alone_passes(tmp_path: Path) -> None:
+    # threshold far above any real filesystem forces the early-warning block
+    blocked = check_mount(tmp_path, min_free_bytes=2**62)
+    assert blocked.writable and not blocked.ok()
+    fine = check_mount(tmp_path, min_free_bytes=1)
+    assert fine.ok()
+    # unknown free space must not fail a writable mount: probe is authoritative
+    unknown = MountHealth(path="x", writable=True, free_bytes=-1, min_free_bytes=2**62)
+    assert unknown.ok()
+
+
+def test_check_disk_home_is_warn_only(tmp_path: Path) -> None:
+    state = tmp_path / "state"
+    home = tmp_path / "home"
+    home.mkdir()
+    home.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        health = check_disk(state, min_free_bytes=1, home=home)
+        if not os.access(home, os.W_OK):
+            assert health.warnings() and "warn-only" in health.warnings()[0]
+        assert health.launch_ok()  # a broken HOME never blocks launches
+    finally:
+        home.chmod(stat.S_IRWXU)
+
+
+def test_disk_health_dict_shape(tmp_path: Path) -> None:
+    health = check_disk(tmp_path, min_free_bytes=1, home=tmp_path)
+    d = health.as_dict()
+    assert d["launch_ok"] is True
+    assert isinstance(d["state_root"], dict) and "free_bytes" in d["state_root"]
+
+
+def test_blocked_state_root_gates_launches(tmp_path: Path) -> None:
+    health = DiskHealth(state_root=check_mount(tmp_path, min_free_bytes=2**62))
+    assert not health.launch_ok()
+    assert any("BLOCKED" in w for w in health.warnings())

--- a/tests/test_disk.py
+++ b/tests/test_disk.py
@@ -77,3 +77,11 @@ def test_blocked_state_root_gates_launches(tmp_path: Path) -> None:
     health = DiskHealth(state_root=check_mount(tmp_path, min_free_bytes=2**62))
     assert not health.launch_ok()
     assert any("BLOCKED" in w for w in health.warnings())
+
+
+def test_stale_probe_file_cannot_alias_a_healthy_mount(tmp_path: Path) -> None:
+    """A probe file left by a SIGKILLed process (even one whose name embeds
+    this very PID) must not make healthy storage read as BLOCKED."""
+    (tmp_path / f".disk-probe.{os.getpid()}").write_text("stale")
+    ok, error = probe_writable(tmp_path)
+    assert ok, error

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -672,19 +672,41 @@ def test_disk_preflight_gates_launch_lanes(tmp_path: Path) -> None:
         min_free_bytes=2**62,  # no filesystem passes: forces the block
     )
     assert report.disk and any("BLOCKED" in w for w in report.disk)
+    assert report.launch_blocked is True
     assert report.intake == ("", "") and report.self_initiated == ("", "")
     heartbeat = _json.loads((tmp_path / "heartbeat.json").read_text())
     assert heartbeat["disk"]["launch_ok"] is False
 
 
 def test_disk_preflight_passes_normally(tmp_path: Path) -> None:
-    from autoresearch.tick import tick
+    """Healthy path must actually run the lanes: the report fields are only
+    populated by the github branch, so the test provides one."""
+    from autoresearch.tick import FollowupSpec, tick
 
+    fetched = []
+
+    class G:
+        def get_file_content(self, repo, path, ref):
+            fetched.append(repo)
+            return None  # no contract: self-initiated stops AFTER the gate
+
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="a",
+        partition="p",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+    )
     report = tick(
         tmp_path,
         FakeSlurm().compute(),
         RecordingDispatcher(),
         now=NOW,
+        github=G(),
+        followup_spec=spec,
         min_free_bytes=1,
     )
-    assert report.disk == ()
+    # both intake and self-initiated fetched the contract: the lanes RAN
+    assert fetched and set(fetched) == {"org/pilot"}
+    assert report.disk == () and report.launch_blocked is False

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -633,3 +633,58 @@ def test_self_initiated_pending_marker_blocks_duplicates(tmp_path: Path) -> None
     assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 3600) is None
     assert read_pending(tmp_path, "org/pilot") is None
     assert len(submitted) == 1
+
+
+def test_disk_preflight_gates_launch_lanes(tmp_path: Path) -> None:
+    """A failed preflight turns every LAUNCH lane off for the tick (no
+    follow-up submissions, no intake, no self-initiated) but the tick still
+    heartbeats and reports why."""
+    import json as _json
+
+    from autoresearch.tick import FollowupSpec, tick
+
+    class G:
+        def get_file_content(self, repo, path, ref):
+            raise AssertionError("self-initiated must not even fetch the contract")
+
+        def list_issues(self, *a, **k):
+            raise AssertionError("intake must not scan issues")
+
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="a",
+        partition="p",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+    )
+
+    def unused_runner(argv, timeout_s):
+        raise AssertionError("no slurm calls expected")
+
+    report = tick(
+        tmp_path,
+        SlurmCompute(runner=unused_runner),
+        RecordingDispatcher(),
+        now=NOW,
+        github=G(),
+        followup_spec=spec,
+        min_free_bytes=2**62,  # no filesystem passes: forces the block
+    )
+    assert report.disk and any("BLOCKED" in w for w in report.disk)
+    assert report.intake == ("", "") and report.self_initiated == ("", "")
+    heartbeat = _json.loads((tmp_path / "heartbeat.json").read_text())
+    assert heartbeat["disk"]["launch_ok"] is False
+
+
+def test_disk_preflight_passes_normally(tmp_path: Path) -> None:
+    from autoresearch.tick import tick
+
+    report = tick(
+        tmp_path,
+        FakeSlurm().compute(),
+        RecordingDispatcher(),
+        now=NOW,
+        min_free_bytes=1,
+    )
+    assert report.disk == ()


### PR DESCRIPTION
Follow-up to #43, per review of today's quota incident: #43 made crashes on full disks *visible*; this makes the loop stop *launching onto* them.

Findings from the live investigation that shaped the design:
- On Torch, `df` on home reports the whole 910T filesystem, `quota` is administratively blocked, and there is no VAST quota CLI — **user-quota exhaustion is invisible until a write fails with EDQUOT**. So the authoritative check is a **write probe** (create + fsync + unlink, catching EDQUOT/ENOSPC exactly as real work would).
- Cluster-level scratch is at 99% (39T free of 2.7P) and can fill from other users at any time — there statvfs IS honest, so a configurable free-space threshold (`--min-free-gb`, default 10) gives early warning.

Wiring:
- **Tick**: preflight before anything; failure turns every launch lane off for that tick (follow-up submissions, intake, self-initiated) while the sweep still runs — ending runs matters more when storage is failing, not less. Status lands in `heartbeat.json` (for the future watchdog) and the tick summary line. Home is probed warn-only: a full home is a human problem the agent should surface, not a launch blocker.
- **Climb**: preflight before any run state exists; refusal posts a could-not-start note to the requesting issue.
- **Chain script**: `UV_CACHE_DIR` and `APPTAINER_CACHEDIR` default under `$AUTORESEARCH_ROOT/cache/` (scratch-class, configurable; explicit env wins) — the last host-side writers leave $HOME, and submitted jobs inherit the exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)