### PR TITLE
Arm auto-merge on improvement PRs at publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Improvement PRs arm GitHub auto-merge at publish (best-effort): the bot
+  still never merges — arming hands the merge to the human approval that
+  branch protection requires, so approving is the last human action needed.
+
 - Disk preflight (`disk` module): quota exhaustion is invisible on some
   clusters until a write fails, so the tick and the climb now write-probe
   their storage (plus a statvfs early-warning threshold, `--min-free-gb`)

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -331,6 +331,17 @@ def live_climb(
                 base=base_branch,
                 body=body,
             )
+            # Arm auto-merge, best-effort: arming merges nothing — it hands
+            # the merge to the human approval branch protection requires, so
+            # an approval alone completes the loop. Repos without auto-merge
+            # enabled just log the refusal.
+            pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
+            if pr_number.isdigit():
+                _best_effort(
+                    "auto-merge arming",
+                    lambda: github.enable_auto_merge(config.target, int(pr_number)),
+                    secrets,
+                )
             final = RunRecord(
                 **{
                     **record.__dict__,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -331,15 +331,17 @@ def live_climb(
                 base=base_branch,
                 body=body,
             )
-            # Arm auto-merge, best-effort: arming merges nothing — it hands
-            # the merge to the human approval branch protection requires, so
-            # an approval alone completes the loop. Repos without auto-merge
-            # enabled just log the refusal.
+            # Arm auto-merge, best-effort, and ONLY when branch protection
+            # requires a human review — the guard keeps bot-never-merges
+            # enforced in code, not in per-repo config. Repos without
+            # auto-merge enabled just log the refusal.
             pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
             if pr_number.isdigit():
                 _best_effort(
                     "auto-merge arming",
-                    lambda: github.enable_auto_merge(config.target, int(pr_number)),
+                    lambda: github.arm_auto_merge_when_review_required(
+                        config.target, int(pr_number)
+                    ),
                     secrets,
                 )
             final = RunRecord(

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -250,6 +250,32 @@ class GitHubClient:
         path = f"/repos/{urllib.parse.quote(repo)}/pulls/{number}"
         return self._expect_dict(self._request("GET", path), path)
 
+    def enable_auto_merge(self, repo: str, number: int, method: str = "MERGE") -> None:
+        """Arm GitHub's auto-merge on a PR (a GraphQL-only capability).
+
+        Arming does not merge anything: it hands the merge to whatever
+        branch protection still requires — for bot PRs, a human approval.
+        The bot-never-merges rule holds; approval is what executes.
+        """
+        if self.dry_run:
+            log.info("[dry-run] arm auto-merge on %s#%d", repo, number)
+            return
+        node_id = str(self.get_pull_request(repo, number)["node_id"])
+        mutation = (
+            "mutation($pr: ID!, $method: PullRequestMergeMethod!) {"
+            " enablePullRequestAutoMerge(input: {pullRequestId: $pr, mergeMethod: $method})"
+            " { pullRequest { number } } }"
+        )
+        data = self._request(
+            "POST",
+            "/graphql",
+            {"query": mutation, "variables": {"pr": node_id, "method": method}},
+        )
+        # GraphQL reports failures as 200 + errors[]; surface them as errors.
+        errors = data.get("errors") if isinstance(data, dict) else None
+        if errors:
+            raise GitHubError(200, "/graphql", str(errors)[:300])
+
     def get_pull_request_diff(self, repo: str, number: int) -> str:
         """Fetch a PR's unified diff (uses the diff media type)."""
         path = f"/repos/{urllib.parse.quote(repo)}/pulls/{number}"

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -250,31 +250,91 @@ class GitHubClient:
         path = f"/repos/{urllib.parse.quote(repo)}/pulls/{number}"
         return self._expect_dict(self._request("GET", path), path)
 
+    def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:
+        data = self._request("POST", "/graphql", {"query": query, "variables": variables})
+        if not isinstance(data, dict):
+            raise GitHubError(0, "/graphql", f"expected an object, got {type(data).__name__}")
+        # GraphQL reports failures inside a 200; status 0 keeps callers'
+        # retry/permanence classification honest (this is not an HTTP 200
+        # success and not an HTTP error either).
+        if data.get("errors"):
+            raise GitHubError(0, "/graphql", str(data["errors"])[:300])
+        inner = data.get("data")
+        return inner if isinstance(inner, dict) else {}
+
+    def review_decision(self, repo: str, number: int) -> str:
+        """The PR's reviewDecision ("REVIEW_REQUIRED", "APPROVED",
+        "CHANGES_REQUESTED", or "" when the base branch requires no
+        reviews). GraphQL-only; readable with normal read permissions."""
+        owner, _, name = repo.partition("/")
+        query = (
+            "query($owner: String!, $name: String!, $number: Int!) {"
+            " repository(owner: $owner, name: $name) {"
+            " pullRequest(number: $number) { reviewDecision } } }"
+        )
+        data = self._graphql(query, {"owner": owner, "name": name, "number": number})
+        pr = (data.get("repository") or {}).get("pullRequest") or {}
+        return str(pr.get("reviewDecision") or "")
+
+    def allowed_merge_methods(self, repo: str) -> list[str]:
+        """Merge methods the repo permits, in our preference order (merge
+        commits first — trailer/provenance-preserving)."""
+        path = f"/repos/{urllib.parse.quote(repo)}"
+        settings = self._expect_dict(self._request("GET", path), path)
+        order = [
+            ("MERGE", "allow_merge_commit"),
+            ("SQUASH", "allow_squash_merge"),
+            ("REBASE", "allow_rebase_merge"),
+        ]
+        return [m for m, key in order if settings.get(key)]
+
     def enable_auto_merge(self, repo: str, number: int, method: str = "MERGE") -> None:
         """Arm GitHub's auto-merge on a PR (a GraphQL-only capability).
 
         Arming does not merge anything: it hands the merge to whatever
-        branch protection still requires — for bot PRs, a human approval.
-        The bot-never-merges rule holds; approval is what executes.
+        branch protection still requires. Callers that must preserve the
+        bot-never-merges rule should use arm_auto_merge_when_review_required
+        instead of calling this directly. Repos that also run the follow-up
+        lane should have dismiss-stale-reviews enabled, so a bot push after
+        arming re-requires a human look instead of merging unseen code.
         """
         if self.dry_run:
             log.info("[dry-run] arm auto-merge on %s#%d", repo, number)
             return
-        node_id = str(self.get_pull_request(repo, number)["node_id"])
+        pr_path = f"/repos/{urllib.parse.quote(repo)}/pulls/{number}"
+        node_id = self.get_pull_request(repo, number).get("node_id")
+        if not node_id:
+            raise GitHubError(0, pr_path, "no node_id in PR payload")
         mutation = (
             "mutation($pr: ID!, $method: PullRequestMergeMethod!) {"
             " enablePullRequestAutoMerge(input: {pullRequestId: $pr, mergeMethod: $method})"
             " { pullRequest { number } } }"
         )
-        data = self._request(
-            "POST",
-            "/graphql",
-            {"query": mutation, "variables": {"pr": node_id, "method": method}},
-        )
-        # GraphQL reports failures as 200 + errors[]; surface them as errors.
-        errors = data.get("errors") if isinstance(data, dict) else None
-        if errors:
-            raise GitHubError(200, "/graphql", str(errors)[:300])
+        self._graphql(mutation, {"pr": str(node_id), "method": method})
+
+    def arm_auto_merge_when_review_required(self, repo: str, number: int) -> bool:
+        """Arm auto-merge ONLY when branch protection makes a human review
+        the missing condition (reviewDecision == REVIEW_REQUIRED).
+
+        On a repo without required reviews, arming would merge the bot's own
+        PR the moment CI is green — no human ever acts. That would break the
+        bot-never-merges rule via nothing but per-repo config drift, so the
+        guard lives here, in code. The merge method falls back through what
+        the repo allows (merge-commit preferred: it preserves the Agent
+        trailers and commit sequence as provenance)."""
+        decision = self.review_decision(repo, number)
+        if decision != "REVIEW_REQUIRED":
+            log.warning(
+                "not arming auto-merge on %s#%d: reviewDecision=%r "
+                "(no required human review would stand between arming and merging)",
+                repo,
+                number,
+                decision,
+            )
+            return False
+        methods = self.allowed_merge_methods(repo) or ["MERGE"]
+        self.enable_auto_merge(repo, number, method=methods[0])
+        return True
 
     def get_pull_request_diff(self, repo: str, number: int) -> str:
         """Fetch a PR's unified diff (uses the diff media type)."""

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -93,10 +93,17 @@ class QueueEvaluator:
 @dataclass
 class FakeGitHub:
     prs: list[dict] = field(default_factory=list)
+    armed: list[tuple[str, int]] = field(default_factory=list)
+    arming_error: str = ""
 
     def create_pull(self, repo, title, head, base, body, draft=False) -> str:
         self.prs.append(dict(repo=repo, title=title, head=head, base=base, body=body))
         return f"https://github.com/{repo}/pull/1"
+
+    def enable_auto_merge(self, repo, number, method="MERGE") -> None:
+        if self.arming_error:
+            raise RuntimeError(self.arming_error)
+        self.armed.append((repo, number))
 
 
 @dataclass
@@ -671,3 +678,37 @@ def test_first_record_write_failure_is_contained(tmp_path, target_repo, monkeypa
     assert outcome.outcome == "climb-error"
     assert outcome.report_path == ""  # never point at a report that was not written
     assert any("could not start" in body for _, body in github.issue_comments)
+
+
+def test_improvement_arms_auto_merge(tmp_path, target_repo) -> None:
+    """Publish hands the merge to the human approval: auto-merge is armed on
+    the fresh PR, so approving is the last human action needed."""
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "am=1\n"},
+        values=[13.876, 13.1],
+        run_id="tsp-arm",
+    )
+    assert outcome.outcome == "improved"
+    assert github.armed == [("org/pilot", 1)]
+
+
+def test_arming_failure_never_fails_the_publish(tmp_path, target_repo) -> None:
+    """Repos without auto-merge enabled refuse the mutation; the PR must
+    survive that (arming is convenience, not correctness)."""
+    github = FakeGitHub(arming_error="auto merge is not allowed")
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-noarm",
+        harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "na=2\n"}),
+        evaluator=QueueEvaluator(values=[13.876, 13.1]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "improved"
+    assert outcome.pr_url.endswith("/pull/1")
+    assert github.armed == []

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -100,10 +100,11 @@ class FakeGitHub:
         self.prs.append(dict(repo=repo, title=title, head=head, base=base, body=body))
         return f"https://github.com/{repo}/pull/1"
 
-    def enable_auto_merge(self, repo, number, method="MERGE") -> None:
+    def arm_auto_merge_when_review_required(self, repo, number) -> bool:
         if self.arming_error:
             raise RuntimeError(self.arming_error)
         self.armed.append((repo, number))
+        return True
 
 
 @dataclass

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -247,7 +247,9 @@ def test_enable_auto_merge_arms_via_graphql(provider: FileTokenProvider) -> None
     assert "enablePullRequestAutoMerge" in body["query"]
 
 
-def test_enable_auto_merge_surfaces_graphql_errors(provider: FileTokenProvider) -> None:
+def test_enable_auto_merge_surfaces_graphql_errors_as_status_zero(
+    provider: FileTokenProvider,
+) -> None:
     transport = FakeTransport(
         [
             {"node_id": "PR_node123", "number": 7},
@@ -255,11 +257,45 @@ def test_enable_auto_merge_surfaces_graphql_errors(provider: FileTokenProvider) 
         ]
     )
     client = GitHubClient(auth=provider, transport=transport)
-    with pytest.raises(GitHubError, match="not allowed"):
+    with pytest.raises(GitHubError, match="not allowed") as exc_info:
         client.enable_auto_merge("org/repo", 7)
+    assert exc_info.value.status == 0  # not an HTTP failure; not a success either
+
+
+def test_enable_auto_merge_missing_node_id_is_typed(provider: FileTokenProvider) -> None:
+    transport = FakeTransport([{"number": 7}])
+    with pytest.raises(GitHubError, match="node_id"):
+        GitHubClient(auth=provider, transport=transport).enable_auto_merge("org/repo", 7)
 
 
 def test_enable_auto_merge_dry_run_touches_nothing(provider: FileTokenProvider) -> None:
     transport = FakeTransport([])
     GitHubClient(auth=provider, transport=transport, dry_run=True).enable_auto_merge("o/r", 1)
     assert transport.requests == []
+
+
+def test_arming_guard_requires_a_required_review(provider: FileTokenProvider) -> None:
+    """No required human review between arming and merging -> refuse to arm:
+    the bot-never-merges rule must hold in code, not per-repo config."""
+    transport = FakeTransport([{"data": {"repository": {"pullRequest": {"reviewDecision": None}}}}])
+    client = GitHubClient(auth=provider, transport=transport)
+    assert client.arm_auto_merge_when_review_required("org/repo", 7) is False
+    assert len(transport.requests) == 1  # decision query only; no mutation sent
+
+
+def test_arming_guard_arms_with_repo_allowed_method(provider: FileTokenProvider) -> None:
+    """REVIEW_REQUIRED -> arm, falling back to a merge method the repo
+    actually allows (squash-only self-hosters still get arming)."""
+    transport = FakeTransport(
+        [
+            {"data": {"repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}}},
+            {"allow_merge_commit": False, "allow_squash_merge": True, "allow_rebase_merge": True},
+            {"node_id": "PR_n", "number": 7},
+            {"data": {"enablePullRequestAutoMerge": {"pullRequest": {"number": 7}}}},
+        ]
+    )
+    client = GitHubClient(auth=provider, transport=transport)
+    assert client.arm_auto_merge_when_review_required("org/repo", 7) is True
+    assert isinstance(transport.requests[-1].data, bytes)
+    body = json.loads(transport.requests[-1].data.decode())
+    assert body["variables"]["method"] == "SQUASH"

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from autoresearch.github import FileTokenProvider, GitHubClient, Workspace
+from autoresearch.github import FileTokenProvider, GitHubClient, GitHubError, Workspace
 
 
 class FakeTransport:
@@ -228,3 +228,38 @@ def test_file_content_is_none_on_error_or_nonfile(provider: FileTokenProvider) -
 
     directory = GitHubClient(auth=provider, transport=FakeTransport([[{"name": "sub"}]]))
     assert directory.get_file_content("org/repo", "dir", "sha") is None
+
+
+def test_enable_auto_merge_arms_via_graphql(provider: FileTokenProvider) -> None:
+    transport = FakeTransport(
+        [
+            {"node_id": "PR_node123", "number": 7},
+            {"data": {"enablePullRequestAutoMerge": {"pullRequest": {"number": 7}}}},
+        ]
+    )
+    client = GitHubClient(auth=provider, transport=transport)
+    client.enable_auto_merge("org/repo", 7)
+    graphql = transport.requests[-1]
+    assert graphql.full_url.endswith("/graphql")
+    assert isinstance(graphql.data, bytes)
+    body = json.loads(graphql.data.decode())
+    assert body["variables"] == {"pr": "PR_node123", "method": "MERGE"}
+    assert "enablePullRequestAutoMerge" in body["query"]
+
+
+def test_enable_auto_merge_surfaces_graphql_errors(provider: FileTokenProvider) -> None:
+    transport = FakeTransport(
+        [
+            {"node_id": "PR_node123", "number": 7},
+            {"errors": [{"message": "Pull request Auto merge is not allowed"}]},
+        ]
+    )
+    client = GitHubClient(auth=provider, transport=transport)
+    with pytest.raises(GitHubError, match="not allowed"):
+        client.enable_auto_merge("org/repo", 7)
+
+
+def test_enable_auto_merge_dry_run_touches_nothing(provider: FileTokenProvider) -> None:
+    transport = FakeTransport([])
+    GitHubClient(auth=provider, transport=transport, dry_run=True).enable_auto_merge("o/r", 1)
+    assert transport.requests == []


### PR DESCRIPTION
Closes the gap Mengye hit on pilot #11: approval + green checks, yet nothing merged, because arming is per-PR and the publish step never did it. Now `live_climb` arms auto-merge (GraphQL `enablePullRequestAutoMerge`) right after `create_pull`, best-effort — the bot-never-merges rule holds since arming only delegates to the human approval branch protection requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)