### PR TITLE
Outage-class containment: API refusals never burn retry caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,11 @@ Versions follow [SemVer](https://semver.org).
   throttling) ends the run `stuck` with the refusal named, releases a
   steward claim without counting it toward the attempt cap, refunds the
   follow-up wake attempt, and stamps a latch that pauses all
-  session-spawning lanes for a 45-minute cooldown — one canary per hour
-  re-probes instead of every lane burning retries each tick. The
+  that role's session-spawning lanes (per-role latches: a dead steward
+  key never idles the solver lanes) for a 45-minute cooldown — 5 minutes
+  for transient throttling — so one canary per hour re-probes instead of
+  every lane burning retries each tick. Persistent refusals escalate:
+  after 5 outage releases a work order waits for a human. The
   advisory reviewer and verifier post a skip stub on the PR thread
   (own marker; never counts as a round, never rides as wake context)
   when the model API refuses their round, so a missing review is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- API outages are contained instead of billed to runs: a session the
+  model API refuses (credit balance, usage/spend limit, auth,
+  throttling) ends the run `stuck` with the refusal named, releases a
+  steward claim without counting it toward the attempt cap, refunds the
+  follow-up wake attempt, and stamps a latch that pauses all
+  session-spawning lanes for a 45-minute cooldown — one canary per hour
+  re-probes instead of every lane burning retries each tick. The
+  advisory reviewer and verifier post a skip stub on the PR thread
+  (own marker; never counts as a round, never rides as wake context)
+  when the model API refuses their round, so a missing review is
+  visible on the thread rather than only in the Actions tab.
+
 - Session budgets raised (60/60/90/60 → 120-turn sessions, 90-minute
   session walltime, 120-minute climb jobs, 90-minute follow-up jobs):
   the first steward work order to BUILD an environment burned its full

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -192,9 +192,14 @@ session dies because the model API refused us — dead credits, a spend
 limit, auth, throttling — the failure is classified as an outage: the
 run ends `stuck` with the refusal in its note, a steward claim releases
 WITHOUT counting toward its attempt cap, a follow-up's wake attempt is
-refunded, and a latch pauses every session-spawning lane for a cooldown
-(~45 min), so one canary session per hour re-probes the API instead of
-every lane burning its retry budget each tick. Endings, nudges, and all
+refunded, and a PER-ROLE latch (roles hold separate keys — a dead
+steward key must not idle the solver lanes) pauses that role's
+session-spawning for a cooldown: ~45 minutes for account-level refusals,
+5 for transient throttling, so one canary session per hour re-probes the
+API instead of every lane burning its retry budget each tick. Outage
+releases have their own cap — a PERMANENT refusal (revoked key) stops
+retrying after a handful of releases and waits for a human, keeping the
+escalate-to-a-human guarantee that the attempt cap exists to provide. Endings, nudges, and all
 other model-free bookkeeping keep running through an outage. The
 Actions reviewers get the mirror treatment: a round the model API
 refused posts a skip stub on the thread under its own marker — an

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -187,6 +187,20 @@ are garbage-collected (grace period first — an `in-review` run's context must
 survive until its PR closes). The notebook is the memory; the run directory
 is scaffolding.
 
+**An API outage is the orchestrator's failure, never a run's.** When a
+session dies because the model API refused us — dead credits, a spend
+limit, auth, throttling — the failure is classified as an outage: the
+run ends `stuck` with the refusal in its note, a steward claim releases
+WITHOUT counting toward its attempt cap, a follow-up's wake attempt is
+refunded, and a latch pauses every session-spawning lane for a cooldown
+(~45 min), so one canary session per hour re-probes the API instead of
+every lane burning its retry budget each tick. Endings, nudges, and all
+other model-free bookkeeping keep running through an outage. The
+Actions reviewers get the mirror treatment: a round the model API
+refused posts a skip stub on the thread under its own marker — an
+outage notice, not a round — because silence only visible in the
+Actions tab is not a defensible way to miss a verification.
+
 **The loop itself has no end state.** It pauses (sentinel) and resumes.
 Offboarding a target has a graceful path and a hard path: *graceful* — remove
 the contract; intake stops and in-flight runs drain to their natural endings

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -50,8 +50,10 @@ from autoresearch.runstate import (
     ENDED,
     IN_REVIEW,
     NEGATIVE_RESULT,
+    STUCK,
     RunRecord,
     save_record,
+    stamp_outage,
 )
 
 log = logging.getLogger(__name__)
@@ -83,6 +85,7 @@ _ENDINGS_BY_OUTCOME = {
     "no-improvement": NEGATIVE_RESULT,
     "session-error": ABORTED,
     "session-budget": BUDGET_EXHAUSTED,
+    "session-outage": STUCK,  # infrastructure failure, nothing about the run
     "eval-error": ABORTED,
     "scope-violation": ABORTED,
 }
@@ -508,6 +511,12 @@ def live_climb(
                 }
             )
     else:
+        if result.outcome == "session-outage":
+            _best_effort(
+                "outage stamp",
+                lambda: stamp_outage(run_root, redact(result.note, secrets)[:300], now),
+                secrets,
+            )
         final = RunRecord(
             **{
                 **record.__dict__,

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -387,12 +387,18 @@ def _respond(
             # The API refused us — refund the wake attempt the tick billed
             # at submit (this responder holds the lease) and stamp the
             # latch so the lanes pause instead of burning the retry cap
-            # on a dead key every half hour.
-            stamp_outage(run_root, session.error_detail[:300], now)
-            latest = load_record(run_root, run_id)
-            save_record(
-                run_root, replace(latest, wake_attempts=max(0, latest.wake_attempts - 1)), now
-            )
+            # on a dead key every half hour. Best-effort: a full state
+            # disk must degrade to a plain error outcome, not lose the
+            # honest note to an escaping exception.
+            role = "steward" if is_steward else "solver"
+            try:
+                stamp_outage(run_root, session.error_detail[:300], now, role=role)
+                latest = load_record(run_root, run_id)
+                save_record(
+                    run_root, replace(latest, wake_attempts=max(0, latest.wake_attempts - 1)), now
+                )
+            except (OSError, ValueError) as exc:
+                log.warning("outage bookkeeping failed for %s: %s", run_id, exc)
             return FollowupOutcome(
                 run_id, "error", f"api outage: {session.error_detail or session.stop_reason}"
             )

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from autoresearch.brief import render_review_wake
 from autoresearch.contract import load_contract
 from autoresearch.github import GitHubClient, Workspace
-from autoresearch.harness import Harness, redact
+from autoresearch.harness import Harness, outage, redact
 from autoresearch.orchestrator import Evaluator, out_of_scope, steward_out_of_scope
 from autoresearch.orchestrator import improved as orch_improved
 from autoresearch.progress import (
@@ -44,6 +44,7 @@ from autoresearch.runstate import (
     release_lease,
     run_dir,
     save_record,
+    stamp_outage,
 )
 from autoresearch.verifier import VERIFY_MARKER
 
@@ -382,6 +383,19 @@ def _respond(
         # the run, and "error" is what keeps cursors un-advanced so the next
         # tick retries the reply (wake_attempts caps the spend). The detail
         # string still names the real cause for the log reader.
+        if outage(session):
+            # The API refused us — refund the wake attempt the tick billed
+            # at submit (this responder holds the lease) and stamp the
+            # latch so the lanes pause instead of burning the retry cap
+            # on a dead key every half hour.
+            stamp_outage(run_root, session.error_detail[:300], now)
+            latest = load_record(run_root, run_id)
+            save_record(
+                run_root, replace(latest, wake_attempts=max(0, latest.wake_attempts - 1)), now
+            )
+            return FollowupOutcome(
+                run_id, "error", f"api outage: {session.error_detail or session.stop_reason}"
+            )
         return FollowupOutcome(
             run_id, "error", f"session: {session.error_detail or session.stop_reason}"
         )

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -113,6 +113,33 @@ def _error_result(stop_reason: str, transcript_path: str = "", detail: str = "")
     )
 
 
+# Substrings that mean "the API itself is unavailable to us" — credit,
+# limit, auth, throttling. Matched only against error surfaces of an
+# is_error result (backend error text, never agent prose).
+OUTAGE_PATTERNS = (
+    "credit balance",
+    "usage limit",
+    "spending limit",
+    "billing",
+    "authentication_error",
+    "invalid x-api-key",
+    "rate_limit_error",
+    "overloaded_error",
+)
+
+
+def outage(result: SessionResult) -> bool:
+    """True when the session failed because the API refused us — dead
+    credits, spend cap, bad key, throttling — not because of anything in
+    the run. Callers treat this as an infrastructure outage: pause the
+    lanes, and never bill the failure against a run's retry caps or a
+    work order's attempts."""
+    if not result.is_error:
+        return False
+    surface = f"{result.error_detail}\n{result.final_text}".casefold()
+    return any(pattern in surface for pattern in OUTAGE_PATTERNS)
+
+
 def budget_exhausted(result: SessionResult) -> bool:
     """True when the session stopped because OUR limits ran out — turns or
     session walltime — rather than because anything failed. Callers report

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -137,11 +137,16 @@ def outage(result: SessionResult) -> bool:
     if not result.is_error:
         return False
     # error_detail is backend error text and always wins; final_text is
-    # consulted ONLY when no detail exists (older CLI error shapes put the
-    # API refusal in the result string). Never both — a turn-exhausted
-    # session carries the agent's own prose in final_text, and a report
-    # that MENTIONS billing must not read as an outage (review finding).
-    surface = (result.error_detail or result.final_text).casefold()
+    # consulted ONLY when no detail exists AND it carries the legacy CLI
+    # error shape ("API Error ..."), never agent prose — a failed session's
+    # report that merely MENTIONS billing or limits must not trip a latch
+    # that pauses every lane (review findings, rounds 1 and 2).
+    surface = result.error_detail.casefold()
+    if not surface:
+        text = result.final_text.strip().casefold()
+        if not text.startswith("api error"):
+            return False
+        surface = text
     return any(pattern in surface for pattern in OUTAGE_PATTERNS)
 
 

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -136,7 +136,12 @@ def outage(result: SessionResult) -> bool:
     work order's attempts."""
     if not result.is_error:
         return False
-    surface = f"{result.error_detail}\n{result.final_text}".casefold()
+    # error_detail is backend error text and always wins; final_text is
+    # consulted ONLY when no detail exists (older CLI error shapes put the
+    # API refusal in the result string). Never both — a turn-exhausted
+    # session carries the agent's own prose in final_text, and a report
+    # that MENTIONS billing must not read as an outage (review finding).
+    surface = (result.error_detail or result.final_text).casefold()
     return any(pattern in surface for pattern in OUTAGE_PATTERNS)
 
 

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -31,7 +31,7 @@ from autoresearch.contract import (
     normalize_path,
     path_is_forbidden,
 )
-from autoresearch.harness import Harness, SessionResult, budget_exhausted, redact
+from autoresearch.harness import Harness, SessionResult, budget_exhausted, outage, redact
 
 log = logging.getLogger(__name__)
 
@@ -279,7 +279,7 @@ class ClimbResult:
     """What one attempt produced — the raw material of the run report."""
 
     # improved | no-improvement | session-error | session-budget |
-    # eval-error | scope-violation
+    # session-outage | eval-error | scope-violation
     outcome: str
     baseline: float | None = None
     candidate: float | None = None
@@ -458,9 +458,16 @@ def climb_once(
     )
     session = harness.run(render(brief), workspace)
     if session.is_error:
+        # our caps running out is a budget ending, not a malfunction; the
+        # API refusing us is an outage — neither is the run's own failure
+        if outage(session):
+            kind = "session-outage"
+        elif budget_exhausted(session):
+            kind = "session-budget"
+        else:
+            kind = "session-error"
         return ClimbResult(
-            # our caps running out is a budget ending, not a malfunction
-            outcome="session-budget" if budget_exhausted(session) else "session-error",
+            outcome=kind,
             baseline=baseline,
             session=session,
             note=session.error_detail or session.stop_reason,

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -124,6 +124,30 @@ def post_round(
     return round_label
 
 
+SKIP_MARKER = "<!-- autoresearch:round-skipped -->"
+
+
+def post_skip_stub(client: GitHubClient, repo: str, number: int, role: str, exc: Exception) -> None:
+    """Silence is invisible: when the model API refuses a round (dead
+    credits, spend cap, auth), say so on the thread instead of leaving a
+    gap only the Actions tab can see. A DIFFERENT marker than a real
+    round, deliberately — a stub never counts toward round numbering and
+    never rides as follow-up wake context (both match on their own
+    markers)."""
+    note = str(exc)[:200]
+    try:
+        client.comment(
+            repo,
+            number,
+            f"{SKIP_MARKER}\n*The {role} round could not run — the model API "
+            f"refused the request ({type(exc).__name__}: {note}). Treat this "
+            f"as an outage, not a clean read; re-add the review label to "
+            f"re-request once the API recovers.*",
+        )
+    except EXPECTED_FAILURES as post_exc:
+        log.warning("could not post the skip stub: %s", post_exc)
+
+
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     repo = os.environ["PR_REPO"]
@@ -180,6 +204,8 @@ def main() -> int:
         log.info("posted advisory review (%s) on %s#%s", round_label, repo, number)
     except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
         log.warning("advisory review did not complete: %s: %s", type(exc).__name__, exc)
+        if isinstance(exc, CompleterError):
+            post_skip_stub(client, repo, number, "advisory review", exc)
     return 0
 
 

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -18,6 +18,7 @@ from dataclasses import replace
 from datetime import UTC, datetime
 
 from autoresearch.github import EnvTokenProvider, GitHubClient, GitHubError
+from autoresearch.harness import redact
 from autoresearch.llm import AnthropicCompleter, CompleterError, RefusalError, TruncatedError
 from autoresearch.review import (
     MARKER,
@@ -134,7 +135,17 @@ def post_skip_stub(client: GitHubClient, repo: str, number: int, role: str, exc:
     round, deliberately — a stub never counts toward round numbering and
     never rides as follow-up wake context (both match on their own
     markers)."""
-    note = str(exc)[:200]
+    # the reviewer/verifier keys are the only secrets this process holds;
+    # auth errors are exactly the class that can echo request material
+    secrets = tuple(
+        v
+        for v in (
+            os.environ.get("ANTHROPIC_REVIEWER_KEY", ""),
+            os.environ.get("ANTHROPIC_VERIFIER_KEY", ""),
+        )
+        if v
+    )
+    note = redact(str(exc), secrets)[:200]
     try:
         client.comment(
             repo,

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -54,6 +54,10 @@ LEASE_NAME = "lease.json"
 OUTAGE_COOLDOWN_S = 45 * 60
 THROTTLE_COOLDOWN_S = 5 * 60
 _THROTTLE_HINTS = ("rate_limit", "overloaded")
+# Stamps are written on compute nodes and read on other hosts: a stamp a
+# few seconds "in the future" is NTP skew and must count as active, while
+# a far-future timestamp is corruption and must not pause forever.
+MAX_CLOCK_SKEW_S = 5 * 60
 
 MAX_WAKE_ATTEMPTS = 3
 
@@ -89,8 +93,9 @@ def outage_active(root: Path, now: float, role: str = "solver") -> str:
     """The stamped detail while this role's cooldown holds, else "". The
     cooldown lives IN the stamp (decided at stamp time from the failure
     class); unreadable or stale stamps read as inactive — a corrupt latch
-    must never brick the loop, and time moving backwards reads as
-    expired."""
+    must never brick the loop; cross-host clock skew within
+    MAX_CLOCK_SKEW_S counts as active, anything further future as
+    corrupt."""
     path = _outage_path(root, role)
     try:
         data = json.loads(path.read_text())
@@ -99,7 +104,7 @@ def outage_active(root: Path, now: float, role: str = "solver") -> str:
         cooldown_s = float(data.get("cooldown_s", OUTAGE_COOLDOWN_S))
     except (OSError, ValueError, KeyError, TypeError):
         return ""
-    if 0 <= now - stamped < cooldown_s:
+    if -MAX_CLOCK_SKEW_S <= now - stamped < cooldown_s:
         return detail or "api outage"
     return ""
 

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -58,7 +58,11 @@ MAX_WAKE_ATTEMPTS = 3
 def stamp_outage(root: Path, detail: str, now: float) -> None:
     """Record that the API refused us (atomic rename, like the records)."""
     root.mkdir(parents=True, exist_ok=True)
-    tmp = root / f".{OUTAGE_NAME}.tmp"
+    # pid in the tmp name, like save_record: several lanes' jobs can fail
+    # to the same outage in one window, and interleaved writers must not
+    # install a truncated stamp — an unreadable latch reads as NO pause,
+    # which is exactly the failure the latch exists to prevent
+    tmp = root / f".{OUTAGE_NAME}.{os.getpid()}.tmp"
     tmp.write_text(json.dumps({"detail": detail[:300], "time": now}))
     os.replace(tmp, root / OUTAGE_NAME)
 

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -49,8 +49,12 @@ OUTAGE_NAME = "outage.json"
 # How long the session-spawning lanes stay paused after an API outage is
 # stamped. 45 minutes skips roughly one tick, so during a sustained outage
 # one canary session per ~hour re-probes the API instead of every lane
-# burning attempts every half hour.
+# burning attempts every half hour. Throttling (429/529) is transient by
+# nature and gets a short pause instead — a momentary spike must not idle
+# the orchestrator for most of an hour (review finding).
 OUTAGE_COOLDOWN_S = 45 * 60
+THROTTLE_COOLDOWN_S = 5 * 60
+_THROTTLE_HINTS = ("rate_limit", "overloaded")
 
 MAX_WAKE_ATTEMPTS = 3
 
@@ -63,19 +67,26 @@ def stamp_outage(root: Path, detail: str, now: float) -> None:
     # install a truncated stamp — an unreadable latch reads as NO pause,
     # which is exactly the failure the latch exists to prevent
     tmp = root / f".{OUTAGE_NAME}.{os.getpid()}.tmp"
-    tmp.write_text(json.dumps({"detail": detail[:300], "time": now}))
+    cooldown = (
+        THROTTLE_COOLDOWN_S
+        if any(hint in detail.casefold() for hint in _THROTTLE_HINTS)
+        else OUTAGE_COOLDOWN_S
+    )
+    tmp.write_text(json.dumps({"detail": detail[:300], "time": now, "cooldown_s": cooldown}))
     os.replace(tmp, root / OUTAGE_NAME)
 
 
-def outage_active(root: Path, now: float, cooldown_s: float = OUTAGE_COOLDOWN_S) -> str:
-    """The stamped detail while the cooldown holds, else "". Unreadable or
-    stale stamps read as inactive — a corrupt latch must never brick the
-    loop, and time moving backwards reads as expired."""
+def outage_active(root: Path, now: float) -> str:
+    """The stamped detail while the cooldown holds, else "". The cooldown
+    lives IN the stamp (decided at stamp time from the failure class);
+    unreadable or stale stamps read as inactive — a corrupt latch must
+    never brick the loop, and time moving backwards reads as expired."""
     path = root / OUTAGE_NAME
     try:
         data = json.loads(path.read_text())
         stamped = float(data["time"])
         detail = str(data.get("detail", ""))
+        cooldown_s = float(data.get("cooldown_s", OUTAGE_COOLDOWN_S))
     except (OSError, ValueError, KeyError, TypeError):
         return ""
     if 0 <= now - stamped < cooldown_s:

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -44,8 +44,39 @@ ENDINGS = (MERGED, REJECTED, NEGATIVE_RESULT, BUDGET_EXHAUSTED, ABORTED, STUCK)
 
 RECORD_NAME = "state.json"
 LEASE_NAME = "lease.json"
+OUTAGE_NAME = "outage.json"
+
+# How long the session-spawning lanes stay paused after an API outage is
+# stamped. 45 minutes skips roughly one tick, so during a sustained outage
+# one canary session per ~hour re-probes the API instead of every lane
+# burning attempts every half hour.
+OUTAGE_COOLDOWN_S = 45 * 60
 
 MAX_WAKE_ATTEMPTS = 3
+
+
+def stamp_outage(root: Path, detail: str, now: float) -> None:
+    """Record that the API refused us (atomic rename, like the records)."""
+    root.mkdir(parents=True, exist_ok=True)
+    tmp = root / f".{OUTAGE_NAME}.tmp"
+    tmp.write_text(json.dumps({"detail": detail[:300], "time": now}))
+    os.replace(tmp, root / OUTAGE_NAME)
+
+
+def outage_active(root: Path, now: float, cooldown_s: float = OUTAGE_COOLDOWN_S) -> str:
+    """The stamped detail while the cooldown holds, else "". Unreadable or
+    stale stamps read as inactive — a corrupt latch must never brick the
+    loop, and time moving backwards reads as expired."""
+    path = root / OUTAGE_NAME
+    try:
+        data = json.loads(path.read_text())
+        stamped = float(data["time"])
+        detail = str(data.get("detail", ""))
+    except (OSError, ValueError, KeyError, TypeError):
+        return ""
+    if 0 <= now - stamped < cooldown_s:
+        return detail or "api outage"
+    return ""
 
 
 @dataclass(frozen=True)

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -44,7 +44,6 @@ ENDINGS = (MERGED, REJECTED, NEGATIVE_RESULT, BUDGET_EXHAUSTED, ABORTED, STUCK)
 
 RECORD_NAME = "state.json"
 LEASE_NAME = "lease.json"
-OUTAGE_NAME = "outage.json"
 
 # How long the session-spawning lanes stay paused after an API outage is
 # stamped. 45 minutes skips roughly one tick, so during a sustained outage
@@ -59,29 +58,40 @@ _THROTTLE_HINTS = ("rate_limit", "overloaded")
 MAX_WAKE_ATTEMPTS = 3
 
 
-def stamp_outage(root: Path, detail: str, now: float) -> None:
-    """Record that the API refused us (atomic rename, like the records)."""
+def _outage_path(root: Path, role: str) -> Path:
+    # per-ROLE latches: roles hold separate keys, and a permanently dead
+    # steward key re-stamping its latch every cooldown must not keep the
+    # solver lanes paused forever (review finding). Role names are ours
+    # ("solver"/"steward"), sanitized only as filename hygiene.
+    safe = "".join(ch for ch in role if ch.isalnum() or ch == "-") or "solver"
+    return root / f"outage-{safe}.json"
+
+
+def stamp_outage(root: Path, detail: str, now: float, role: str = "solver") -> None:
+    """Record that the API refused this ROLE's key (atomic rename)."""
     root.mkdir(parents=True, exist_ok=True)
     # pid in the tmp name, like save_record: several lanes' jobs can fail
     # to the same outage in one window, and interleaved writers must not
     # install a truncated stamp — an unreadable latch reads as NO pause,
     # which is exactly the failure the latch exists to prevent
-    tmp = root / f".{OUTAGE_NAME}.{os.getpid()}.tmp"
+    path = _outage_path(root, role)
+    tmp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
     cooldown = (
         THROTTLE_COOLDOWN_S
         if any(hint in detail.casefold() for hint in _THROTTLE_HINTS)
         else OUTAGE_COOLDOWN_S
     )
     tmp.write_text(json.dumps({"detail": detail[:300], "time": now, "cooldown_s": cooldown}))
-    os.replace(tmp, root / OUTAGE_NAME)
+    os.replace(tmp, path)
 
 
-def outage_active(root: Path, now: float) -> str:
-    """The stamped detail while the cooldown holds, else "". The cooldown
-    lives IN the stamp (decided at stamp time from the failure class);
-    unreadable or stale stamps read as inactive — a corrupt latch must
-    never brick the loop, and time moving backwards reads as expired."""
-    path = root / OUTAGE_NAME
+def outage_active(root: Path, now: float, role: str = "solver") -> str:
+    """The stamped detail while this role's cooldown holds, else "". The
+    cooldown lives IN the stamp (decided at stamp time from the failure
+    class); unreadable or stale stamps read as inactive — a corrupt latch
+    must never brick the loop, and time moving backwards reads as
+    expired."""
+    path = _outage_path(root, role)
     try:
         data = json.loads(path.read_text())
         stamped = float(data["time"])

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -35,7 +35,7 @@ from autoresearch.climb import (
 )
 from autoresearch.contract import Contract, load_contract
 from autoresearch.github import FileTokenProvider, GitHubClient, Workspace
-from autoresearch.harness import Harness, budget_exhausted, redact
+from autoresearch.harness import Harness, budget_exhausted, outage, redact
 from autoresearch.intake import (
     CLAIM_MARKER,
     STEWARD_LABEL,
@@ -57,8 +57,10 @@ from autoresearch.runstate import (
     ENDED,
     IN_REVIEW,
     NEGATIVE_RESULT,
+    STUCK,
     RunRecord,
     save_record,
+    stamp_outage,
 )
 
 log = logging.getLogger(__name__)
@@ -66,6 +68,10 @@ log = logging.getLogger(__name__)
 # posted when a claim ends without a merged PR (submit failure, aborted
 # run): a release AFTER the last claim makes the issue claimable again
 RELEASE_MARKER = "<!-- autoresearch:claim-released -->"
+# rides WITH the release marker when the run died to an API outage: the
+# claim is released AND does not count toward MAX_STEWARD_ATTEMPTS — the
+# API being down is the orchestrator's failure, not the work order's
+OUTAGE_MARKER = "<!-- autoresearch:outage-release -->"
 # TOTAL claims after which the lane stops retrying a work order: a
 # persistently-failing order must not become a paid retry loop — three
 # sessions is the escalate-to-a-human point
@@ -75,11 +81,14 @@ STEWARD_AGENT_ID = "steward-01"
 
 class SessionFailure(Exception):
     """The steward's own session failed or ran dry. `budget` separates
-    "our caps ran out" (an honest ending) from a genuine malfunction."""
+    "our caps ran out" (an honest ending) from a genuine malfunction;
+    `outage` separates "the API refused us" from both — an outage is the
+    orchestrator's problem, so it never counts against the work order."""
 
-    def __init__(self, detail: str, budget: bool) -> None:
+    def __init__(self, detail: str, budget: bool, outage: bool = False) -> None:
         super().__init__(detail)
         self.budget = budget
+        self.outage = outage
 
 
 STEWARD_BRANCH_PREFIX = "feat/steward/steward-01"
@@ -222,6 +231,10 @@ def pick_steward_issue(
                 attempts += 1
             if RELEASE_MARKER in body:
                 claimed = False
+                if OUTAGE_MARKER in body:
+                    # an API outage is our failure, not the order's: the
+                    # claim it released does not count toward the cap
+                    attempts = max(0, attempts - 1)
         if claimed or attempts >= MAX_STEWARD_ATTEMPTS:
             continue
         text = f"{issue.get('title', '')}\n{issue.get('body') or ''}"
@@ -424,7 +437,9 @@ def live_steward(
         )
         if session.is_error:
             raise SessionFailure(
-                session.error_detail or session.stop_reason, budget_exhausted(session)
+                session.error_detail or session.stop_reason,
+                budget_exhausted(session),
+                outage(session),
             )
 
         changed = changed_paths()
@@ -550,16 +565,26 @@ def live_steward(
         # session used its full 120-turn budget" tells the maintainer what
         # to decide; "ValueError: tool_use" told them nothing.
         budget = isinstance(exc, SessionFailure) and exc.budget
+        api_outage = isinstance(exc, SessionFailure) and exc.outage
         exc_name = type(exc).__name__
         cause = redact(str(exc), secrets)[:500]
-        note = cause if budget else f"{exc_name}: {cause}"[:500]
-        outcome_label = "budget-exhausted" if budget else "steward-error"
+        note = cause if (budget or api_outage) else f"{exc_name}: {cause}"[:500]
+        if api_outage:
+            outcome_label = "infra-outage"
+            ending = STUCK  # infrastructure failure, nothing about the run
+            _best_effort("outage stamp", lambda: stamp_outage(run_root, note, now), secrets)
+        elif budget:
+            outcome_label = "budget-exhausted"
+            ending = BUDGET_EXHAUSTED
+        else:
+            outcome_label = "steward-error"
+            ending = ABORTED
         log.warning("stewardship failed for %s: %s", run_id, note)
         final = RunRecord(
             **{
                 **record.__dict__,
                 "state": ENDED,
-                "ending": BUDGET_EXHAUSTED if budget else ABORTED,
+                "ending": ending,
                 "ending_note": note,
             }
         )
@@ -574,20 +599,28 @@ def live_steward(
             secrets,
         )
         if issue_number:
-            finished = (
-                f"ran out of its session budget ({note})"
-                if budget
-                else f"finished ({outcome_label}): {note}"
-            )
-            _best_effort(
-                "issue report",
-                lambda: github.comment(
-                    config.target,
-                    issue_number,
+            if api_outage:
+                release = (
+                    f"{RELEASE_MARKER}\n{OUTAGE_MARKER}\nSteward run `{run_id}` "
+                    f"could not run — the API refused the orchestrator "
+                    f"({note}). Claim released; this does NOT count toward "
+                    f"the {MAX_STEWARD_ATTEMPTS}-attempt cap. The lanes pause "
+                    f"and retry after the outage cooldown."
+                )
+            else:
+                finished = (
+                    f"ran out of its session budget ({note})"
+                    if budget
+                    else f"finished ({outcome_label}): {note}"
+                )
+                release = (
                     f"{RELEASE_MARKER}\nSteward run `{run_id}` {finished}. "
                     f"Claim released — the lane retries up to "
-                    f"{MAX_STEWARD_ATTEMPTS} total attempts, then waits for a human.",
-                ),
+                    f"{MAX_STEWARD_ATTEMPTS} total attempts, then waits for a human."
+                )
+            _best_effort(
+                "issue report",
+                lambda: github.comment(config.target, issue_number, release),
                 secrets,
             )
         return LiveClimbOutcome(

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -267,7 +267,8 @@ def release_orphaned_claims(
     now: float,
     stale_s: float = 4 * 3600,
     limit: int = 2,
-    bot_login: str = "agentic-learning-bot",
+    *,
+    bot_login: str,
 ) -> int:
     """Post release markers for claimed work orders whose runs are DEAD.
 

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -212,6 +212,11 @@ def pick_steward_issue(
     """The oldest qualifying, unclaimed issue carrying the steward label and
     naming exactly one benchmark. Maintainer-authored only: the label routes,
     the author's standing authorizes."""
+    if not bot_login.strip():
+        # the identity gate below would see NO claims and re-claim every
+        # tick — an unbounded paid loop; without an identity, fail closed
+        log.warning("steward lane: empty bot_login; refusing to scan claims")
+        return None
     issues = sorted(github.list_open_issues(repo), key=lambda i: i.get("number", 0))
     for issue in issues:
         labels = {
@@ -291,6 +296,9 @@ def release_orphaned_claims(
     issue with NO record at all is released once the claim is stale
     (submit succeeded but the job died pre-record). Bounded per tick.
     """
+    if not bot_login.strip():
+        log.warning("reconciliation: empty bot_login; refusing to scan claims")
+        return 0
     released = 0
     for issue in github.list_open_issues(repo):
         if released >= limit:

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -225,6 +225,14 @@ def pick_steward_issue(
         claimed = False
         attempts = 0
         for c in github.list_comments(repo, number):
+            # The markers are the BOT'S protocol: only its own comments
+            # move the claim state. On a public repo, a stranger posting
+            # a release (or an outage release) must be able to neither
+            # free a claimed order, nor burn its attempts, nor erase them
+            # into an unbounded paid retry loop (review finding).
+            author = str((c.get("user") or {}).get("login", ""))
+            if author.casefold() != bot_login.casefold():
+                continue
             body = str(c.get("body", ""))
             if CLAIM_MARKER in body:
                 claimed = True
@@ -253,7 +261,13 @@ def pick_steward_issue(
 
 
 def release_orphaned_claims(
-    github: Any, repo: str, records: list, now: float, stale_s: float = 4 * 3600, limit: int = 2
+    github: Any,
+    repo: str,
+    records: list,
+    now: float,
+    stale_s: float = 4 * 3600,
+    limit: int = 2,
+    bot_login: str = "agentic-learning-bot",
 ) -> int:
     """Post release markers for claimed work orders whose runs are DEAD.
 
@@ -279,6 +293,9 @@ def release_orphaned_claims(
         claimed = False
         claim_time = ""
         for c in github.list_comments(repo, number):
+            author = str((c.get("user") or {}).get("login", ""))
+            if author.casefold() != bot_login.casefold():
+                continue  # same identity gate as pick_steward_issue
             body = str(c.get("body", ""))
             if CLAIM_MARKER in body:
                 claimed = True

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -76,6 +76,12 @@ OUTAGE_MARKER = "<!-- autoresearch:outage-release -->"
 # persistently-failing order must not become a paid retry loop — three
 # sessions is the escalate-to-a-human point
 MAX_STEWARD_ATTEMPTS = 3
+# Outage releases don't count as attempts, but they cannot refund forever:
+# a PERMANENT refusal (revoked key, misconfigured key file) would otherwise
+# oscillate 0->1->0 below the cap and never reach a human (review finding).
+# After this many outage releases the order waits for a human too — the
+# release comments on the thread say exactly why.
+MAX_OUTAGE_RELEASES = 5
 STEWARD_AGENT_ID = "steward-01"
 
 
@@ -224,6 +230,7 @@ def pick_steward_issue(
         # a human, not a fourth session.
         claimed = False
         attempts = 0
+        outage_releases = 0
         for c in github.list_comments(repo, number):
             # The markers are the BOT'S protocol: only its own comments
             # move the claim state. On a public repo, a stranger posting
@@ -241,10 +248,15 @@ def pick_steward_issue(
                 claimed = False
                 if OUTAGE_MARKER in body:
                     # an API outage is our failure, not the order's: the
-                    # claim it released does not count toward the cap
+                    # claim it released does not count toward the cap —
+                    # but outage releases have their OWN cap, or a
+                    # permanent refusal would retry forever
                     attempts = max(0, attempts - 1)
+                    outage_releases += 1
         if claimed or attempts >= MAX_STEWARD_ATTEMPTS:
             continue
+        if outage_releases >= MAX_OUTAGE_RELEASES:
+            continue  # persistent refusals escalate to a human too
         text = f"{issue.get('title', '')}\n{issue.get('body') or ''}"
         benchmark = infer_benchmark(text, contract)
         if not benchmark:
@@ -590,7 +602,11 @@ def live_steward(
         if api_outage:
             outcome_label = "infra-outage"
             ending = STUCK  # infrastructure failure, nothing about the run
-            _best_effort("outage stamp", lambda: stamp_outage(run_root, note, now), secrets)
+            _best_effort(
+                "outage stamp",
+                lambda: stamp_outage(run_root, note, now, role="steward"),
+                secrets,
+            )
         elif budget:
             outcome_label = "budget-exhausted"
             ending = BUDGET_EXHAUSTED
@@ -623,7 +639,10 @@ def live_steward(
                     f"could not run — the API refused the orchestrator "
                     f"({note}). Claim released; this does NOT count toward "
                     f"the {MAX_STEWARD_ATTEMPTS}-attempt cap. The lanes pause "
-                    f"and retry after the outage cooldown."
+                    f"and retry after the outage cooldown; after "
+                    f"{MAX_OUTAGE_RELEASES} outage releases this order waits "
+                    f"for a human (persistent refusals need a key fix, not "
+                    f"retries)."
                 )
             else:
                 finished = (

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -47,6 +47,7 @@ from autoresearch.runstate import (
     lease_is_stale,
     list_runs,
     load_record,
+    outage_active,
     read_lease,
     reap_lease,
     release_lease,
@@ -153,6 +154,10 @@ def service_in_review(
     """
     from autoresearch.followup import close_if_done, has_new_comments
 
+    paused = outage_active(root, now)
+    if paused and allow_submit:
+        log.info("follow-up submissions paused (api outage: %s)", paused)
+        allow_submit = False  # state transitions below still run
     ended: list[tuple[str, str]] = []
     submitted: list[tuple[str, str]] = []
     for record in list_runs(root):
@@ -835,6 +840,10 @@ def service_self_initiated(
     every tick during Slurm queue latency would launch a duplicate climb.
     """
     limits = limits if limits is not None else effective_limits(getattr(contract, "budgets", None))
+    paused = outage_active(root, now)
+    if paused:
+        log.info("self-initiated lane paused (api outage: %s)", paused)
+        return None
     try:
         records = list_runs(root)
         pending = read_pending(root, spec.target)
@@ -920,6 +929,10 @@ def service_steward(
     if not target or not spec.steward_key_file:
         return None
     if getattr(contract, "steward", None) is None:
+        return None
+    paused = outage_active(root, now)
+    if paused:
+        log.info("steward lane paused (api outage: %s)", paused)
         return None
     try:
         from autoresearch.steward import release_orphaned_claims
@@ -1039,6 +1052,10 @@ def service_intake(
 
     target = spec.target
     if not target:
+        return None
+    paused = outage_active(root, now)
+    if paused:
+        log.info("intake lane paused (api outage: %s)", paused)
         return None
     try:
         if contract is None:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -930,10 +930,6 @@ def service_steward(
         return None
     if getattr(contract, "steward", None) is None:
         return None
-    paused = outage_active(root, now)
-    if paused:
-        log.info("steward lane paused (api outage: %s)", paused)
-        return None
     try:
         from autoresearch.steward import release_orphaned_claims
 
@@ -941,8 +937,15 @@ def service_steward(
         # must not fly alongside a solver climb (the drift/freshness
         # machinery does not coordinate them) or another stewardship.
         records = list_runs(root)
-        # reconcile first: killed jobs never post their own release
-        release_orphaned_claims(github, target, records, now)
+        # reconcile first: killed jobs never post their own release — and
+        # BEFORE the outage pause below, because a claim orphaned by the
+        # very session the outage killed must not stay held all cooldown
+        # (reconciliation is model-free bookkeeping; only spawning pauses)
+        release_orphaned_claims(github, target, records, now, bot_login=spec.bot_login)
+        paused = outage_active(root, now)
+        if paused:
+            log.info("steward lane paused (api outage: %s)", paused)
+            return None
         if any(r.target == target and r.state != ENDED for r in records):
             return None
         # The queue window (submit -> job writes its record) is bridged by

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -154,10 +154,6 @@ def service_in_review(
     """
     from autoresearch.followup import close_if_done, has_new_comments
 
-    paused = outage_active(root, now)
-    if paused and allow_submit:
-        log.info("follow-up submissions paused (api outage: %s)", paused)
-        allow_submit = False  # state transitions below still run
     ended: list[tuple[str, str]] = []
     submitted: list[tuple[str, str]] = []
     for record in list_runs(root):
@@ -174,6 +170,12 @@ def service_in_review(
             # lane stays human-answered.
             is_steward = record.agent_id.startswith("steward")
             if is_steward and not spec.steward_key_file:
+                continue
+            # per-ROLE outage latch: state transitions above still ran,
+            # only this record's session spawn sits the cooldown out
+            paused = outage_active(root, now, role="steward" if is_steward else "solver")
+            if paused:
+                log.info("follow-up for %s paused (api outage: %s)", record.run_id, paused)
                 continue
             if not has_new_comments(record, github, spec.bot_login):
                 continue
@@ -840,7 +842,7 @@ def service_self_initiated(
     every tick during Slurm queue latency would launch a duplicate climb.
     """
     limits = limits if limits is not None else effective_limits(getattr(contract, "budgets", None))
-    paused = outage_active(root, now)
+    paused = outage_active(root, now, role="solver")
     if paused:
         log.info("self-initiated lane paused (api outage: %s)", paused)
         return None
@@ -942,7 +944,7 @@ def service_steward(
         # very session the outage killed must not stay held all cooldown
         # (reconciliation is model-free bookkeeping; only spawning pauses)
         release_orphaned_claims(github, target, records, now, bot_login=spec.bot_login)
-        paused = outage_active(root, now)
+        paused = outage_active(root, now, role="steward")
         if paused:
             log.info("steward lane paused (api outage: %s)", paused)
             return None
@@ -1056,7 +1058,7 @@ def service_intake(
     target = spec.target
     if not target:
         return None
-    paused = outage_active(root, now)
+    paused = outage_active(root, now, role="solver")
     if paused:
         log.info("intake lane paused (api outage: %s)", paused)
         return None

--- a/src/autoresearch/verifier_cli.py
+++ b/src/autoresearch/verifier_cli.py
@@ -19,9 +19,14 @@ from datetime import UTC, datetime
 
 from autoresearch.followup import QUALIFYING_ASSOCIATIONS
 from autoresearch.github import EnvTokenProvider, GitHubClient
-from autoresearch.llm import AnthropicCompleter
+from autoresearch.llm import AnthropicCompleter, CompleterError
 from autoresearch.review import PullRequest
-from autoresearch.review_cli import EXPECTED_FAILURES, _gather_context, post_round
+from autoresearch.review_cli import (
+    EXPECTED_FAILURES,
+    _gather_context,
+    post_round,
+    post_skip_stub,
+)
 from autoresearch.verifier import (
     MAX_RULER_FILES,
     VERIFY_MARKER,
@@ -216,6 +221,8 @@ def main() -> int:
         log.info("posted verification (%s) on %s#%s", round_label, repo, number)
     except EXPECTED_FAILURES as exc:  # advisory role: never fail the target's CI
         log.warning("verification did not complete: %s: %s", type(exc).__name__, exc)
+        if isinstance(exc, CompleterError):
+            post_skip_stub(client, repo, number, "verification", exc)
     return 0
 
 

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from autoresearch.contract_cli import main as contract_main
+from autoresearch.llm import CompleterError
 from autoresearch.review_cli import main as review_main
 
 GOOD = """
@@ -125,6 +126,49 @@ def _cli_env(monkeypatch) -> None:
     monkeypatch.setenv("GITHUB_TOKEN", "t")
     # ambient env must not flip the explicit-request path under a test
     monkeypatch.delenv("REVIEW_EXPLICIT_REQUEST", raising=False)
+
+
+def test_review_cli_posts_a_skip_stub_when_the_model_api_refuses(monkeypatch) -> None:
+    """A missing round must not be invisible: when the completer dies to an
+    API refusal (credits, auth), the thread gets a stub — under its OWN
+    marker, so it never counts as a round and never rides as context."""
+    import autoresearch.review_cli as cli
+
+    fake_client = FakeReviewClient()
+
+    def fake_review(pr, completer, bot_login, today=None, explicit_request=False):
+        raise CompleterError("BadRequestError: credit balance is too low")
+
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
+    monkeypatch.setattr(cli, "review", fake_review)
+    monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
+    _cli_env(monkeypatch)
+    assert cli.main() == 0  # still never fails the target's CI
+    (stub,) = [c["body"] for c in fake_client.posted]
+    assert stub.lstrip().startswith(cli.SKIP_MARKER)
+    assert "could not run" in stub and "credit balance" in stub
+    from autoresearch.review import MARKER
+    from autoresearch.verifier import VERIFY_MARKER
+
+    assert MARKER not in stub and VERIFY_MARKER not in stub
+
+
+def test_skip_stub_posting_failure_is_swallowed(monkeypatch, caplog) -> None:
+    import autoresearch.review_cli as cli
+    from autoresearch.github import GitHubError
+
+    class RefusingClient(FakeReviewClient):
+        def comment(self, repo, number, body):
+            raise GitHubError(403, "/repos/org/repo", "forbidden")
+
+    cli.post_skip_stub(
+        RefusingClient(),  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        "advisory review",
+        CompleterError("x"),
+    )
+    assert "could not post the skip stub" in caplog.text
 
 
 def test_review_cli_threads_date_and_context(monkeypatch) -> None:

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -691,7 +691,15 @@ def test_context_excludes_drive_by_and_forged_marker_comments(review_run) -> Non
         "user": {"login": "stranger2"},
         "author_association": "NONE",
     }
-    github = FakeGitHub(comments=[drive_by, forged, member(104, "please respond")])
+    skip_stub = {
+        "id": 105,
+        # a real outage stub from the Actions bot: right identity, but its
+        # own marker — "the API was down" is a notice, not a review round
+        "body": "<!-- autoresearch:round-skipped -->\n*The verification round could not run*",
+        "user": {"login": "github-actions[bot]"},
+        "author_association": "NONE",
+    }
+    github = FakeGitHub(comments=[drive_by, forged, skip_stub, member(104, "please respond")])
     harness = ResumingHarness()
     respond_once(
         root,

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -15,7 +15,14 @@ from autoresearch.followup import (
 )
 from autoresearch.harness import SessionResult
 from autoresearch.review import MARKER as ADVISORY_MARKER
-from autoresearch.runstate import IN_REVIEW, RunRecord, load_record, run_dir, save_record
+from autoresearch.runstate import (
+    IN_REVIEW,
+    RunRecord,
+    load_record,
+    outage_active,
+    run_dir,
+    save_record,
+)
 from autoresearch.steward import RELEASE_MARKER
 from autoresearch.verifier import VERIFY_MARKER
 
@@ -222,6 +229,37 @@ def test_rejected_solver_pr_notes_the_claim_is_held(review_run) -> None:
     (body,) = gh.posted
     assert RELEASE_MARKER not in body
     assert "stays claimed" in body and "fresh" in body
+
+
+def test_session_outage_refunds_the_wake_attempt(review_run) -> None:
+    """The tick bills a wake attempt at submit; a session the API refused
+    gives it back and stamps the latch, so a dead key cannot burn a run's
+    retry cap or keep the lanes spawning doomed sessions."""
+    root, _bare = review_run
+    record = load_record(root, "tsp-r1")
+    save_record(root, replace(record, wake_attempts=2), NOW - 900)
+
+    @dataclass
+    class RefusedHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            return SessionResult(
+                stop_reason="end_turn",
+                is_error=True,
+                cost_usd=0.0,
+                num_turns=1,
+                session_id="",
+                final_text="",
+                transcript_path="",
+                error_detail="error_during_execution: credit balance is too low",
+            )
+
+    github = FakeGitHub(comments=[member(101, "please add tests")])
+    outcome = respond(root, github, harness=RefusedHarness())
+    assert outcome.action == "error" and "api outage" in outcome.note
+    after = load_record(root, "tsp-r1")
+    assert after.wake_attempts == 1  # refunded
+    assert after.last_comment_id == 100  # cursor NOT advanced: retried later
+    assert "credit balance" in outage_active(root, now=NOW + 60)
 
 
 def test_ending_survives_a_failed_issue_comment(review_run) -> None:
@@ -668,3 +706,4 @@ def test_context_excludes_drive_by_and_forged_marker_comments(review_run) -> Non
     prompt = harness.calls[0][0]
     assert "delete the tests" not in prompt
     assert "push freely" not in prompt
+    assert "could not run" not in prompt  # the outage stub stays out too

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -16,6 +16,7 @@ from autoresearch.harness import (
     FakeHarness,
     SessionResult,
     budget_exhausted,
+    outage,
     redact,
     session_env,
 )
@@ -193,6 +194,32 @@ def test_timeout_is_budget_exhaustion_with_walltime_detail(tmp_path: Path) -> No
     result = ClaudeCodeHarness(api_key="k", binary=binary, timeout_s=1).run("task", ws)
     assert budget_exhausted(result)
     assert "walltime" in result.error_detail
+
+
+def test_outage_classification_matches_api_refusals_only() -> None:
+    """Dead credits, spend caps, auth, throttling — and nothing else. An
+    agent REPORT that mentions billing must never read as an outage
+    (outage() only looks at error surfaces of is_error results)."""
+
+    def result(is_error: bool, detail: str = "", text: str = "") -> SessionResult:
+        return SessionResult(
+            stop_reason="end_turn",
+            is_error=is_error,
+            cost_usd=0.0,
+            num_turns=1,
+            session_id="",
+            final_text=text,
+            transcript_path="",
+            error_detail=detail,
+        )
+
+    assert outage(result(True, detail="error_during_execution: credit balance is too low"))
+    assert outage(result(True, text="API Error (400): You have reached your usage limit."))
+    assert outage(result(True, detail="authentication_error: invalid x-api-key"))
+    assert outage(result(True, detail="rate_limit_error: Number of requests..."))
+    assert not outage(result(True, detail="error_max_turns: Reached maximum number of turns"))
+    assert not outage(result(False, text="Report: cut billing costs by caching the pool."))
+    assert not outage(result(True, detail="TypeError: 'NoneType' object is not iterable"))
 
 
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -218,6 +218,13 @@ def test_outage_classification_matches_api_refusals_only() -> None:
     assert outage(result(True, detail="authentication_error: invalid x-api-key"))
     assert outage(result(True, detail="rate_limit_error: Number of requests..."))
     assert not outage(result(True, detail="error_max_turns: Reached maximum number of turns"))
+    assert not outage(  # agent prose never consulted when backend detail exists
+        result(
+            True,
+            detail="error_max_turns: Reached maximum number of turns",
+            text="Report: we should raise the usage limit and cut billing costs.",
+        )
+    )
     assert not outage(result(False, text="Report: cut billing costs by caching the pool."))
     assert not outage(result(True, detail="TypeError: 'NoneType' object is not iterable"))
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -227,6 +227,9 @@ def test_outage_classification_matches_api_refusals_only() -> None:
     )
     assert not outage(result(False, text="Report: cut billing costs by caching the pool."))
     assert not outage(result(True, detail="TypeError: 'NoneType' object is not iterable"))
+    # empty detail: prose is consulted only in the legacy "API Error" shape
+    assert outage(result(True, text="API Error (400): credit balance is too low"))
+    assert not outage(result(True, text="Report: raise the usage limit, cut billing costs."))
 
 
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:

--- a/tests/test_runstate.py
+++ b/tests/test_runstate.py
@@ -8,6 +8,7 @@ import pytest
 
 from autoresearch.runstate import (
     ENDED,
+    OUTAGE_COOLDOWN_S,
     STUCK,
     WAITING,
     RunRecord,
@@ -15,10 +16,12 @@ from autoresearch.runstate import (
     lease_is_stale,
     list_runs,
     load_record,
+    outage_active,
     read_lease,
     release_lease,
     run_dir,
     save_record,
+    stamp_outage,
     update_lease_holder,
 )
 
@@ -174,3 +177,19 @@ def test_unreadable_lease_synthesizes_mtime_timestamp(tmp_path: Path) -> None:
     assert lease is not None
     assert lease.holder == "unreadable"
     assert lease.acquired == 500.0
+
+
+def test_outage_latch_pauses_then_expires(tmp_path) -> None:
+    assert outage_active(tmp_path, now=1000.0) == ""  # no stamp: inactive
+    stamp_outage(tmp_path, "credit balance is too low", now=1000.0)
+    assert "credit balance" in outage_active(tmp_path, now=1000.0 + OUTAGE_COOLDOWN_S - 1)
+    assert outage_active(tmp_path, now=1000.0 + OUTAGE_COOLDOWN_S) == ""  # expired
+    assert outage_active(tmp_path, now=500.0) == ""  # clock moved backwards: expired
+
+
+def test_corrupt_outage_stamp_reads_inactive(tmp_path) -> None:
+    """A bad latch must never brick the loop."""
+    (tmp_path / "outage.json").write_text("not json")
+    assert outage_active(tmp_path, now=1000.0) == ""
+    (tmp_path / "outage.json").write_text('{"detail": "x"}')  # no time field
+    assert outage_active(tmp_path, now=1000.0) == ""

--- a/tests/test_runstate.py
+++ b/tests/test_runstate.py
@@ -10,6 +10,7 @@ from autoresearch.runstate import (
     ENDED,
     OUTAGE_COOLDOWN_S,
     STUCK,
+    THROTTLE_COOLDOWN_S,
     WAITING,
     RunRecord,
     acquire_lease,
@@ -185,6 +186,14 @@ def test_outage_latch_pauses_then_expires(tmp_path) -> None:
     assert "credit balance" in outage_active(tmp_path, now=1000.0 + OUTAGE_COOLDOWN_S - 1)
     assert outage_active(tmp_path, now=1000.0 + OUTAGE_COOLDOWN_S) == ""  # expired
     assert outage_active(tmp_path, now=500.0) == ""  # clock moved backwards: expired
+
+
+def test_throttling_stamps_a_short_pause(tmp_path) -> None:
+    """A 429/529 is transient: the stamp carries its own short cooldown,
+    so one throttled session never idles the lanes for most of an hour."""
+    stamp_outage(tmp_path, "rate_limit_error: Number of requests exceeded", now=1000.0)
+    assert "rate_limit" in outage_active(tmp_path, now=1000.0 + THROTTLE_COOLDOWN_S - 1)
+    assert outage_active(tmp_path, now=1000.0 + THROTTLE_COOLDOWN_S) == ""
 
 
 def test_corrupt_outage_stamp_reads_inactive(tmp_path) -> None:

--- a/tests/test_runstate.py
+++ b/tests/test_runstate.py
@@ -8,6 +8,7 @@ import pytest
 
 from autoresearch.runstate import (
     ENDED,
+    MAX_CLOCK_SKEW_S,
     OUTAGE_COOLDOWN_S,
     STUCK,
     THROTTLE_COOLDOWN_S,
@@ -197,8 +198,22 @@ def test_throttling_stamps_a_short_pause(tmp_path) -> None:
 
 
 def test_corrupt_outage_stamp_reads_inactive(tmp_path) -> None:
-    """A bad latch must never brick the loop."""
-    (tmp_path / "outage.json").write_text("not json")
+    """A bad latch must never brick the loop. The path must be the one the
+    reader actually consults (review finding: a stale filename made this
+    vacuous) — prove it by planting a VALID stamp at the same path first."""
+    latch = tmp_path / "outage-solver.json"
+    stamp_outage(tmp_path, "credit balance", now=1000.0)
+    assert latch.exists() and outage_active(tmp_path, now=1000.0) != ""
+    latch.write_text("not json")
     assert outage_active(tmp_path, now=1000.0) == ""
-    (tmp_path / "outage.json").write_text('{"detail": "x"}')  # no time field
+    latch.write_text('{"detail": "x"}')  # no time field
     assert outage_active(tmp_path, now=1000.0) == ""
+
+
+def test_future_stamp_within_skew_is_active(tmp_path) -> None:
+    """Stamps are written on compute nodes and read by the tick on another
+    host: small NTP skew must not void the pause, while a far-future
+    timestamp (corrupt) reads as inactive."""
+    stamp_outage(tmp_path, "credit balance", now=1000.0)
+    assert outage_active(tmp_path, now=1000.0 - 60) != ""  # reader behind writer
+    assert outage_active(tmp_path, now=1000.0 - MAX_CLOCK_SKEW_S - 1) == ""

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -437,7 +437,11 @@ def test_api_outage_releases_claim_without_counting(tmp_path, steward_repo) -> N
     assert "credit balance" in record.ending_note
     (release,) = [b for _, b in github.issue_comments if RELEASE_MARKER in b]
     assert OUTAGE_MARKER in release and "does NOT count" in release
-    assert "credit balance" in outage_active(tmp_path / "state", now=1_000_000.0 + 60)
+    assert "credit balance" in outage_active(
+        tmp_path / "state", now=1_000_000.0 + 60, role="steward"
+    )
+    # and the STEWARD'S dead key never pauses the solver lanes
+    assert outage_active(tmp_path / "state", now=1_000_000.0 + 60, role="solver") == ""
 
 
 def test_outage_releases_do_not_count_toward_the_attempt_cap() -> None:

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -9,9 +9,12 @@ import pytest
 
 from autoresearch.contract import load_contract
 from autoresearch.harness import SessionResult
+from autoresearch.intake import CLAIM_MARKER
 from autoresearch.orchestrator import steward_out_of_scope
-from autoresearch.runstate import load_record
+from autoresearch.runstate import load_record, outage_active
 from autoresearch.steward import (
+    OUTAGE_MARKER,
+    RELEASE_MARKER,
     StewardConfig,
     live_steward,
     pick_steward_issue,
@@ -386,6 +389,86 @@ def test_exhausted_session_is_a_budget_ending_not_an_error(tmp_path, steward_rep
         "claim-released" in body and "ran out of its session budget" in body
         for _, body in github.issue_comments
     )
+
+
+def test_api_outage_releases_claim_without_counting(tmp_path, steward_repo) -> None:
+    """The API refusing us is the orchestrator's failure: the run ends
+    stuck, the release comment carries the outage marker (so the claim
+    does not count toward the cap), and the latch pauses the lanes."""
+
+    @dataclass
+    class RefusedHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            return SessionResult(
+                stop_reason="end_turn",
+                is_error=True,
+                cost_usd=0.0,
+                num_turns=1,
+                session_id="",
+                final_text="",
+                transcript_path="",
+                error_detail="error_during_execution: credit balance is too low",
+            )
+
+    github = StewardGitHub()
+    outcome = live_steward(
+        config=StewardConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="steward-tsp-out",
+        harness=RefusedHarness(),
+        evaluator=CheckingEvaluator(values=[14.9]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="2026-08-09T00:00:00Z",
+        issue_number=21,
+        work_order="w",
+    )
+    assert outcome.outcome == "infra-outage"
+    record = load_record(tmp_path / "state", "steward-tsp-out")
+    assert record.ending == "stuck"
+    assert "credit balance" in record.ending_note
+    (release,) = [b for _, b in github.issue_comments if RELEASE_MARKER in b]
+    assert OUTAGE_MARKER in release and "does NOT count" in release
+    assert "credit balance" in outage_active(tmp_path / "state", now=1_000_000.0 + 60)
+
+
+def test_outage_releases_do_not_count_toward_the_attempt_cap() -> None:
+    """Three claims, one of them released by an outage: two attempts —
+    the order is still claimable. Three COUNTED claims: capped."""
+
+    def claim():
+        return {"body": f"{CLAIM_MARKER}\nworking"}
+
+    def release(outage_kind: bool):
+        marker = f"{RELEASE_MARKER}\n{OUTAGE_MARKER}" if outage_kind else RELEASE_MARKER
+        return {"body": f"{marker}\nreleased"}
+
+    issue = {
+        "number": 5,
+        "title": "steward: harden tsp",
+        "body": "the tsp pool is stale",
+        "user": {"login": "renmengye", "type": "User"},
+        "author_association": "OWNER",
+        "labels": [{"name": "autoresearch:steward"}],
+    }
+
+    @dataclass
+    class G:
+        comments: list
+
+        def list_open_issues(self, repo):
+            return [issue]
+
+        def list_comments(self, repo, number):
+            return self.comments
+
+    contract = load_contract(CONTRACT, "org/pilot")
+    thread = [claim(), release(True), claim(), release(False), claim(), release(False)]
+    picked = pick_steward_issue(G(thread), "org/pilot", contract, "bot")
+    assert picked is not None and picked.number == 5  # 2 counted attempts
+    thread += [claim(), release(False)]
+    assert pick_steward_issue(G(thread), "org/pilot", contract, "bot") is None  # 3 counted
 
 
 def test_solver_territory_edit_is_aborted(tmp_path, steward_repo) -> None:

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -131,7 +131,7 @@ def test_pick_steward_issue_gates_on_label_standing_and_claim() -> None:
         comments={
             4: [
                 {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
-                {"body": "<!-- autoresearch:claim-released -->"},
+                {"body": "<!-- autoresearch:claim-released -->", "user": {"login": BOT}},
                 {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
             ]
         },
@@ -143,15 +143,19 @@ def test_pick_steward_issue_gates_on_label_standing_and_claim() -> None:
         comments={
             4: [
                 {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
-                {"body": "<!-- autoresearch:claim-released -->"},
+                {"body": "<!-- autoresearch:claim-released -->", "user": {"login": BOT}},
                 {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
-                {"body": "<!-- autoresearch:claim-released -->"},
+                {"body": "<!-- autoresearch:claim-released -->", "user": {"login": BOT}},
                 {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
-                {"body": "<!-- autoresearch:claim-released -->"},
+                {"body": "<!-- autoresearch:claim-released -->", "user": {"login": BOT}},
             ]
         },
     )
     assert pick_steward_issue(github5, "org/pilot", c, BOT) is None
+    # and it is the ATTEMPT COUNT holding, not a lingering claim flag:
+    # the same thread ends released, so only the cap can exclude it
+    released_last = github5.comments[4][-1]
+    assert "claim-released" in released_last["body"]
 
 
 def test_steward_scope_folds_case_against_solver_territory() -> None:
@@ -646,7 +650,9 @@ def test_orphaned_claims_are_released_for_dead_runs() -> None:
         issue_number=7,
     )
     github = G([_issue(7, "re-base the tsp pool")], {7: [claimed]})
-    n = release_orphaned_claims(github, "org/pilot", [dead_record], now=2_000_000_000.0)
+    n = release_orphaned_claims(
+        github, "org/pilot", [dead_record], now=2_000_000_000.0, bot_login="agentic-learning-bot"
+    )
     assert n == 1
     assert github.posted and "claim-released" in github.posted[0][1]
     # a LIVE run keeps its claim
@@ -659,10 +665,24 @@ def test_orphaned_claims_are_released_for_dead_runs() -> None:
         issue_number=7,
     )
     github2 = G([_issue(7, "re-base the tsp pool")], {7: [claimed]})
-    assert release_orphaned_claims(github2, "org/pilot", [live_record], now=2_000_000_000.0) == 0
+    assert (
+        release_orphaned_claims(
+            github2,
+            "org/pilot",
+            [live_record],
+            now=2_000_000_000.0,
+            bot_login="agentic-learning-bot",
+        )
+        == 0
+    )
     # no record + stale claim -> released; fresh claim -> kept
     github3 = G([_issue(7, "re-base the tsp pool")], {7: [claimed]})
-    assert release_orphaned_claims(github3, "org/pilot", [], now=2_000_000_000.0) == 1
+    assert (
+        release_orphaned_claims(
+            github3, "org/pilot", [], now=2_000_000_000.0, bot_login="agentic-learning-bot"
+        )
+        == 1
+    )
     # now=2e9 is 2033-05-18T03:33Z; a claim 33 minutes old is not stale
     fresh = {
         "body": "<!-- autoresearch:claimed -->",
@@ -670,4 +690,9 @@ def test_orphaned_claims_are_released_for_dead_runs() -> None:
         "user": {"login": "agentic-learning-bot"},
     }
     github4 = G([_issue(7, "re-base the tsp pool")], {7: [fresh]})
-    assert release_orphaned_claims(github4, "org/pilot", [], now=2_000_000_000.0) == 0
+    assert (
+        release_orphaned_claims(
+            github4, "org/pilot", [], now=2_000_000_000.0, bot_login="agentic-learning-bot"
+        )
+        == 0
+    )

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -107,7 +107,7 @@ def test_pick_steward_issue_gates_on_label_standing_and_claim() -> None:
     # claimed issues are skipped
     github2 = FakeIssues(
         [_issue(4, "re-base the tsp pool")],
-        comments={4: [{"body": "<!-- autoresearch:claimed -->\ntaken"}]},
+        comments={4: [{"body": "<!-- autoresearch:claimed -->\ntaken", "user": {"login": BOT}}]},
     )
     assert pick_steward_issue(github2, "org/pilot", c, BOT) is None
     # a released claim makes the order claimable again
@@ -115,8 +115,11 @@ def test_pick_steward_issue_gates_on_label_standing_and_claim() -> None:
         [_issue(4, "re-base the tsp pool")],
         comments={
             4: [
-                {"body": "<!-- autoresearch:claimed -->\ntaken"},
-                {"body": "<!-- autoresearch:claim-released -->\nsubmission failed"},
+                {"body": "<!-- autoresearch:claimed -->\ntaken", "user": {"login": BOT}},
+                {
+                    "body": "<!-- autoresearch:claim-released -->\nsubmission failed",
+                    "user": {"login": BOT},
+                },
             ]
         },
     )
@@ -127,9 +130,9 @@ def test_pick_steward_issue_gates_on_label_standing_and_claim() -> None:
         [_issue(4, "re-base the tsp pool")],
         comments={
             4: [
-                {"body": "<!-- autoresearch:claimed -->"},
+                {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
                 {"body": "<!-- autoresearch:claim-released -->"},
-                {"body": "<!-- autoresearch:claimed -->"},
+                {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
             ]
         },
     )
@@ -139,11 +142,11 @@ def test_pick_steward_issue_gates_on_label_standing_and_claim() -> None:
         [_issue(4, "re-base the tsp pool")],
         comments={
             4: [
-                {"body": "<!-- autoresearch:claimed -->"},
+                {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
                 {"body": "<!-- autoresearch:claim-released -->"},
-                {"body": "<!-- autoresearch:claimed -->"},
+                {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
                 {"body": "<!-- autoresearch:claim-released -->"},
-                {"body": "<!-- autoresearch:claimed -->"},
+                {"body": "<!-- autoresearch:claimed -->", "user": {"login": BOT}},
                 {"body": "<!-- autoresearch:claim-released -->"},
             ]
         },
@@ -437,12 +440,12 @@ def test_outage_releases_do_not_count_toward_the_attempt_cap() -> None:
     """Three claims, one of them released by an outage: two attempts —
     the order is still claimable. Three COUNTED claims: capped."""
 
-    def claim():
-        return {"body": f"{CLAIM_MARKER}\nworking"}
+    def claim(author: str = BOT):
+        return {"body": f"{CLAIM_MARKER}\nworking", "user": {"login": author}}
 
-    def release(outage_kind: bool):
+    def release(outage_kind: bool, author: str = BOT):
         marker = f"{RELEASE_MARKER}\n{OUTAGE_MARKER}" if outage_kind else RELEASE_MARKER
-        return {"body": f"{marker}\nreleased"}
+        return {"body": f"{marker}\nreleased", "user": {"login": author}}
 
     issue = {
         "number": 5,
@@ -465,10 +468,51 @@ def test_outage_releases_do_not_count_toward_the_attempt_cap() -> None:
 
     contract = load_contract(CONTRACT, "org/pilot")
     thread = [claim(), release(True), claim(), release(False), claim(), release(False)]
-    picked = pick_steward_issue(G(thread), "org/pilot", contract, "bot")
+    picked = pick_steward_issue(G(thread), "org/pilot", contract, BOT)
     assert picked is not None and picked.number == 5  # 2 counted attempts
     thread += [claim(), release(False)]
-    assert pick_steward_issue(G(thread), "org/pilot", contract, "bot") is None  # 3 counted
+    assert pick_steward_issue(G(thread), "org/pilot", contract, BOT) is None  # 3 counted
+
+
+def test_marker_spoofing_by_strangers_moves_nothing() -> None:
+    """Only the BOT'S comments move claim state (review finding, public-repo
+    threat): a stranger's outage-release must not erase attempts into an
+    unbounded paid retry loop, a stranger's release must not free a live
+    claim, and a stranger's claim must not burn attempts."""
+
+    def marked(body: str, author: str):
+        return {"body": body, "user": {"login": author}}
+
+    issue = {
+        "number": 6,
+        "title": "steward: harden tsp",
+        "body": "the tsp pool is stale",
+        "user": {"login": "renmengye", "type": "User"},
+        "author_association": "OWNER",
+        "labels": [{"name": "autoresearch:steward"}],
+    }
+
+    @dataclass
+    class G:
+        comments: list
+
+        def list_open_issues(self, repo):
+            return [issue]
+
+        def list_comments(self, repo, number):
+            return self.comments
+
+    contract = load_contract(CONTRACT, "org/pilot")
+    # capped order + stranger outage-releases: attempts stay at 3
+    thread = [marked(f"{CLAIM_MARKER}\nx", BOT) for _ in range(3)]
+    thread += [marked(f"{RELEASE_MARKER}\n{OUTAGE_MARKER}\nnice try", "stranger")] * 3
+    assert pick_steward_issue(G(thread), "org/pilot", contract, BOT) is None
+    # live claim + stranger release: still claimed
+    thread2 = [marked(f"{CLAIM_MARKER}\nx", BOT), marked(f"{RELEASE_MARKER}\nfree it", "stranger")]
+    assert pick_steward_issue(G(thread2), "org/pilot", contract, BOT) is None
+    # stranger claims alone: not claimed, no attempts burned
+    thread3 = [marked(f"{CLAIM_MARKER}\nmine now", "stranger")] * 5
+    assert pick_steward_issue(G(thread3), "org/pilot", contract, BOT) is not None
 
 
 def test_solver_territory_edit_is_aborted(tmp_path, steward_repo) -> None:
@@ -587,7 +631,11 @@ def test_orphaned_claims_are_released_for_dead_runs() -> None:
         def comment(self, repo, number, body):
             self.posted.append((number, body))
 
-    claimed = {"body": "<!-- autoresearch:claimed -->", "created_at": "2026-08-09T00:00:00Z"}
+    claimed = {
+        "body": "<!-- autoresearch:claimed -->",
+        "created_at": "2026-08-09T00:00:00Z",
+        "user": {"login": "agentic-learning-bot"},
+    }
     dead_record = RunRecord(
         run_id="steward-tsp-9",
         target="org/pilot",
@@ -616,6 +664,10 @@ def test_orphaned_claims_are_released_for_dead_runs() -> None:
     github3 = G([_issue(7, "re-base the tsp pool")], {7: [claimed]})
     assert release_orphaned_claims(github3, "org/pilot", [], now=2_000_000_000.0) == 1
     # now=2e9 is 2033-05-18T03:33Z; a claim 33 minutes old is not stale
-    fresh = {"body": "<!-- autoresearch:claimed -->", "created_at": "2033-05-18T03:00:00Z"}
+    fresh = {
+        "body": "<!-- autoresearch:claimed -->",
+        "created_at": "2033-05-18T03:00:00Z",
+        "user": {"login": "agentic-learning-bot"},
+    }
     github4 = G([_issue(7, "re-base the tsp pool")], {7: [fresh]})
     assert release_orphaned_claims(github4, "org/pilot", [], now=2_000_000_000.0) == 0

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -947,9 +947,13 @@ roadmap: docs/roadmap.md
         def get_pull_request(self, repo, number):
             return {"state": "closed", "merged": True}
 
-    stamp_outage(tmp_path, "credit balance is too low", now=NOW - 60)
-    assert service_steward(tmp_path, G(), compute, spec, NOW, contract, limits) is None
+    # per-role latches: each role's stamp pauses only its own lanes (the
+    # cross-role isolation itself is pinned in test_steward via
+    # outage_active role separation)
+    stamp_outage(tmp_path, "credit balance is too low", now=NOW - 60, role="solver")
+    stamp_outage(tmp_path, "credit balance is too low", now=NOW - 60, role="steward")
     assert service_self_initiated(tmp_path, compute, spec, contract, NOW, limits) is None
+    assert service_steward(tmp_path, G(), compute, spec, NOW, contract, limits) is None
     # an in-review record: the merged ending still lands, no job submitted
     save_record(
         tmp_path,

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -881,6 +881,96 @@ roadmap: docs/roadmap.md
     assert min(operator_minutes, limits.followup_job_minutes) == 30
 
 
+def test_outage_latch_pauses_spawning_lanes_but_not_endings(tmp_path: Path) -> None:
+    """A stamped outage sits every session-spawning lane out for the
+    cooldown — steward claims, self-initiated climbs, follow-up
+    submissions — while PR-state transitions (endings) keep running."""
+    from autoresearch.contract import load_contract
+    from autoresearch.limits import effective_limits
+    from autoresearch.runstate import stamp_outage
+    from autoresearch.tick import (
+        FollowupSpec,
+        service_in_review,
+        service_self_initiated,
+        service_steward,
+    )
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets: {gpu_hours_per_run: 0, runs_per_week: 20}
+scope: {allowed: [src/pilot/solvers/]}
+steward: {allowed: [src/pilot/instances.py]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    limits = effective_limits(contract.budgets)
+    submitted: list[list[str]] = []
+
+    def runner(argv, timeout_s):
+        submitted.append(list(argv))
+        return CommandResult(0, "77\n", "")
+
+    compute = SlurmCompute(runner=runner)
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="a",
+        partition="p",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+        key_file="/k",
+        steward_key_file="/k",
+    )
+
+    class G:
+        def list_open_issues(self, repo, max_pages: int = 3):
+            return [
+                {
+                    "number": 21,
+                    "title": "re-base the tsp pool",
+                    "body": "",
+                    "user": {"login": "renmengye"},
+                    "author_association": "OWNER",
+                    "labels": [{"name": "autoresearch:steward"}],
+                }
+            ]
+
+        def list_comments(self, repo, number, max_pages: int = 20):
+            return []
+
+        def comment(self, repo, number, body):
+            pass
+
+        def get_pull_request(self, repo, number):
+            return {"state": "closed", "merged": True}
+
+    stamp_outage(tmp_path, "credit balance is too low", now=NOW - 60)
+    assert service_steward(tmp_path, G(), compute, spec, NOW, contract, limits) is None
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW, limits) is None
+    # an in-review record: the merged ending still lands, no job submitted
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="rev-1",
+            target="org/pilot",
+            task_title="t",
+            state="in-review",
+            pr_url="https://github.com/org/pilot/pull/9",
+        ),
+        now=NOW - 5000,
+    )
+    ended, followups = service_in_review(tmp_path, G(), compute, spec, NOW)
+    assert ended == [("rev-1", "merged")]
+    assert submitted == [] and followups == []
+    # cooldown over: the lanes wake back up (steward claims and submits)
+    late = NOW + 45 * 60 + 1
+    out = service_steward(tmp_path, G(), compute, spec, late, contract, limits)
+    assert out is not None and submitted
+
+
 def test_steward_lane_gates_on_key_and_contract_scope(tmp_path: Path) -> None:
     """Off without the steward's own key; off without a contract steward
     section; claims + submits when both exist."""


### PR DESCRIPTION
Maintainer-directed ("worth the hardening on this type of outage class") after the API spend limit was lowered.

**Classification** — `harness.outage()`: credit balance / usage- and spend-limit / auth / throttling patterns, matched only against error surfaces (`error_detail` + the error result's text) of `is_error` sessions, so agent prose mentioning billing can never trip it.

**Containment, per role** — steward: run ends `stuck`, release comment carries an outage marker, and `pick_steward_issue` subtracts outage-released claims from the attempt cap; climb: new `session-outage` outcome → `stuck`; follow-up: the wake attempt billed at submit is refunded (the responder holds the lease) and cursors stay put.

**Backoff** — any outage stamps `outage.json` in the state root; all four session-spawning paths (steward, intake, self-initiated, follow-up submissions) sit out a 45-minute cooldown while PR-state transitions, ending nudges, and reconciliation keep running. Net effect during a sustained outage: one canary session per hour instead of every lane burning bounded retries every tick.

**Reviewer visibility** — when the model API refuses an advisory or verification round, the CLI posts a skip stub on the thread under its own marker (`round-skipped`): it never counts toward round numbering, never rides as follow-up wake context (both match on their own markers — tested), and turns "silent missing round" into a visible outage notice.

Tests: classification true/false table, latch stamp/expiry/corruption, per-lane pause + resume after cooldown with endings still landing, steward uncounted-release arithmetic at the cap boundary, follow-up refund, stub posting + stub-failure swallowing + stub exclusion from wake context. 409 pass; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)