### PR TITLE
Explicit review-label requests override the automatic bot-author skip

### DIFF
--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -93,8 +93,9 @@ jobs:
           # override requires the SPECIFIC re-request label (any-label would
           # defeat the bot-skip via unrelated triage labels, even though
           # callers also gate at the job level — defense in depth) and a
-          # labeler who is NOT the PR's author — the direct statement of
-          # "the author must not unlock review of its own work", robust to
-          # the bot acting through an app token or a second account.
+          # labeler who is NOT the PR's author — "the author must not
+          # unlock review of its own work". Scope honestly stated: other
+          # accounts with triage access are trusted per GitHub's own
+          # permission model; this guard only stops self-unlocking.
           REVIEW_EXPLICIT_REQUEST: ${{ github.event.action == 'labeled' && github.event.label.name == 'autoresearch:review' && github.event.sender.login != github.event.pull_request.user.login }}
         run: uv run --extra review python -m autoresearch.review_cli

--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -93,7 +93,8 @@ jobs:
           # override requires the SPECIFIC re-request label (any-label would
           # defeat the bot-skip via unrelated triage labels, even though
           # callers also gate at the job level — defense in depth) and a
-          # sender other than the bot itself (the bot labeling its own PR
-          # must not unlock review of its own work).
-          REVIEW_EXPLICIT_REQUEST: ${{ github.event.action == 'labeled' && github.event.label.name == 'autoresearch:review' && github.event.sender.login != inputs.bot_login }}
+          # labeler who is NOT the PR's author — the direct statement of
+          # "the author must not unlock review of its own work", robust to
+          # the bot acting through an app token or a second account.
+          REVIEW_EXPLICIT_REQUEST: ${{ github.event.action == 'labeled' && github.event.label.name == 'autoresearch:review' && github.event.sender.login != github.event.pull_request.user.login }}
         run: uv run --extra review python -m autoresearch.review_cli

--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -89,7 +89,11 @@ jobs:
           REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
           REVIEW_MODEL: ${{ inputs.model }}
           REVIEW_EFFORT: ${{ inputs.effort }}
-          # the caller's triggering event flows through workflow_call: a
-          # labeled event means a human explicitly re-requested this review
-          REVIEW_EXPLICIT_REQUEST: ${{ github.event.action == 'labeled' }}
+          # The caller's triggering event flows through workflow_call. The
+          # override requires the SPECIFIC re-request label (any-label would
+          # defeat the bot-skip via unrelated triage labels, even though
+          # callers also gate at the job level — defense in depth) and a
+          # sender other than the bot itself (the bot labeling its own PR
+          # must not unlock review of its own work).
+          REVIEW_EXPLICIT_REQUEST: ${{ github.event.action == 'labeled' && github.event.label.name == 'autoresearch:review' && github.event.sender.login != inputs.bot_login }}
         run: uv run --extra review python -m autoresearch.review_cli

--- a/.github/workflows/advisory-review.yml
+++ b/.github/workflows/advisory-review.yml
@@ -1,7 +1,9 @@
 # Reusable advisory-review workflow. Target repos call this with `uses:`;
 # they never vendor the reviewer code. Constraints enforced here and in
-# autoresearch.review: never reviews bot-authored PRs, never approves, never
-# fails the caller's CI, and never runs with secrets on a fork PR.
+# autoresearch.review: never reviews bot-authored PRs automatically (a
+# maintainer-added re-request label overrides — an explicit human ask is
+# not an echo chamber), never approves, never fails the caller's CI, and
+# never runs with secrets on a fork PR.
 name: advisory-review
 
 on:
@@ -87,4 +89,7 @@ jobs:
           REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
           REVIEW_MODEL: ${{ inputs.model }}
           REVIEW_EFFORT: ${{ inputs.effort }}
+          # the caller's triggering event flows through workflow_call: a
+          # labeled event means a human explicitly re-requested this review
+          REVIEW_EXPLICIT_REQUEST: ${{ github.event.action == 'labeled' }}
         run: uv run --extra review python -m autoresearch.review_cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- The `autoresearch:review` label now works on bot-authored PRs too: a
+  maintainer-added label is an explicit ask and overrides the automatic
+  bot-author skip (which exists to prevent echo chambers, not to refuse
+  humans). The opt-out label still wins over contradictory signals. When
+  the verifier ships, the same gesture will route bot PRs to it instead.
+
 - Review-until-quiet merge gate documented (CONTRIBUTING, CLAUDE.md):
   development PRs iterate advisory-review rounds with a judged termination
   criterion — code PRs stop at no new medium+/behavior-affecting findings,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,11 +39,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
-- The `autoresearch:review` label now works on bot-authored PRs too: a
-  maintainer-added label is an explicit ask and overrides the automatic
-  bot-author skip (which exists to prevent echo chambers, not to refuse
-  humans). The opt-out label still wins over contradictory signals. When
-  the verifier ships, the same gesture will route bot PRs to it instead.
+- Adding the `autoresearch:review` label now runs a review on bot-authored
+  PRs too: the labeling EVENT (not the label sitting on the PR — re-request
+  by removing and re-adding, same as on human PRs) is an explicit ask and
+  overrides the automatic bot-author skip, which exists to prevent echo
+  chambers, not to refuse humans. The opt-out label still wins over
+  contradictory signals. When the verifier ships, the same gesture will
+  route bot PRs to it instead.
 
 - Review-until-quiet merge gate documented (CONTRIBUTING, CLAUDE.md):
   development PRs iterate advisory-review rounds with a judged termination

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -43,7 +43,8 @@ always forbidden write paths; the contract is read from the default branch only;
 ## Roles
 
 1. **Advisory reviewer** — comments on PRs in opted-in repos. Constraints: fixed
-   "advisory, not an approval" header; never comments on bot-authored PRs; one
+   "advisory, not an approval" header; never comments on bot-authored PRs
+   automatically (a maintainer's explicit re-request label overrides); one
    review thread per PR; maintainers can opt a PR out by label. Ships first; no
    GPU needed.
 2. **Benchmark climber** — the research loop below.

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -1,9 +1,12 @@
 """Advisory PR reviewer.
 
 Posts review comments on opted-in repos. It is advisory only: it never
-approves, never blocks, and never comments on bot-authored PRs (the
-architecture's guard against the pipeline nudging humans to merge its own
-work). Maintainers opt a PR out with a label.
+approves, never blocks, and never comments on bot-authored PRs
+AUTOMATICALLY — the guard against the pipeline nudging humans to merge its
+own work. A maintainer's explicit re-request label overrides that one
+skip (a human asking for a machine opinion is not the pipeline nudging
+anyone); the opt-out label always wins. Maintainers opt a PR out with a
+label.
 
 The model call goes through :class:`Completer`, so the review logic is
 testable without an API key and the backend can change without touching

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -137,9 +137,17 @@ FINDINGS_SCHEMA: dict[str, Any] = {
 }
 
 
-def skip_reason(pr: PullRequest, bot_login: str) -> str | None:
-    """Why this PR must not be reviewed, or None if it may be."""
-    if pr.author.casefold() == bot_login.casefold():
+def skip_reason(pr: PullRequest, bot_login: str, explicit_request: bool = False) -> str | None:
+    """Why this PR must not be reviewed, or None if it may be.
+
+    `explicit_request` (a maintainer added the re-request label) overrides
+    the AUTOMATIC bot-author skip: that skip exists so the loop never
+    reviews its own PRs into an echo chamber, not to refuse a human who
+    deliberately asked for a machine opinion. The opt-out label still wins
+    even then — two contradictory labels resolve to silence, and the human
+    can remove the opt-out to break the tie.
+    """
+    if pr.author.casefold() == bot_login.casefold() and not explicit_request:
         return "bot-authored PR: the reviewer never comments on its own work"
     if any(label.casefold() == OPT_OUT_LABEL for label in pr.labels):
         return f"opted out via the {OPT_OUT_LABEL} label"
@@ -226,10 +234,14 @@ def build_prompt(pr: PullRequest, today: str | None = None) -> str:
 
 
 def review(
-    pr: PullRequest, completer: Completer, bot_login: str, today: str | None = None
+    pr: PullRequest,
+    completer: Completer,
+    bot_login: str,
+    today: str | None = None,
+    explicit_request: bool = False,
 ) -> ReviewResult:
     """Run one advisory review. Skips (rather than raises) when constraints say so."""
-    skip = skip_reason(pr, bot_login)
+    skip = skip_reason(pr, bot_login, explicit_request)
     if skip is not None:
         log.info("skipping review of %s#%s: %s", pr.repo, pr.number, skip)
         return ReviewResult(findings=[], notes="", skipped=skip)

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -124,12 +124,17 @@ def main() -> int:
             model=os.environ.get("REVIEW_MODEL") or "claude-opus-5",
             effort=os.environ.get("REVIEW_EFFORT") or "high",
         )
+        # A maintainer-added re-request label is an explicit ask: it
+        # overrides the automatic bot-author skip (see review.skip_reason).
+        explicit = os.environ.get("REVIEW_EXPLICIT_REQUEST", "").strip().lower() == "true"
         # Context is fetched only for PRs that will actually be reviewed —
         # bot-authored and opted-out PRs must not pay the API fan-out.
-        if skip_reason(pr, bot_login) is None:
+        if skip_reason(pr, bot_login, explicit) is None:
             pr = replace(pr, context_files=_gather_context(client, repo, number, pr_data))
         today = datetime.now(UTC).date().isoformat()
-        body = format_comment(review(pr, completer, bot_login, today=today))
+        body = format_comment(
+            review(pr, completer, bot_login, today=today, explicit_request=explicit)
+        )
         if body is None:
             log.info("nothing to post")
             return 0

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -209,3 +209,27 @@ def test_fork_fallback_when_head_repo_lacks_full_name(monkeypatch) -> None:
     _cli_env(monkeypatch)
     assert cli.main() == 0
     assert fake_client.repos_fetched and set(fake_client.repos_fetched) == {"org/repo"}
+
+
+def test_explicit_request_env_reaches_review_for_bot_prs(monkeypatch) -> None:
+    """REVIEW_EXPLICIT_REQUEST=true must flow through main(): the bot PR
+    pays the context fan-out and review() receives explicit_request=True —
+    a misspelled env key or dropped argument leaves this red."""
+    import autoresearch.review_cli as cli
+    from autoresearch.review import ReviewResult
+
+    fake_client = FakeReviewClient(author="Some-Bot")
+    seen: dict = {}
+
+    def fake_review(pr, completer, bot_login, today=None, explicit_request=False):
+        seen["explicit"] = explicit_request
+        return ReviewResult(findings=[], notes="")
+
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
+    monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
+    monkeypatch.setattr(cli, "review", fake_review)
+    _cli_env(monkeypatch)
+    monkeypatch.setenv("REVIEW_EXPLICIT_REQUEST", "true")
+    assert cli.main() == 0
+    assert seen["explicit"] is True
+    assert fake_client.content_fetches != []  # explicitly-requested: fan-out paid

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -115,6 +115,8 @@ def _cli_env(monkeypatch) -> None:
     monkeypatch.setenv("REVIEW_BOT_LOGIN", "some-bot")
     monkeypatch.setenv("ANTHROPIC_REVIEWER_KEY", "k")
     monkeypatch.setenv("GITHUB_TOKEN", "t")
+    # ambient env must not flip the explicit-request path under a test
+    monkeypatch.delenv("REVIEW_EXPLICIT_REQUEST", raising=False)
 
 
 def test_review_cli_threads_date_and_context(monkeypatch) -> None:

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -125,7 +125,7 @@ def test_review_cli_threads_date_and_context(monkeypatch) -> None:
     captured: dict = {}
     fake_client = FakeReviewClient()
 
-    def fake_review(pr, completer, bot_login, today=None):
+    def fake_review(pr, completer, bot_login, today=None, explicit_request=False):
         captured["today"] = today
         captured["context"] = tuple(pr.context_files)
         from autoresearch.review import ReviewResult
@@ -168,7 +168,7 @@ def test_context_fetch_stops_at_file_cap(monkeypatch) -> None:
     monkeypatch.setattr(
         cli,
         "review",
-        lambda pr, c, b, today=None: __import__(
+        lambda pr, c, b, today=None, explicit_request=False: __import__(
             "autoresearch.review", fromlist=["ReviewResult"]
         ).ReviewResult(findings=[], notes=""),
     )
@@ -202,7 +202,7 @@ def test_fork_fallback_when_head_repo_lacks_full_name(monkeypatch) -> None:
     monkeypatch.setattr(
         cli,
         "review",
-        lambda pr, c, b, today=None: __import__(
+        lambda pr, c, b, today=None, explicit_request=False: __import__(
             "autoresearch.review", fromlist=["ReviewResult"]
         ).ReviewResult(findings=[], notes=""),
     )

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -157,3 +157,18 @@ def test_schema_forbids_extra_keys() -> None:
 
 def test_skipped_result_renders_nothing() -> None:
     assert format_comment(ReviewResult(findings=[], notes="", skipped="because")) is None
+
+
+def test_explicit_request_overrides_bot_skip() -> None:
+    """A maintainer-added re-request label reviews a bot PR; the automatic
+    path still never does."""
+    pr = make_pr(author=BOT)
+    assert skip_reason(pr, BOT) is not None  # automatic: skipped
+    assert skip_reason(pr, BOT, explicit_request=True) is None  # asked: reviewed
+
+
+def test_opt_out_still_wins_over_explicit_request() -> None:
+    """Contradictory labels resolve to silence, not to a review."""
+    pr = make_pr(author=BOT, labels=("autoresearch:no-review",))
+    reason = skip_reason(pr, BOT, explicit_request=True)
+    assert reason is not None and "opted out" in reason


### PR DESCRIPTION
UX fix from Mengye labeling pilot #13 and getting a silent green no-op: the advisory reviewer refuses bot-authored PRs *automatically* (echo-chamber prevention), but a maintainer-added `autoresearch:review` label is an explicit human ask and now overrides that one skip. The opt-out label still wins when both are present. No caller-workflow changes needed — the labeled event flows through `workflow_call` context. Interim UX until the verifier ships, which will take over the bot-PR lane with its gaming-focused prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)