### PR TITLE
Publish-time freshness: merge a moved base and re-measure before pushing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,11 @@ Versions follow [SemVer](https://semver.org).
 - Publish-time freshness: when the base branch moves during a climb, the
   run branch merges the fresh base (merge commit, never rebase), the claim
   is re-measured on the merged tree, and the leader check runs against the
-  fresh ledger — before anything is pushed. A conflicting merge or an
-  absorbed improvement ends the run honestly instead of opening an
-  unmergeable or unverified PR.
+  fresh ledger — before anything is pushed; both sides are measured in
+  throwaway worktrees of commits (equivalent pristine environments; the
+  shas pin content). A conflicting merge or an absorbed improvement ends
+  the run honestly instead of opening an unmergeable or unverified PR, and
+  a final base re-check before push narrows (not eliminates) the window.
 
 - Improvement PRs arm GitHub auto-merge at publish (best-effort): the bot
   still never merges — arming hands the merge to the human approval that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Publish-time freshness: when the base branch moves during a climb, the
+  run branch merges the fresh base (merge commit, never rebase), the claim
+  is re-measured on the merged tree, and the leader check runs against the
+  fresh ledger — before anything is pushed. A conflicting merge or an
+  absorbed improvement ends the run honestly instead of opening an
+  unmergeable or unverified PR.
+
 - Improvement PRs arm GitHub auto-merge at publish (best-effort): the bot
   still never merges — arming hands the merge to the human approval that
   branch protection requires, so approving is the last human action needed.

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -17,6 +17,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import replace as dc_replace
 from pathlib import Path
+from typing import Any
 
 from autoresearch.contract import load_contract
 from autoresearch.github import (
@@ -106,6 +107,30 @@ def _best_effort(what: str, fn: Callable[[], object], secrets: tuple[str, ...] =
     except Exception as exc:
         log.warning("%s failed: %s", what, redact(f"{type(exc).__name__}: {exc}", secrets))
         return False
+
+
+def _measure_committed(
+    ws: Workspace, evaluator: Evaluator, run_dir: Path, name: str, sha: str, bench: Any
+) -> float:
+    """Measure a COMMITTED tree in a throwaway worktree.
+
+    Both sides of the post-merge comparison run in equivalent pristine
+    environments — the long-lived workspace carries session-created caches
+    and virtualenvs a fresh tree lacks, so measuring one side there would
+    bias the accept/reject decision. Eval writes are discarded with the
+    worktree, and the measured content is exactly the commit: the sha IS
+    the drift fingerprint.
+    """
+    wt = run_dir / f"measure-{name}"
+    ws.git("worktree", "add", "--detach", str(wt), sha)
+    try:
+        return float(evaluator.evaluate(wt, bench.command, bench.metric))
+    finally:
+        removed = _best_effort(
+            "worktree cleanup", lambda: ws.git("worktree", "remove", "--force", str(wt))
+        )
+        if not removed:  # never silent: a leaked worktree is a disk leak
+            _best_effort("worktree prune", lambda: ws.git("worktree", "prune"))
 
 
 def live_climb(
@@ -322,32 +347,36 @@ def live_climb(
                         "FETCH_HEAD",
                     )
                 except GitError as exc:
+                    # a content conflict and an infrastructure failure need
+                    # different triage — do not report one as the other
+                    conflicted = False
+                    with contextlib.suppress(GitError):
+                        conflicted = bool(ws.git("ls-files", "-u").strip())
                     with contextlib.suppress(GitError):
                         ws.git("merge", "--abort")
+                    if conflicted:
+                        raise WorkspaceDrift(
+                            f"base branch moved during the climb and the merge "
+                            f"conflicted: {str(exc)[:300]}"
+                        ) from exc
                     raise WorkspaceDrift(
-                        f"base branch moved during the climb and the merge "
-                        f"conflicted: {str(exc)[:300]}"
+                        f"base branch moved and the merge FAILED (not a content "
+                        f"conflict): {str(exc)[:300]}"
                     ) from exc
                 # The claim must hold on the tree that actually lands —
                 # BOTH sides of it. Upstream may have changed the metric for
                 # everyone, so comparing a merged-tree candidate against the
                 # pre-merge baseline would describe a delta that never
                 # existed on any single tree (and could push a regression
-                # relative to the fresh base). Baseline: the fresh base
-                # alone, in a detached worktree. Candidate: the merged tree.
-                fresh_dir = run_dir / "fresh-base"
-                ws.git("worktree", "add", "--detach", str(fresh_dir), fresh_base)
-                try:
-                    baseline = evaluator.evaluate(fresh_dir, bench.command, bench.metric)
-                finally:
-                    with contextlib.suppress(GitError):
-                        ws.git("worktree", "remove", "--force", str(fresh_dir))
-                candidate = evaluator.evaluate(workspace, bench.command, bench.metric)
-                # dirty-tree check BEFORE the accept/reject decision, so an
-                # eval that writes files can never influence the verdict
-                # (same add -A visibility as the main drift fingerprints)
-                if ws.git("status", "--porcelain").strip():
-                    raise WorkspaceDrift("re-eval on the merged tree wrote files")
+                # relative to the fresh base). Both sides are measured in
+                # throwaway worktrees of COMMITS — equivalent pristine
+                # environments, and no dirty-tree check needed: eval writes
+                # are discarded with the worktree and the shas pin content.
+                merged_sha = ws.git("rev-parse", "HEAD").strip()
+                baseline = _measure_committed(
+                    ws, evaluator, run_dir, "fresh-base", fresh_base, bench
+                )
+                candidate = _measure_committed(ws, evaluator, run_dir, "merged", merged_sha, bench)
                 if not orch_improved(
                     baseline, candidate, bench.direction, config.min_relative_improvement
                 ):
@@ -393,6 +422,15 @@ def live_climb(
                 author=config.bot_login,
                 forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
             )
+            # Last-moment re-check: the re-measurement above can take
+            # minutes, and the base can move AGAIN meanwhile. This narrows
+            # the unverified window to seconds; it cannot eliminate it.
+            ws.git_network("fetch", str(ws.url or ws.remote_url()), base_branch)
+            if ws.git("rev-parse", "FETCH_HEAD").strip() != fresh_base:
+                raise WorkspaceDrift(
+                    "base branch moved again during re-measurement; "
+                    "ending without pushing (a later run will retry)"
+                )
             ws.push(branch)
             pushed = True
             body = pr_body(result, config, redact_secrets=secrets)

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -169,7 +169,10 @@ def live_climb(
     tree_hashes: list[str] = []
     try:
         ws = Workspace.clone(f"https://github.com/{config.target}.git", workspace, auth=bot_auth)
-        base_sha = ws.git("rev-parse", "HEAD").strip()
+        # the BASE BRANCH tip, not HEAD: they differ if the PR base is ever
+        # not the clone's default branch, and the freshness comparison below
+        # must be against the branch the PR will actually land on
+        base_sha = ws.git("rev-parse", f"origin/{base_branch}").strip()
         contract_text = (workspace / ".autoresearch.yaml").read_text()
         contract = load_contract(contract_text, config.target)
 
@@ -325,19 +328,35 @@ def live_climb(
                         f"base branch moved during the climb and the merge "
                         f"conflicted: {str(exc)[:300]}"
                     ) from exc
-                # The claim must hold on the tree that actually lands.
+                # The claim must hold on the tree that actually lands —
+                # BOTH sides of it. Upstream may have changed the metric for
+                # everyone, so comparing a merged-tree candidate against the
+                # pre-merge baseline would describe a delta that never
+                # existed on any single tree (and could push a regression
+                # relative to the fresh base). Baseline: the fresh base
+                # alone, in a detached worktree. Candidate: the merged tree.
+                fresh_dir = run_dir / "fresh-base"
+                ws.git("worktree", "add", "--detach", str(fresh_dir), fresh_base)
+                try:
+                    baseline = evaluator.evaluate(fresh_dir, bench.command, bench.metric)
+                finally:
+                    with contextlib.suppress(GitError):
+                        ws.git("worktree", "remove", "--force", str(fresh_dir))
                 candidate = evaluator.evaluate(workspace, bench.command, bench.metric)
+                # dirty-tree check BEFORE the accept/reject decision, so an
+                # eval that writes files can never influence the verdict
+                # (same add -A visibility as the main drift fingerprints)
+                if ws.git("status", "--porcelain").strip():
+                    raise WorkspaceDrift("re-eval on the merged tree wrote files")
                 if not orch_improved(
                     baseline, candidate, bench.direction, config.min_relative_improvement
                 ):
                     raise WorkspaceDrift(
-                        f"after merging the moved base, candidate {candidate} no "
-                        f"longer beats baseline {baseline} (upstream absorbed "
-                        f"or invalidated the improvement)"
+                        f"candidate {candidate} does not beat the fresh base's "
+                        f"{baseline} after merging the moved base (upstream "
+                        f"absorbed or invalidated the improvement)"
                     )
-                if ws.git("status", "--porcelain").strip():
-                    raise WorkspaceDrift("re-eval on the merged tree wrote files")
-                result = dc_replace(result, candidate=candidate)
+                result = dc_replace(result, baseline=baseline, candidate=candidate)
 
             # Progress record (BENCHMARKS.md + results/leader.json), written
             # by the orchestrator from ITS measurements after the drift check

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -11,14 +11,17 @@ has ended; the session sees only its own capped API key inside its container.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
+from dataclasses import replace as dc_replace
 from pathlib import Path
 
 from autoresearch.contract import load_contract
 from autoresearch.github import (
     FileTokenProvider,
+    GitError,
     GitHubClient,
     Workspace,
 )
@@ -166,6 +169,7 @@ def live_climb(
     tree_hashes: list[str] = []
     try:
         ws = Workspace.clone(f"https://github.com/{config.target}.git", workspace, auth=bot_auth)
+        base_sha = ws.git("rev-parse", "HEAD").strip()
         contract_text = (workspace / ".autoresearch.yaml").read_text()
         contract = load_contract(contract_text, config.target)
 
@@ -281,18 +285,70 @@ def live_climb(
             # unique branch per run: a fixed name collides on the second run
             branch = f"{config.branch_prefix}/{run_id}"
             ws.branch(branch)
-            # Progress record (BENCHMARKS.md + results/leader.json), written
-            # by the orchestrator from ITS measurements after the drift check
-            # — the improvement and its human-readable record land in one PR.
             if result.baseline is None or result.candidate is None:
                 raise WorkspaceDrift("improved result missing measurements")
             bench = next(b for b in contract.benchmarks if b.name == config.benchmark)
+            baseline, candidate = result.baseline, result.candidate
+
+            # Freshness: the base branch may have MOVED during the climb
+            # (sessions run for many minutes; another PR can merge meanwhile).
+            # Landing the change on the clone's snapshot would open a
+            # conflicted PR — or worse, a clean-merging one whose claim was
+            # never measured against what it actually lands on. So: merge the
+            # moved base INTO the run branch (merge commit — never rebase)
+            # and re-measure on the merged tree before anything is pushed.
+            ws.git_network("fetch", str(ws.url or ws.remote_url()), base_branch)
+            fresh_base = ws.git("rev-parse", "FETCH_HEAD").strip()
+            base_moved = fresh_base != base_sha
+            if base_moved:
+                # the agent's work goes in its own commit first, so the merge
+                # commit stays a pure merge
+                ws.commit_all(
+                    f"agent: improve {config.benchmark}\n\nAgent: {config.agent_id}",
+                    author=config.bot_login,
+                    forbidden=lambda p: bool(out_of_scope([p], contract)),
+                )
+                try:
+                    ws.git(
+                        "-c",
+                        f"user.name={config.bot_login}",
+                        "-c",
+                        f"user.email={config.bot_login}@users.noreply.github.com",
+                        "merge",
+                        "--no-edit",
+                        "FETCH_HEAD",
+                    )
+                except GitError as exc:
+                    with contextlib.suppress(GitError):
+                        ws.git("merge", "--abort")
+                    raise WorkspaceDrift(
+                        f"base branch moved during the climb and the merge "
+                        f"conflicted: {str(exc)[:300]}"
+                    ) from exc
+                # The claim must hold on the tree that actually lands.
+                candidate = evaluator.evaluate(workspace, bench.command, bench.metric)
+                if not orch_improved(
+                    baseline, candidate, bench.direction, config.min_relative_improvement
+                ):
+                    raise WorkspaceDrift(
+                        f"after merging the moved base, candidate {candidate} no "
+                        f"longer beats baseline {baseline} (upstream absorbed "
+                        f"or invalidated the improvement)"
+                    )
+                if ws.git("status", "--porcelain").strip():
+                    raise WorkspaceDrift("re-eval on the merged tree wrote files")
+                result = dc_replace(result, candidate=candidate)
+
+            # Progress record (BENCHMARKS.md + results/leader.json), written
+            # by the orchestrator from ITS measurements after the drift check
+            # — read from the (possibly merged) tree, so the leader check runs
+            # against the FRESH ledger, not the clone's snapshot.
             prior = load_leader(workspace).get(config.benchmark)
             if prior is not None and not orch_improved(
-                prior.best, result.candidate, bench.direction, config.min_relative_improvement
+                prior.best, candidate, bench.direction, config.min_relative_improvement
             ):
                 raise WorkspaceDrift(
-                    f"candidate {result.candidate} does not beat the recorded "
+                    f"candidate {candidate} does not beat the recorded "
                     f"best {prior.best} by the noise floor (stale clone or eval noise)"
                 )
             entries = update_leader(
@@ -300,8 +356,8 @@ def live_climb(
                 benchmark=bench.name,
                 metric=bench.metric,
                 direction=bench.direction,
-                baseline=result.baseline,
-                candidate=result.candidate,
+                baseline=baseline,
+                candidate=candidate,
                 run_id=run_id,
                 date=created[:10],
             )
@@ -309,9 +365,11 @@ def live_climb(
             # The commit veto re-checks FULL scope (allowed + forbidden) as
             # defense in depth behind climb_once's pre-eval check. The two
             # orchestrator-written progress files are the only exemption.
+            # (When the base moved, the agent's work is already committed and
+            # only the progress files remain to stage.)
             ws.commit_all(
                 f"agent: improve {config.benchmark} "
-                f"({_title_pair(result.baseline, result.candidate)})"
+                f"({_title_pair(baseline, candidate)})"
                 f"\n\nAgent: {config.agent_id}",
                 author=config.bot_login,
                 forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
@@ -325,8 +383,7 @@ def live_climb(
                 config.target,
                 # short precision in the title; full precision lives in the
                 # PR body table and the ledger
-                title=f"[agent] {config.benchmark}: "
-                f"{_title_pair(result.baseline, result.candidate)}",
+                title=f"[agent] {config.benchmark}: {_title_pair(baseline, candidate)}",
                 head=branch,
                 base=base_branch,
                 body=body,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
 from dataclasses import replace as dc_replace
@@ -129,7 +130,10 @@ def _measure_committed(
         removed = _best_effort(
             "worktree cleanup", lambda: ws.git("worktree", "remove", "--force", str(wt))
         )
-        if not removed:  # never silent: a leaked worktree is a disk leak
+        if not removed:  # never silent: a leaked worktree is a disk leak —
+            # and prune alone only drops the ADMIN entry, so delete the
+            # directory itself first
+            _best_effort("worktree dir removal", lambda: shutil.rmtree(wt, ignore_errors=True))
             _best_effort("worktree prune", lambda: ws.git("worktree", "prune"))
 
 

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -713,3 +713,120 @@ def test_arming_failure_never_fails_the_publish(tmp_path, target_repo) -> None:
     assert outcome.outcome == "improved"
     assert outcome.pr_url.endswith("/pull/1")
     assert github.armed == []
+
+
+def _push_upstream(target_repo, tmp_path, rel_path: str, content: str, name: str) -> None:
+    """Simulate a concurrent merge: land a commit on the origin's main."""
+    side = tmp_path / f"side-{name}"
+    _git(tmp_path, "clone", "-q", str(target_repo), str(side))
+    p = side / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(content)
+    _git(side, "-c", "user.name=u", "-c", "user.email=u@u", "add", "-A")
+    _git(side, "-c", "user.name=u", "-c", "user.email=u@u", "commit", "-qm", f"upstream {name}")
+    _git(side, "push", "-q", "origin", "main")
+
+
+@dataclass
+class RacingHarness(ScriptedHarness):
+    """Applies its edits AND lands an upstream commit mid-session."""
+
+    target_repo: object = None
+    tmp_path: object = None
+    upstream_path: str = "docs/roadmap.md"
+    upstream_content: str = "# roadmap moved\n"
+
+    def run(self, brief_text, workspace, resume_session_id=None):
+        _push_upstream(
+            self.target_repo, self.tmp_path, self.upstream_path, self.upstream_content, "race"
+        )
+        return super().run(brief_text, workspace, resume_session_id)
+
+
+def test_moved_base_is_merged_and_remeasured_before_push(tmp_path, target_repo) -> None:
+    """Main moves during the climb (disjoint file): the branch merges the
+    fresh base (merge commit, never rebase), the claim is RE-MEASURED on the
+    merged tree, and the PR lands with both histories."""
+    github = FakeGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-race",
+        harness=RacingHarness(
+            edits={"src/pilot/solvers/tsp.py": "r=1\n"},
+            target_repo=target_repo,
+            tmp_path=tmp_path,
+        ),
+        # third value = the re-measurement on the merged tree
+        evaluator=QueueEvaluator(values=[13.876, 13.1, 13.1]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="2026-08-07T00:00:00Z",
+    )
+    assert outcome.outcome == "improved"
+    assert github.prs and github.prs[0]["head"] == "feat/auto/agent-01/tsp-race"
+    # the branch contains the upstream commit (merged, not ignored)
+    branch_files = _git(target_repo, "ls-tree", "-r", "--name-only", "feat/auto/agent-01/tsp-race")
+    assert "docs/roadmap.md" in branch_files
+    upstream_on_branch = _git(target_repo, "show", "feat/auto/agent-01/tsp-race:docs/roadmap.md")
+    assert upstream_on_branch == "# roadmap moved\n"
+    # vs the MOVED main, the branch changes only solver + progress files
+    files = set(
+        _git(target_repo, "diff", "--name-only", "main", "feat/auto/agent-01/tsp-race").split()
+    )
+    assert files == {"src/pilot/solvers/tsp.py", "BENCHMARKS.md", "results/leader.json"}
+
+
+def test_conflicting_moved_base_is_publish_error_not_a_broken_pr(tmp_path, target_repo) -> None:
+    """Upstream rewrites the SAME file the agent edited: the merge conflicts,
+    nothing is pushed, and the run ends honestly instead of opening an
+    unmergeable PR."""
+    github = FakeGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-clash",
+        harness=RacingHarness(
+            edits={"src/pilot/solvers/tsp.py": "mine=1\n"},
+            target_repo=target_repo,
+            tmp_path=tmp_path,
+            upstream_path="src/pilot/solvers/tsp.py",
+            upstream_content="theirs=2\n",
+        ),
+        evaluator=QueueEvaluator(values=[13.876, 13.1]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "publish-error"
+    assert github.prs == []
+    assert "feat/auto/agent-01/tsp-clash" not in _git(target_repo, "branch", "--list")
+    record = load_record(tmp_path / "state", "tsp-clash")
+    assert "merge" in record.ending_note and "conflict" in record.ending_note
+
+
+def test_absorbed_improvement_after_merge_is_rejected(tmp_path, target_repo) -> None:
+    """The merged tree no longer beats the baseline (upstream absorbed the
+    win): re-measurement vetoes the push."""
+    github = FakeGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-absorbed",
+        harness=RacingHarness(
+            edits={"src/pilot/solvers/tsp.py": "a=1\n"},
+            target_repo=target_repo,
+            tmp_path=tmp_path,
+        ),
+        # merged-tree re-measurement says NO improvement
+        evaluator=QueueEvaluator(values=[13.876, 13.1, 13.876]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "publish-error"
+    assert github.prs == []
+    assert "no longer beats" in load_record(tmp_path / "state", "tsp-absorbed").ending_note

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -743,6 +743,21 @@ class RacingHarness(ScriptedHarness):
         return super().run(brief_text, workspace, resume_session_id)
 
 
+@dataclass
+class DirCheckingEvaluator(QueueEvaluator):
+    """Pops values like QueueEvaluator but also records, per call, whether
+    the tree it was handed contained the agent's edit — proving the two
+    post-merge measurements ran on the intended PRISTINE trees, not on the
+    session's long-lived workspace."""
+
+    saw_agent_edit: list = field(default_factory=list)
+
+    def evaluate(self, workspace, command, metric) -> float:
+        solver = Path(workspace) / "src" / "pilot" / "solvers" / "tsp.py"
+        self.saw_agent_edit.append(solver.exists() and "r=1" in solver.read_text())
+        return super().evaluate(workspace, command, metric)
+
+
 def test_moved_base_is_merged_and_remeasured_before_push(tmp_path, target_repo) -> None:
     """Main moves during the climb (disjoint file): the branch merges the
     fresh base (merge commit, never rebase), the claim is RE-MEASURED on the
@@ -750,7 +765,7 @@ def test_moved_base_is_merged_and_remeasured_before_push(tmp_path, target_repo) 
     github = FakeGitHub()
     # values: session baseline, session candidate, then the post-merge pair —
     # fresh-base baseline (worktree of FETCH_HEAD) and merged-tree candidate
-    evaluator = QueueEvaluator(values=[13.876, 13.1, 13.9, 13.2])
+    evaluator = DirCheckingEvaluator(values=[13.876, 13.1, 13.9, 13.2])
     outcome = live_climb(
         config=ClimbConfig(target="org/pilot", benchmark="tsp"),
         run_root=tmp_path / "state",
@@ -768,6 +783,12 @@ def test_moved_base_is_merged_and_remeasured_before_push(tmp_path, target_repo) 
     )
     assert outcome.outcome == "improved"
     assert evaluator.values == []  # both post-merge measurements actually ran
+    # call 3 = fresh base WITHOUT the agent edit; call 4 = merged tree WITH it
+    # (calls 1-2 are the session-time pair in the live workspace)
+    assert evaluator.saw_agent_edit[2:] == [False, True]
+    # the worktrees were cleaned up (no disk leak in the run dir)
+    leftovers = [p.name for p in (tmp_path / "state" / "runs" / "tsp-race").iterdir()]
+    assert "measure-fresh-base" not in leftovers and "measure-merged" not in leftovers
     assert github.prs and github.prs[0]["head"] == "feat/auto/agent-01/tsp-race"
     # the PR claims the post-merge pair, not the session-time numbers
     assert "13.9 -> 13.2" in github.prs[0]["title"]

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -832,7 +832,10 @@ def test_conflicting_moved_base_is_publish_error_not_a_broken_pr(tmp_path, targe
     assert github.prs == []
     assert "feat/auto/agent-01/tsp-clash" not in _git(target_repo, "branch", "--list")
     record = load_record(tmp_path / "state", "tsp-clash")
-    assert "merge" in record.ending_note and "conflict" in record.ending_note
+    # pin the TRIAGE branch, not just the topic: this is a content conflict,
+    # and must not be reported through the infrastructure-failure message
+    assert "conflicted" in record.ending_note
+    assert "not a content conflict" not in record.ending_note
 
 
 def test_absorbed_improvement_after_merge_is_rejected(tmp_path, target_repo) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -748,6 +748,9 @@ def test_moved_base_is_merged_and_remeasured_before_push(tmp_path, target_repo) 
     fresh base (merge commit, never rebase), the claim is RE-MEASURED on the
     merged tree, and the PR lands with both histories."""
     github = FakeGitHub()
+    # values: session baseline, session candidate, then the post-merge pair —
+    # fresh-base baseline (worktree of FETCH_HEAD) and merged-tree candidate
+    evaluator = QueueEvaluator(values=[13.876, 13.1, 13.9, 13.2])
     outcome = live_climb(
         config=ClimbConfig(target="org/pilot", benchmark="tsp"),
         run_root=tmp_path / "state",
@@ -757,15 +760,19 @@ def test_moved_base_is_merged_and_remeasured_before_push(tmp_path, target_repo) 
             target_repo=target_repo,
             tmp_path=tmp_path,
         ),
-        # third value = the re-measurement on the merged tree
-        evaluator=QueueEvaluator(values=[13.876, 13.1, 13.1]),
+        evaluator=evaluator,
         github=github,  # type: ignore[arg-type]
         bot_auth=NoAuth(),  # type: ignore[arg-type]
         now=1_000_000.0,
         created="2026-08-07T00:00:00Z",
     )
     assert outcome.outcome == "improved"
+    assert evaluator.values == []  # both post-merge measurements actually ran
     assert github.prs and github.prs[0]["head"] == "feat/auto/agent-01/tsp-race"
+    # the PR claims the post-merge pair, not the session-time numbers
+    assert "13.9 -> 13.2" in github.prs[0]["title"]
+    # a true merge commit landed (never a rebase)
+    assert _git(target_repo, "log", "--merges", "--oneline", "feat/auto/agent-01/tsp-race")
     # the branch contains the upstream commit (merged, not ignored)
     branch_files = _git(target_repo, "ls-tree", "-r", "--name-only", "feat/auto/agent-01/tsp-race")
     assert "docs/roadmap.md" in branch_files
@@ -820,8 +827,9 @@ def test_absorbed_improvement_after_merge_is_rejected(tmp_path, target_repo) -> 
             target_repo=target_repo,
             tmp_path=tmp_path,
         ),
-        # merged-tree re-measurement says NO improvement
-        evaluator=QueueEvaluator(values=[13.876, 13.1, 13.876]),
+        # post-merge: fresh base measures 13.0, merged tree only 13.05 —
+        # upstream absorbed the win; the candidate REGRESSES the fresh base
+        evaluator=QueueEvaluator(values=[13.876, 13.1, 13.0, 13.05]),
         github=github,  # type: ignore[arg-type]
         bot_auth=NoAuth(),  # type: ignore[arg-type]
         now=1_000_000.0,
@@ -829,4 +837,7 @@ def test_absorbed_improvement_after_merge_is_rejected(tmp_path, target_repo) -> 
     )
     assert outcome.outcome == "publish-error"
     assert github.prs == []
-    assert "no longer beats" in load_record(tmp_path / "state", "tsp-absorbed").ending_note
+    assert (
+        "does not beat the fresh base"
+        in load_record(tmp_path / "state", "tsp-absorbed").ending_note
+    )


### PR DESCRIPTION
Part (a) of the merge-conflict hardening Mengye asked for: the publish step now handles a base branch that moved during the climb.

- **Clean race** (upstream touched other files): the run branch merges the fresh base — merge commit, never rebase — the candidate is **re-measured on the merged tree**, the leader-never-regresses check runs against the **fresh** ledger, and only then do progress files get written and pushed. Tested with a harness that lands an upstream commit on the origin mid-session.
- **Conflicting race** (upstream rewrote the same file): merge aborts, nothing is pushed, the run ends publish-error with the conflict named — no unmergeable PR for a human to untangle.
- **Absorbed win**: if the merged tree no longer beats the baseline by the noise floor, the push is vetoed with both numbers recorded.

Part (b) — waking the authoring session when an already-open PR turns conflicted (`mergeable_state=dirty`) — comes separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)