### PR TITLE
Evals never share the session's venv: private env per eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,8 @@ Versions follow [SemVer](https://semver.org).
 ### Fixed
 
 - Evals and validation runs build a PRIVATE environment per eval
-  (`UV_PROJECT_ENVIRONMENT` in the throwaway eval home) instead of
+  (`UV_PROJECT_ENVIRONMENT` on node-local scratch, beside the uv
+  cache, dying with the eval) instead of
   consuming the workspace venv the session built: no shared mutable state
   across processes (the first live steward validation lost a race to NFS
   close-to-open consistency on a venv another process had just written),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- Evals and validation runs build a PRIVATE environment per eval
+  (`UV_PROJECT_ENVIRONMENT` in the throwaway eval home) instead of
+  consuming the workspace venv the session built: no shared mutable state
+  across processes (the first live steward validation lost a race to NFS
+  close-to-open consistency on a venv another process had just written),
+  and the orchestrator never executes session-authored entrypoints.
+
 - Post-merge advisory findings on the climb glue: content-fingerprint drift
   check (rewrites during eval, not just new files), leader best never
   regresses, climb exceptions record aborted (never a stale implementing),

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -355,6 +355,22 @@ partitions and lets the scheduler place jobs, never nodes.
 
 ## Environments and containers (decided 2026-08-06)
 
+**One writer per environment (rule, 2026-08-09).** A Python environment is
+single-client state: two processes consuming a venv that another process
+recently wrote race NFS close-to-open consistency (seen live — the first
+steward validation spawned a binary that was not yet visible). So no venv
+is ever shared across process boundaries: orchestrator evals and
+validation runs each build a private `UV_PROJECT_ENVIRONMENT` on
+node-local scratch from the lockfile (also keeping session-authored
+entrypoints out of the orchestrator's execution path); a session's
+`ws/.venv` is that session's alone (safe today because a session is one
+job — sequential subprocesses, one NFS client); and the future experiment
+path MUST give every batch job its own env built from the committed tree
+— parallel experiment jobs sharing a workspace venv would reintroduce
+exactly this race at scale. Locking was considered and rejected: locks on
+NFS are their own failure mode, and not-sharing is strictly better here.
+
+
 Torch supports exactly one container runtime — Apptainer (Singularity); no
 Docker daemon exists ([cluster docs](https://services.rt.nyu.edu/docs/hpc/containers/intro/)).
 Containers are applied where they pay, not uniformly:

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -148,10 +148,21 @@ class SubprocessEvaluator:
         # the cache on node-local scratch and copy across filesystems.
         env["UV_CACHE_DIR"] = str(cache_dir)
         env["UV_LINK_MODE"] = "copy"
+        # PRIVATE project env per eval (maintainer decision 2026-08-09:
+        # "either not share, or have a lock" — we don't share): the session
+        # builds ws/.venv for its own use, and a second process consuming a
+        # venv another process just wrote races NFS close-to-open
+        # consistency (seen live: the first steward validation spawned a
+        # pytest whose binary was not yet visible). The eval builds its own
+        # environment from the LOCKFILE into its throwaway home — no shared
+        # mutable state, and the orchestrator never executes
+        # session-authored entrypoints.
+        env["UV_PROJECT_ENVIRONMENT"] = str(eval_home / "venv")
         if self.container_image:
             # --cleanenv drops the host env; APPTAINERENV_* survives it
             env["APPTAINERENV_UV_CACHE_DIR"] = env["UV_CACHE_DIR"]
             env["APPTAINERENV_UV_LINK_MODE"] = "copy"
+            env["APPTAINERENV_UV_PROJECT_ENVIRONMENT"] = env["UV_PROJECT_ENVIRONMENT"]
         env["HOME"] = str(eval_home)
         try:
             # process group, like the harness: a timed-out eval must not

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -154,10 +154,11 @@ class SubprocessEvaluator:
         # venv another process just wrote races NFS close-to-open
         # consistency (seen live: the first steward validation spawned a
         # pytest whose binary was not yet visible). The eval builds its own
-        # environment from the LOCKFILE into its throwaway home — no shared
-        # mutable state, and the orchestrator never executes
-        # session-authored entrypoints.
-        env["UV_PROJECT_ENVIRONMENT"] = str(eval_home / "venv")
+        # environment from the LOCKFILE on NODE-LOCAL scratch (beside the
+        # uv cache: fast IO, zero NFS in the venv path, dies with the
+        # eval) — no shared mutable state, and the orchestrator never
+        # executes session-authored entrypoints.
+        env["UV_PROJECT_ENVIRONMENT"] = str(cache_dir / "venv")
         if self.container_image:
             # --cleanenv drops the host env; APPTAINERENV_* survives it
             env["APPTAINERENV_UV_CACHE_DIR"] = env["UV_CACHE_DIR"]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -371,6 +371,10 @@ def test_eval_cache_is_bound_alone_and_cleaned(tmp_path: Path, monkeypatch) -> N
     assert f"--bind {scratch}:{scratch}" not in argv  # never the whole tmp
     seen_env = (tmp_path / "eval_env").read_text()
     assert "APPTAINERENV_UV_CACHE_DIR=" in seen_env
+    # the private env crosses --cleanenv too, or the container's uv would
+    # silently fall back to the workspace venv — the raced, session-built
+    # state this design removes
+    assert "APPTAINERENV_UV_PROJECT_ENVIRONMENT=" in seen_env
     assert list(scratch.glob("uv-cache-*")) == []  # cleaned up after
 
 
@@ -383,7 +387,7 @@ def test_subprocess_evaluator_env_is_private_per_eval(tmp_path: Path) -> None:
 
     command = (
         """printf '{"m": %s}\\n' """
-        '''"$(echo "$UV_PROJECT_ENVIRONMENT" | grep -c "eval-home")"'''
+        '''"$(echo "$UV_PROJECT_ENVIRONMENT" | grep -c "cache")"'''
     )
     evaluator = SubprocessEvaluator(timeout_s=30)
     assert evaluator.evaluate(tmp_path, command, "m") == 1.0

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -382,7 +382,7 @@ def test_subprocess_evaluator_env_is_private_per_eval(tmp_path: Path) -> None:
     """The eval never consumes a workspace venv (no shared mutable state
     with the session, no NFS close-to-open race, no session-authored
     entrypoints in the orchestrator's path): UV_PROJECT_ENVIRONMENT points
-    into the eval's own throwaway home, a different path every eval."""
+    at node-local scratch beside the uv cache, unique per eval."""
     from autoresearch.orchestrator import SubprocessEvaluator
 
     command = (

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -372,3 +372,26 @@ def test_eval_cache_is_bound_alone_and_cleaned(tmp_path: Path, monkeypatch) -> N
     seen_env = (tmp_path / "eval_env").read_text()
     assert "APPTAINERENV_UV_CACHE_DIR=" in seen_env
     assert list(scratch.glob("uv-cache-*")) == []  # cleaned up after
+
+
+def test_subprocess_evaluator_env_is_private_per_eval(tmp_path: Path) -> None:
+    """The eval never consumes a workspace venv (no shared mutable state
+    with the session, no NFS close-to-open race, no session-authored
+    entrypoints in the orchestrator's path): UV_PROJECT_ENVIRONMENT points
+    into the eval's own throwaway home, a different path every eval."""
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    command = (
+        """printf '{"m": %s}\\n' """
+        '''"$(echo "$UV_PROJECT_ENVIRONMENT" | grep -c "eval-home")"'''
+    )
+    evaluator = SubprocessEvaluator(timeout_s=30)
+    assert evaluator.evaluate(tmp_path, command, "m") == 1.0
+    # and the venv path is unique per eval: capture it twice
+    capture = 'printf \'{"m": 1}\\n\'; echo "$UV_PROJECT_ENVIRONMENT" >> ' + str(
+        tmp_path / "seen.txt"
+    )
+    evaluator.evaluate(tmp_path, capture, "m")
+    evaluator.evaluate(tmp_path, capture, "m")
+    seen = (tmp_path / "seen.txt").read_text().split()
+    assert len(seen) == 2 and seen[0] != seen[1]


### PR DESCRIPTION
Root fix for the first steward run's failure, per Mengye's call: "either not share, or have a lock — deleting is not safe in the long run." We don't share. `UV_PROJECT_ENVIRONMENT` points each eval/check at its own env inside the throwaway eval home: the session's `ws/.venv` stays session-private evidence, validation builds from the lockfile, the NFS close-to-open race is structurally gone, and the orchestrator stops executing entrypoints the session built. Cost: each eval builds its env (~seconds against the node-local cache) — the same accepted isolation cost as the per-eval home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)