### PR TITLE
Advisory reviewer posts one comment per round

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- The advisory reviewer posts one comment PER ROUND (numbered, stamped
+  with the reviewed head SHA) instead of editing a single thread: under
+  review-until-quiet, humans must see each round — comment edits fire no
+  notifications and bury prior rounds in edit history. The upsert guarded
+  against synchronize-era spam; runs are now open- or label-triggered
+  only.
+
 - Adding the `autoresearch:review` label now runs a review on bot-authored
   PRs too: the labeling EVENT (not the label sitting on the PR — re-request
   by removing and re-adding, same as on human PRs) is an explicit ask and

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -146,17 +146,24 @@ def main() -> int:
         # bury prior rounds in edit history). The old one-thread upsert
         # guarded against synchronize-triggered spam; runs are now only
         # PR-open or an explicit label request, so volume is human-bounded.
-        # The round number is cosmetic: a failure counting prior rounds
-        # must never cost the round itself.
+        head_sha = str((pr_data.get("head") or {}).get("sha", ""))[:8]
+        # The round number is cosmetic: an EXPECTED failure counting prior
+        # rounds must never cost the round itself. Programming errors still
+        # propagate, per this module's policy.
         try:
-            prior_rounds = sum(
-                1 for c in client.list_comments(repo, number) if MARKER in str(c.get("body", ""))
-            )
-            round_label = f"**Round {prior_rounds + 1}**"
-        except Exception as exc:
+            prior = [
+                str(c.get("body", ""))
+                for c in client.list_comments(repo, number)
+                # bot-authored only: a human quote-reply copies the marker
+                if MARKER in str(c.get("body", ""))
+                and str((c.get("user") or {}).get("type", "")).casefold() == "bot"
+            ]
+            round_label = f"**Round {len(prior) + 1}**"
+            if head_sha and any(f"reviewed head `{head_sha}`" in b for b in prior):
+                round_label += " (re-run on the same head)"
+        except EXPECTED_FAILURES as exc:
             log.warning("could not count prior rounds: %s", exc)
             round_label = "**New round** (prior count unavailable)"
-        head_sha = str((pr_data.get("head") or {}).get("sha", ""))[:8]
         stamp = f"{round_label} — reviewed head `{head_sha or 'unknown'}`.\n\n"
         client.comment(repo, number, body.replace(MARKER, f"{MARKER}\n{stamp}", 1))
         log.info("posted advisory review (%s) on %s#%s", round_label, repo, number)

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -138,8 +138,19 @@ def main() -> int:
         if body is None:
             log.info("nothing to post")
             return 0
-        client.upsert_comment(repo, number, MARKER, body)
-        log.info("posted advisory review on %s#%s", repo, number)
+        # One comment PER ROUND, numbered and stamped with the reviewed
+        # head: rounds are first-class under review-until-quiet, and a
+        # human must see each one (comment EDITS fire no notifications and
+        # bury prior rounds in edit history). The old one-thread upsert
+        # guarded against synchronize-triggered spam; runs are now only
+        # PR-open or an explicit label request, so volume is human-bounded.
+        prior_rounds = sum(
+            1 for c in client.list_comments(repo, number) if MARKER in str(c.get("body", ""))
+        )
+        head_sha = str((pr_data.get("head") or {}).get("sha", ""))[:8]
+        stamp = f"**Round {prior_rounds + 1}** — reviewed head `{head_sha or 'unknown'}`.\n\n"
+        client.comment(repo, number, body.replace(MARKER, f"{MARKER}\n{stamp}", 1))
+        log.info("posted advisory review round %d on %s#%s", prior_rounds + 1, repo, number)
     except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
         log.warning("advisory review did not complete: %s: %s", type(exc).__name__, exc)
     return 0

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -146,7 +146,8 @@ def main() -> int:
         # bury prior rounds in edit history). The old one-thread upsert
         # guarded against synchronize-triggered spam; runs are now only
         # PR-open or an explicit label request, so volume is human-bounded.
-        head_sha = str((pr_data.get("head") or {}).get("sha", ""))[:8]
+        head = pr_data.get("head")
+        head_sha = str(head.get("sha", ""))[:8] if isinstance(head, dict) else ""
         # The round number is cosmetic: an EXPECTED failure counting prior
         # rounds must never cost the round itself. Programming errors still
         # propagate, per this module's policy.

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -154,9 +154,11 @@ def main() -> int:
             prior = [
                 str(c.get("body", ""))
                 for c in client.list_comments(repo, number)
-                # bot-authored only: a human quote-reply copies the marker
-                if MARKER in str(c.get("body", ""))
-                and str((c.get("user") or {}).get("type", "")).casefold() == "bot"
+                # STARTS WITH the marker: a quote-reply prefixes every line
+                # with "> ", so it cannot match — and this stays true for
+                # any posting identity (Actions token, GitHub App, or a
+                # self-hoster's machine-user PAT, which posts as type User)
+                if str(c.get("body", "")).lstrip().startswith(MARKER)
             ]
             round_label = f"**Round {len(prior) + 1}**"
             if head_sha and any(f"reviewed head `{head_sha}`" in b for b in prior):

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -1,8 +1,10 @@
 """Entry point for the advisory-review workflow.
 
 Reads the PR from the environment the workflow provides, runs one review, and
-upserts a single comment (one thread per PR). Exits 0 even when it skips or
-fails: an advisory reviewer must never turn a target repo's CI red.
+posts one NEW comment per round — numbered, stamped with the reviewed head —
+so every round notifies and stays visible (edits do neither). Exits 0 even
+when it skips or fails: an advisory reviewer must never turn a target repo's
+CI red.
 """
 
 from __future__ import annotations
@@ -144,13 +146,20 @@ def main() -> int:
         # bury prior rounds in edit history). The old one-thread upsert
         # guarded against synchronize-triggered spam; runs are now only
         # PR-open or an explicit label request, so volume is human-bounded.
-        prior_rounds = sum(
-            1 for c in client.list_comments(repo, number) if MARKER in str(c.get("body", ""))
-        )
+        # The round number is cosmetic: a failure counting prior rounds
+        # must never cost the round itself.
+        try:
+            prior_rounds = sum(
+                1 for c in client.list_comments(repo, number) if MARKER in str(c.get("body", ""))
+            )
+            round_label = f"**Round {prior_rounds + 1}**"
+        except Exception as exc:
+            log.warning("could not count prior rounds: %s", exc)
+            round_label = "**New round** (prior count unavailable)"
         head_sha = str((pr_data.get("head") or {}).get("sha", ""))[:8]
-        stamp = f"**Round {prior_rounds + 1}** — reviewed head `{head_sha or 'unknown'}`.\n\n"
+        stamp = f"{round_label} — reviewed head `{head_sha or 'unknown'}`.\n\n"
         client.comment(repo, number, body.replace(MARKER, f"{MARKER}\n{stamp}", 1))
-        log.info("posted advisory review round %d on %s#%s", prior_rounds + 1, repo, number)
+        log.info("posted advisory review (%s) on %s#%s", round_label, repo, number)
     except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
         log.warning("advisory review did not complete: %s: %s", type(exc).__name__, exc)
     return 0

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -266,4 +266,28 @@ def test_each_round_posts_a_new_numbered_comment(monkeypatch) -> None:
     bodies = [c["body"] for c in fake_client.posted]
     assert len(bodies) == 2  # two comments, never an edit
     assert "**Round 1**" in bodies[0] and "**Round 2**" in bodies[1]
-    assert "reviewed head `abc12345" in bodies[0] or "reviewed head `" in bodies[0]
+    # the stamp carries the EXACT reviewed head from the PR payload
+    assert "reviewed head `abc123`" in bodies[0]
+
+
+def test_round_count_failure_never_costs_the_round(monkeypatch) -> None:
+    """Numbering is cosmetic; a listing failure must not suppress the post."""
+    import autoresearch.review_cli as cli
+    from autoresearch.review import ReviewResult
+
+    class ListlessClient(FakeReviewClient):
+        def list_comments(self, repo, number, max_pages=20):
+            raise RuntimeError("transient")
+
+    fake_client = ListlessClient()
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
+    monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
+    monkeypatch.setattr(
+        cli,
+        "review",
+        lambda pr, c, b, today=None, explicit_request=False: ReviewResult(findings=[], notes="n"),
+    )
+    _cli_env(monkeypatch)
+    assert cli.main() == 0
+    assert len(fake_client.posted) == 1
+    assert "New round" in fake_client.posted[0]["body"]

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -275,8 +275,11 @@ def test_each_round_posts_a_new_numbered_comment(monkeypatch) -> None:
 
 
 def test_quote_replies_do_not_inflate_round_count(monkeypatch) -> None:
-    """A human quoting the advisory comment copies the marker; only
-    BOT-authored comments count as rounds."""
+    """A human quoting the advisory comment copies the marker, but quoted
+    lines are prefixed — counting is TEXTUAL (marker at line start) and
+    deliberately identity-agnostic, so self-hosters posting with
+    machine-user PATs number correctly. A verbatim unquoted paste would
+    inflate the cosmetic number; accepted."""
     import autoresearch.review_cli as cli
     from autoresearch.review import MARKER, ReviewResult
 

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -268,16 +268,39 @@ def test_each_round_posts_a_new_numbered_comment(monkeypatch) -> None:
     assert "**Round 1**" in bodies[0] and "**Round 2**" in bodies[1]
     # the stamp carries the EXACT reviewed head from the PR payload
     assert "reviewed head `abc123`" in bodies[0]
+    # same head twice -> the second round says so
+    assert "(re-run on the same head)" in bodies[1]
+
+
+def test_quote_replies_do_not_inflate_round_count(monkeypatch) -> None:
+    """A human quoting the advisory comment copies the marker; only
+    BOT-authored comments count as rounds."""
+    import autoresearch.review_cli as cli
+    from autoresearch.review import MARKER, ReviewResult
+
+    fake_client = FakeReviewClient()
+    fake_client.posted.append({"body": f"quoting: {MARKER}", "user": {"type": "User"}})
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
+    monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
+    monkeypatch.setattr(
+        cli,
+        "review",
+        lambda pr, c, b, today=None, explicit_request=False: ReviewResult(findings=[], notes="n"),
+    )
+    _cli_env(monkeypatch)
+    assert cli.main() == 0
+    assert "**Round 1**" in fake_client.posted[-1]["body"]
 
 
 def test_round_count_failure_never_costs_the_round(monkeypatch) -> None:
     """Numbering is cosmetic; a listing failure must not suppress the post."""
     import autoresearch.review_cli as cli
+    from autoresearch.github import GitHubError
     from autoresearch.review import ReviewResult
 
     class ListlessClient(FakeReviewClient):
         def list_comments(self, repo, number, max_pages=20):
-            raise RuntimeError("transient")
+            raise GitHubError(500, "/comments", "transient")
 
     fake_client = ListlessClient()
     monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -112,7 +112,9 @@ class FakeReviewClient:
         return list(self.posted)
 
     def comment(self, repo: str, number: int, body: str) -> None:
-        self.posted.append({"body": body, "user": {"type": "Bot"}})
+        # deliberately type User: round counting must be identity-agnostic
+        # (self-hosters post reviews with machine-user PATs)
+        self.posted.append({"body": body, "user": {"type": "User"}})
 
 
 def _cli_env(monkeypatch) -> None:
@@ -279,7 +281,10 @@ def test_quote_replies_do_not_inflate_round_count(monkeypatch) -> None:
     from autoresearch.review import MARKER, ReviewResult
 
     fake_client = FakeReviewClient()
-    fake_client.posted.append({"body": f"quoting: {MARKER}", "user": {"type": "User"}})
+    # a real quote-reply: every quoted line is prefixed, marker not at start
+    fake_client.posted.append(
+        {"body": f"> {MARKER}\n> old finding\n\nmy reply", "user": {"type": "User"}}
+    )
     monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
     monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
     monkeypatch.setattr(

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -82,7 +82,10 @@ def test_completer_failures_are_expected_failures() -> None:
 class FakeReviewClient:
     """Stands in for GitHubClient in review_cli tests; records content fetches."""
 
+    posted: list
+
     def __init__(self, auth: object = None, author: str = "human-dev") -> None:
+        self.posted = []
         self.author = author
         self.content_fetches: list[str] = []
 
@@ -105,8 +108,11 @@ class FakeReviewClient:
         self.content_fetches.append(path)
         return "def f(): pass"
 
-    def upsert_comment(self, repo: str, number: int, marker: str, body: str) -> None:
-        pass
+    def list_comments(self, repo: str, number: int, max_pages: int = 20) -> list[dict]:
+        return list(self.posted)
+
+    def comment(self, repo: str, number: int, body: str) -> None:
+        self.posted.append({"body": body, "user": {"type": "Bot"}})
 
 
 def _cli_env(monkeypatch) -> None:
@@ -235,3 +241,29 @@ def test_explicit_request_env_reaches_review_for_bot_prs(monkeypatch) -> None:
     assert cli.main() == 0
     assert seen["explicit"] is True
     assert fake_client.content_fetches != []  # explicitly-requested: fan-out paid
+
+
+def test_each_round_posts_a_new_numbered_comment(monkeypatch) -> None:
+    """Rounds are first-class: every run posts a NEW comment (edits fire no
+    notifications), numbered by counting prior marker comments, stamped with
+    the reviewed head."""
+    import autoresearch.review_cli as cli
+    from autoresearch.review import ReviewResult
+
+    fake_client = FakeReviewClient()
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
+    monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
+    monkeypatch.setattr(
+        cli,
+        "review",
+        lambda pr, c, b, today=None, explicit_request=False: ReviewResult(
+            findings=[], notes="looked fine"
+        ),
+    )
+    _cli_env(monkeypatch)
+    assert cli.main() == 0
+    assert cli.main() == 0
+    bodies = [c["body"] for c in fake_client.posted]
+    assert len(bodies) == 2  # two comments, never an edit
+    assert "**Round 1**" in bodies[0] and "**Round 2**" in bodies[1]
+    assert "reviewed head `abc12345" in bodies[0] or "reviewed head `" in bodies[0]


### PR DESCRIPTION
Mengye couldn't find rounds 2-4 on #49: the upsert edited one comment in place, burying prior rounds in edit history and firing zero notifications. Every round now posts a new numbered comment stamped with the head SHA it reviewed. Volume is bounded because runs only trigger on open or explicit label since the Actions-economy change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)