### PR TITLE
Follow-up pushes rewrite the measured candidate row in place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Follow-up pushes rewrite the PR body's measured candidate row in place
+  (the one mechanical, orchestrator-owned number that must never go
+  stale), scoped to the preamble so report text with a lookalike row is
+  untouched; the narrative is never rewritten — the Edit block points at
+  the replies.
+
 - The roles now read each other (both gaps found live on the first
   verifier exchange): the verifier's context includes the PR discussion —
   bounded, with its own prior rounds marked as its own findings to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Display precision follows convention, not float repr (maintainer
+  decision): human surfaces — PR tables, BENCHMARKS.md, the rewritten
+  candidate row — render at the benchmark's `display_digits` (contract
+  knob, 2–12 significant digits, default 6); full precision lives only in
+  `results/leader.json`, and every comparison runs on full floats, so
+  display can never hide or fake an improvement.
 - Follow-up pushes rewrite the PR body's measured candidate row in place
   (the one mechanical, orchestrator-owned number that must never go
   stale), scoped to the preamble so report text with a lookalike row is

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -417,7 +417,12 @@ def live_climb(
                 run_id=run_id,
                 date=created[:10],
             )
-            write_progress(workspace, entries, config.target)
+            write_progress(
+                workspace,
+                entries,
+                config.target,
+                digits={b.name: b.display_digits for b in contract.benchmarks if b.display_digits},
+            )
             # The commit veto re-checks FULL scope (allowed + forbidden) as
             # defense in depth behind climb_once's pre-eval check. The two
             # orchestrator-written progress files are the only exemption.
@@ -441,7 +446,9 @@ def live_climb(
                 )
             ws.push(branch)
             pushed = True
-            body = pr_body(result, config, redact_secrets=secrets)
+            body = pr_body(
+                result, config, redact_secrets=secrets, display_digits=bench.display_digits
+            )
             if issue_number:
                 body = f"Addresses #{issue_number}.\n\n{body}"
             pr_url = github.create_pull(

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -66,6 +66,12 @@ class Benchmark(_StrictModel):
     command: str = Field(min_length=1)
     metric: str = Field(min_length=1)
     direction: Literal["min", "max"]
+    # Significant digits for HUMAN surfaces (PR tables, BENCHMARKS.md,
+    # replies) per the benchmark's community convention. Full precision
+    # lives only in results/leader.json, the machine ledger (maintainer
+    # decision 2026-08-09). Display-only: comparisons always use full
+    # floats, so this can never hide or fake an improvement.
+    display_digits: int | None = Field(default=None, ge=2, le=12)
 
 
 class SuiteAggregate(_StrictModel):

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -308,7 +308,16 @@ def _respond(
                         run_id=run_id,
                         date=created[:10],
                     )
-                    write_progress(workspace, entries, record.target)
+                    write_progress(
+                        workspace,
+                        entries,
+                        record.target,
+                        digits={
+                            b.name: b.display_digits
+                            for b in contract.benchmarks
+                            if b.display_digits
+                        },
+                    )
                     branch = _current_branch(ws)
                     ws.commit_all(
                         f"agent: address review feedback ({bench.metric}={candidate:.6g})"
@@ -338,7 +347,9 @@ def _respond(
         try:
             # the measured table is rewritten in place; the narrative is
             # never rewritten (the Edit block below points at the replies)
-            github.update_candidate_row(record.target, number, candidate)
+            github.update_candidate_row(
+                record.target, number, candidate, digits=bench.display_digits
+            )
         except Exception as exc:
             log.warning("candidate-row rewrite failed for %s#%s: %s", record.target, number, exc)
         # Code changed after publish: the body's report now describes an

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -24,7 +24,13 @@ from autoresearch.github import GitHubClient, Workspace
 from autoresearch.harness import Harness, redact
 from autoresearch.orchestrator import Evaluator, out_of_scope
 from autoresearch.orchestrator import improved as orch_improved
-from autoresearch.progress import PROGRESS_PATHS, load_leader, update_leader, write_progress
+from autoresearch.progress import (
+    PROGRESS_PATHS,
+    fmt_metric,
+    load_leader,
+    update_leader,
+    write_progress,
+)
 from autoresearch.review import APPROVAL_PATTERN, REDACTED
 from autoresearch.runstate import (
     ENDED,
@@ -320,7 +326,8 @@ def _respond(
                     )
                     branch = _current_branch(ws)
                     ws.commit_all(
-                        f"agent: address review feedback ({bench.metric}={candidate:.6g})"
+                        f"agent: address review feedback "
+                        f"({bench.metric}={fmt_metric(candidate, bench.display_digits)})"
                         f"\n\nAgent: {record.agent_id}",
                         author=bot_login,
                         forbidden=lambda p: (
@@ -334,7 +341,7 @@ def _respond(
                     )
                     measured_note = (
                         f"\n\n**Re-measured after this change: `{bench.metric}` = "
-                        f"{candidate:.6g}**"
+                        f"{fmt_metric(candidate, bench.display_digits)}**"
                         + (
                             " — worse than the PR's previous number, stated plainly."
                             if worse

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -335,6 +335,12 @@ def _respond(
 
     github.comment(record.target, number, f"{REPLY_MARKER}\n{reply_body}{measured_note}")
     if change_pushed:
+        try:
+            # the measured table is rewritten in place; the narrative is
+            # never rewritten (the Edit block below points at the replies)
+            github.update_candidate_row(record.target, number, candidate)
+        except Exception as exc:
+            log.warning("candidate-row rewrite failed for %s#%s: %s", record.target, number, exc)
         # Code changed after publish: the body's report now describes an
         # older tree. Mark it edited (maintainer decision 2026-08-09) so no
         # reader — human or verifier — mistakes the original report for the

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -277,6 +277,11 @@ class GitHubClient:
         # (before the report section) — agent report text could contain a
         # lookalike row, and it must stay untouched
         head, sep, tail = current.partition("## Research report")
+        if not sep:
+            # No report heading -> the preamble boundary is gone (human
+            # body edit?): fail CLOSED rather than rewrite report text —
+            # the Edit addendum already carries the number.
+            return False
         if not self._CANDIDATE_ROW.search(head):
             return False
         from autoresearch.progress import fmt_metric

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -22,6 +22,7 @@ import base64
 import json
 import logging
 import os
+import re
 import subprocess
 import urllib.error
 import urllib.parse
@@ -251,6 +252,33 @@ class GitHubClient:
         return self._expect_dict(self._request("GET", path), path)
 
     BODY_EDIT_MARKER = "<!-- autoresearch:body-edit -->"
+    # the orchestrator-owned candidate row in pr_body's results table
+    _CANDIDATE_ROW = re.compile(r"^\| candidate \| .* \|$", re.MULTILINE)
+
+    def update_candidate_row(self, repo: str, number: int, candidate: float) -> bool:
+        """Rewrite the results table's candidate row in place (PATCH).
+
+        The row is orchestrator-owned and mechanical — the ONE part of the
+        body that must never go stale when a follow-up push re-measures
+        (maintainer decision 2026-08-09: rewrite the measured numbers,
+        never the narrative). Returns False when the row is not found
+        (older body formats), in which case the Edit addendum still
+        carries the number.
+        """
+        if self.dry_run:
+            log.info("[dry-run] update candidate row %s#%d -> %s", repo, number, candidate)
+            return True
+        path = f"/repos/{urllib.parse.quote(repo)}/pulls/{number}"
+        current = str(self._expect_dict(self._request("GET", path), path).get("body") or "")
+        # only the FIRST match, and only in the orchestrator's preamble
+        # (before the report section) — agent report text could contain a
+        # lookalike row, and it must stay untouched
+        head, sep, tail = current.partition("## Research report")
+        if not self._CANDIDATE_ROW.search(head):
+            return False
+        head = self._CANDIDATE_ROW.sub(f"| candidate | {candidate} |", head, count=1)
+        self._request("PATCH", path, {"body": f"{head}{sep}{tail}"})
+        return True
 
     def append_pull_body(self, repo: str, number: int, addendum: str) -> None:
         """Upsert an EDIT addendum onto a PR body (read-modify-write PATCH).

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -254,7 +254,7 @@ class GitHubClient:
     BODY_EDIT_MARKER = "<!-- autoresearch:body-edit -->"
     # the orchestrator-owned candidate row in pr_body's results table
     # \r-tolerant: a human web-UI edit can normalize the body to CRLF
-    _CANDIDATE_ROW = re.compile(r"^\| candidate \| .* \|\r?$", re.MULTILINE)
+    _CANDIDATE_ROW = re.compile(r"^\| candidate \| .* \|(\r?)$", re.MULTILINE)
 
     def update_candidate_row(
         self, repo: str, number: int, candidate: float, digits: int | None = None
@@ -287,7 +287,7 @@ class GitHubClient:
         from autoresearch.progress import fmt_metric
 
         head = self._CANDIDATE_ROW.sub(
-            f"| candidate | {fmt_metric(candidate, digits)} |", head, count=1
+            rf"| candidate | {fmt_metric(candidate, digits)} |\1", head, count=1
         )
         self._request("PATCH", path, {"body": f"{head}{sep}{tail}"})
         return True

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -253,7 +253,8 @@ class GitHubClient:
 
     BODY_EDIT_MARKER = "<!-- autoresearch:body-edit -->"
     # the orchestrator-owned candidate row in pr_body's results table
-    _CANDIDATE_ROW = re.compile(r"^\| candidate \| .* \|$", re.MULTILINE)
+    # \r-tolerant: a human web-UI edit can normalize the body to CRLF
+    _CANDIDATE_ROW = re.compile(r"^\| candidate \| .* \|\r?$", re.MULTILINE)
 
     def update_candidate_row(self, repo: str, number: int, candidate: float) -> bool:
         """Rewrite the results table's candidate row in place (PATCH).

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -256,7 +256,9 @@ class GitHubClient:
     # \r-tolerant: a human web-UI edit can normalize the body to CRLF
     _CANDIDATE_ROW = re.compile(r"^\| candidate \| .* \|\r?$", re.MULTILINE)
 
-    def update_candidate_row(self, repo: str, number: int, candidate: float) -> bool:
+    def update_candidate_row(
+        self, repo: str, number: int, candidate: float, digits: int | None = None
+    ) -> bool:
         """Rewrite the results table's candidate row in place (PATCH).
 
         The row is orchestrator-owned and mechanical — the ONE part of the
@@ -277,7 +279,11 @@ class GitHubClient:
         head, sep, tail = current.partition("## Research report")
         if not self._CANDIDATE_ROW.search(head):
             return False
-        head = self._CANDIDATE_ROW.sub(f"| candidate | {candidate} |", head, count=1)
+        from autoresearch.progress import fmt_metric
+
+        head = self._CANDIDATE_ROW.sub(
+            f"| candidate | {fmt_metric(candidate, digits)} |", head, count=1
+        )
         self._request("PATCH", path, {"body": f"{head}{sep}{tail}"})
         return True
 

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -418,8 +418,20 @@ def climb_once(
     )
 
 
-def pr_body(result: ClimbResult, config: ClimbConfig, redact_secrets: tuple[str, ...]) -> str:
-    """The PR body for an improved run: results table + the agent's report."""
+def pr_body(
+    result: ClimbResult,
+    config: ClimbConfig,
+    redact_secrets: tuple[str, ...],
+    display_digits: int | None = None,
+) -> str:
+    """The PR body for an improved run: results table + the agent's report.
+
+    Human surfaces render at the benchmark's conventional precision
+    (maintainer decision 2026-08-09); full precision lives only in
+    results/leader.json, and every comparison runs on full floats.
+    """
+    from autoresearch.progress import fmt_metric
+
     if result.outcome != "improved" or result.baseline is None or result.candidate is None:
         raise ValueError("pr_body requires an improved result with both measurements")
     body = "\n".join(
@@ -429,8 +441,8 @@ def pr_body(result: ClimbResult, config: ClimbConfig, redact_secrets: tuple[str,
             "",
             "| | value |",
             "| --- | --- |",
-            f"| baseline ({config.benchmark}) | {result.baseline} |",
-            f"| candidate | {result.candidate} |",
+            f"| baseline ({config.benchmark}) | {fmt_metric(result.baseline, display_digits)} |",
+            f"| candidate | {fmt_metric(result.candidate, display_digits)} |",
             "",
             "Both numbers were measured by the orchestrator re-running the "
             "contract's eval command — not taken from the session. CI "

--- a/src/autoresearch/progress.py
+++ b/src/autoresearch/progress.py
@@ -105,7 +105,22 @@ def _delta(entry: LeaderEntry) -> str:
     return f"{'▲' if good else '▼'} {rel:+.1f}%"
 
 
-def render_markdown(entries: dict[str, LeaderEntry], target: str) -> str:
+DEFAULT_DISPLAY_DIGITS = 6
+
+
+def fmt_metric(value: float, digits: int | None = None) -> str:
+    """Render a measurement for a HUMAN surface at the benchmark's
+    conventional precision. The ledger keeps the full float; every
+    comparison (improvement thresholds, leader monotonicity) runs on full
+    floats — this is presentation only."""
+    return f"{value:.{digits or DEFAULT_DISPLAY_DIGITS}g}"
+
+
+def render_markdown(
+    entries: dict[str, LeaderEntry],
+    target: str,
+    digits: dict[str, int] | None = None,
+) -> str:
     lines = [
         "# Benchmark progress",
         "",
@@ -120,9 +135,10 @@ def render_markdown(entries: dict[str, LeaderEntry], target: str) -> str:
     for name in sorted(entries):
         e = entries[name]
         arrow = "↓" if e.direction == "min" else "↑"
+        d = (digits or {}).get(e.benchmark)
         lines.append(
-            f"| {e.benchmark} | `{e.metric}` {arrow} | {e.baseline:g} | "
-            f"{e.best:g} | {_delta(e)} | {e.updated} | `{e.best_run}` |"
+            f"| {e.benchmark} | `{e.metric}` {arrow} | {fmt_metric(e.baseline, d)} | "
+            f"{fmt_metric(e.best, d)} | {_delta(e)} | {e.updated} | `{e.best_run}` |"
         )
     lines += [
         "",
@@ -133,10 +149,16 @@ def render_markdown(entries: dict[str, LeaderEntry], target: str) -> str:
     return "\n".join(lines)
 
 
-def write_progress(workspace: Path, entries: dict[str, LeaderEntry], target: str) -> None:
+def write_progress(
+    workspace: Path,
+    entries: dict[str, LeaderEntry],
+    target: str,
+    digits: dict[str, int] | None = None,
+) -> None:
     leader_path = workspace / LEADER_FILE
     leader_path.parent.mkdir(parents=True, exist_ok=True)
+    # the ledger keeps FULL precision — it feeds comparisons, never eyes
     leader_path.write_text(
         json.dumps({name: asdict(e) for name, e in sorted(entries.items())}, indent=2) + "\n"
     )
-    (workspace / PROGRESS_FILE).write_text(render_markdown(entries, target))
+    (workspace / PROGRESS_FILE).write_text(render_markdown(entries, target, digits))

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -49,6 +49,7 @@ class FakeGitHub:
     review_comments: list[dict] = field(default_factory=list)
     posted: list[str] = field(default_factory=list)
     body_addenda: list[str] = field(default_factory=list)
+    row_updates: list[float] = field(default_factory=list)
     auth: object = None
 
     def get_pull_request(self, repo, number):
@@ -68,6 +69,10 @@ class FakeGitHub:
 
     def append_pull_body(self, repo, number, addendum):
         self.body_addenda.append(addendum)
+
+    def update_candidate_row(self, repo, number, candidate):
+        self.row_updates.append(candidate)
+        return True
 
 
 @dataclass
@@ -367,6 +372,8 @@ def test_pushed_changes_append_a_body_addendum(review_run) -> None:
     assert addendum.startswith("---")
     assert "**Edit (" in addendum and "follow-up" in addendum
     assert "original version" in addendum
+    # the measured table is rewritten in place with the re-measured value
+    assert github.row_updates == [10.2]
 
 
 def test_reverted_change_appends_no_addendum(review_run) -> None:
@@ -378,6 +385,7 @@ def test_reverted_change_appends_no_addendum(review_run) -> None:
     outcome = respond(root, github, harness)
     assert outcome.action == "replied"
     assert not github.body_addenda  # reverted -> body untouched
+    assert not github.row_updates
 
 
 def test_reply_without_changes_leaves_the_body_alone(review_run) -> None:

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -70,7 +70,7 @@ class FakeGitHub:
     def append_pull_body(self, repo, number, addendum):
         self.body_addenda.append(addendum)
 
-    def update_candidate_row(self, repo, number, candidate):
+    def update_candidate_row(self, repo, number, candidate, digits=None):
         self.row_updates.append(candidate)
         return True
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -320,6 +320,17 @@ def test_candidate_row_rewrite_touches_only_the_preamble(provider: FileTokenProv
     assert "| candidate | 13.1 |" not in patched
 
 
+def test_candidate_row_rewrite_fails_closed_without_report_heading(
+    provider: FileTokenProvider,
+) -> None:
+    """No report heading -> no preamble boundary -> no rewrite (the row
+    found could be inside agent text)."""
+    transport = FakeTransport([{"body": "| candidate | 13.1 |\nno heading here"}])
+    client = GitHubClient(auth=provider, transport=transport)
+    assert client.update_candidate_row("org/repo", 9, 10.2) is False
+    assert len(transport.requests) == 1
+
+
 def test_candidate_row_rewrite_reports_missing_row(provider: FileTokenProvider) -> None:
     transport = FakeTransport([{"body": "no table here\n\n## Research report\nx"}])
     client = GitHubClient(auth=provider, transport=transport)

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -299,3 +299,29 @@ def test_arming_guard_arms_with_repo_allowed_method(provider: FileTokenProvider)
     assert isinstance(transport.requests[-1].data, bytes)
     body = json.loads(transport.requests[-1].data.decode())
     assert body["variables"]["method"] == "SQUASH"
+
+
+def test_candidate_row_rewrite_touches_only_the_preamble(provider: FileTokenProvider) -> None:
+    """The report can contain a lookalike row; only the orchestrator's
+    table row (before the report section) is rewritten."""
+    body = (
+        "intro\n| | value |\n| --- | --- |\n| baseline (tsp) | 13.88 |\n"
+        "| candidate | 13.1 |\n\n## Research report\n\nprose "
+        "with a lookalike:\n| candidate | 999 |\n"
+    )
+    transport = FakeTransport([{"body": body}, None])
+    client = GitHubClient(auth=provider, transport=transport)
+    assert client.update_candidate_row("org/repo", 9, 10.2) is True
+    payload = transport.requests[-1].data
+    assert isinstance(payload, bytes)
+    patched = json.loads(payload.decode())["body"]
+    assert "| candidate | 10.2 |" in patched
+    assert "| candidate | 999 |" in patched  # the report's lookalike untouched
+    assert "| candidate | 13.1 |" not in patched
+
+
+def test_candidate_row_rewrite_reports_missing_row(provider: FileTokenProvider) -> None:
+    transport = FakeTransport([{"body": "no table here\n\n## Research report\nx"}])
+    client = GitHubClient(auth=provider, transport=transport)
+    assert client.update_candidate_row("org/repo", 9, 10.2) is False
+    assert len(transport.requests) == 1  # GET only, no PATCH

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,27 @@
+def test_fmt_metric_renders_at_convention() -> None:
+    from autoresearch.progress import fmt_metric
+
+    assert fmt_metric(13.879999999999999) == "13.88"  # default 6 sig figs
+    assert fmt_metric(13.879999999999999, 3) == "13.9"
+    assert fmt_metric(0.00022631418795999767, 4) == "0.0002263"
+    assert fmt_metric(1.0) == "1"
+
+
+def test_render_markdown_honors_per_benchmark_digits() -> None:
+    from autoresearch.progress import LeaderEntry, render_markdown
+
+    entries = {
+        "tsp": LeaderEntry(
+            benchmark="tsp",
+            metric="mean_tour_length",
+            direction="min",
+            baseline=13.875696168157484,
+            best=10.844662077277105,
+            best_run="r1",
+            updated="2026-08-09",
+        )
+    }
+    md = render_markdown(entries, "org/pilot", digits={"tsp": 4})
+    assert "| 13.88 |" in md and "| 10.84 |" in md
+    md_default = render_markdown(entries, "org/pilot")
+    assert "13.8757" in md_default  # 6 sig figs


### PR DESCRIPTION
The rewrite half of yesterday's rewrite-vs-addendum decision: follow-up pushes now PATCH the body's `| candidate | … |` row to the re-measured value — mechanical and orchestrator-owned, so rewriting in place is provenance-safe — while the narrative report stays frozen and the (single, upserted) Edit block keeps pointing at the replies. Scoped to the preamble so a lookalike row inside the agent's report text is untouched; older bodies without the row degrade to addendum-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)