### PR TITLE
Readable reviews: calm headers, prose findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Review and verification comments read like a colleague, not a legal
+  notice (maintainer feedback): one calm italic header line per role, and
+  findings rendered as prose paragraphs with the reference at the end
+  instead of bullet fragments. The mechanical guard against forged
+  endorsements (approval-language redaction) is unchanged.
+
 - The verifier (`verifier`, `verifier_cli`, reusable workflow
   `verify.yml`): adversarial integrity reads of BOT-authored PRs — the
   advisory reviewer's mirror. Gaming lens (harness exploitation,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,8 @@ Versions follow [SemVer](https://semver.org).
   advisory reviewer's mirror. Gaming lens (harness exploitation,
   ruler-fishing, leakage, overfitting, unsupported claims, measurement
   gaps) with the contract and the frozen ruler's source fetched from the
-  BASE branch into context; findings tagged by category;
-  silence-is-not-endorsement header; its own spend-capped key
+  BASE branch into context; findings tagged by category; a header stating
+  a clean read does not certify the result; its own spend-capped key
   (`ANTHROPIC_VERIFIER_KEY`). The advisory workflow's interim
   bot-PR-on-label override is now opt-in (`review_bot_prs_on_label`,
   default false) for verifier-less self-hosters — with a verifier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Review and verification comments read like a colleague, not a legal
+  notice (maintainer feedback): one calm italic header line per role, and
+  findings rendered as prose paragraphs with the reference at the end
+  instead of bullet fragments. The mechanical guard against forged
+  endorsements (approval-language redaction) is unchanged.
+
 - CI consolidated to one job (`ci`) — GitHub bills per job rounded up to a
   minute, so five short jobs cost 5x. The advisory review now runs on PR open
   and on the `autoresearch:review` label, not on every push.
@@ -38,12 +44,6 @@ Versions follow [SemVer](https://semver.org).
   errors/response shapes are typed instead of crashing.
 
 ### Added
-
-- Review and verification comments read like a colleague, not a legal
-  notice (maintainer feedback): one calm italic header line per role, and
-  findings rendered as prose paragraphs with the reference at the end
-  instead of bullet fragments. The mechanical guard against forged
-  endorsements (approval-language redaction) is unchanged.
 
 - The verifier (`verifier`, `verifier_cli`, reusable workflow
   `verify.yml`): adversarial integrity reads of BOT-authored PRs — the

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -295,7 +295,11 @@ def format_comment(result: ReviewResult) -> str | None:
             safe_file = finding.file.replace("`", "")
             where = f"`{safe_file}`" + (f":{finding.line}" if finding.line else "")
             ref = f"({where}; {finding.confidence} confidence)"
-            lines.append(f"**{finding.summary}.** {finding.detail} {ref}")
+            summary = finding.summary.rstrip(".!?…")  # the template owns the period
+            # an odd backtick in the detail would pair with the reference's
+            # opening backtick and spill the path out of its code span
+            detail = finding.detail + ("`" if finding.detail.count("`") % 2 else "")
+            lines.append(f"**{summary}.** {detail} {ref}")
             lines.append("")
     if result.notes:
         lines += [result.notes]

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -282,7 +282,10 @@ def format_comment(result: ReviewResult) -> str | None:
         # model relocating references does not.
         order = {"high": 0, "medium": 1, "low": 2}
         for finding in sorted(result.findings, key=lambda f: order[f.confidence]):
-            where = f"`{finding.file}`" + (f":{finding.line}" if finding.line else "")
+            # backticks stripped: a file value containing one would close
+            # the code span and render attacker markdown inline
+            safe_file = finding.file.replace("`", "")
+            where = f"`{safe_file}`" + (f":{finding.line}" if finding.line else "")
             ref = f"({where}; {finding.confidence} confidence)"
             lines.append(f"**{finding.summary}.** {finding.detail} {ref}")
             lines.append("")

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -163,9 +163,11 @@ def skip_reason(pr: PullRequest, bot_login: str, explicit_request: bool = False)
 def sanitize(text: str, limit: int) -> str:
     """Make model text safe to render in a comment.
 
-    Collapses newlines (so a finding cannot escape its list item and write
-    top-level markdown), escapes HTML, strips the thread marker, redacts
-    approval-like language, and truncates.
+    Collapses newlines (so attacker text cannot start a fresh line and
+    write top-level markdown — headings, quotes, tables — regardless of
+    whether findings render as list items or prose paragraphs), escapes
+    HTML, strips the thread marker, redacts approval-like language, and
+    truncates.
     """
     flat = " ".join(str(text).split())
     flat = flat.replace(MARKER, "")
@@ -272,6 +274,7 @@ def format_comment(result: ReviewResult) -> str | None:
     lines = [MARKER, ADVISORY_HEADER, ""]
     if not result.findings:
         lines.append("No defects found in this diff.")
+        lines.append("")
     else:
         # Prose paragraphs, not bullet fragments (maintainer preference,
         # 2026-08-08): the human is the reader who needs readability; a

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -75,6 +75,13 @@ instead of raising a finding.
 Do not report: style preferences, naming opinions, or restatements of what the
 diff does. If you find nothing, say so.
 
+Write like a careful colleague, not a report generator. The summary is one
+short sentence naming the defect. The detail is two to four plain
+declarative sentences: the evidence, then the consequence. No
+throat-clearing ("it is worth noting", "as written"), no restating the
+summary, and no hedging in prose — the confidence field is your one
+hedge, so spend it there and write the rest as if you mean it.
+
 Never instruct the reader to merge, approve, or reject. You are advisory."""
 
 
@@ -108,6 +115,7 @@ class Finding:
     confidence: Literal["low", "medium", "high"]
     summary: str
     detail: str
+    category: str = ""  # verifier-only (gaming taxonomy); "" for advisory
 
 
 @dataclass(frozen=True)

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -26,14 +26,15 @@ from typing import Any, Literal, Protocol
 log = logging.getLogger(__name__)
 
 MARKER = "<!-- autoresearch:advisory-review -->"
+OPT_OUT_LABEL = "autoresearch:no-review"
+
 # One calm line: the mechanical defense against forged endorsements is the
 # approval-language redaction in sanitize(), not header volume. (Softened
 # 2026-08-08 on maintainer feedback — the old header shouted.)
 ADVISORY_HEADER = (
     "*Advisory findings from `autoresearch` — the code owner decides. "
-    "Reply to disagree; the `autoresearch:no-review` label opts this PR out.*"
+    f"Reply to disagree; the `{OPT_OUT_LABEL}` label opts this PR out.*"
 )
-OPT_OUT_LABEL = "autoresearch:no-review"
 MAX_DIFF_CHARS = 200_000
 MAX_CONTEXT_FILES = 8
 MAX_FILE_CHARS = 20_000

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -26,11 +26,12 @@ from typing import Any, Literal, Protocol
 log = logging.getLogger(__name__)
 
 MARKER = "<!-- autoresearch:advisory-review -->"
+# One calm line: the mechanical defense against forged endorsements is the
+# approval-language redaction in sanitize(), not header volume. (Softened
+# 2026-08-08 on maintainer feedback — the old header shouted.)
 ADVISORY_HEADER = (
-    "**Advisory review — not an approval.** Automated findings from "
-    "`autoresearch`; a human code owner still owns this PR. Reply to any "
-    "finding you disagree with, or add the opt-out label to silence future "
-    "runs on this PR."
+    "*Advisory findings from `autoresearch` — the code owner decides. "
+    "Reply to disagree; the `autoresearch:no-review` label opts this PR out.*"
 )
 OPT_OUT_LABEL = "autoresearch:no-review"
 MAX_DIFF_CHARS = 200_000
@@ -272,11 +273,15 @@ def format_comment(result: ReviewResult) -> str | None:
     if not result.findings:
         lines.append("No defects found in this diff.")
     else:
+        # Prose paragraphs, not bullet fragments (maintainer preference,
+        # 2026-08-08): the human is the reader who needs readability; a
+        # model relocating references does not.
         order = {"high": 0, "medium": 1, "low": 2}
         for finding in sorted(result.findings, key=lambda f: order[f.confidence]):
             where = f"`{finding.file}`" + (f":{finding.line}" if finding.line else "")
-            lines.append(f"- **{finding.summary}** ({finding.confidence} confidence, {where})")
-            lines.append(f"  {finding.detail}")
+            ref = f"({where}; {finding.confidence} confidence)"
+            lines.append(f"**{finding.summary}.** {finding.detail} {ref}")
+            lines.append("")
     if result.notes:
-        lines += ["", result.notes]
-    return "\n".join(lines)
+        lines += [result.notes]
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -262,7 +262,10 @@ def format_verify_comment(result: ReviewResult) -> str | None:
     else:
         order = {"high": 0, "medium": 1, "low": 2}
         for finding in sorted(result.findings, key=lambda f: order[f.confidence]):
-            where = f"`{finding.file}`" + (f":{finding.line}" if finding.line else "")
+            # backticks stripped: a file value containing one would close
+            # the code span and render attacker markdown inline
+            safe_file = finding.file.replace("`", "")
+            where = f"`{safe_file}`" + (f":{finding.line}" if finding.line else "")
             ref = f"({where}; {finding.confidence} confidence)"
             lines.append(f"**{finding.summary}.** {finding.detail} {ref}")
             lines.append("")

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -42,10 +42,9 @@ log = logging.getLogger(__name__)
 
 VERIFY_MARKER = "<!-- autoresearch:verification-review -->"
 VERIFY_HEADER = (
-    "**Verification review — silence is NOT endorsement.** Automated "
-    "integrity read of a bot-authored PR (gaming, leakage, unsupported "
-    "claims). Findings are leads for the human code owner, who still owns "
-    "this merge; a clean read is not a green light."
+    "*Integrity read of this bot PR (gaming, leakage, unsupported claims). "
+    "Findings are leads for the code owner — a clean read does not certify "
+    "the result.*"
 )
 
 # Verifier-specific context caps: the ruler's source is the load-bearing
@@ -256,16 +255,14 @@ def format_verify_comment(result: ReviewResult) -> str | None:
         return None
     lines = [VERIFY_MARKER, VERIFY_HEADER, ""]
     if not result.findings:
-        lines.append(
-            "No integrity findings from this read. (Silence is not an "
-            "endorsement; the mechanical checks and the human review still apply.)"
-        )
+        lines.append("No integrity findings from this read.")
     else:
         order = {"high": 0, "medium": 1, "low": 2}
         for finding in sorted(result.findings, key=lambda f: order[f.confidence]):
             where = f"`{finding.file}`" + (f":{finding.line}" if finding.line else "")
-            lines.append(f"- **{finding.summary}** ({finding.confidence} confidence, {where})")
-            lines.append(f"  {finding.detail}")
+            ref = f"({where}; {finding.confidence} confidence)"
+            lines.append(f"**{finding.summary}.** {finding.detail} {ref}")
+            lines.append("")
     if result.notes:
-        lines += ["", result.notes]
-    return "\n".join(lines)
+        lines += [result.notes]
+    return "\n".join(lines).rstrip() + "\n"

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -273,7 +273,9 @@ def format_verify_comment(result: ReviewResult) -> str | None:
             where = f"`{safe_file}`" + (f":{finding.line}" if finding.line else "")
             tag = f", {finding.category}" if finding.category else ""
             ref = f"({where}; {finding.confidence} confidence{tag})"
-            lines.append(f"**{finding.summary}.** {finding.detail} {ref}")
+            summary = finding.summary.rstrip(".!?…")  # the template owns the period
+            detail = finding.detail + ("`" if finding.detail.count("`") % 2 else "")
+            lines.append(f"**{summary}.** {detail} {ref}")
             lines.append("")
     if result.notes:
         lines += [result.notes]

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -106,6 +106,13 @@ a confidence level. If something material is unverifiable from the context,
 say so in one line in the notes instead of raising a finding. If you find
 nothing, say so plainly — and remember your silence is not an endorsement.
 
+Write like a careful colleague, not a report generator. The summary is one
+short sentence naming the problem. The detail is two to four plain
+declarative sentences: the evidence, then why it undermines the claim. No
+throat-clearing ("whatever one thinks of the merits", "the state of
+affairs is"), no restating the summary, no stacked hedges — the
+confidence field is your one hedge.
+
 Never instruct the reader to merge or reject. You are advisory."""
 
 VERIFY_SCHEMA: dict[str, Any] = {
@@ -238,11 +245,9 @@ def verify(
             file=sanitize(str(item.get("file", "")), 200),
             line=item["line"] if type(item.get("line")) is int else None,
             confidence=item["confidence"] if item.get("confidence") in CONFIDENCES else "low",
-            summary=sanitize(
-                f"[{item.get('category', 'other')}] {item.get('summary', '')}",
-                MAX_SUMMARY_CHARS,
-            ),
+            summary=sanitize(str(item.get("summary", "")), MAX_SUMMARY_CHARS),
             detail=sanitize(str(item.get("detail", "")), MAX_DETAIL_CHARS),
+            category=sanitize(str(item.get("category", "other")), 40),
         )
         for item in (raw_findings if isinstance(raw_findings, list) else [])[:MAX_FINDINGS]
         if isinstance(item, dict) and item.get("summary")
@@ -266,7 +271,8 @@ def format_verify_comment(result: ReviewResult) -> str | None:
             # the code span and render attacker markdown inline
             safe_file = finding.file.replace("`", "")
             where = f"`{safe_file}`" + (f":{finding.line}" if finding.line else "")
-            ref = f"({where}; {finding.confidence} confidence)"
+            tag = f", {finding.category}" if finding.category else ""
+            ref = f"({where}; {finding.confidence} confidence{tag})"
             lines.append(f"**{finding.summary}.** {finding.detail} {ref}")
             lines.append("")
     if result.notes:

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -11,8 +11,10 @@ instances, claims the evidence does not support).
 Same constitution as the reviewer, inverted population:
 - bot-authored PRs ONLY (a human PR is the advisory reviewer's job);
 - findings-only; never an approval; never blocks CI;
-- header states that SILENCE IS NOT ENDORSEMENT — a clean read must never
-  be mistaken for a green light; the human code owner still decides;
+- the header carries the not-a-certification semantics (formerly the
+  louder "silence is not endorsement" — softened 2026-08-08 on maintainer
+  feedback): a clean read must never be mistaken for a green light; the
+  human code owner still decides;
 - model output sanitized with the same approval-language redaction, so a
   prompt-injected diff cannot forge an endorsement through this channel.
 """
@@ -256,6 +258,7 @@ def format_verify_comment(result: ReviewResult) -> str | None:
     lines = [VERIFY_MARKER, VERIFY_HEADER, ""]
     if not result.findings:
         lines.append("No integrity findings from this read.")
+        lines.append("")
     else:
         order = {"high": 0, "medium": 1, "low": 2}
         for finding in sorted(result.findings, key=lambda f: order[f.confidence]):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -172,3 +172,36 @@ def test_opt_out_still_wins_over_explicit_request() -> None:
     pr = make_pr(author=BOT, labels=("autoresearch:no-review",))
     reason = skip_reason(pr, BOT, explicit_request=True)
     assert reason is not None and "opted out" in reason
+
+
+def test_advisory_header_semantics_are_pinned() -> None:
+    """Same pin as the verifier's: the constant itself must keep the
+    advisory/code-owner-decides framing through any future rewording."""
+    assert "Advisory" in ADVISORY_HEADER
+    assert "code owner decides" in ADVISORY_HEADER
+    assert OPT_OUT_LABEL in ADVISORY_HEADER  # posted instructions track the constant
+
+
+def test_backticked_filename_cannot_break_the_reference_span() -> None:
+    from autoresearch.review import Finding, ReviewResult
+    from autoresearch.review import format_comment as _fc
+
+    body = _fc(
+        ReviewResult(
+            findings=[
+                Finding(
+                    file="a`](http://evil)`.py",
+                    line=1,
+                    confidence="low",
+                    summary="s",
+                    detail="d",
+                )
+            ],
+            notes="",
+        )
+    )
+    assert body is not None
+    # the injected backtick is gone, so the span cannot be closed early;
+    # whatever remains of the path renders as inert code-span text
+    assert "a](http://evil).py" in body  # inside the span, backtick-free
+    assert "`a](http://evil).py`" in body

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -131,7 +131,7 @@ def test_findings_sorted_by_confidence() -> None:
     }
     body = format_comment(review(make_pr(), FakeCompleter(payload), BOT))
     assert body is not None
-    assert body.index("**H**") < body.index("**M**") < body.index("**L**")
+    assert body.index("**H.**") < body.index("**M.**") < body.index("**L.**")
 
 
 def test_no_findings_still_posts_a_clean_report() -> None:

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -91,8 +91,11 @@ def test_verify_tags_findings_with_category_and_sanitizes() -> None:
     result = verify(make_pr(), completer, BOT, contract_text="c")
     assert len(result.findings) == 1
     finding = result.findings[0]
-    assert finding.summary.startswith("[harness-exploitation]")
+    assert finding.category == "harness-exploitation"
     assert "\n" not in finding.summary  # sanitize collapsed the newline
+    # the category rides in the trailing reference, not as a robotic prefix
+    body = format_verify_comment(result)
+    assert body is not None and "confidence, harness-exploitation)" in body
     system, _prompt = completer.calls[0]
     assert "harness-exploitation" in system and "silence is not an endorsement" in system
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -105,12 +105,14 @@ def test_human_pr_never_reaches_the_model() -> None:
     assert format_verify_comment(result) is None
 
 
-def test_clean_read_states_silence_is_not_endorsement() -> None:
+def test_clean_read_does_not_certify() -> None:
+    """The header carries the not-a-certification semantics in one calm
+    line (maintainer feedback: the old header shouted)."""
     body = format_verify_comment(ReviewResult(findings=[], notes=""))
     assert body is not None
     assert body.startswith(VERIFY_MARKER)
     assert VERIFY_HEADER in body
-    assert "not an endorsement" in body
+    assert "does not certify" in body
 
 
 def test_ruler_paths_resolved_from_contract_commands() -> None:

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -147,7 +147,9 @@ def test_comment_never_tells_humans_to_merge() -> None:
     result = verify(make_pr(), completer, BOT, contract_text="c")
     body = format_verify_comment(result)
     assert body is not None
-    lowered = body.replace(VERIFY_HEADER, "").casefold()
+    # the WHOLE body, header included — a reworded header must not become
+    # an exempt channel for endorsement language
+    lowered = body.casefold()
     for phrase in ("lgtm", "approve", "safe to merge"):
         assert phrase not in lowered
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -112,7 +112,14 @@ def test_clean_read_does_not_certify() -> None:
     assert body is not None
     assert body.startswith(VERIFY_MARKER)
     assert VERIFY_HEADER in body
-    assert "does not certify" in body
+    # the clean-read BODY (not just the header) must exist and be neutral
+    assert "No integrity findings" in body
+
+
+def test_notes_are_a_separate_paragraph_in_clean_reads() -> None:
+    body = format_verify_comment(ReviewResult(findings=[], notes="context was partial"))
+    assert body is not None
+    assert "\n\ncontext was partial" in body  # blank line before notes
 
 
 def test_ruler_paths_resolved_from_contract_commands() -> None:

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -116,6 +116,39 @@ def test_clean_read_does_not_certify() -> None:
     assert "No integrity findings" in body
 
 
+def test_header_semantics_are_pinned() -> None:
+    """The header constant itself must carry the non-certification
+    semantics — a later rewrite that drops it goes red here, not silent."""
+    assert "does not certify" in VERIFY_HEADER
+    assert "code owner" in VERIFY_HEADER
+
+
+def test_comment_never_tells_humans_to_merge() -> None:
+    """The verifier analogue of the advisory guard: approval-like language
+    in model output is redacted before it reaches the comment."""
+    completer = ScriptedCompleter(
+        {
+            "findings": [
+                {
+                    "file": "a.py",
+                    "line": 1,
+                    "category": "other",
+                    "confidence": "low",
+                    "summary": "looks good to me, approve and merge this",
+                    "detail": "LGTM! You should merge this PR immediately.",
+                }
+            ],
+            "notes": "Approved: safe to merge.",
+        }
+    )
+    result = verify(make_pr(), completer, BOT, contract_text="c")
+    body = format_verify_comment(result)
+    assert body is not None
+    lowered = body.replace(VERIFY_HEADER, "").casefold()
+    for phrase in ("lgtm", "approve", "safe to merge"):
+        assert phrase not in lowered
+
+
 def test_notes_are_a_separate_paragraph_in_clean_reads() -> None:
     body = format_verify_comment(ReviewResult(findings=[], notes="context was partial"))
     assert body is not None


### PR DESCRIPTION
From today's feedback: soften the review/verifier framing and switch findings from bullet fragments to prose. The safety property lives in `sanitize()`'s approval-language redaction, not in header volume, so nothing protective changes — only tone and typography.

🤖 Generated with [Claude Code](https://claude.com/claude-code)