### PR TITLE
Honest budget-exhaustion endings + session budgets sized for construction work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Session budgets raised (60/60/90/60 → 120-turn sessions, 90-minute
+  session walltime, 120-minute climb jobs, 90-minute follow-up jobs):
+  the first steward work order to BUILD an environment burned its full
+  60-turn budget mid-work — budgets sized for solver tweaks starve
+  construction work. Ceilings still equal defaults, so contracts shape
+  spend strictly downward.
+
+- A session that runs out of turns or walltime now ends as
+  budget-exhausted — one of the six honest deaths — instead of an
+  error, and every surface a human reads carries the real cause: the
+  record's ending note, the run report, the work-order comment ("ran
+  out of its session budget: Reached maximum number of turns (120)"),
+  where before all three said `ValueError: steward session error:
+  tool_use`.
+
 - Review and verification comments read like a colleague, not a legal
   notice (maintainer feedback): one calm italic header line per role, and
   findings rendered as prose paragraphs with the reference at the end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,9 @@ Versions follow [SemVer](https://semver.org).
   budget-exhausted — one of the six honest deaths — instead of an
   error, and every surface a human reads carries the real cause: the
   record's ending note, the run report, the work-order comment ("ran
-  out of its session budget: Reached maximum number of turns (120)"),
-  where before all three said `ValueError: steward session error:
-  tool_use`.
+  out of its session budget (error_max_turns: Reached maximum number
+  of turns (120))"), where before all three said `ValueError: steward
+  session error: tool_use`.
 
 - Review and verification comments read like a colleague, not a legal
   notice (maintainer feedback): one calm italic header line per role, and

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -46,6 +46,7 @@ from autoresearch.progress import (
 )
 from autoresearch.runstate import (
     ABORTED,
+    BUDGET_EXHAUSTED,
     ENDED,
     IN_REVIEW,
     NEGATIVE_RESULT,
@@ -81,6 +82,7 @@ RULER = (
 _ENDINGS_BY_OUTCOME = {
     "no-improvement": NEGATIVE_RESULT,
     "session-error": ABORTED,
+    "session-budget": BUDGET_EXHAUSTED,
     "eval-error": ABORTED,
     "scope-violation": ABORTED,
 }

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -378,7 +378,9 @@ def _respond(
     session = harness.run(prompt, workspace, resume_session_id=record.resume_session_id or None)
     if session.is_error:
         # cursor NOT advanced: the next attempt sees the same comments
-        return FollowupOutcome(run_id, "error", f"session: {session.stop_reason}")
+        return FollowupOutcome(
+            run_id, "error", f"session: {session.error_detail or session.stop_reason}"
+        )
 
     # Same self-approval scrub as the reviewer: the pipeline must never nudge
     # humans toward merging its own work, even in the author's voice.

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -378,6 +378,10 @@ def _respond(
     session = harness.run(prompt, workspace, resume_session_id=record.resume_session_id or None)
     if session.is_error:
         # cursor NOT advanced: the next attempt sees the same comments
+        # Deliberately NOT a budget-exhausted ending: follow-ups never end
+        # the run, and "error" is what keeps cursors un-advanced so the next
+        # tick retries the reply (wake_attempts caps the spend). The detail
+        # string still names the real cause for the log reader.
         return FollowupOutcome(
             run_id, "error", f"session: {session.error_detail or session.stop_reason}"
         )

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -34,10 +34,12 @@ log = logging.getLogger(__name__)
 # OS-level sandboxing lands.)
 SESSION_ENV_ALLOWLIST = ("PATH", "TERM", "LANG", "LC_ALL", "TMPDIR")
 
-DEFAULT_TIMEOUT_S = 3600
-# Fallback only — every orchestrated path threads effective_limits in
-# explicitly. Kept at the session ceiling so a site that forgets still
-# grants the intended budget rather than silently undercutting it.
+# Fallbacks only — every orchestrated path threads effective_limits in
+# explicitly (climb/steward CLIs pass turns and minutes; the follow-up CLI
+# derives its timeout from the job walltime). Kept at the session ceilings
+# so a site that forgets still grants the intended budget rather than
+# silently undercutting it.
+DEFAULT_TIMEOUT_S = 5400
 DEFAULT_MAX_TURNS = 120
 
 
@@ -102,7 +104,7 @@ def _error_result(stop_reason: str, transcript_path: str = "", detail: str = "")
     return SessionResult(
         stop_reason=stop_reason,
         is_error=True,
-        error_detail=detail or stop_reason,
+        error_detail=(detail or stop_reason)[:500],
         cost_usd=0.0,
         num_turns=0,
         session_id="",
@@ -322,6 +324,8 @@ class ClaudeCodeHarness:
         errors = data.get("errors")
         messages = "; ".join(str(e) for e in errors if e) if isinstance(errors, list) else ""
         detail = f"{subtype}: {messages}" if subtype and messages else (subtype or messages)
+        # bounded here so every downstream note/report/comment inherits it
+        detail = detail[:500]
         return SessionResult(
             stop_reason=str(data.get("stop_reason") or data.get("subtype") or "unknown"),
             is_error=is_error,

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -35,7 +35,10 @@ log = logging.getLogger(__name__)
 SESSION_ENV_ALLOWLIST = ("PATH", "TERM", "LANG", "LC_ALL", "TMPDIR")
 
 DEFAULT_TIMEOUT_S = 3600
-DEFAULT_MAX_TURNS = 80
+# Fallback only — every orchestrated path threads effective_limits in
+# explicitly. Kept at the session ceiling so a site that forgets still
+# grants the intended budget rather than silently undercutting it.
+DEFAULT_MAX_TURNS = 120
 
 
 @dataclass(frozen=True)

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -56,6 +56,12 @@ class SessionResult:
     session_id: str
     final_text: str  # the agent's closing message (the research report draft)
     transcript_path: str  # raw backend output, api-key-redacted, on disk
+    # human-readable cause when is_error: the backend's error subtype and
+    # messages (e.g. "error_max_turns: Reached maximum number of turns
+    # (60)"), or our own explanation on the timeout path. This is what
+    # reports and issue comments show — stop_reason alone reads as noise
+    # ("tool_use") when a session dies mid-tool-call.
+    error_detail: str = ""
 
 
 class Harness(Protocol):
@@ -89,16 +95,25 @@ def redact(text: str, secrets: tuple[str, ...]) -> str:
     return text
 
 
-def _error_result(stop_reason: str, transcript_path: str = "") -> SessionResult:
+def _error_result(stop_reason: str, transcript_path: str = "", detail: str = "") -> SessionResult:
     return SessionResult(
         stop_reason=stop_reason,
         is_error=True,
+        error_detail=detail or stop_reason,
         cost_usd=0.0,
         num_turns=0,
         session_id="",
         final_text="",
         transcript_path=transcript_path,
     )
+
+
+def budget_exhausted(result: SessionResult) -> bool:
+    """True when the session stopped because OUR limits ran out — turns or
+    session walltime — rather than because anything failed. Callers report
+    this as the budget-exhausted ending, never as an error: "caps hit
+    mid-run" is one of the six honest deaths, not a malfunction."""
+    return result.stop_reason == "timeout" or result.error_detail.startswith("error_max_turns")
 
 
 def _write_private(directory: Path, stem: str, suffix: str, text: str) -> str:
@@ -284,7 +299,11 @@ class ClaudeCodeHarness:
                 workspace.parent, transcript_stem, ".json", redact(stdout or "", (self.api_key,))
             )
             log.warning("session timed out after %ss in %s", self.timeout_s, workspace)
-            return _error_result("timeout", path)
+            return _error_result(
+                "timeout",
+                path,
+                detail=f"session hit its {self.timeout_s}s walltime and was killed",
+            )
 
         stdout = redact(stdout, (self.api_key,))
         transcript_path = _write_private(workspace.parent, transcript_stem, ".json", stdout)
@@ -295,9 +314,15 @@ class ClaudeCodeHarness:
             return _error_result("unparseable-output", transcript_path)
         # Field-level salvage: a quirky cost value must not cost us the
         # session id (which resume depends on) or vice versa.
+        is_error = bool(data.get("is_error", process.returncode != 0))
+        subtype = str(data.get("subtype") or "")
+        errors = data.get("errors")
+        messages = "; ".join(str(e) for e in errors if e) if isinstance(errors, list) else ""
+        detail = f"{subtype}: {messages}" if subtype and messages else (subtype or messages)
         return SessionResult(
             stop_reason=str(data.get("stop_reason") or data.get("subtype") or "unknown"),
-            is_error=bool(data.get("is_error", process.returncode != 0)),
+            is_error=is_error,
+            error_detail=detail if is_error else "",
             cost_usd=_float(data.get("total_cost_usd")),
             num_turns=_int(data.get("num_turns")),
             session_id=str(data.get("session_id") or ""),

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -21,13 +21,16 @@ from typing import Any
 # ceiling above the default would let them raise our spend — the knobs
 # shape strictly downward. Raising a target's budget is an
 # orchestrator-side decision (config we control), not a contract edit.
+# Raised from 60/60/90/60 on 2026-08-10 (maintainer decision): the first
+# steward work order to BUILD an env burned its full 60-turn budget mid-
+# work — session budgets sized for solver tweaks starve construction work.
 _BOUNDS: dict[str, tuple[int, int, int]] = {
-    "session_max_turns": (60, 10, 60),
-    "session_minutes": (60, 10, 60),
+    "session_max_turns": (120, 10, 120),
+    "session_minutes": (90, 10, 90),
     # floor = session floor + overhead + self-deadline margin: even at the
     # floors, a session must fit inside its job with the ending's runway
-    "climb_job_minutes": (90, 40, 90),
-    "followup_job_minutes": (60, 20, 60),
+    "climb_job_minutes": (120, 40, 120),
+    "followup_job_minutes": (90, 20, 90),
 }
 
 # A climb job must outlive its session long enough for the orchestrator's

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -21,7 +21,7 @@ from typing import Any
 # ceiling above the default would let them raise our spend — the knobs
 # shape strictly downward. Raising a target's budget is an
 # orchestrator-side decision (config we control), not a contract edit.
-# Raised from 60/60/90/60 on 2026-08-10 (maintainer decision): the first
+# Raised from 60/60/90/60 on 2026-08-09 (maintainer decision): the first
 # steward work order to BUILD an env burned its full 60-turn budget mid-
 # work — session budgets sized for solver tweaks starve construction work.
 _BOUNDS: dict[str, tuple[int, int, int]] = {

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -31,7 +31,7 @@ from autoresearch.contract import (
     normalize_path,
     path_is_forbidden,
 )
-from autoresearch.harness import Harness, SessionResult, redact
+from autoresearch.harness import Harness, SessionResult, budget_exhausted, redact
 
 log = logging.getLogger(__name__)
 
@@ -278,7 +278,9 @@ class ClimbConfig:
 class ClimbResult:
     """What one attempt produced — the raw material of the run report."""
 
-    outcome: str  # improved | no-improvement | session-error | eval-error | scope-violation
+    # improved | no-improvement | session-error | session-budget |
+    # eval-error | scope-violation
+    outcome: str
     baseline: float | None = None
     candidate: float | None = None
     branch: str = ""
@@ -457,10 +459,11 @@ def climb_once(
     session = harness.run(render(brief), workspace)
     if session.is_error:
         return ClimbResult(
-            outcome="session-error",
+            # our caps running out is a budget ending, not a malfunction
+            outcome="session-budget" if budget_exhausted(session) else "session-error",
             baseline=baseline,
             session=session,
-            note=session.stop_reason,
+            note=session.error_detail or session.stop_reason,
         )
 
     # Scope BEFORE measurement: an out-of-scope tree is never evaluated,

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -35,7 +35,7 @@ from autoresearch.climb import (
 )
 from autoresearch.contract import Contract, load_contract
 from autoresearch.github import FileTokenProvider, GitHubClient, Workspace
-from autoresearch.harness import Harness, redact
+from autoresearch.harness import Harness, budget_exhausted, redact
 from autoresearch.intake import (
     CLAIM_MARKER,
     STEWARD_LABEL,
@@ -53,6 +53,7 @@ from autoresearch.progress import (
 )
 from autoresearch.runstate import (
     ABORTED,
+    BUDGET_EXHAUSTED,
     ENDED,
     IN_REVIEW,
     NEGATIVE_RESULT,
@@ -70,6 +71,17 @@ RELEASE_MARKER = "<!-- autoresearch:claim-released -->"
 # sessions is the escalate-to-a-human point
 MAX_STEWARD_ATTEMPTS = 3
 STEWARD_AGENT_ID = "steward-01"
+
+
+class SessionFailure(Exception):
+    """The steward's own session failed or ran dry. `budget` separates
+    "our caps ran out" (an honest ending) from a genuine malfunction."""
+
+    def __init__(self, detail: str, budget: bool) -> None:
+        super().__init__(detail)
+        self.budget = budget
+
+
 STEWARD_BRANCH_PREFIX = "feat/steward/steward-01"
 # The validation suite the orchestrator runs after steward edits. A
 # contract-declared command can replace this later; every current target is
@@ -411,7 +423,9 @@ def live_steward(
             steward_brief(contract_text, contract, work_order, config.benchmark), workspace
         )
         if session.is_error:
-            raise ValueError(f"steward session error: {session.stop_reason}")
+            raise SessionFailure(
+                session.error_detail or session.stop_reason, budget_exhausted(session)
+            )
 
         changed = changed_paths()
         if not changed:
@@ -530,14 +544,22 @@ def live_steward(
         )
         outcome_name = "stewarded"
     except (Exception, Terminated) as exc:
+        # Running out of budget is one of the six honest deaths, not a
+        # malfunction: name it, and put the real cause in every surface a
+        # human reads (record note, report, work-order comment) — "the
+        # session used its full 120-turn budget" tells the maintainer what
+        # to decide; "ValueError: tool_use" told them nothing.
+        budget = isinstance(exc, SessionFailure) and exc.budget
         exc_name = type(exc).__name__
-        note = redact(f"{exc_name}: {exc}", secrets)[:500]
+        cause = redact(str(exc), secrets)[:500]
+        note = cause if budget else f"{exc_name}: {cause}"[:500]
+        outcome_label = "budget-exhausted" if budget else "steward-error"
         log.warning("stewardship failed for %s: %s", run_id, note)
         final = RunRecord(
             **{
                 **record.__dict__,
                 "state": ENDED,
-                "ending": ABORTED,
+                "ending": BUDGET_EXHAUSTED if budget else ABORTED,
                 "ending_note": note,
             }
         )
@@ -547,26 +569,30 @@ def live_steward(
             "error report",
             lambda: report_path.write_text(
                 f"# Steward report — {config.target} / {config.benchmark}\n"
-                f"Outcome: **steward-error**\nNote: {note}\n"
+                f"Outcome: **{outcome_label}**\nNote: {note}\n"
             ),
             secrets,
         )
         if issue_number:
+            finished = (
+                f"ran out of its session budget ({note})"
+                if budget
+                else f"finished ({outcome_label}): {note}"
+            )
             _best_effort(
                 "issue report",
                 lambda: github.comment(
                     config.target,
                     issue_number,
-                    f"{RELEASE_MARKER}\nSteward run `{run_id}` finished "
-                    f"(steward-error): {exc_name}. Details are in the run's "
-                    f"record. Claim released — the lane retries up to "
+                    f"{RELEASE_MARKER}\nSteward run `{run_id}` {finished}. "
+                    f"Claim released — the lane retries up to "
                     f"{MAX_STEWARD_ATTEMPTS} total attempts, then waits for a human.",
                 ),
                 secrets,
             )
         return LiveClimbOutcome(
             run_id=run_id,
-            outcome="steward-error",
+            outcome=outcome_label,
             report_path=str(report_path) if wrote else "",
         )
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -122,7 +122,7 @@ class FollowupSpec:
     image: str
     home: Path  # AUTORESEARCH_HOME: cwd for the submitted job
     bot_login: str = "agentic-learning-bot"
-    time_minutes: int = 60
+    time_minutes: int = 90  # min()'d with the contract's followup_job_minutes
     pat_file: str = ""  # forwarded to the job; "" = the followup CLI default
     key_file: str = ""
     target: str = ""  # the repo the intake pass scans for requested-lane issues

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -207,7 +207,7 @@ def test_session_error_aborts_cleanly(tmp_path, target_repo) -> None:
     class DeadHarness:
         def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
             return SessionResult(
-                stop_reason="timeout",
+                stop_reason="spawn-error",
                 is_error=True,
                 cost_usd=0.0,
                 num_turns=0,

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -232,6 +232,41 @@ def test_session_error_aborts_cleanly(tmp_path, target_repo) -> None:
     assert github.prs == []
 
 
+def test_exhausted_live_climb_ends_budget_exhausted(tmp_path, target_repo) -> None:
+    """The session-budget outcome flows through the ending map on a LIVE
+    climb: the record says budget-exhausted with the real cause."""
+
+    @dataclass
+    class DryHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            return SessionResult(
+                stop_reason="tool_use",
+                is_error=True,
+                cost_usd=2.0,
+                num_turns=120,
+                session_id="",
+                final_text="",
+                transcript_path="",
+                error_detail="error_max_turns: Reached maximum number of turns (120)",
+            )
+
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-dry",
+        harness=DryHarness(),
+        evaluator=QueueEvaluator(values=[13.876]),
+        github=FakeGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "session-budget"
+    record = load_record(tmp_path / "state", "tsp-dry")
+    assert record.ending == "budget-exhausted"
+    assert "maximum number of turns" in record.ending_note
+
+
 def test_second_run_gets_its_own_branch(tmp_path, target_repo) -> None:
     """A fixed branch name would non-fast-forward on run two."""
     edits = {"src/pilot/solvers/tsp.py": "def solve(): return 1\n"}

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -15,6 +15,7 @@ from autoresearch.harness import (
     ClaudeCodeHarness,
     FakeHarness,
     SessionResult,
+    budget_exhausted,
     redact,
     session_env,
 )
@@ -163,6 +164,45 @@ def test_timeout_returns_error_result_not_exception(tmp_path: Path) -> None:
     result = ClaudeCodeHarness(api_key="k", binary=binary, timeout_s=1).run("task", ws)
     assert result.is_error
     assert result.stop_reason == "timeout"
+
+
+def test_exhausted_turns_carry_an_honest_detail(tmp_path: Path) -> None:
+    """A session that dies at max turns reports WHY on the result — the
+    subtype and the backend's message — and classifies as budget
+    exhaustion, because stop_reason alone reads as noise ("tool_use")."""
+    payload = dict(CANNED)
+    payload.update(
+        is_error=True,
+        stop_reason="tool_use",
+        subtype="error_max_turns",
+        errors=["Reached maximum number of turns (120)"],
+    )
+    binary = fake_claude(tmp_path, json.dumps(payload))
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    result = ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
+    assert result.is_error
+    assert result.error_detail == "error_max_turns: Reached maximum number of turns (120)"
+    assert budget_exhausted(result)
+
+
+def test_timeout_is_budget_exhaustion_with_walltime_detail(tmp_path: Path) -> None:
+    binary = fake_claude(tmp_path, json.dumps(CANNED), sleep=30)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    result = ClaudeCodeHarness(api_key="k", binary=binary, timeout_s=1).run("task", ws)
+    assert budget_exhausted(result)
+    assert "walltime" in result.error_detail
+
+
+def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:
+    binary = fake_claude(tmp_path, json.dumps(CANNED))
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    ok = ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
+    assert ok.error_detail == "" and not budget_exhausted(ok)
+    dead = ClaudeCodeHarness(api_key="k", binary=str(tmp_path / "nope")).run("task", tmp_path)
+    assert not budget_exhausted(dead)
 
 
 def test_missing_binary_returns_spawn_error(tmp_path: Path) -> None:

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -20,10 +20,10 @@ def _limits(budget_extra: str = "") -> EffectiveLimits:
 
 def test_absent_knobs_yield_the_standing_defaults() -> None:
     assert _limits() == EffectiveLimits(
-        session_max_turns=60,
-        session_minutes=60,
-        climb_job_minutes=90,
-        followup_job_minutes=60,
+        session_max_turns=120,
+        session_minutes=90,
+        climb_job_minutes=120,
+        followup_job_minutes=90,
     )
     assert effective_limits(None) == _limits()  # no contract at all
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -110,7 +110,7 @@ def test_noise_below_threshold_is_no_improvement(tmp_path: Path) -> None:
 
 def test_session_error_short_circuits_before_second_eval(tmp_path: Path) -> None:
     bad = SessionResult(
-        stop_reason="timeout",
+        stop_reason="spawn-error",
         is_error=True,
         cost_usd=0.0,
         num_turns=0,
@@ -122,6 +122,28 @@ def test_session_error_short_circuits_before_second_eval(tmp_path: Path) -> None
     assert result.outcome == "session-error"
     assert len(evaluator.calls) == 1  # baseline only
     assert result.baseline == 13.876
+
+
+def test_exhausted_session_is_a_budget_ending_not_an_error(tmp_path: Path) -> None:
+    """Turns or walltime running out is 'caps hit mid-run' — the outcome
+    names it, and the note carries the real cause, not a stop reason."""
+    for stop, detail in (
+        ("timeout", "session hit its 90-minute walltime and was killed"),
+        ("tool_use", "error_max_turns: Reached maximum number of turns (120)"),
+    ):
+        dry = SessionResult(
+            stop_reason=stop,
+            is_error=True,
+            cost_usd=1.0,
+            num_turns=120,
+            session_id="",
+            final_text="",
+            transcript_path="",
+            error_detail=detail,
+        )
+        result, _, _evaluator = run_climb(tmp_path, [13.876, 999.0], session=dry)
+        assert result.outcome == "session-budget"
+        assert result.note == detail
 
 
 def test_baseline_eval_failure_never_starts_a_session(tmp_path: Path) -> None:

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -344,6 +344,50 @@ def test_stewardship_rebased_env_lands_with_orchestrator_records(tmp_path, stewa
     assert "| re-based baseline (current solver, new env) | 14.9 |" in body
 
 
+def test_exhausted_session_is_a_budget_ending_not_an_error(tmp_path, steward_repo) -> None:
+    """Turns running out is one of the six honest deaths: the record says
+    budget-exhausted with the real cause, and the work order hears "ran
+    out of its session budget" — not "ValueError: tool_use"."""
+
+    @dataclass
+    class DryHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            return SessionResult(
+                stop_reason="tool_use",
+                is_error=True,
+                cost_usd=2.0,
+                num_turns=120,
+                session_id="steward-sess",
+                final_text="",
+                transcript_path="",
+                error_detail="error_max_turns: Reached maximum number of turns (120)",
+            )
+
+    github = StewardGitHub()
+    outcome = live_steward(
+        config=StewardConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="steward-tsp-dry",
+        harness=DryHarness(),
+        evaluator=CheckingEvaluator(values=[14.9]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="2026-08-09T00:00:00Z",
+        issue_number=21,
+        work_order="the pool is exploitable; re-base it",
+    )
+    assert outcome.outcome == "budget-exhausted"
+    record = load_record(tmp_path / "state", "steward-tsp-dry")
+    assert record.ending == "budget-exhausted"
+    assert "maximum number of turns" in record.ending_note
+    assert "ValueError" not in record.ending_note
+    assert any(
+        "claim-released" in body and "ran out of its session budget" in body
+        for _, body in github.issue_comments
+    )
+
+
 def test_solver_territory_edit_is_aborted(tmp_path, steward_repo) -> None:
     outcome, github, _ = run_steward(
         tmp_path,

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -853,11 +853,11 @@ roadmap: docs/roadmap.md
     out = service_self_initiated(tmp_path, SlurmCompute(runner=runner), spec, contract, NOW)
     assert out == ("tsp", "123")
     sbatch = submitted[0]
-    assert "--time=90" in sbatch  # 100000 clamped to the default-as-ceiling
+    assert "--time=120" in sbatch  # 100000 clamped to the default-as-ceiling
     wrap = sbatch[-1]
     assert "--max-turns 30" in wrap
     assert "--session-minutes 25" in wrap
-    assert "--job-minutes 90" in wrap  # the job's own walltime, for the alarm
+    assert "--job-minutes 120" in wrap  # the job's own walltime, for the alarm
 
 
 def test_contract_followup_walltime_never_raises_operator_config(tmp_path: Path) -> None:
@@ -986,7 +986,7 @@ roadmap: docs/roadmap.md
     wrap = submitted[0][-1]
     assert "autoresearch.steward" in wrap
     assert "--key-file /k" in wrap
-    assert "--job-minutes 90" in wrap
+    assert "--job-minutes 120" in wrap
 
 
 def test_followup_key_routing_by_role(tmp_path: Path) -> None:


### PR DESCRIPTION
Maintainer-directed, from the reach steward failure: "we should definitely increase session budget. And fix the error message."

**The error message.** `SessionResult` gains `error_detail` — the backend's error subtype and messages ("error_max_turns: Reached maximum number of turns (60)"), or our own explanation on the timeout path. `budget_exhausted()` classifies turns/walltime exhaustion, and every role treats it as the budget-exhausted ending rather than an error: the steward's record, report, and work-order comment say "ran out of its session budget (…)" with the claim still released for retry; the climb maps a new `session-budget` outcome to the budget-exhausted ending; follow-up error notes carry the detail. Genuine malfunctions still read as errors, now with the cause attached.

**The budgets.** `_BOUNDS` rises from 60/60/90/60 to **120 turns / 90 session-minutes / 120-minute climb jobs / 90-minute follow-up jobs** (the follow-up spec default follows). Ceiling==default is unchanged — contracts still shape spend strictly downward; this raises what the orchestrator itself grants.

Tests: harness detail parsing + classification, steward budget ending (record/report/comment wording), climb session-budget mapping, limits and tick argv expectations at the new ceilings. 399 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)