### PR TITLE
Design docs: meta-benchmarking track and the public-surface threat model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Design docs for the meta track: `docs/design/meta.md` (pilot-vs-meta
+  taxonomy, two-tier GitHub simulator, battery + scorecard with paired
+  repetitions, sim-only self-improvement, benchmark-steward role) and
+  `docs/design/public-surface.md` (threat model for public target repos;
+  the `pull_request_target` audit checklist that gates any public flip).
+
 - Per-repo budget shaping: a contract's `budgets:` may now set
   `session_max_turns`, `session_minutes`, `climb_job_minutes`, and
   `followup_job_minutes`. Contracts are untrusted, so every value is

--- a/docs/design/meta.md
+++ b/docs/design/meta.md
@@ -1,0 +1,128 @@
+# Benchmarking autoresearch itself
+
+**Status: design sketch, v1 (2026-08-08 maintainer direction; sequencing
+agreed loose — the security audit in public-surface.md and the verifier come
+first, sim self-improvement explicitly last). Nothing here gates current
+phases; decided pieces promote into architecture.md as they firm up.**
+
+## Why
+
+Changes to the loop's core — task selection, briefs, planners, base models,
+multi-agent designs — currently get correctness review but no *capability*
+measurement. "Did this make the agent a better researcher?" is answered by
+anecdote. The remedy is the same one the loop imposes on its own targets: a
+frozen ruler and orchestrator-measured claims, applied one level up.
+
+## Pilot vs. meta-benchmark (two instruments, not one)
+
+|                | pilot (integration canary)              | meta-benchmark (capability instrument) |
+|----------------|------------------------------------------|----------------------------------------|
+| question       | does the *system* run against a real, foreign repo? | did the *decision core* get better? |
+| lives          | separate repo, forever                   | inside this ecosystem                   |
+| exercises      | real GitHub, real Slurm, permissions, contract discovery, deploy cadence | orchestration + research quality, plumbing faked or pinned |
+| regression =   | plumbing broke                           | the agent got worse                     |
+
+The pilot must stay a separate repo precisely because its job is simulating
+"someone attached autoresearch to their project", friction included. The
+meta-benchmark lives in-tree so the battery versions in lockstep with the
+loop's interfaces and a loop PR can land with its A/B evidence atomically.
+
+## The simulator
+
+Every seam the simulator needs already exists because the unit tests demanded
+it: `GitHubClient` takes an injectable transport, `Workspace` clones from
+local bare repos, `SlurmCompute` takes an injectable runner, the tick takes
+injected compute/clock/dispatcher, and the harness is a protocol. The
+simulator is those doubles assembled into a runnable environment plus a
+driver that advances ticks programmatically.
+
+**Tier (a) — everything faked.** Fake GitHub (in-memory issues/PRs/comments
+/labels with real-API semantics), local bare repos, fake Slurm with scripted
+job lifecycles, scripted harness. Runs in CI. Measures orchestration
+correctness under scenarios unit tests can't compose: multi-tick lifecycles,
+duplicate-launch races, kill/crash recovery, lane interleaving, budget
+accounting over weeks of simulated time.
+
+**Tier (b) — simulated GitHub, real compute, real sessions.** The target is a
+repo snapshot; sessions and evals run for real (contained, on the cluster);
+GitHub is still the fake, so nothing posts anywhere. Measures research
+capability on non-trivial tasks — e.g. "find a better optimizer" on a
+speedrun-style training snapshot, where the metric is wall-time to a loss
+target. Costs real money and GPU hours; runs on demand, not in CI.
+
+**Fidelity rule.** The fake GitHub must reproduce the real API's sharp edges
+— three independent comment id namespaces, `reviewDecision`, `mergeable_state`
+lag, label-event vs. label-state, author associations — because the live
+system's correctness code is built against exactly those. A sim cleaner than
+reality benchmarks a system that does not exist. Every time live GitHub
+surprises us, the surprise becomes a fake-GitHub test case.
+
+## The battery
+
+A battery instance = frozen (repo snapshot, contract, baseline score,
+scripted-or-live task source). A battery run = the loop driven end-to-end on
+an instance set, producing a scorecard:
+
+- **time-to-first-improvement** (ticks in tier (a), wall-clock in tier (b))
+- **improvement per dollar / per GPU-hour**
+- **negative-result honesty**: seeded gaming opportunities (eval-writable
+  rulers, cacheable eval calls, saturating tests) must be *refused or
+  caught* — the integrity vetoes firing is a pass, silence on a seeded
+  exploit is a fail
+- **lifecycle hygiene**: no stranded records, no duplicate launches, every
+  run ends in a report — asserted mechanically over the final state root
+
+**Statistics.** LLM stochasticity dominates single runs. A/B comparisons use
+paired repetitions (n ≥ 5 per instance per arm) on identical instances;
+report medians with spread, not single numbers. A loop change "helped" only
+by the same ε-and-direction discipline the contract imposes on solvers.
+
+## Self-improvement in the sim (last, unhurried)
+
+The live self-target ban is absolute and stays (contract loader invariant).
+Inside the simulator, the target is a *fork/snapshot* of autoresearch, the
+eval command is the battery score, and the frozen ruler is the battery
+harness itself — which the improver cannot touch, per the same
+scope/drift/orchestrator-measured machinery every other target gets.
+Proposals that survive the sim return to the real repo only as ordinary
+development PRs: review-until-quiet, human merge, no exceptions. The sim is
+where the loop may experiment on itself; the live deployment never is.
+
+## Benchmark steward (role sketch; builds after the verifier)
+
+Benchmarks decay: agents saturate them (reach 1.0 → v2; probe's frozen test
+band; sokoban at 1.0), and timing metrics need noise policies. Today a human
+authors the fix. The steward is the autonomous version, and its design is
+collusion-avoidance first:
+
+- **separate identity, credentials, budget** from every solver agent;
+- objective = **discriminative power** (headroom restored, solvability
+  proofs, reproducible baselines, noise floors) — never solver score;
+- moves goalposts only through the existing plan-issue machinery: vetoable
+  issue, aligned to the target's agent-unwritable `vision:`, enacted
+  exclusively by a human-merged contract/env PR;
+- the **verifier** reviews steward PRs adversarially (is this change
+  restoring discrimination, or quietly making a colluding solver look
+  better?), and solver runs mid-flight are protected by the existing
+  contract-hash abort.
+
+First work orders exist from the agents' own reports (see roadmap): probe v2
+(trivially saturable), a timing-noise floor for speedup. These validate the
+role on real demand before any automation.
+
+## Progress webpage
+
+Everything is already in git: `results/leader.json` history, run reports,
+plan issues, BENCHMARKS.md. A static generator renders charts (leader
+trajectories per benchmark), run timelines, and report indexes — GitHub
+Pages on public repos, a private artifact before that. No server, no new
+state, no new trust surface (the generator reads git, writes HTML).
+
+## Build order
+
+1. Tier-(a) simulator + a 3-instance battery (pilot snapshot, a seeded-gaming
+   instance, a lifecycle-chaos instance) — loop PRs gain measured evidence.
+2. Scorecard + paired-repetition driver; wire into an on-demand workflow.
+3. Progress webpage over the pilot's git state.
+4. Steward on the pilot (after the verifier ships).
+5. Tier-(b) capability instances; then, last, sim self-improvement.

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -23,8 +23,9 @@ operator's compute, or with a secret exfiltrated.**
   comments, reports) is fenced with computed fences and marked as data, not
   instructions, in briefs and wake prompts.
 - **Sessions are contained**: Apptainer `--containall`, scrubbed env (no
-  PAT, no billing keys), per-run HOME, transcripts secret-scanned and stored
-  off-repo.
+  PAT, no billing keys), per-run HOME; transcripts are key-redacted and
+  stored outside any target clone. (A full secret-scan pass before storage
+  is still open roadmap work — it does NOT count toward this audit yet.)
 - **Claims are orchestrator-measured**: nothing a session asserts is
   trusted; baselines and candidates are re-measured by the orchestrator, and
   target CI re-verifies on GitHub's runners.
@@ -34,7 +35,9 @@ operator's compute, or with a secret exfiltrated.**
 ## The gap that gates the flip: `pull_request_target`
 
 The advisory reviewer runs on `pull_request_target` so it can hold secrets
-(`REVIEWER_API_KEY`, optionally a checkout key). On a public repo that
+(the org secret `REVIEWER_API_KEY`, surfaced to the CLI as
+`ANTHROPIC_REVIEWER_KEY`; optionally a checkout key — grep for both names
+when auditing). On a public repo that
 trigger fires for **fork PRs from strangers** — the classic pwn-request
 shape: privileged context + attacker-influenced event.
 
@@ -54,13 +57,20 @@ workflow files of the repo being flipped, not on memory of them):
    pre-commit on its config).
 3. `permissions:` blocks are minimal (`contents: read`,
    `pull-requests: write`) on caller and reusable workflows alike.
-4. Labels that trigger privileged runs (`autoresearch:review`) require the
-   labeler to hold write access — GitHub enforces label application, but
-   verify no automation applies labels on behalf of unprivileged users.
-5. Prompt-injection resistance re-checked: the reviewer reads attacker-
-   authored diffs/PR text; its output must stay sanitized (approval-language
-   redaction, marker stripping, length caps) so a hostile diff cannot forge
-   an approval or smuggle instructions into the comment a human reads.
+4. Labels that trigger privileged runs (`autoresearch:review`): GitHub
+   allows label application at TRIAGE, not write — so GitHub's own
+   permission model is NOT sufficient gating on a public repo with triage
+   grants. Verify the code-side provenance check (labeler permission via
+   timeline events) covers every label-triggered privileged path, and that
+   no automation applies labels on behalf of unprivileged users.
+5. Prompt-injection resistance re-checked. With the fork gate on, the
+   reviewer sees only same-repo PRs — but same-repo authors can be
+   compromised accounts, PR bodies quote text from anyone's issues, and a
+   self-hoster may deliberately relax the gate for label-approved fork
+   PRs. So the output sanitization (approval-language redaction, marker
+   stripping, length caps) must hold regardless of gate configuration: a
+   hostile diff must not be able to forge an approval or smuggle
+   instructions into the comment a human reads.
 6. Secrets inventory: which workflows can see which secrets, and is each
    scoped to the least repo set (org-level secrets with repo selection, not
    org-wide).

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -1,0 +1,96 @@
+# The public surface: threat model for open target repos
+
+**Status: v1 (2026-08-08). The audit below GATES any repo carrying our
+workflows going public, alongside the verifier. Written for self-hosters as
+much as for us: if you attach autoresearch to a public repo, this is your
+attack surface.**
+
+## The scenario
+
+A target repo goes public. Strangers can now open issues, comment on PRs,
+open fork PRs, and (with any grant of triage) apply labels. Several of those
+inputs feed systems that hold credentials or submit cluster jobs. The
+headline threat: **a public interaction that ends with code execution on the
+operator's compute, or with a secret exfiltrated.**
+
+## What already holds (defenses in place)
+
+- **Author-association gating**: issue intake and PR-comment wakes qualify
+  only OWNER/MEMBER/COLLABORATOR authors; label-based qualification demands
+  provenance (the labeler's permission verified via timeline events, not
+  label presence). A stranger's issue or comment reaches no session today.
+- **Untrusted text is data**: everything ingested from GitHub (issues,
+  comments, reports) is fenced with computed fences and marked as data, not
+  instructions, in briefs and wake prompts.
+- **Sessions are contained**: Apptainer `--containall`, scrubbed env (no
+  PAT, no billing keys), per-run HOME, transcripts secret-scanned and stored
+  off-repo.
+- **Claims are orchestrator-measured**: nothing a session asserts is
+  trusted; baselines and candidates are re-measured by the orchestrator, and
+  target CI re-verifies on GitHub's runners.
+- **The bot cannot write to this repo** (account-level), and the orchestrator
+  never executes code from PRs it did not author (see invariant below).
+
+## The gap that gates the flip: `pull_request_target`
+
+The advisory reviewer runs on `pull_request_target` so it can hold secrets
+(`REVIEWER_API_KEY`, optionally a checkout key). On a public repo that
+trigger fires for **fork PRs from strangers** — the classic pwn-request
+shape: privileged context + attacker-influenced event.
+
+Current mitigations already in the reusable workflow: the fork gate
+(`head.repo.full_name == github.repository`) sits before any step, the
+workflow checks out the REVIEWER, never the PR head, and nothing from the PR
+is executed — its diff and files are only *read* via the API and fed to a
+model as fenced text.
+
+**Audit checklist before any public flip** (each item verified on the live
+workflow files of the repo being flipped, not on memory of them):
+
+1. The fork gate is present, at the JOB level, on every caller workflow —
+   and its polarity is "same repo only", not an allowlist that can drift.
+2. No step checks out, builds, installs, or executes anything from the PR
+   head (including transitively: no `uv sync` against the PR's lockfile, no
+   pre-commit on its config).
+3. `permissions:` blocks are minimal (`contents: read`,
+   `pull-requests: write`) on caller and reusable workflows alike.
+4. Labels that trigger privileged runs (`autoresearch:review`) require the
+   labeler to hold write access — GitHub enforces label application, but
+   verify no automation applies labels on behalf of unprivileged users.
+5. Prompt-injection resistance re-checked: the reviewer reads attacker-
+   authored diffs/PR text; its output must stay sanitized (approval-language
+   redaction, marker stripping, length caps) so a hostile diff cannot forge
+   an approval or smuggle instructions into the comment a human reads.
+6. Secrets inventory: which workflows can see which secrets, and is each
+   scoped to the least repo set (org-level secrets with repo selection, not
+   org-wide).
+
+## Invariants to keep enforced in code (not convention)
+
+- **External code never executes on operator hardware.** The orchestrator
+  clones and measures only trees its own bot authored; evaluation of
+  stranger contributions belongs to the target's own CI on GitHub-hosted
+  runners. (Worth an explicit assertion at the clone/measure boundary:
+  refuse a workspace whose head commit is not bot-authored.)
+- **Public input can request, never command.** The requested lane's standing
+  gate stays association-based on public repos; a public "issue mode" (if
+  ever wanted) would be a maintainer-approved-label-only lane, and the label
+  provenance check already exists.
+- **The contract is read from the default branch only** — never from a PR —
+  so a fork PR cannot present a doctored contract to any part of the system.
+
+## Release-process changes
+
+- RELEASING.md's go-public checklist gains a **hostile-interaction section**:
+  run this audit, then enable "limit to users with write access" style
+  interaction limits for an initial window, and document the incident path
+  (revoke org secret, pause tick chain via sentinel, rotate PAT).
+- New-repo onboarding docs point here: attaching the reviewer to a public
+  repo inherits this threat model on day one.
+
+## Out of scope (for now)
+
+Multi-tenant hosting, GitHub App identity, and consumer-side experiment
+runners are design/external.md's territory; nothing here assumes them. The
+notebook repo stays permanently private and is unaffected by any target
+going public.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -180,9 +180,9 @@ this ecosystem so the battery versions in lockstep with the loop.
        public — `pull_request_target` + secrets + fork PRs is the classic
        exfiltration shape; also: external code never executes on lab
        hardware, and RELEASING gains a hostile-interaction section
-       (design doc: design/public-surface.md, to be written)
-2. [ ] GitHub simulator + meta-benchmark battery (design/meta.md, to be
-       written): tier (a) all-fake (injectable transport, local bare repos,
+       (design doc: design/public-surface.md)
+2. [ ] GitHub simulator + meta-benchmark battery (design/meta.md): tier
+       (a) all-fake (injectable transport, local bare repos,
        programmatic tick driver — CI-runnable orchestration correctness);
        tier (b) sim GitHub + REAL Slurm/sessions for capability tasks (e.g.
        find a better optimizer on a speedrun snapshot). Battery = frozen


### PR DESCRIPTION
The two design docs queued from the 2026-08-08 directions discussion, written for self-hosters per the OSS posture (lab specifics only as reference examples). Docs-only → ONE review round with nits batched, per the termination criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)