### PR TITLE
Per-repo budget shaping + self-deadline alarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,10 @@ Versions follow [SemVer](https://semver.org).
   `session_max_turns`, `session_minutes`, `climb_job_minutes`, and
   `followup_job_minutes`. Contracts are untrusted, so every value is
   clamped into orchestrator-side [floor, ceiling] bounds (`limits` module)
-  — a target can spend less of the orchestrator, never more — and the
-  session is shrunk to fit inside its job. The tick fetches the contract
+  with CEILING == DEFAULT — contracts are merged by target-repo
+  maintainers, so the knobs shape strictly downward; raising a budget is
+  orchestrator-side config — and the session is shrunk to fit inside its
+  job. The tick fetches the contract
   once per cycle and threads the limits through all three launch lanes.
 - Self-deadline: climbs arm a SIGALRM at walltime-minus-margin (default
   120s, floor 60s, `--deadline-margin-s`) raising into the ordinary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Per-repo budget shaping: a contract's `budgets:` may now set
+  `session_max_turns`, `session_minutes`, `climb_job_minutes`, and
+  `followup_job_minutes`. Contracts are untrusted, so every value is
+  clamped into orchestrator-side [floor, ceiling] bounds (`limits` module)
+  — a target can spend less of the orchestrator, never more — and the
+  session is shrunk to fit inside its job. The tick fetches the contract
+  once per cycle and threads the limits through all three launch lanes.
+- Self-deadline: climbs arm a SIGALRM at walltime-minus-margin (default
+  120s, floor 60s, `--deadline-margin-s`) raising into the ordinary
+  containment — the only pre-kill warning on clusters that deliver no
+  signals to job processes (measured on Torch 2026-08-08). The tick passes
+  each climb its own walltime via `--job-minutes`.
+
 - The advisory reviewer posts one comment PER ROUND (numbered, stamped
   with the reviewed head SHA) instead of editing a single thread: under
   review-until-quiet, humans must see each round — comment edits fire no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,12 +59,15 @@ Versions follow [SemVer](https://semver.org).
   against synchronize-era spam; runs are now open- or label-triggered
   only.
 
-- Killed climbs now reach a recorded ending: SIGTERM (walltime, preemption,
-  scancel) raises into the climb's ordinary containment inside the KillWait
-  grace, the record stores the climb's own Slurm job id, and a new sweep
-  pass ends `implementing` records whose job is terminal — Slurm truth
-  plus grace, outage never reads as dead. Previously only crashes (Python
-  exceptions) were contained; kills stranded the record forever.
+- Killed climbs now reach a recorded ending: the record stores the climb's
+  own Slurm job id and a new sweep pass ends `implementing` records whose
+  job is terminal — Slurm truth plus grace, outage never reads as dead.
+  Previously only crashes (Python exceptions) were contained; kills
+  stranded the record forever. A SIGTERM handler also raises into the
+  ordinary containment, but measurement (Torch, 2026-08-08) showed Slurm
+  delivers no signal to job processes there — on such clusters the sweep
+  and the self-deadline (below) are the real teardown paths; the handler
+  covers direct kills and other sites.
 
 - Adding the `autoresearch:review` label now runs a review on bot-authored
   PRs too: the labeling EVENT (not the label sitting on the PR — re-request

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,7 @@
 # Roadmap
 
+Kept current by whoever lands the change (maintainer rule 2026-08-08: the
+roadmap is updated in the same PR that moves it, not batched later).
 Phases ship in order; each is a reviewed PR. The reviewer role delivers value
 before any target repo has a benchmark harness; the climber needs one
 (jepa-agent roadmap phases 1–3, egolearn evals).
@@ -76,9 +78,10 @@ standing instruction they supersede — a resumed agent honors stale constraints
       --locked` → exec tick; every step best-effort (bad merges crash ticks,
       never the chain). Bot PAT on Torch + repo in the token's selection
       still owed by the maintainer before live deploy
-- [ ] Pause sentinel + lease (compare-and-swap on the state branch); heartbeat at
-      tick start; stale-lease reaping
-- [ ] `compute`: sbatch submit / squeue poll, jobs tagged + `--nice`, GPU-hour caps
+- [x] Pause sentinel, heartbeat at tick start (now with disk preflight
+      payload), stale-lease reaping (TTL + tombstone CAS)
+- [x] `compute`: sbatch submit / sacct status / cancel behind an injectable
+      runner (GPU-hour caps land with the experiment path)
 - [ ] Watchdog Action: stale-heartbeat alert issue + email escalation
 - [ ] Ops runbook: manual restart, `scancel` procedures, PAT rotation calendar
 - [ ] Transcript storage on project space with stated retention
@@ -109,8 +112,16 @@ the research repos' porting timelines; mistakes are free; adversarial testing
       self-initiated selection (least-recently-attempted, budget + cooldown
       bounded, one active run per target) all exercised; auto-merge armed by
       approval for bot PRs
-- [ ] Every run ends with a research report — hypothesis, outcome, takeaways,
-      next steps — posted to the PR or the ledger (negative results included)
+- [x] Every run ends with a research report — hypothesis, outcome, takeaways,
+      next steps — in the PR body and the run dir; requested-lane runs also
+      report to their issue on every terminal path. Hardening series merged
+      2026-08-07/08: crash containment (#43), disk preflight + scratch-first
+      caches (#44), auto-merge armed only when a human review is required
+      (#45), publish-time freshness (moved base merged + re-measured, #46),
+      killed-climb endings (SIGTERM containment + implementing sweep, #49),
+      per-repo budget shaping + self-deadline (#51). Measured on Torch
+      2026-08-08: Slurm delivers NO signal to job processes before SIGKILL —
+      the sweep and the self-deadline are the real teardown paths
 - [x] `in-review` follow-up (followup.respond_once + CLI): merge/close →
       endings; org-member comments wake the authoring session (resume, data-
       fenced, scope/drift/re-measure on changes) → reply as bot. Tick wiring,
@@ -138,12 +149,55 @@ open-ended sweep space.
 - [ ] Verification agent (scaling.md Part 2d): verifier mode on the review
       chassis — bot-PRs only, metric-gaming prompt, own capped key, and the
       silence-is-not-endorsement header. REQUIRED before any statistically-verifiable
-      target onboards
+      target onboards. The `autoresearch:review` label then routes by author:
+      human PRs → advisory reviewer, bot PRs → verifier (today an explicit
+      label on a bot PR runs the advisory reviewer as interim UX, #48)
+- [ ] Benchmark steward role (maintainer direction 2026-08-08): a separate
+      agent identity whose objective is benchmark DISCRIMINATIVE POWER
+      (headroom, solvability, reproducible baselines), never solver score;
+      goal moves only as vetoable plan issues under the agent-unwritable
+      `vision:`, enacted only by human-merged contract PRs; the verifier is
+      the anti-collusion backstop. First work orders, from the agents' own
+      reports: probe v2 (trivially saturable — degree-2 features hit 1.000
+      against the frozen <0.8 band) and a timing-noise floor policy for
+      speedup (±5% machine noise)
 - [ ] jepa-agent as the first research target: `.autoresearch.yaml` + bot Write
       grant + token scope, once its benchmark harness lands and the pilot's
       PR-quality bar is met
 - [ ] egolearn as second research target; second harness backend if volume warrants
 - [ ] API model tiering informed by pilot data; cloud burst if queues block
+
+## Meta: benchmarking autoresearch itself (maintainer direction 2026-08-08)
+
+Sequencing agreed loose — no deadline pressure; item 5 explicitly last.
+Distinction to preserve: the PILOT is the integration canary (system
+feasibility under realistic attachment — foreign repo, real GitHub/Slurm
+friction; stays a separate repo forever), while the META-BENCHMARK is the
+capability instrument (does the decision core improve?) and lives inside
+this ecosystem so the battery versions in lockstep with the loop.
+
+1. [ ] Public-surface security audit before ANY repo with our workflows goes
+       public — `pull_request_target` + secrets + fork PRs is the classic
+       exfiltration shape; also: external code never executes on lab
+       hardware, and RELEASING gains a hostile-interaction section
+       (design doc: design/public-surface.md, to be written)
+2. [ ] GitHub simulator + meta-benchmark battery (design/meta.md, to be
+       written): tier (a) all-fake (injectable transport, local bare repos,
+       programmatic tick driver — CI-runnable orchestration correctness);
+       tier (b) sim GitHub + REAL Slurm/sessions for capability tasks (e.g.
+       find a better optimizer on a speedrun snapshot). Battery = frozen
+       (repo snapshot, contract, baseline) instances; loop changes run A/B
+       against the incumbent with paired repetitions (LLM variance dominates
+       single runs); metrics incl. time-to-first-improvement, improvement
+       per dollar/GPU-hour, integrity-veto honesty (seeded gaming must be
+       caught)
+3. [ ] Progress webpage: static generator over git state (leader.json
+       history, reports, plan issues) — charts, run timelines; no server
+4. [ ] Benchmark steward live on the pilot (phase-7 entry above)
+5. [ ] Self-improvement in the sim (LAST, explicitly unhurried): the live
+       self-target ban stays absolute; inside the simulator the target is a
+       snapshot of autoresearch and the eval is the battery score;
+       improvements return only as human-reviewed development PRs
 
 ## Beyond 1.0 — external-facing (design: design/external.md)
 

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -719,31 +719,38 @@ def main() -> int:
         log.info("self-deadline armed: Terminated in %ds", armed)
 
     try:
-        outcome = live_climb(
-            config=ClimbConfig(target=args.target, benchmark=args.benchmark),
-            run_root=args.run_root,
-            run_id=run_id,
-            harness=ClaudeCodeHarness(
-                api_key=api_key,
-                binary=args.claude_bin,
-                model=args.model,
-                max_turns=args.max_turns,
-                timeout_s=args.session_minutes * 60,
-                container_image=args.image,
-            ),
-            evaluator=SubprocessEvaluator(container_image=args.image),
-            github=GitHubClient(auth=bot_auth),
-            bot_auth=bot_auth,
-            now=time.time(),
-            created=datetime.now(UTC).isoformat(),
-            secrets=(api_key, bot_auth.token()),
-            issue_number=args.issue,
-            task_hypothesis=(
-                __import__("base64").b64decode(args.hypothesis_b64).decode()
-                if args.hypothesis_b64
-                else ""
-            ),
-        )
+        try:
+            outcome = live_climb(
+                config=ClimbConfig(target=args.target, benchmark=args.benchmark),
+                run_root=args.run_root,
+                run_id=run_id,
+                harness=ClaudeCodeHarness(
+                    api_key=api_key,
+                    binary=args.claude_bin,
+                    model=args.model,
+                    max_turns=args.max_turns,
+                    timeout_s=args.session_minutes * 60,
+                    container_image=args.image,
+                ),
+                evaluator=SubprocessEvaluator(container_image=args.image),
+                github=GitHubClient(auth=bot_auth),
+                bot_auth=bot_auth,
+                now=time.time(),
+                created=datetime.now(UTC).isoformat(),
+                secrets=(api_key, bot_auth.token()),
+                issue_number=args.issue,
+                task_hypothesis=(
+                    __import__("base64").b64decode(args.hypothesis_b64).decode()
+                    if args.hypothesis_b64
+                    else ""
+                ),
+            )
+        except Terminated as exc:
+            # Fired in live_climb's microseconds-wide pre-containment window:
+            # any record it saved strands and the sweep ends it from Slurm
+            # truth; here we only avoid dying as an unexplained traceback.
+            log.error("self-deadline fired before containment: %s", exc)
+            return 3
     finally:
         _signal.alarm(0)
     print(f"outcome={outcome.outcome} pr={outcome.pr_url or '-'} report={outcome.report_path}")

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -552,6 +553,11 @@ class Terminated(Exception):
     the KillWait grace window before SIGKILL arrives."""
 
 
+# Below this, arming is pointless: the alarm would fire during setup,
+# outside containment, and a job this short cannot finish a climb anyway.
+MIN_ARM_S = 180
+
+
 def arm_self_deadline(job_minutes: int, margin_s: float = 120.0) -> int:
     """Arm our own end-of-walltime alarm; returns the armed seconds (0 = off).
 
@@ -561,15 +567,25 @@ def arm_self_deadline(job_minutes: int, margin_s: float = 120.0) -> int:
     wall is our own clock. SIGALRM fires `margin_s` before the job's
     walltime and raises Terminated into the ordinary containment; the
     margin floor covers the containment's own tail (GitHub calls are 30s
-    timeout x retries).
+    timeout x retries). The walltime clock starts at JOB start, not
+    process start — SLURM_JOB_START_TIME anchors the deadline when
+    present so startup latency erodes the runway, never the margin.
     """
     if job_minutes <= 0:
         return 0
     import signal
+    import time as _time
 
     margin = max(60.0, margin_s)
-    remaining = int(job_minutes * 60 - margin)
-    if remaining <= 0:
+    start_raw = os.environ.get("SLURM_JOB_START_TIME", "")
+    if start_raw.isdigit():
+        remaining = int(int(start_raw) + job_minutes * 60 - margin - _time.time())
+    else:
+        remaining = int(job_minutes * 60 - margin)
+    if remaining < MIN_ARM_S:
+        log.warning(
+            "self-deadline NOT armed: %ds runway is below the %ds floor", remaining, MIN_ARM_S
+        )
         return 0
 
     def _on_alarm(signum: int, frame: object) -> None:
@@ -659,10 +675,6 @@ def main() -> int:
     if not args.image and not args.uncontained:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")
 
-    armed = arm_self_deadline(args.job_minutes, args.deadline_margin_s)
-    if armed:
-        log.info("self-deadline armed: Terminated in %ds", armed)
-
     # same 0600 discipline as the PAT: this key spends real money
     api_key = FileTokenProvider(Path(args.key_file)).token()
     bot_auth = FileTokenProvider(Path(args.pat_file))
@@ -690,6 +702,12 @@ def main() -> int:
                 ),
             )
         return 3
+
+    # Armed LAST, immediately before the contained region: an alarm that
+    # fired during setup would escape uncaught and die unrecorded.
+    armed = arm_self_deadline(args.job_minutes, args.deadline_margin_s)
+    if armed:
+        log.info("self-deadline armed: Terminated in %ds", armed)
 
     outcome = live_climb(
         config=ClimbConfig(target=args.target, benchmark=args.benchmark),

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -703,37 +703,43 @@ def main() -> int:
             )
         return 3
 
-    # Armed LAST, immediately before the contained region: an alarm that
-    # fired during setup would escape uncaught and die unrecorded.
+    # Armed LAST, immediately before the contained region — and DISARMED
+    # right after it: a run finishing inside the margin must not have the
+    # alarm fire during the uncontained epilogue (print/exit).
+    import signal as _signal
+
     armed = arm_self_deadline(args.job_minutes, args.deadline_margin_s)
     if armed:
         log.info("self-deadline armed: Terminated in %ds", armed)
 
-    outcome = live_climb(
-        config=ClimbConfig(target=args.target, benchmark=args.benchmark),
-        run_root=args.run_root,
-        run_id=run_id,
-        harness=ClaudeCodeHarness(
-            api_key=api_key,
-            binary=args.claude_bin,
-            model=args.model,
-            max_turns=args.max_turns,
-            timeout_s=args.session_minutes * 60,
-            container_image=args.image,
-        ),
-        evaluator=SubprocessEvaluator(container_image=args.image),
-        github=GitHubClient(auth=bot_auth),
-        bot_auth=bot_auth,
-        now=time.time(),
-        created=datetime.now(UTC).isoformat(),
-        secrets=(api_key, bot_auth.token()),
-        issue_number=args.issue,
-        task_hypothesis=(
-            __import__("base64").b64decode(args.hypothesis_b64).decode()
-            if args.hypothesis_b64
-            else ""
-        ),
-    )
+    try:
+        outcome = live_climb(
+            config=ClimbConfig(target=args.target, benchmark=args.benchmark),
+            run_root=args.run_root,
+            run_id=run_id,
+            harness=ClaudeCodeHarness(
+                api_key=api_key,
+                binary=args.claude_bin,
+                model=args.model,
+                max_turns=args.max_turns,
+                timeout_s=args.session_minutes * 60,
+                container_image=args.image,
+            ),
+            evaluator=SubprocessEvaluator(container_image=args.image),
+            github=GitHubClient(auth=bot_auth),
+            bot_auth=bot_auth,
+            now=time.time(),
+            created=datetime.now(UTC).isoformat(),
+            secrets=(api_key, bot_auth.token()),
+            issue_number=args.issue,
+            task_hypothesis=(
+                __import__("base64").b64decode(args.hypothesis_b64).decode()
+                if args.hypothesis_b64
+                else ""
+            ),
+        )
+    finally:
+        _signal.alarm(0)
     print(f"outcome={outcome.outcome} pr={outcome.pr_url or '-'} report={outcome.report_path}")
     return 0
 

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -552,6 +552,36 @@ class Terminated(Exception):
     the KillWait grace window before SIGKILL arrives."""
 
 
+def arm_self_deadline(job_minutes: int, margin_s: float = 120.0) -> int:
+    """Arm our own end-of-walltime alarm; returns the armed seconds (0 = off).
+
+    Slurm delivers NO signal to our process on Torch before SIGKILL
+    (measured 2026-08-08: scancel and walltime timeout both signal the
+    batch shell only) — so the only way to end a run richly before the
+    wall is our own clock. SIGALRM fires `margin_s` before the job's
+    walltime and raises Terminated into the ordinary containment; the
+    margin floor covers the containment's own tail (GitHub calls are 30s
+    timeout x retries).
+    """
+    if job_minutes <= 0:
+        return 0
+    import signal
+
+    margin = max(60.0, margin_s)
+    remaining = int(job_minutes * 60 - margin)
+    if remaining <= 0:
+        return 0
+
+    def _on_alarm(signum: int, frame: object) -> None:
+        raise Terminated(
+            f"self-deadline: {margin:.0f}s before the job's {job_minutes}-minute walltime"
+        )
+
+    signal.signal(signal.SIGALRM, _on_alarm)
+    signal.alarm(remaining)
+    return remaining
+
+
 def arm_sigterm_containment() -> None:
     """Convert the FIRST SIGTERM into a Terminated exception, one-shot.
 
@@ -597,6 +627,19 @@ def main() -> int:
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument("--model", default="claude-opus-5")
     parser.add_argument("--max-turns", type=int, default=60)
+    parser.add_argument("--session-minutes", type=int, default=60)
+    parser.add_argument(
+        "--job-minutes",
+        type=int,
+        default=0,
+        help="this job's Slurm walltime; arms the self-deadline (0 = off)",
+    )
+    parser.add_argument(
+        "--deadline-margin-s",
+        type=float,
+        default=120.0,
+        help="how long before the walltime the self-deadline fires (floor 60)",
+    )
     parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
     parser.add_argument(
         "--key-file", default=os.path.expanduser("~/.config/autoresearch/harness_key")
@@ -615,6 +658,10 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     if not args.image and not args.uncontained:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")
+
+    armed = arm_self_deadline(args.job_minutes, args.deadline_margin_s)
+    if armed:
+        log.info("self-deadline armed: Terminated in %ds", armed)
 
     # same 0600 discipline as the PAT: this key spends real money
     api_key = FileTokenProvider(Path(args.key_file)).token()
@@ -653,6 +700,7 @@ def main() -> int:
             binary=args.claude_bin,
             model=args.model,
             max_turns=args.max_turns,
+            timeout_s=args.session_minutes * 60,
             container_image=args.image,
         ),
         evaluator=SubprocessEvaluator(container_image=args.image),

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -577,9 +577,15 @@ def arm_self_deadline(job_minutes: int, margin_s: float = 120.0) -> int:
     import time as _time
 
     margin = max(60.0, margin_s)
+    now = _time.time()
     start_raw = os.environ.get("SLURM_JOB_START_TIME", "")
-    if start_raw.isdigit():
-        remaining = int(int(start_raw) + job_minutes * 60 - margin - _time.time())
+    # Sanity-bounded: the env can carry a STALE value inherited from the
+    # submitting job (tick jobs sbatch climb jobs). A start time outside
+    # [now - walltime, now] is not this job's — fall back to the process
+    # clock rather than silently disarm (past) or overshoot the wall
+    # (future).
+    if start_raw.isdigit() and now - job_minutes * 60 <= int(start_raw) <= now:
+        remaining = int(int(start_raw) + job_minutes * 60 - margin - now)
     else:
         remaining = int(job_minutes * 60 - margin)
     if remaining < MIN_ARM_S:

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -79,6 +79,14 @@ class SuiteAggregate(_StrictModel):
 class Budgets(_StrictModel):
     gpu_hours_per_run: float = Field(ge=0)
     runs_per_week: int = Field(gt=0)
+    # Optional per-repo shaping of the orchestrator's session/job limits.
+    # These are WISHES, not grants: limits.effective_limits clamps every
+    # value into orchestrator-side [floor, ceiling] bounds, so a target can
+    # spend less of us, never more. Absent = orchestrator defaults.
+    session_max_turns: int | None = Field(default=None, gt=0)
+    session_minutes: int | None = Field(default=None, gt=0)
+    climb_job_minutes: int | None = Field(default=None, gt=0)
+    followup_job_minutes: int | None = Field(default=None, gt=0)
 
 
 class Scope(_StrictModel):

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -383,6 +383,12 @@ def main() -> int:
     parser.add_argument("--model", default="claude-opus-5")
     parser.add_argument("--max-turns", type=int, default=40)
     parser.add_argument("--bot-login", default="agentic-learning-bot")
+    parser.add_argument(
+        "--job-minutes",
+        type=int,
+        default=0,
+        help="this job's Slurm walltime; arms the self-deadline (0 = off)",
+    )
     parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
     parser.add_argument(
         "--key-file", default=os.path.expanduser("~/.config/autoresearch/harness_key")
@@ -396,6 +402,16 @@ def main() -> int:
 
     api_key = FileTokenProvider(Path(args.key_file)).token()
     bot_auth = FileTokenProvider(Path(args.pat_file))
+
+    # Same self-deadline as the climb: Slurm never signals this process,
+    # so walltime deaths must be our own clock's job. respond_once contains
+    # exceptions per-lane, and its lease/cursor rules keep a Terminated
+    # ending honest (cursors un-advanced on failure -> the next tick retries).
+    from autoresearch.climb import arm_self_deadline
+
+    armed = arm_self_deadline(args.job_minutes)
+    if armed:
+        log.info("self-deadline armed: Terminated in %ds", armed)
     outcome = respond_once(
         args.run_root,
         args.run_id,

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -423,6 +423,13 @@ def main() -> int:
                 binary=args.claude_bin,
                 model=args.model,
                 max_turns=args.max_turns,
+                # the session must end before its job does: bound by the
+                # walltime minus the self-deadline margin when one is known
+                timeout_s=(
+                    min(3600, max(300, args.job_minutes * 60 - 300))
+                    if args.job_minutes > 0
+                    else 3600
+                ),
                 container_image=args.image,
             ),
             evaluator=SubprocessEvaluator(container_image=args.image),

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -407,28 +407,33 @@ def main() -> int:
     # so walltime deaths must be our own clock's job. respond_once contains
     # exceptions per-lane, and its lease/cursor rules keep a Terminated
     # ending honest (cursors un-advanced on failure -> the next tick retries).
+    import signal as _signal
+
     from autoresearch.climb import arm_self_deadline
 
     armed = arm_self_deadline(args.job_minutes)
     if armed:
         log.info("self-deadline armed: Terminated in %ds", armed)
-    outcome = respond_once(
-        args.run_root,
-        args.run_id,
-        harness=ClaudeCodeHarness(
-            api_key=api_key,
-            binary=args.claude_bin,
-            model=args.model,
-            max_turns=args.max_turns,
-            container_image=args.image,
-        ),
-        evaluator=SubprocessEvaluator(container_image=args.image),
-        github=GitHubClient(auth=bot_auth),
-        bot_login=args.bot_login,
-        now=time.time(),
-        secrets=(api_key, bot_auth.token()),
-        created=datetime.now(UTC).isoformat(),
-    )
+    try:
+        outcome = respond_once(
+            args.run_root,
+            args.run_id,
+            harness=ClaudeCodeHarness(
+                api_key=api_key,
+                binary=args.claude_bin,
+                model=args.model,
+                max_turns=args.max_turns,
+                container_image=args.image,
+            ),
+            evaluator=SubprocessEvaluator(container_image=args.image),
+            github=GitHubClient(auth=bot_auth),
+            bot_login=args.bot_login,
+            now=time.time(),
+            secrets=(api_key, bot_auth.token()),
+            created=datetime.now(UTC).isoformat(),
+        )
+    finally:
+        _signal.alarm(0)
     print(f"action={outcome.action} note={outcome.note}")
     return 0
 

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -1,0 +1,63 @@
+"""Effective session/job limits: contract wishes clamped by our ceilings.
+
+Contracts live in TARGET repos and are untrusted input (contract.py's
+threat model). A target may therefore SHAPE the orchestrator's spend on it
+— shorter sessions, tighter job walltimes — but must never be able to
+raise it: every contract value is clamped into [floor, ceiling], and the
+ceilings are code on the orchestrator side, not configuration a target
+can reach. Absent values fall back to the defaults the pilot has run with
+all along.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+# (default, floor, ceiling) per knob. Floors keep a hostile-or-typo'd
+# contract from starving runs into uselessness (a 1-turn session still
+# spends money and reports nothing); ceilings are the spend guarantee.
+_BOUNDS: dict[str, tuple[int, int, int]] = {
+    "session_max_turns": (60, 10, 120),
+    "session_minutes": (60, 10, 120),
+    "climb_job_minutes": (90, 20, 240),
+    "followup_job_minutes": (60, 15, 120),
+}
+
+# A climb job must outlive its session long enough for the orchestrator's
+# own work around it (clone, two evals, publish, ending writes).
+_CLIMB_OVERHEAD_MINUTES = 20
+
+
+@dataclass(frozen=True)
+class EffectiveLimits:
+    session_max_turns: int
+    session_minutes: int
+    climb_job_minutes: int
+    followup_job_minutes: int
+
+
+def _clamp(name: str, value: int | None) -> int:
+    default, floor, ceiling = _BOUNDS[name]
+    if value is None:
+        return default
+    return max(floor, min(int(value), ceiling))
+
+
+def effective_limits(budgets: Any = None) -> EffectiveLimits:
+    """Resolve a contract's optional budget knobs into enforceable limits.
+
+    `budgets` is the contract's Budgets model (or None for pure defaults);
+    unknown/absent attributes read as None. The session is finally shrunk
+    to fit inside the climb job with room for the orchestrator's overhead —
+    a session that outlives its job ends as a kill, not a report.
+    """
+    values = {
+        name: _clamp(name, getattr(budgets, name, None) if budgets is not None else None)
+        for name in _BOUNDS
+    }
+    max_session = values["climb_job_minutes"] - _CLIMB_OVERHEAD_MINUTES
+    if values["session_minutes"] > max_session:
+        floor = _BOUNDS["session_minutes"][1]
+        values["session_minutes"] = max(floor, max_session)
+    return EffectiveLimits(**values)

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -20,8 +20,10 @@ from typing import Any
 _BOUNDS: dict[str, tuple[int, int, int]] = {
     "session_max_turns": (60, 10, 120),
     "session_minutes": (60, 10, 120),
-    "climb_job_minutes": (90, 20, 240),
-    "followup_job_minutes": (60, 15, 120),
+    # floor = session floor + overhead + self-deadline margin: even at the
+    # floors, a session must fit inside its job with the ending's runway
+    "climb_job_minutes": (90, 40, 240),
+    "followup_job_minutes": (60, 20, 120),
 }
 
 # A climb job must outlive its session long enough for the orchestrator's

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -16,14 +16,18 @@ from typing import Any
 
 # (default, floor, ceiling) per knob. Floors keep a hostile-or-typo'd
 # contract from starving runs into uselessness (a 1-turn session still
-# spends money and reports nothing); ceilings are the spend guarantee.
+# spends money and reports nothing). CEILING == DEFAULT, deliberately:
+# contracts are merged by TARGET-repo maintainers, not by us, so any
+# ceiling above the default would let them raise our spend — the knobs
+# shape strictly downward. Raising a target's budget is an
+# orchestrator-side decision (config we control), not a contract edit.
 _BOUNDS: dict[str, tuple[int, int, int]] = {
-    "session_max_turns": (60, 10, 120),
-    "session_minutes": (60, 10, 120),
+    "session_max_turns": (60, 10, 60),
+    "session_minutes": (60, 10, 60),
     # floor = session floor + overhead + self-deadline margin: even at the
     # floors, a session must fit inside its job with the ending's runway
-    "climb_job_minutes": (90, 40, 240),
-    "followup_job_minutes": (60, 20, 120),
+    "climb_job_minutes": (90, 40, 90),
+    "followup_job_minutes": (60, 20, 60),
 }
 
 # A climb job must outlive its session long enough for the orchestrator's

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -197,6 +197,8 @@ def service_in_review(
                 spec.image,
                 "--bot-login",
                 spec.bot_login,
+                "--job-minutes",
+                str(spec.time_minutes),
             ]
             if spec.pat_file:
                 argv += ["--pat-file", spec.pat_file]
@@ -625,7 +627,12 @@ def tick(
             except Exception as exc:
                 log.warning("contract fetch failed for %s: %s", followup_spec.target, exc)
         limits = effective_limits(contract.budgets if contract is not None else None)
-        spec = replace(followup_spec, time_minutes=limits.followup_job_minutes)
+        # The contract's followup walltime only overrides when EXPLICITLY
+        # set: absent, the operator-configured spec value stands (the
+        # limits default is a fallback, not a mandate).
+        spec = followup_spec
+        if contract is not None and contract.budgets.followup_job_minutes is not None:
+            spec = replace(followup_spec, time_minutes=limits.followup_job_minutes)
         ended, submitted = service_in_review(
             root,
             github,

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -33,6 +33,7 @@ from autoresearch.compute import (
     quote_command,
 )
 from autoresearch.disk import DEFAULT_MIN_FREE_BYTES, check_disk
+from autoresearch.limits import EffectiveLimits, effective_limits
 from autoresearch.runstate import (
     ABORTED,
     ENDED,
@@ -607,35 +608,52 @@ def tick(
     if not launch_ok:
         log.warning("disk preflight failed; launch lanes are OFF this tick")
     if github is not None and followup_spec is not None:
-        ended, submitted = service_in_review(
-            root,
-            github,
-            compute,
-            followup_spec,
-            now,
-            dry_run=followup_dry_run,
-            allow_submit=launch_ok,
-        )
-        intake_job = (
-            service_intake(root, github, compute, followup_spec, now, dry_run=followup_dry_run)
-            if launch_ok
-            else None
-        )
-        self_job = None
-        if launch_ok and intake_job is None and followup_spec.target:
+        # ONE contract fetch per tick feeds every lane: the requested and
+        # self-initiated lanes need its benchmarks, and all three lanes now
+        # take their session/job limits from its budgets — clamped by our
+        # ceilings (limits.py), so a target shapes spend, never raises it.
+        # A failed fetch leaves in-review servicing running on defaults;
+        # the launch lanes need the contract and sit out this tick.
+        contract = None
+        if followup_spec.target:
             try:
                 from autoresearch.contract import load_contract
 
                 raw = github.get_file_content(followup_spec.target, ".autoresearch.yaml", "main")
                 if raw is not None:
-                    self_job = service_self_initiated(
-                        root,
-                        compute,
-                        followup_spec,
-                        load_contract(raw, followup_spec.target),
-                        now,
-                        dry_run=followup_dry_run,
-                    )
+                    contract = load_contract(raw, followup_spec.target)
+            except Exception as exc:
+                log.warning("contract fetch failed for %s: %s", followup_spec.target, exc)
+        limits = effective_limits(contract.budgets if contract is not None else None)
+        spec = replace(followup_spec, time_minutes=limits.followup_job_minutes)
+        ended, submitted = service_in_review(
+            root,
+            github,
+            compute,
+            spec,
+            now,
+            dry_run=followup_dry_run,
+            allow_submit=launch_ok,
+        )
+        intake_job = (
+            service_intake(
+                root, github, compute, spec, now, contract, limits, dry_run=followup_dry_run
+            )
+            if launch_ok and contract is not None
+            else None
+        )
+        self_job = None
+        if launch_ok and intake_job is None and contract is not None:
+            try:
+                self_job = service_self_initiated(
+                    root,
+                    compute,
+                    spec,
+                    contract,
+                    now,
+                    limits=limits,
+                    dry_run=followup_dry_run,
+                )
             except Exception as exc:
                 log.warning("self-initiated selection failed: %s", exc)
         report = replace_report(
@@ -747,12 +765,27 @@ def clear_pending(root: Path, target: str) -> None:
     _pending_path(root, target).unlink(missing_ok=True)
 
 
+def _climb_limit_argv(limits: EffectiveLimits) -> list[str]:
+    """Climb-CLI flags carrying the tick-resolved limits: the job's own
+    walltime rides along so the climb can arm its self-deadline (Slurm
+    delivers no signals to our processes on Torch — measured 2026-08-08)."""
+    return [
+        "--max-turns",
+        str(limits.session_max_turns),
+        "--session-minutes",
+        str(limits.session_minutes),
+        "--job-minutes",
+        str(limits.climb_job_minutes),
+    ]
+
+
 def service_self_initiated(
     root: Path,
     compute: SlurmCompute,
     spec: FollowupSpec,
     contract: Any,
     now: float,
+    limits: EffectiveLimits | None = None,
     dry_run: bool = False,
 ) -> tuple[str, str] | None:
     """The default background mode: when nothing else needs doing, climb the
@@ -762,6 +795,7 @@ def service_self_initiated(
     `compute.submit` and the climb job writing its run record — without it,
     every tick during Slurm queue latency would launch a duplicate climb.
     """
+    limits = limits if limits is not None else effective_limits(getattr(contract, "budgets", None))
     try:
         records = list_runs(root)
         pending = read_pending(root, spec.target)
@@ -802,6 +836,7 @@ def service_self_initiated(
             str(spec.run_root),
             "--image",
             spec.image,
+            *_climb_limit_argv(limits),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
@@ -812,7 +847,7 @@ def service_self_initiated(
                 job_name=f"climb-{benchmark}"[:60],
                 account=spec.account,
                 partition=spec.partition,
-                time_minutes=90,
+                time_minutes=limits.climb_job_minutes,
                 command=f"cd {quote_command([str(spec.home)])} && {quote_command(argv)}",
                 cpus=4,
                 mem="8G",
@@ -832,12 +867,15 @@ def service_intake(
     compute: SlurmCompute,
     spec: FollowupSpec,
     now: float,
+    contract: Any = None,
+    limits: EffectiveLimits | None = None,
     dry_run: bool = False,
 ) -> tuple[str, str] | None:
     """The requested lane: claim at most ONE qualifying issue per tick and
     submit a climb job for it. The claim comment (posted by the climb job
     before its session) marks an issue taken; one-per-tick keeps a burst of
-    issues from bursting the budget."""
+    issues from bursting the budget. The contract arrives from the tick's
+    single per-target fetch; None (fetch failed) sits the lane out."""
     from autoresearch.contract import load_contract
     from autoresearch.intake import issue_hypothesis, pick_issue
 
@@ -845,10 +883,12 @@ def service_intake(
     if not target:
         return None
     try:
-        contract_raw = github.get_file_content(target, ".autoresearch.yaml", "main")
-        if contract_raw is None:
-            return None
-        contract = load_contract(contract_raw, target)
+        if contract is None:
+            contract_raw = github.get_file_content(target, ".autoresearch.yaml", "main")
+            if contract_raw is None:
+                return None
+            contract = load_contract(contract_raw, target)
+        limits = limits if limits is not None else effective_limits(contract.budgets)
         task = pick_issue(github, target, contract, spec.bot_login)
         if task is None:
             return None
@@ -885,6 +925,7 @@ def service_intake(
             str(task.number),
             "--hypothesis-b64",
             hypothesis_b64,
+            *_climb_limit_argv(limits),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
@@ -895,7 +936,7 @@ def service_intake(
                 job_name=f"climb-issue-{task.number}",
                 account=spec.account,
                 partition=spec.partition,
-                time_minutes=90,
+                time_minutes=limits.climb_job_minutes,
                 command=f"cd {quote_command([str(spec.home)])} && {quote_command(argv)}",
                 cpus=4,
                 mem="8G",

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -628,11 +628,15 @@ def tick(
                 log.warning("contract fetch failed for %s: %s", followup_spec.target, exc)
         limits = effective_limits(contract.budgets if contract is not None else None)
         # The contract's followup walltime only overrides when EXPLICITLY
-        # set: absent, the operator-configured spec value stands (the
-        # limits default is a fallback, not a mandate).
+        # set — and only DOWNWARD from the operator's spec value: strictly-
+        # downward shaping must hold against operator config too, not just
+        # against the module defaults.
         spec = followup_spec
         if contract is not None and contract.budgets.followup_job_minutes is not None:
-            spec = replace(followup_spec, time_minutes=limits.followup_job_minutes)
+            spec = replace(
+                followup_spec,
+                time_minutes=min(followup_spec.time_minutes, limits.followup_job_minutes),
+            )
         ended, submitted = service_in_review(
             root,
             github,

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -929,3 +929,54 @@ def test_climb_job_id_is_stamped_from_slurm_env(tmp_path, target_repo, monkeypat
         run_id="tsp-jid",
     )
     assert load_record(tmp_path / "state", "tsp-jid").climb_job_id == "4242"
+
+
+def test_self_deadline_arms_before_the_walltime() -> None:
+    """The alarm fires margin seconds before the job's walltime — our only
+    pre-kill warning on clusters that never signal our process."""
+    import signal
+
+    from autoresearch.climb import arm_self_deadline
+
+    original = signal.getsignal(signal.SIGALRM)
+    try:
+        armed = arm_self_deadline(90, margin_s=120.0)
+        assert armed == 90 * 60 - 120
+        assert signal.alarm(0) > 0  # a real alarm was pending
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, original)
+
+
+def test_self_deadline_margin_floor_and_off_switch() -> None:
+    import signal
+
+    from autoresearch.climb import arm_self_deadline
+
+    original = signal.getsignal(signal.SIGALRM)
+    try:
+        assert arm_self_deadline(0) == 0  # off
+        assert arm_self_deadline(1, margin_s=1.0) == 0  # walltime <= floored margin
+        assert arm_self_deadline(10, margin_s=1.0) == 10 * 60 - 60  # floor 60 applies
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, original)
+
+
+def test_self_deadline_raises_terminated_into_containment() -> None:
+    import signal
+
+    import pytest
+
+    from autoresearch.climb import Terminated, arm_self_deadline
+
+    original = signal.getsignal(signal.SIGALRM)
+    try:
+        arm_self_deadline(90)
+        handler = signal.getsignal(signal.SIGALRM)
+        assert callable(handler)
+        with pytest.raises(Terminated, match="self-deadline"):
+            handler(signal.SIGALRM, None)
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, original)

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -931,13 +931,15 @@ def test_climb_job_id_is_stamped_from_slurm_env(tmp_path, target_repo, monkeypat
     assert load_record(tmp_path / "state", "tsp-jid").climb_job_id == "4242"
 
 
-def test_self_deadline_arms_before_the_walltime() -> None:
+def test_self_deadline_arms_before_the_walltime(monkeypatch) -> None:
     """The alarm fires margin seconds before the job's walltime — our only
-    pre-kill warning on clusters that never signal our process."""
+    pre-kill warning on clusters that never signal our process. Hermetic:
+    inside a real allocation SLURM_JOB_START_TIME would change the math."""
     import signal
 
     from autoresearch.climb import arm_self_deadline
 
+    monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
     original = signal.getsignal(signal.SIGALRM)
     try:
         armed = arm_self_deadline(90, margin_s=120.0)
@@ -948,28 +950,50 @@ def test_self_deadline_arms_before_the_walltime() -> None:
         signal.signal(signal.SIGALRM, original)
 
 
-def test_self_deadline_margin_floor_and_off_switch() -> None:
+def test_self_deadline_anchors_on_slurm_job_start(monkeypatch) -> None:
+    """With SLURM_JOB_START_TIME set, startup latency erodes the runway,
+    never the margin: a job already 10 minutes in arms 10 minutes less."""
     import signal
+    import time
 
     from autoresearch.climb import arm_self_deadline
 
+    monkeypatch.setenv("SLURM_JOB_START_TIME", str(int(time.time()) - 600))
     original = signal.getsignal(signal.SIGALRM)
     try:
-        assert arm_self_deadline(0) == 0  # off
-        assert arm_self_deadline(1, margin_s=1.0) == 0  # walltime <= floored margin
-        assert arm_self_deadline(10, margin_s=1.0) == 10 * 60 - 60  # floor 60 applies
+        armed = arm_self_deadline(90, margin_s=120.0)
+        assert abs(armed - (90 * 60 - 600 - 120)) <= 2
     finally:
         signal.alarm(0)
         signal.signal(signal.SIGALRM, original)
 
 
-def test_self_deadline_raises_terminated_into_containment() -> None:
+def test_self_deadline_margin_floor_and_off_switch(monkeypatch) -> None:
+    import signal
+
+    from autoresearch.climb import MIN_ARM_S, arm_self_deadline
+
+    monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
+    original = signal.getsignal(signal.SIGALRM)
+    try:
+        assert arm_self_deadline(0) == 0  # off
+        assert arm_self_deadline(1, margin_s=1.0) == 0  # walltime <= floored margin
+        assert arm_self_deadline(3, margin_s=1.0) == 0  # 120s runway < 180s floor
+        armed = arm_self_deadline(10, margin_s=1.0)
+        assert armed == 10 * 60 - 60 and armed >= MIN_ARM_S  # margin floor 60
+    finally:
+        signal.alarm(0)
+        signal.signal(signal.SIGALRM, original)
+
+
+def test_self_deadline_raises_terminated_into_containment(monkeypatch) -> None:
     import signal
 
     import pytest
 
     from autoresearch.climb import Terminated, arm_self_deadline
 
+    monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
     original = signal.getsignal(signal.SIGALRM)
     try:
         arm_self_deadline(90)

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -1,0 +1,69 @@
+"""Contract budget wishes clamped by orchestrator ceilings."""
+
+from __future__ import annotations
+
+from autoresearch.contract import load_contract
+from autoresearch.limits import EffectiveLimits, effective_limits
+
+BASE = """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3%s}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+
+
+def _limits(budget_extra: str = "") -> EffectiveLimits:
+    return effective_limits(load_contract(BASE % budget_extra, "org/pilot").budgets)
+
+
+def test_absent_knobs_yield_the_standing_defaults() -> None:
+    assert _limits() == EffectiveLimits(
+        session_max_turns=60,
+        session_minutes=60,
+        climb_job_minutes=90,
+        followup_job_minutes=60,
+    )
+    assert effective_limits(None) == _limits()  # no contract at all
+
+
+def test_contract_shapes_spend_downward() -> None:
+    lim = _limits(", session_max_turns: 20, session_minutes: 15, climb_job_minutes: 40")
+    assert lim.session_max_turns == 20
+    assert lim.session_minutes == 15
+    assert lim.climb_job_minutes == 40
+
+
+def test_ceilings_cannot_be_raised_by_a_contract() -> None:
+    """The security property: a hostile target may never dial spend UP."""
+    lim = _limits(
+        ", session_max_turns: 100000, session_minutes: 100000"
+        ", climb_job_minutes: 100000, followup_job_minutes: 100000"
+    )
+    assert lim.session_max_turns == 120
+    assert lim.session_minutes == 120  # its own ceiling (240-min job has room)
+    assert lim.climb_job_minutes == 240
+    assert lim.followup_job_minutes == 120
+
+
+def test_floors_defeat_starvation() -> None:
+    lim = _limits(", session_max_turns: 1, session_minutes: 1, climb_job_minutes: 1")
+    assert lim.session_max_turns == 10
+    assert lim.session_minutes == 10
+    assert lim.climb_job_minutes == 20
+
+
+def test_session_is_shrunk_to_fit_inside_the_job() -> None:
+    """A session that outlives its job ends as a kill, not a report."""
+    lim = _limits(", session_minutes: 110, climb_job_minutes: 60")
+    assert lim.climb_job_minutes == 60
+    assert lim.session_minutes == 40  # 60 - 20 overhead
+
+
+def test_contract_rejects_nonpositive_knobs() -> None:
+    import pytest
+
+    # pydantic surfaces schema violations as ValueError subclasses
+    with pytest.raises(ValueError):
+        load_contract(BASE % ", session_minutes: 0", "org/pilot")

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -36,15 +36,14 @@ def test_contract_shapes_spend_downward() -> None:
 
 
 def test_ceilings_cannot_be_raised_by_a_contract() -> None:
-    """The security property: a hostile target may never dial spend UP."""
+    """The security property: contracts are merged by TARGET maintainers,
+    so shaping is strictly downward — asking for more yields the default,
+    on every knob."""
     lim = _limits(
         ", session_max_turns: 100000, session_minutes: 100000"
         ", climb_job_minutes: 100000, followup_job_minutes: 100000"
     )
-    assert lim.session_max_turns == 120
-    assert lim.session_minutes == 120  # its own ceiling (240-min job has room)
-    assert lim.climb_job_minutes == 240
-    assert lim.followup_job_minutes == 120
+    assert lim == effective_limits(None)  # identical to no knobs at all
 
 
 def test_floors_defeat_starvation() -> None:
@@ -59,7 +58,7 @@ def test_floors_defeat_starvation() -> None:
 
 def test_session_is_shrunk_to_fit_inside_the_job() -> None:
     """A session that outlives its job ends as a kill, not a report."""
-    lim = _limits(", session_minutes: 110, climb_job_minutes: 60")
+    lim = _limits(", session_minutes: 60, climb_job_minutes: 60")
     assert lim.climb_job_minutes == 60
     assert lim.session_minutes == 40  # 60 - 20 overhead
 

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -51,7 +51,10 @@ def test_floors_defeat_starvation() -> None:
     lim = _limits(", session_max_turns: 1, session_minutes: 1, climb_job_minutes: 1")
     assert lim.session_max_turns == 10
     assert lim.session_minutes == 10
-    assert lim.climb_job_minutes == 20
+    # floor 40 = session floor (10) + orchestrator overhead (20) + runway:
+    # even the floor combination keeps the session inside the job
+    assert lim.climb_job_minutes == 40
+    assert lim.session_minutes <= lim.climb_job_minutes - 20
 
 
 def test_session_is_shrunk_to_fit_inside_the_job() -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -812,3 +812,49 @@ def test_legacy_record_without_job_id_ends_only_past_deadline(tmp_path: Path) ->
     assert report.implementing_ended == ("r-old",)
     assert load_record(tmp_path, "r-stranded").state == "implementing"
     assert "past its run deadline" in load_record(tmp_path, "r-old").ending_note
+
+
+def test_self_initiated_carries_contract_limits_into_the_job(tmp_path: Path) -> None:
+    """The submitted climb job wears the contract's (clamped) limits: Slurm
+    walltime from climb_job_minutes, and the climb argv carries the session
+    knobs plus its own walltime for the self-deadline."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import FollowupSpec, service_self_initiated
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets:
+  gpu_hours_per_run: 1
+  runs_per_week: 3
+  session_max_turns: 30
+  session_minutes: 25
+  climb_job_minutes: 100000
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="acct",
+        partition="part",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+    )
+    submitted: list[list[str]] = []
+
+    def runner(argv, timeout_s):
+        submitted.append(list(argv))
+        return CommandResult(0, "123\n", "")
+
+    out = service_self_initiated(tmp_path, SlurmCompute(runner=runner), spec, contract, NOW)
+    assert out == ("tsp", "123")
+    sbatch = submitted[0]
+    assert "--time=240" in sbatch  # 100000 clamped to the 240-minute ceiling
+    wrap = sbatch[-1]
+    assert "--max-turns 30" in wrap
+    assert "--session-minutes 25" in wrap
+    assert "--job-minutes 240" in wrap  # the job's own walltime, for the alarm

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -853,8 +853,8 @@ roadmap: docs/roadmap.md
     out = service_self_initiated(tmp_path, SlurmCompute(runner=runner), spec, contract, NOW)
     assert out == ("tsp", "123")
     sbatch = submitted[0]
-    assert "--time=240" in sbatch  # 100000 clamped to the 240-minute ceiling
+    assert "--time=90" in sbatch  # 100000 clamped to the default-as-ceiling
     wrap = sbatch[-1]
     assert "--max-turns 30" in wrap
     assert "--session-minutes 25" in wrap
-    assert "--job-minutes 240" in wrap  # the job's own walltime, for the alarm
+    assert "--job-minutes 90" in wrap  # the job's own walltime, for the alarm

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -858,3 +858,24 @@ roadmap: docs/roadmap.md
     assert "--max-turns 30" in wrap
     assert "--session-minutes 25" in wrap
     assert "--job-minutes 90" in wrap  # the job's own walltime, for the alarm
+
+
+def test_contract_followup_walltime_never_raises_operator_config(tmp_path: Path) -> None:
+    """Strictly-downward holds against the OPERATOR's spec too: a contract
+    asking for more follow-up walltime than the spec grants gets the spec."""
+    from autoresearch.contract import load_contract
+    from autoresearch.limits import effective_limits
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3, followup_job_minutes: 60}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    limits = effective_limits(contract.budgets)
+    operator_minutes = 30
+    assert min(operator_minutes, limits.followup_job_minutes) == 30


### PR DESCRIPTION
Mengye's ask from the job-anatomy discussion: "We should be able to config these budget per repo."

- **Contract side**: `budgets:` grows four optional knobs. All are WISHES: the new `limits` module clamps them into orchestrator-side `[floor, ceiling]` bounds (contracts live in target repos and are untrusted — a target may shape our spend down, never raise it), with floors so a typo'd contract can't starve runs into uselessness, and a final pass shrinking the session to fit inside its job.
- **Tick side**: one contract fetch per cycle (intake and self-initiated previously fetched independently) feeding all three lanes — follow-up job walltime, climb job walltime, and the climb argv (`--max-turns`, `--session-minutes`, `--job-minutes`).
- **Self-deadline** (from yesterday's live SIGTERM experiment: Torch delivers NO signal to our processes before SIGKILL): the climb arms a SIGALRM at its own walltime minus a margin (`--deadline-margin-s`, default 120s, floor 60s — sized to the observed GitHub-call tail) raising `Terminated` into the ordinary containment, so walltime deaths end with a real record and report instead of a sweep-authored stub.

Not in scope: the followup CLI's internal session timeout keeps its default (its job walltime IS now contract-shaped); per-target partition config arrives with the GPU experiment path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)