### PR TITLE
Run seeds in the ledger + cross-seed noise floors (min_delta)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Ledger numbers on resampled pools are re-derivable and noise-honest
+  (verifier finding on the first reach re-base): a benchmark declaring
+  `seed_env` gets one orchestrator-drawn seed per measurement pass,
+  injected into BOTH sides of every comparison (paired) and recorded as
+  `run_seed` in results/leader.json — by the climb, the steward re-base,
+  and both follow-up re-measure paths. A new `min_delta` contract knob
+  (absolute units) sets the cross-seed noise floor: candidates that beat
+  the recorded best by less end as honest negative results ("within the
+  noise floor"), not PRs and not aborts.
+
 - API outages are contained instead of billed to runs: a session the
   model API refuses (credit balance, usage/spend limit, auth,
   throttling) ends the run `stuck` with the refusal named, releases a

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -135,14 +135,19 @@ sides of every comparison to it (paired, common random numbers — baseline
 vs candidate, and both sides of the freshness re-measure), and records it
 in the ledger row (`run_seed` in results/leader.json), so the recorded
 number is re-derivable instead of pool luck. Comparisons against the
-RECORDED best are the one place two different seeds meet, so they must
-additionally clear the benchmark's `min_delta` — an absolute cross-seed
-noise floor (the steward's stated stderr, times a safety factor). A
-candidate inside that floor is an honest negative result ("within the
-noise floor"), never a PR and never an abort. The seed is drawn by the
+RECORDED best are the one place two different seeds meet, so on a
+benchmark that declares `min_delta` — an absolute cross-seed noise floor
+(the steward's stated stderr, times a safety factor) — EVERY sub-floor
+delta over the recorded best, including one below the relative
+threshold, is an honest negative result ("does not clear the noise
+floor"), never a PR and never an abort; the stale-clone abort remains
+the semantics for fixed-pool benchmarks only. The seed is drawn by the
 orchestrator at measurement time — never knowable when the solver wrote
-its code — which is what makes a resampled pool tuning-proof while
-staying reproducible.
+its code — and the baseline is measured in a throwaway worktree of the
+pre-session commit, so even an eval that persists artifacts cannot leak
+the pinned seed or the sampled pool into the tree the solver session
+sees. That combination is what makes a resampled pool tuning-proof
+while staying reproducible.
 
 ## The life of a run
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -128,6 +128,22 @@ tick → pick task (benchmark gap / roadmap item / approved issue)
 → weekly digest issue: tried / worked / cost
 ```
 
+**Measurement on resampled pools (seeds and noise floors).** A benchmark
+whose instance pool re-rolls per run declares `seed_env` in the contract:
+the orchestrator draws ONE fresh seed per measurement pass, pins both
+sides of every comparison to it (paired, common random numbers — baseline
+vs candidate, and both sides of the freshness re-measure), and records it
+in the ledger row (`run_seed` in results/leader.json), so the recorded
+number is re-derivable instead of pool luck. Comparisons against the
+RECORDED best are the one place two different seeds meet, so they must
+additionally clear the benchmark's `min_delta` — an absolute cross-seed
+noise floor (the steward's stated stderr, times a safety factor). A
+candidate inside that floor is an honest negative result ("within the
+noise floor"), never a PR and never an abort. The seed is drawn by the
+orchestrator at measurement time — never knowable when the solver wrote
+its code — which is what makes a resampled pool tuning-proof while
+staying reproducible.
+
 ## The life of a run
 
 Explicit lifecycle: where work comes from, how humans steer it in flight, and

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -33,6 +33,7 @@ from autoresearch.orchestrator import (
     ClimbConfig,
     Evaluator,
     SubprocessEvaluator,
+    clears_min_delta,
     climb_once,
     out_of_scope,
     pr_body,
@@ -57,6 +58,12 @@ from autoresearch.runstate import (
 )
 
 log = logging.getLogger(__name__)
+
+
+class NoiseFloored(RuntimeError):
+    """The candidate beat the recorded best, but by less than the
+    benchmark's cross-seed noise floor — pool luck, not progress. An
+    honest negative result, never an abort."""
 
 
 class WorkspaceDrift(RuntimeError):
@@ -117,7 +124,13 @@ def _best_effort(what: str, fn: Callable[[], object], secrets: tuple[str, ...] =
 
 
 def _measure_committed(
-    ws: Workspace, evaluator: Evaluator, run_dir: Path, name: str, sha: str, bench: Any
+    ws: Workspace,
+    evaluator: Evaluator,
+    run_dir: Path,
+    name: str,
+    sha: str,
+    bench: Any,
+    extra_env: dict[str, str] | None = None,
 ) -> float:
     """Measure a COMMITTED tree in a throwaway worktree.
 
@@ -131,7 +144,7 @@ def _measure_committed(
     wt = run_dir / f"measure-{name}"
     ws.git("worktree", "add", "--detach", str(wt), sha)
     try:
-        return float(evaluator.evaluate(wt, bench.command, bench.metric))
+        return float(evaluator.evaluate(wt, bench.command, bench.metric, extra_env=extra_env))
     finally:
         removed = _best_effort(
             "worktree cleanup", lambda: ws.git("worktree", "remove", "--force", str(wt))
@@ -386,10 +399,17 @@ def live_climb(
                 # environments, and no dirty-tree check needed: eval writes
                 # are discarded with the worktree and the shas pin content.
                 merged_sha = ws.git("rev-parse", "HEAD").strip()
-                baseline = _measure_committed(
-                    ws, evaluator, run_dir, "fresh-base", fresh_base, bench
+                seed_env = (
+                    {bench.seed_env: str(result.run_seed)}
+                    if bench.seed_env and result.run_seed
+                    else None
                 )
-                candidate = _measure_committed(ws, evaluator, run_dir, "merged", merged_sha, bench)
+                baseline = _measure_committed(
+                    ws, evaluator, run_dir, "fresh-base", fresh_base, bench, seed_env
+                )
+                candidate = _measure_committed(
+                    ws, evaluator, run_dir, "merged", merged_sha, bench, seed_env
+                )
                 if not orch_improved(
                     baseline, candidate, bench.direction, config.min_relative_improvement
                 ):
@@ -412,6 +432,16 @@ def live_climb(
                     f"candidate {candidate} does not beat the recorded "
                     f"best {prior.best} by the noise floor (stale clone or eval noise)"
                 )
+            if prior is not None and not clears_min_delta(
+                prior.best, candidate, bench.direction, bench.min_delta
+            ):
+                # the recorded best was measured under a DIFFERENT seed:
+                # inside the declared floor, this delta is pool luck
+                raise NoiseFloored(
+                    f"candidate {candidate} is within the benchmark's cross-seed "
+                    f"noise floor (min_delta={bench.min_delta}) of the recorded "
+                    f"best {prior.best}"
+                )
             entries = update_leader(
                 load_leader(workspace),
                 benchmark=bench.name,
@@ -421,6 +451,7 @@ def live_climb(
                 candidate=candidate,
                 run_id=run_id,
                 date=created[:10],
+                run_seed=result.run_seed,
             )
             write_progress(
                 workspace,
@@ -485,6 +516,19 @@ def live_climb(
                     "pr_url": pr_url,
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
+                }
+            )
+        except NoiseFloored as exc:
+            # honest negative: the work was fine, the delta is not evidence
+            outcome_name = "no-improvement"
+            result = dc_replace(result, outcome="no-improvement", note=str(exc))
+            log.info("noise-floored for %s: %s", run_id, exc)
+            final = RunRecord(
+                **{
+                    **record.__dict__,
+                    "state": ENDED,
+                    "ending": NEGATIVE_RESULT,
+                    "ending_note": redact(str(exc), secrets)[:480],
                 }
             )
         except Exception as exc:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -252,17 +252,34 @@ def live_climb(
                     f"(benchmark `{config.benchmark}`). A report will follow here.",
                 )
 
-        result = climb_once(
-            config,
-            contract_text,
-            workspace,
-            harness,
-            evaluator,
-            ruler=RULER,
-            changed_paths=changed_paths,
-            created=created,
-            task_hypothesis=task_hypothesis,
-        )
+        # The baseline is measured in a throwaway worktree of the pre-session
+        # commit — the session never sees the directory the baseline eval ran
+        # in, so eval artifacts (even gitignored ones) cannot leak the run
+        # seed or the sampled pool into the solver's view.
+        baseline_wt = run_dir / "measure-baseline"
+        ws.git("worktree", "add", "--detach", str(baseline_wt), "HEAD")
+        try:
+            result = climb_once(
+                config,
+                contract_text,
+                workspace,
+                harness,
+                evaluator,
+                ruler=RULER,
+                changed_paths=changed_paths,
+                created=created,
+                task_hypothesis=task_hypothesis,
+                baseline_workspace=baseline_wt,
+            )
+        finally:
+            if not _best_effort(
+                "baseline worktree cleanup",
+                lambda: ws.git("worktree", "remove", "--force", str(baseline_wt)),
+            ):
+                import shutil
+
+                shutil.rmtree(baseline_wt, ignore_errors=True)
+                _best_effort("worktree prune", lambda: ws.git("worktree", "prune"))
     except Exception as exc:
         exc_name = type(exc).__name__
         note = redact(f"{exc_name}: {exc}", secrets)[:500]
@@ -425,23 +442,31 @@ def live_climb(
             # — read from the (possibly merged) tree, so the leader check runs
             # against the FRESH ledger, not the clone's snapshot.
             prior = load_leader(workspace).get(config.benchmark)
-            if prior is not None and not orch_improved(
-                prior.best, candidate, bench.direction, config.min_relative_improvement
-            ):
-                raise WorkspaceDrift(
-                    f"candidate {candidate} does not beat the recorded "
-                    f"best {prior.best} by the noise floor (stale clone or eval noise)"
+            if prior is not None:
+                rel_ok = orch_improved(
+                    prior.best, candidate, bench.direction, config.min_relative_improvement
                 )
-            if prior is not None and not clears_min_delta(
-                prior.best, candidate, bench.direction, bench.min_delta
-            ):
-                # the recorded best was measured under a DIFFERENT seed:
-                # inside the declared floor, this delta is pool luck
-                raise NoiseFloored(
-                    f"candidate {candidate} is within the benchmark's cross-seed "
-                    f"noise floor (min_delta={bench.min_delta}) of the recorded "
-                    f"best {prior.best}"
-                )
+                if bench.min_delta:
+                    # A resampled pool re-rolls between runs, so ANY
+                    # sub-floor delta over the recorded best — including
+                    # one below the relative threshold — is an expected
+                    # honest negative, never an anomaly (round-4 review
+                    # finding: the abort band contradicted the promise).
+                    if not rel_ok or not clears_min_delta(
+                        prior.best, candidate, bench.direction, bench.min_delta
+                    ):
+                        raise NoiseFloored(
+                            f"candidate {candidate} does not clear the recorded "
+                            f"best {prior.best} beyond the cross-seed noise "
+                            f"floor (min_delta={bench.min_delta})"
+                        )
+                elif not rel_ok:
+                    # fixed pool: the ledger says this run's own baseline
+                    # was stale — an anomaly worth a loud ending
+                    raise WorkspaceDrift(
+                        f"candidate {candidate} does not beat the recorded "
+                        f"best {prior.best} by the noise floor (stale clone or eval noise)"
+                    )
             entries = update_leader(
                 load_leader(workspace),
                 benchmark=bench.name,

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -18,7 +18,7 @@ from pathlib import PurePosixPath
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 SELF_REPO = "agentic-learning-ai-lab/autoresearch"
 ALWAYS_FORBIDDEN: tuple[str, ...] = (".github", ".autoresearch.yaml")
@@ -77,8 +77,22 @@ class Benchmark(_StrictModel):
     # fresh seed per measurement pass and pins BOTH sides of a comparison
     # to it (paired, common random numbers), then records it in the ledger
     # row — the number becomes re-derivable instead of pool luck. Strict
-    # env-var shape: this string reaches a subprocess environment.
+    # env-var shape: this string reaches a subprocess environment. RULER
+    # INVARIANT the eval must uphold: emit the seed to stdout only, never
+    # persist it into the tree — a seed artifact in the workspace would be
+    # readable by the solver session that runs between the paired evals
+    # (the verifier's ruler read covers this).
     seed_env: str | None = Field(default=None, pattern=r"^[A-Z][A-Z0-9_]{0,63}$")
+
+    @field_validator("seed_env")
+    @classmethod
+    def _seed_env_never_managed(cls, value: str | None) -> str | None:
+        from autoresearch.orchestrator import PROTECTED_EVAL_ENV
+
+        if value is not None and value in PROTECTED_EVAL_ENV:
+            raise ValueError(f"seed_env must not name the evaluator's managed variable {value!r}")
+        return value
+
     # Cross-seed noise floor in ABSOLUTE metric units (a resampled pool
     # re-rolls between runs; the steward's stated stderr belongs here,
     # e.g. ~2x). Comparisons against the RECORDED best — measured under a

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -87,10 +87,12 @@ class Benchmark(_StrictModel):
     @field_validator("seed_env")
     @classmethod
     def _seed_env_never_managed(cls, value: str | None) -> str | None:
-        from autoresearch.orchestrator import PROTECTED_EVAL_ENV
+        from autoresearch.orchestrator import managed_eval_env
 
-        if value is not None and value in PROTECTED_EVAL_ENV:
-            raise ValueError(f"seed_env must not name the evaluator's managed variable {value!r}")
+        if value is not None and managed_eval_env(value):
+            raise ValueError(
+                f"seed_env must not name or prefix the evaluator's managed environment ({value!r})"
+            )
         return value
 
     # Cross-seed noise floor in ABSOLUTE metric units (a resampled pool

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -72,6 +72,19 @@ class Benchmark(_StrictModel):
     # decision 2026-08-09). Display-only: comparisons always use full
     # floats, so this can never hide or fake an improvement.
     display_digits: int | None = Field(default=None, ge=2, le=12)
+    # Resampled-pool benchmarks: the env var the eval reads its run seed
+    # from (e.g. PILOT_REACH_SEED). When set, the orchestrator draws ONE
+    # fresh seed per measurement pass and pins BOTH sides of a comparison
+    # to it (paired, common random numbers), then records it in the ledger
+    # row — the number becomes re-derivable instead of pool luck. Strict
+    # env-var shape: this string reaches a subprocess environment.
+    seed_env: str | None = Field(default=None, pattern=r"^[A-Z][A-Z0-9_]{0,63}$")
+    # Cross-seed noise floor in ABSOLUTE metric units (a resampled pool
+    # re-rolls between runs; the steward's stated stderr belongs here,
+    # e.g. ~2x). Comparisons against the RECORDED best — measured under a
+    # different seed — must clear it on top of the relative threshold;
+    # same-seed paired comparisons are exempt by construction.
+    min_delta: float | None = Field(default=None, ge=0)
 
 
 class SuiteAggregate(_StrictModel):

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -489,8 +489,20 @@ def _respond(
                         # sub-floor delta over the recorded best is pool
                         # luck and must not ratchet the ledger (round-1
                         # review finding)
-                        if prior is not None and not clears_min_delta(
-                            prior.best, candidate, bench.direction, bench.min_delta
+                        # The floor explains only a delta that WOULD have
+                        # improved: an outright regression must read as a
+                        # regression (the `worse` flag), never as noise.
+                        beats_prior = prior is not None and (
+                            candidate > prior.best
+                            if bench.direction == "max"
+                            else candidate < prior.best
+                        )
+                        if (
+                            prior is not None
+                            and beats_prior
+                            and not clears_min_delta(
+                                prior.best, candidate, bench.direction, bench.min_delta
+                            )
                         ):
                             # named on the thread, like the climb's ending
                             # note — a silently unchanged ledger row reads

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -466,6 +466,7 @@ def _respond(
                         "changed during measurement, so it was not applied.)_"
                     )
                 else:
+                    floor_note = ""
                     if is_steward:
                         from autoresearch.steward import rebase_leader_row
 
@@ -488,9 +489,18 @@ def _respond(
                         # sub-floor delta over the recorded best is pool
                         # luck and must not ratchet the ledger (round-1
                         # review finding)
-                        if prior is None or clears_min_delta(
+                        if prior is not None and not clears_min_delta(
                             prior.best, candidate, bench.direction, bench.min_delta
                         ):
+                            # named on the thread, like the climb's ending
+                            # note — a silently unchanged ledger row reads
+                            # as a bug (review finding)
+                            floor_note = (
+                                f" — within the cross-seed noise floor "
+                                f"(min_delta={bench.min_delta}) of the recorded "
+                                f"best {prior.best}, so the ledger row is unchanged"
+                            )
+                        if not floor_note:
                             entries = update_leader(
                                 load_leader(workspace),
                                 benchmark=bench.name,
@@ -536,6 +546,7 @@ def _respond(
                             if worse
                             else ""
                         )
+                        + floor_note
                     )
 
     github.comment(record.target, number, f"{REPLY_MARKER}\n{reply_body}{measured_note}")

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, replace
 from pathlib import Path
+from secrets import randbits
 
 from autoresearch.brief import render_review_wake
 from autoresearch.contract import load_contract
@@ -427,13 +428,21 @@ def _respond(
             )
         else:
             pre_eval_tree = _tree_hash(ws)
+            # one fresh seed for this re-measure, recorded with the row —
+            # same pairing/reproducibility rule as the climb and steward
+            run_seed = randbits(31) if bench.seed_env else 0
+            seed_env = {bench.seed_env: str(run_seed)} if bench.seed_env and run_seed else None
             try:
                 if is_steward:
                     from autoresearch.steward import validate_and_measure
 
-                    candidate = validate_and_measure(workspace, contract, bench, evaluator)
+                    candidate = validate_and_measure(
+                        workspace, contract, bench, evaluator, run_seed=run_seed
+                    )
                 else:
-                    candidate = evaluator.evaluate(workspace, bench.command, bench.metric)
+                    candidate = evaluator.evaluate(
+                        workspace, bench.command, bench.metric, extra_env=seed_env
+                    )
             except Exception as exc:
                 ws.git("checkout", "--", ".")
                 ws.git("clean", "-fdq")
@@ -465,6 +474,7 @@ def _respond(
                             run_id,
                             created,
                             record.target,
+                            run_seed=run_seed,
                         )
                     else:
                         prior = load_leader(workspace).get(bench.name)
@@ -477,6 +487,7 @@ def _respond(
                             candidate=candidate,
                             run_id=run_id,
                             date=created[:10],
+                            run_seed=run_seed,
                         )
                         write_progress(
                             workspace,

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -17,13 +17,18 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, replace
 from pathlib import Path
-from secrets import randbits
 
 from autoresearch.brief import render_review_wake
 from autoresearch.contract import load_contract
 from autoresearch.github import GitHubClient, Workspace
 from autoresearch.harness import Harness, outage, redact
-from autoresearch.orchestrator import Evaluator, out_of_scope, steward_out_of_scope
+from autoresearch.orchestrator import (
+    Evaluator,
+    clears_min_delta,
+    draw_run_seed,
+    out_of_scope,
+    steward_out_of_scope,
+)
 from autoresearch.orchestrator import improved as orch_improved
 from autoresearch.progress import (
     PROGRESS_PATHS,
@@ -430,7 +435,7 @@ def _respond(
             pre_eval_tree = _tree_hash(ws)
             # one fresh seed for this re-measure, recorded with the row —
             # same pairing/reproducibility rule as the climb and steward
-            run_seed = randbits(31) if bench.seed_env else 0
+            run_seed = draw_run_seed() if bench.seed_env else 0
             seed_env = {bench.seed_env: str(run_seed)} if bench.seed_env and run_seed else None
             try:
                 if is_steward:
@@ -478,27 +483,35 @@ def _respond(
                         )
                     else:
                         prior = load_leader(workspace).get(bench.name)
-                        entries = update_leader(
-                            load_leader(workspace),
-                            benchmark=bench.name,
-                            metric=bench.metric,
-                            direction=bench.direction,
-                            baseline=candidate,  # pinned by existing entry if present
-                            candidate=candidate,
-                            run_id=run_id,
-                            date=created[:10],
-                            run_seed=run_seed,
-                        )
-                        write_progress(
-                            workspace,
-                            entries,
-                            record.target,
-                            digits={
-                                b.name: b.display_digits
-                                for b in contract.benchmarks
-                                if b.display_digits
-                            },
-                        )
+                        # cross-seed floor, same rule as the climb's publish
+                        # path: this re-measure ran under a FRESH seed, so a
+                        # sub-floor delta over the recorded best is pool
+                        # luck and must not ratchet the ledger (round-1
+                        # review finding)
+                        if prior is None or clears_min_delta(
+                            prior.best, candidate, bench.direction, bench.min_delta
+                        ):
+                            entries = update_leader(
+                                load_leader(workspace),
+                                benchmark=bench.name,
+                                metric=bench.metric,
+                                direction=bench.direction,
+                                baseline=candidate,  # pinned by existing entry
+                                candidate=candidate,
+                                run_id=run_id,
+                                date=created[:10],
+                                run_seed=run_seed,
+                            )
+                            write_progress(
+                                workspace,
+                                entries,
+                                record.target,
+                                digits={
+                                    b.name: b.display_digits
+                                    for b in contract.benchmarks
+                                    if b.display_digits
+                                },
+                            )
                     branch = _current_branch(ws)
                     verb = "steward" if is_steward else "agent"
                     ws.commit_all(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -21,6 +21,7 @@ import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
+from secrets import randbits
 from typing import Protocol
 
 from autoresearch.brief import BriefInputs, BudgetState, Task, build_brief, render
@@ -46,7 +47,9 @@ class EvalError(RuntimeError):
 class Evaluator(Protocol):
     """Runs a benchmark command in a workspace, returns the metric value."""
 
-    def evaluate(self, workspace: Path, command: str, metric: str) -> float: ...
+    def evaluate(
+        self, workspace: Path, command: str, metric: str, extra_env: dict[str, str] | None = None
+    ) -> float: ...
 
 
 @dataclass
@@ -66,7 +69,9 @@ class SubprocessEvaluator:
     container_image: str = ""
     apptainer_binary: str = "apptainer"
 
-    def evaluate(self, workspace: Path, command: str, metric: str) -> float:
+    def evaluate(
+        self, workspace: Path, command: str, metric: str, extra_env: dict[str, str] | None = None
+    ) -> float:
 
         # Throwaway HOME OUTSIDE the clone: never the orchestrator's real home
         # (it shelters the PAT), and never the workspace — eval cache/state
@@ -101,7 +106,7 @@ class SubprocessEvaluator:
             shutil.rmtree(eval_home, ignore_errors=True)
             raise EvalError(f"could not create eval cache dir: {exc}") from exc
         try:
-            return self._measure(workspace, command, metric, eval_home, cache_dir)
+            return self._measure(workspace, command, metric, eval_home, cache_dir, extra_env)
         finally:
             # bounded disk: each eval's home AND cache die with it
             # (re-downloading wheels per eval is the accepted isolation cost)
@@ -111,11 +116,26 @@ class SubprocessEvaluator:
             shutil.rmtree(cache_dir, ignore_errors=True)
 
     def _measure(
-        self, workspace: Path, command: str, metric: str, eval_home: Path, cache_dir: Path
+        self,
+        workspace: Path,
+        command: str,
+        metric: str,
+        eval_home: Path,
+        cache_dir: Path,
+        extra_env: dict[str, str] | None = None,
     ) -> float:
-        return self._parse_measured(self._run(workspace, command, eval_home, cache_dir), metric)
+        return self._parse_measured(
+            self._run(workspace, command, eval_home, cache_dir, extra_env), metric
+        )
 
-    def _run(self, workspace: Path, command: str, eval_home: Path, cache_dir: Path) -> str:
+    def _run(
+        self,
+        workspace: Path,
+        command: str,
+        eval_home: Path,
+        cache_dir: Path,
+        extra_env: dict[str, str] | None = None,
+    ) -> str:
         import os
         import signal
 
@@ -165,6 +185,13 @@ class SubprocessEvaluator:
             env["APPTAINERENV_UV_LINK_MODE"] = "copy"
             env["APPTAINERENV_UV_PROJECT_ENVIRONMENT"] = env["UV_PROJECT_ENVIRONMENT"]
         env["HOME"] = str(eval_home)
+        if extra_env:
+            # explicit injections only (the base env is a scrubbed
+            # allowlist): today this carries the benchmark's run seed
+            env.update(extra_env)
+            if self.container_image:
+                for key, value in extra_env.items():
+                    env[f"APPTAINERENV_{key}"] = value
         try:
             # process group, like the harness: a timed-out eval must not
             # leave orphans mutating a workspace that later gets committed
@@ -289,6 +316,9 @@ class ClimbResult:
     measured_paths: tuple[str, ...] = ()
     session: SessionResult | None = None
     note: str = ""
+    # the seed both measurements ran under (0 = benchmark has no seed_env):
+    # recorded in the ledger row so the number is re-derivable
+    run_seed: int = 0
 
     def report(self, config: ClimbConfig, redact_secrets: tuple[str, ...] = ()) -> str:
         lines = [
@@ -379,6 +409,21 @@ def steward_out_of_scope(paths: Sequence[str], contract: Contract) -> list[str]:
     return violations
 
 
+def clears_min_delta(
+    prior_best: float, candidate: float, direction: str, min_delta: float | None
+) -> bool:
+    """Cross-seed comparisons on a resampled pool must clear the
+    benchmark's ABSOLUTE noise floor: the recorded best was measured under
+    a different seed, so a delta inside the floor is pool luck, not
+    progress. Same-seed paired comparisons never call this."""
+    if not min_delta:
+        return True
+    if not (math.isfinite(prior_best) and math.isfinite(candidate)):
+        return False
+    delta = candidate - prior_best if direction == "max" else prior_best - candidate
+    return delta > min_delta
+
+
 def improved(baseline: float, candidate: float, direction: str, min_rel: float) -> bool:
     """Direction-aware, threshold-clearing improvement. Non-finite values
     never count (the evaluator rejects them; this is defense in depth)."""
@@ -440,7 +485,9 @@ def climb_once(
     # (architecture: "baseline re-run at the merge-base, not a trusted
     # static file").
     try:
-        baseline = evaluator.evaluate(workspace, bench.command, bench.metric)
+        run_seed = randbits(31) if bench.seed_env else 0
+        seed_env = {bench.seed_env: str(run_seed)} if bench.seed_env else None
+        baseline = evaluator.evaluate(workspace, bench.command, bench.metric, extra_env=seed_env)
     except EvalError as exc:
         return ClimbResult(outcome="eval-error", note=f"baseline: {exc}")
 
@@ -486,7 +533,11 @@ def climb_once(
         )
 
     try:
-        candidate = evaluator.evaluate(workspace, bench.command, bench.metric)
+        # SAME seed as the baseline: paired measurement (common random
+        # numbers) — the improvement claim compares like against like even
+        # on a resampled pool, and the seed is fresh per climb so nothing
+        # about the pool was knowable when the solver wrote its code
+        candidate = evaluator.evaluate(workspace, bench.command, bench.metric, extra_env=seed_env)
     except EvalError as exc:
         return ClimbResult(
             outcome="eval-error", baseline=baseline, session=session, note=f"candidate: {exc}"
@@ -500,6 +551,7 @@ def climb_once(
             session=session,
             branch=f"{config.branch_prefix}/{config.benchmark}",
             measured_paths=measured,
+            run_seed=run_seed,
         )
     return ClimbResult(
         outcome="no-improvement",
@@ -507,6 +559,7 @@ def climb_once(
         candidate=candidate,
         session=session,
         note="a negative result reported clearly is a success",
+        run_seed=run_seed,
     )
 
 

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -40,6 +40,13 @@ EVAL_TIMEOUT_S = 1800
 MAX_REPORT_BODY = 20_000
 
 
+# Environment keys the evaluator manages itself; a contract's seed_env may
+# never name one (validated at load; filtered again at injection).
+PROTECTED_EVAL_ENV = frozenset(
+    {"HOME", "PATH", "TMPDIR", "LANG", "UV_CACHE_DIR", "UV_LINK_MODE", "UV_PROJECT_ENVIRONMENT"}
+)
+
+
 class EvalError(RuntimeError):
     """The benchmark command failed or produced no readable metric."""
 
@@ -187,10 +194,16 @@ class SubprocessEvaluator:
         env["HOME"] = str(eval_home)
         if extra_env:
             # explicit injections only (the base env is a scrubbed
-            # allowlist): today this carries the benchmark's run seed
-            env.update(extra_env)
-            if self.container_image:
-                for key, value in extra_env.items():
+            # allowlist): today this carries the benchmark's run seed.
+            # Managed keys are dropped, never overwritten — the contract
+            # validator already rejects them, this is defense in depth
+            # (an injected HOME/UV_* would defeat per-eval isolation)
+            for key, value in extra_env.items():
+                if key in PROTECTED_EVAL_ENV:
+                    log.warning("refusing extra_env override of managed %s", key)
+                    continue
+                env[key] = value
+                if self.container_image:
                     env[f"APPTAINERENV_{key}"] = value
         try:
             # process group, like the harness: a timed-out eval must not
@@ -409,6 +422,12 @@ def steward_out_of_scope(paths: Sequence[str], contract: Contract) -> list[str]:
     return violations
 
 
+def draw_run_seed() -> int:
+    """A fresh measurement seed, never 0 — zero is the ledger's "no seed
+    recorded" sentinel, and the injection guards key off truthiness."""
+    return 1 + randbits(30)
+
+
 def clears_min_delta(
     prior_best: float, candidate: float, direction: str, min_delta: float | None
 ) -> bool:
@@ -485,7 +504,7 @@ def climb_once(
     # (architecture: "baseline re-run at the merge-base, not a trusted
     # static file").
     try:
-        run_seed = randbits(31) if bench.seed_env else 0
+        run_seed = draw_run_seed() if bench.seed_env else 0
         seed_env = {bench.seed_env: str(run_seed)} if bench.seed_env else None
         baseline = evaluator.evaluate(workspace, bench.command, bench.metric, extra_env=seed_env)
     except EvalError as exc:

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -42,14 +42,30 @@ MAX_REPORT_BODY = 20_000
 
 # Environment keys the evaluator manages itself; a contract's seed_env may
 # never name one (validated at load; filtered again at injection).
-PROTECTED_EVAL_ENV = frozenset({"HOME", "PATH", "TMPDIR", "LANG", "VIRTUAL_ENV"})
+PROTECTED_EVAL_ENV = frozenset(
+    {
+        "HOME",
+        "PATH",
+        "TMPDIR",
+        "LANG",
+        "VIRTUAL_ENV",
+        # interpreter/loader steering: a random-integer value cannot carry a
+        # payload, but a contract naming one of these would silently break
+        # every eval in a way that reads as measurement failure
+        "PYTHONPATH",
+        "PYTHONHOME",
+        "PYTHONSTARTUP",
+    }
+)
 # ...and whole families: any UV_* steers uv's env/cache resolution, and any
 # APPTAINERENV_* is translated into the CONTAINER's environment by apptainer
 # (APPTAINERENV_HOME becomes HOME inside), so exact-name checks cannot
 # enumerate them (review finding).
 # APPTAINER_* configures the HOST-side apptainer CLI (bind paths, home,
 # containment) — same family logic, different side of the boundary.
-PROTECTED_ENV_PREFIXES = ("UV_", "APPTAINERENV_", "APPTAINER_")
+# LD_/DYLD_ steer the dynamic loader; GIT_ redirects repo resolution.
+# (PYTHONHASHSEED stays allowed — it IS a seed, and a legitimate seed_env.)
+PROTECTED_ENV_PREFIXES = ("UV_", "APPTAINERENV_", "APPTAINER_", "LD_", "DYLD_", "GIT_")
 
 
 def managed_eval_env(name: str) -> bool:
@@ -498,6 +514,7 @@ def climb_once(
     recent_reports: tuple[str, ...] = (),
     created: str = "",
     task_hypothesis: str = "",
+    baseline_workspace: Path | None = None,
 ) -> ClimbResult:
     """One implement→evaluate→verify cycle in an existing clean workspace.
 
@@ -516,7 +533,13 @@ def climb_once(
     try:
         run_seed = draw_run_seed() if bench.seed_env else 0
         seed_env = {bench.seed_env: str(run_seed)} if bench.seed_env else None
-        baseline = evaluator.evaluate(workspace, bench.command, bench.metric, extra_env=seed_env)
+        # measured in the caller's pristine snapshot when one is given: any
+        # artifact the eval persists (a seed file, sampled instances) lands
+        # OUTSIDE the workspace the solver session sees next, so a pinned
+        # seed cannot become pool foreknowledge (round-4 review finding)
+        baseline = evaluator.evaluate(
+            baseline_workspace or workspace, bench.command, bench.metric, extra_env=seed_env
+        )
     except EvalError as exc:
         return ClimbResult(outcome="eval-error", note=f"baseline: {exc}")
 

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -42,9 +42,17 @@ MAX_REPORT_BODY = 20_000
 
 # Environment keys the evaluator manages itself; a contract's seed_env may
 # never name one (validated at load; filtered again at injection).
-PROTECTED_EVAL_ENV = frozenset(
-    {"HOME", "PATH", "TMPDIR", "LANG", "UV_CACHE_DIR", "UV_LINK_MODE", "UV_PROJECT_ENVIRONMENT"}
-)
+PROTECTED_EVAL_ENV = frozenset({"HOME", "PATH", "TMPDIR", "LANG", "VIRTUAL_ENV"})
+# ...and whole families: any UV_* steers uv's env/cache resolution, and any
+# APPTAINERENV_* is translated into the CONTAINER's environment by apptainer
+# (APPTAINERENV_HOME becomes HOME inside), so exact-name checks cannot
+# enumerate them (review finding).
+PROTECTED_ENV_PREFIXES = ("UV_", "APPTAINERENV_")
+
+
+def managed_eval_env(name: str) -> bool:
+    """True when injecting `name` could disturb the eval's own isolation."""
+    return name in PROTECTED_EVAL_ENV or name.startswith(PROTECTED_ENV_PREFIXES)
 
 
 class EvalError(RuntimeError):
@@ -199,7 +207,7 @@ class SubprocessEvaluator:
             # validator already rejects them, this is defense in depth
             # (an injected HOME/UV_* would defeat per-eval isolation)
             for key, value in extra_env.items():
-                if key in PROTECTED_EVAL_ENV:
+                if managed_eval_env(key):
                     log.warning("refusing extra_env override of managed %s", key)
                     continue
                 env[key] = value

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -47,7 +47,9 @@ PROTECTED_EVAL_ENV = frozenset({"HOME", "PATH", "TMPDIR", "LANG", "VIRTUAL_ENV"}
 # APPTAINERENV_* is translated into the CONTAINER's environment by apptainer
 # (APPTAINERENV_HOME becomes HOME inside), so exact-name checks cannot
 # enumerate them (review finding).
-PROTECTED_ENV_PREFIXES = ("UV_", "APPTAINERENV_")
+# APPTAINER_* configures the HOST-side apptainer CLI (bind paths, home,
+# containment) — same family logic, different side of the boundary.
+PROTECTED_ENV_PREFIXES = ("UV_", "APPTAINERENV_", "APPTAINER_")
 
 
 def managed_eval_env(name: str) -> bool:

--- a/src/autoresearch/progress.py
+++ b/src/autoresearch/progress.py
@@ -38,6 +38,10 @@ class LeaderEntry:
     best: float  # current best orchestrator-measured value
     best_run: str  # run id that set the best
     updated: str  # ISO date
+    # seed the best was measured under (0 = none recorded / fixed pool):
+    # with resampled pools, a bare scalar is not re-derivable — this plus
+    # the eval's seed_env makes the ledger number reproducible
+    run_seed: int = 0
 
 
 def load_leader(workspace: Path) -> dict[str, LeaderEntry]:
@@ -73,6 +77,7 @@ def update_leader(
     candidate: float,
     run_id: str,
     date: str,
+    run_seed: int = 0,
 ) -> dict[str, LeaderEntry]:
     """A new ledger with this run's improvement folded in. The baseline is
     pinned by the FIRST entry and never moves; best follows improvements."""
@@ -93,6 +98,7 @@ def update_leader(
         best=candidate,
         best_run=run_id,
         updated=date,
+        run_seed=run_seed,
     )
     return updated
 

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from secrets import randbits
 from typing import Any, Protocol
 
 from autoresearch.climb import (
@@ -44,7 +43,7 @@ from autoresearch.intake import (
     infer_benchmark,
     qualifying_issue,
 )
-from autoresearch.orchestrator import steward_out_of_scope
+from autoresearch.orchestrator import draw_run_seed, steward_out_of_scope
 from autoresearch.progress import (
     PROGRESS_PATHS,
     LeaderEntry,
@@ -530,7 +529,7 @@ def live_steward(
         # The steward's ruler, run by the ORCHESTRATOR (shared with the
         # steward follow-up path). One fresh seed for the measurement,
         # recorded in the re-based row: the new baseline is re-derivable.
-        run_seed = randbits(31) if getattr(bench, "seed_env", None) else 0
+        run_seed = draw_run_seed() if bench.seed_env else 0
         measured = validate_and_measure(workspace, contract, bench, evaluator, run_seed=run_seed)
 
         # drift protection identical to the climb: the committed tree must

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from secrets import randbits
 from typing import Any, Protocol
 
 from autoresearch.climb import (
@@ -145,7 +146,9 @@ Hard rules:
   to look like."""
 
 
-def validate_and_measure(workspace: Path, contract: Contract, bench: Any, evaluator: Any) -> float:
+def validate_and_measure(
+    workspace: Path, contract: Contract, bench: Any, evaluator: Any, run_seed: int = 0
+) -> float:
     """The steward's ruler, run by the ORCHESTRATOR: the full suite and the
     target benchmark must work on the edited env — and every OTHER
     benchmark's eval must still run (the steward may edit a shared harness;
@@ -155,7 +158,8 @@ def validate_and_measure(workspace: Path, contract: Contract, bench: Any, evalua
     for sibling in contract.benchmarks:
         if sibling.name != bench.name:
             evaluator.check(workspace, sibling.command)
-    return float(evaluator.evaluate(workspace, bench.command, bench.metric))
+    seed_env = {bench.seed_env: str(run_seed)} if bench.seed_env and run_seed else None
+    return float(evaluator.evaluate(workspace, bench.command, bench.metric, extra_env=seed_env))
 
 
 def rebase_leader_row(
@@ -167,6 +171,7 @@ def rebase_leader_row(
     run_id: str,
     created: str,
     target: str,
+    run_seed: int = 0,
 ) -> float:
     """Reset the benchmark's ledger row to the orchestrator's measurement;
     returns the PRIOR best (captured before the overwrite)."""
@@ -181,6 +186,7 @@ def rebase_leader_row(
         best=measured,
         best_run=f"baseline-{run_id}",
         updated=created[:10],
+        run_seed=run_seed,
     )
     write_progress(
         workspace,
@@ -522,8 +528,10 @@ def live_steward(
             )
 
         # The steward's ruler, run by the ORCHESTRATOR (shared with the
-        # steward follow-up path).
-        measured = validate_and_measure(workspace, contract, bench, evaluator)
+        # steward follow-up path). One fresh seed for the measurement,
+        # recorded in the re-based row: the new baseline is re-derivable.
+        run_seed = randbits(31) if getattr(bench, "seed_env", None) else 0
+        measured = validate_and_measure(workspace, contract, bench, evaluator, run_seed=run_seed)
 
         # drift protection identical to the climb: the committed tree must
         # be exactly the validated tree
@@ -539,7 +547,15 @@ def live_steward(
         # Orchestrator-authored record reset: the re-based benchmark's row
         # carries the orchestrator's own measurement, never a pasted number.
         prior_best = rebase_leader_row(
-            workspace, contract, config.benchmark, bench, measured, run_id, created, config.target
+            workspace,
+            contract,
+            config.benchmark,
+            bench,
+            measured,
+            run_id,
+            created,
+            config.target,
+            run_seed=run_seed,
         )
 
         branch = f"{STEWARD_BRANCH_PREFIX}/{run_id}"

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -85,8 +85,10 @@ class ScriptedHarness:
 @dataclass
 class QueueEvaluator:
     values: list[float] = field(default_factory=list)
+    seen_dirs: list = field(default_factory=list)
 
     def evaluate(self, workspace, command, metric, extra_env=None) -> float:
+        self.seen_dirs.append(Path(workspace))
         return self.values.pop(0)
 
 
@@ -590,6 +592,81 @@ def test_within_noise_floor_is_an_honest_negative(tmp_path, target_repo) -> None
     record = load_record(tmp_path / "state", "tsp-floor")
     assert record.ending == "negative-result"
     assert "noise floor" in record.ending_note and "min_delta" in record.ending_note
+
+
+def test_sub_threshold_delta_on_floored_benchmark_is_negative_not_abort(
+    tmp_path, target_repo
+) -> None:
+    """Round-4 finding: with min_delta declared, EVERY sub-floor delta over
+    the recorded best — including one below the relative threshold — is an
+    honest negative, not a stale-clone abort."""
+    import json as _json
+
+    _push_contract(
+        tmp_path,
+        target_repo,
+        CONTRACT.replace("    direction: min\n", "    direction: min\n    min_delta: 0.5\n", 1),
+        "subrel",
+    )
+    seed = tmp_path / "leaderseed2"
+    _git(tmp_path, "clone", "-q", str(target_repo), str(seed))
+    (seed / "results").mkdir(exist_ok=True)
+    (seed / "results" / "leader.json").write_text(
+        _json.dumps(
+            {
+                "tsp": {
+                    "benchmark": "tsp",
+                    "metric": "mean_tour_length",
+                    "direction": "min",
+                    "baseline": 13.876,
+                    "best": 12.0,
+                    "best_run": "r0",
+                    "updated": "d",
+                }
+            }
+        )
+    )
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "leader")
+    _git(seed, "push", "-q", "origin", "main")
+
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "w=11\n"},
+        values=[13.876, 11.999],  # 0.001 over best: below rel threshold AND floor
+        run_id="tsp-subrel",
+    )
+    assert outcome.outcome == "no-improvement"
+    assert github.prs == []
+    record = load_record(tmp_path / "state", "tsp-subrel")
+    assert record.ending == "negative-result"
+    assert "noise floor" in record.ending_note
+
+
+def test_baseline_eval_runs_outside_the_session_workspace(tmp_path, target_repo) -> None:
+    """The baseline is measured in a throwaway worktree of the pre-session
+    commit: eval artifacts (even gitignored) never land in the tree the
+    solver session sees, so a pinned seed cannot leak the pool."""
+    github = FakeGitHub()
+    evaluator = QueueEvaluator(values=[13.876, 13.1])
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-iso",
+        harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "w=5\n"}),
+        evaluator=evaluator,
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "improved"
+    ws = tmp_path / "state" / "runs" / "tsp-iso" / "ws"
+    baseline_dir, candidate_dir = evaluator.seen_dirs
+    assert baseline_dir.name == "measure-baseline" and baseline_dir != ws
+    assert candidate_dir == ws
+    assert not baseline_dir.exists()  # cleaned up with the run
 
 
 def test_seeded_climb_records_the_seed_in_the_ledger(tmp_path, target_repo) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -86,7 +86,7 @@ class ScriptedHarness:
 class QueueEvaluator:
     values: list[float] = field(default_factory=list)
 
-    def evaluate(self, workspace, command, metric) -> float:
+    def evaluate(self, workspace, command, metric, extra_env=None) -> float:
         return self.values.pop(0)
 
 
@@ -288,7 +288,7 @@ def test_files_written_during_eval_void_the_claim(tmp_path, target_repo) -> None
         values: list[float] = field(default_factory=list)
         calls: int = 0
 
-        def evaluate(self, workspace, command, metric) -> float:
+        def evaluate(self, workspace, command, metric, extra_env=None) -> float:
             self.calls += 1
             if self.calls == 2:  # during the candidate eval
                 (workspace / "src" / "pilot" / "solvers" / "planted.py").write_text("x=1\n")
@@ -410,7 +410,7 @@ def test_content_rewrite_during_eval_voids_the_claim(tmp_path, target_repo) -> N
         values: list[float] = field(default_factory=list)
         calls: int = 0
 
-        def evaluate(self, workspace, command, metric) -> float:
+        def evaluate(self, workspace, command, metric, extra_env=None) -> float:
             self.calls += 1
             if self.calls == 2:  # during candidate eval: rewrite the SAME file
                 (workspace / "src" / "pilot" / "solvers" / "tsp.py").write_text(
@@ -533,6 +533,90 @@ def test_not_beating_recorded_best_is_rejected_loudly(tmp_path, target_repo) -> 
         "does not beat the recorded best"
         in load_record(tmp_path / "state", "tsp-stale").ending_note
     )
+
+
+def _push_contract(tmp_path, target_repo, contract_text: str, name: str) -> None:
+    seed = tmp_path / f"contract-{name}"
+    _git(tmp_path, "clone", "-q", str(target_repo), str(seed))
+    (seed / ".autoresearch.yaml").write_text(contract_text)
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", name)
+    _git(seed, "push", "-q", "origin", "main")
+
+
+def test_within_noise_floor_is_an_honest_negative(tmp_path, target_repo) -> None:
+    """Beats the recorded best, but by less than min_delta: the recorded
+    best was measured under a DIFFERENT seed, so the delta is pool luck —
+    an honest negative result, never a PR and never an abort."""
+    import json as _json
+
+    _push_contract(
+        tmp_path,
+        target_repo,
+        CONTRACT.replace("    direction: min\n", "    direction: min\n    min_delta: 0.5\n", 1),
+        "floor",
+    )
+    seed = tmp_path / "leaderseed"
+    _git(tmp_path, "clone", "-q", str(target_repo), str(seed))
+    (seed / "results").mkdir(exist_ok=True)
+    (seed / "results" / "leader.json").write_text(
+        _json.dumps(
+            {
+                "tsp": {
+                    "benchmark": "tsp",
+                    "metric": "mean_tour_length",
+                    "direction": "min",
+                    "baseline": 13.876,
+                    "best": 12.0,
+                    "best_run": "r0",
+                    "updated": "d",
+                }
+            }
+        )
+    )
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "leader")
+    _git(seed, "push", "-q", "origin", "main")
+
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "w=9\n"},
+        values=[13.876, 11.8],  # beats best 12.0, but only by 0.2 < 0.5
+        run_id="tsp-floor",
+    )
+    assert outcome.outcome == "no-improvement"
+    assert github.prs == []
+    record = load_record(tmp_path / "state", "tsp-floor")
+    assert record.ending == "negative-result"
+    assert "noise floor" in record.ending_note and "min_delta" in record.ending_note
+
+
+def test_seeded_climb_records_the_seed_in_the_ledger(tmp_path, target_repo) -> None:
+    """The ledger row carries the seed the best was measured under: the
+    number becomes re-derivable instead of pool luck."""
+    import json as _json
+
+    _push_contract(
+        tmp_path,
+        target_repo,
+        CONTRACT.replace(
+            "    direction: min\n", "    direction: min\n    seed_env: PILOT_TSP_SEED\n", 1
+        ),
+        "seeded",
+    )
+    outcome, _github = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "w=8\n"},
+        values=[13.876, 13.1, 13.876, 13.1],  # climb pair + freshness pair
+        run_id="tsp-seeded",
+    )
+    assert outcome.outcome == "improved"
+    leader = _json.loads(
+        _git(target_repo, "show", "feat/auto/agent-01/tsp-seeded:results/leader.json")
+    )
+    assert leader["tsp"]["run_seed"] > 0
 
 
 def test_climb_error_still_writes_a_report(tmp_path, target_repo) -> None:
@@ -787,7 +871,7 @@ class DirCheckingEvaluator(QueueEvaluator):
 
     saw_agent_edit: list = field(default_factory=list)
 
-    def evaluate(self, workspace, command, metric) -> float:
+    def evaluate(self, workspace, command, metric, extra_env=None) -> float:
         solver = Path(workspace) / "src" / "pilot" / "solvers" / "tsp.py"
         self.saw_agent_edit.append(solver.exists() and "r=1" in solver.read_text())
         return super().evaluate(workspace, command, metric)

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -116,3 +116,40 @@ def test_empty_benchmarks_refused() -> None:
                 "roadmap": "README.md",
             }
         )
+
+
+def test_seed_env_accepts_env_var_names_only() -> None:
+    """seed_env reaches a subprocess environment: strict shape."""
+    from autoresearch.contract import load_contract
+
+    base = """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max, seed_env: %s}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    ok = load_contract(base % "PILOT_REACH_SEED", "org/pilot")
+    assert ok.benchmarks[0].seed_env == "PILOT_REACH_SEED"
+    import pytest
+
+    for bad in ("pilot_seed", "1SEED", '"SEED; rm -rf /"', '"A B"'):
+        with pytest.raises(ValueError):
+            load_contract(base % bad, "org/pilot")
+
+
+def test_min_delta_must_be_non_negative() -> None:
+    from autoresearch.contract import load_contract
+
+    base = """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max, min_delta: %s}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    assert load_contract(base % "0.10", "org/pilot").benchmarks[0].min_delta == 0.10
+    import pytest
+
+    with pytest.raises(ValueError):
+        load_contract(base % "-0.1", "org/pilot")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -169,6 +169,14 @@ roadmap: docs/roadmap.md
 """
     import pytest
 
-    for managed in ("HOME", "UV_PROJECT_ENVIRONMENT", "PATH", "UV_CACHE_DIR"):
+    for managed in (
+        "HOME",
+        "UV_PROJECT_ENVIRONMENT",
+        "PATH",
+        "UV_CACHE_DIR",
+        "VIRTUAL_ENV",
+        "APPTAINERENV_HOME",  # apptainer translates it INSIDE the container
+        "UV_ANYTHING_FUTURE",  # whole families, not enumerable names
+    ):
         with pytest.raises(ValueError):
             load_contract(base % managed, "org/pilot")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -178,6 +178,9 @@ roadmap: docs/roadmap.md
         "APPTAINERENV_HOME",  # apptainer translates it INSIDE the container
         "UV_ANYTHING_FUTURE",  # whole families, not enumerable names
         "APPTAINER_BINDPATH",  # host-side apptainer CLI configuration
+        "PYTHONPATH",
+        "LD_PRELOAD",
+        "GIT_DIR",
     ):
         with pytest.raises(ValueError):
             load_contract(base % managed, "org/pilot")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -153,3 +153,22 @@ roadmap: docs/roadmap.md
 
     with pytest.raises(ValueError):
         load_contract(base % "-0.1", "org/pilot")
+
+
+def test_seed_env_rejects_the_evaluators_managed_names() -> None:
+    """seed_env: UV_PROJECT_ENVIRONMENT (or HOME) would defeat per-eval
+    isolation; contracts are untrusted input, so the loader refuses."""
+    from autoresearch.contract import load_contract
+
+    base = """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max, seed_env: %s}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    import pytest
+
+    for managed in ("HOME", "UV_PROJECT_ENVIRONMENT", "PATH", "UV_CACHE_DIR"):
+        with pytest.raises(ValueError):
+            load_contract(base % managed, "org/pilot")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -177,6 +177,7 @@ roadmap: docs/roadmap.md
         "VIRTUAL_ENV",
         "APPTAINERENV_HOME",  # apptainer translates it INSIDE the container
         "UV_ANYTHING_FUTURE",  # whole families, not enumerable names
+        "APPTAINER_BINDPATH",  # host-side apptainer CLI configuration
     ):
         with pytest.raises(ValueError):
             load_contract(base % managed, "org/pilot")

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -272,6 +272,18 @@ def test_followup_row_update_respects_the_cross_seed_floor(review_run) -> None:
     (reply,) = github.posted
     assert "noise floor" in reply and "ledger row is unchanged" in reply
 
+    # an outright REGRESSION is reported as one — never blamed on the floor
+    record_r = load_record(root, "tsp-r1")
+    save_record(root, replace(record_r, followup_job_id=""), NOW)
+    github_r = FakeGitHub(comments=[member(150, "hm, try again")])
+    harness_r = ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2r\n"})
+    respond(root, github_r, harness=harness_r, evaluator=QueueEvaluator(values=[20.0]))
+    (reply_r,) = github_r.posted
+    assert "worse than" in reply_r
+    assert "noise floor" not in reply_r
+    row_r = _json.loads((ws / "results" / "leader.json").read_text())["tsp"]
+    assert row_r["best"] == 12.0  # best never regresses
+
     # a second round that CLEARS the floor moves the row and records the seed
     record = load_record(root, "tsp-r1")
     save_record(root, replace(record, followup_job_id=""), NOW)

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -116,7 +116,7 @@ class ResumingHarness:
 class QueueEvaluator:
     values: list = field(default_factory=list)
 
-    def evaluate(self, workspace, command, metric) -> float:
+    def evaluate(self, workspace, command, metric, extra_env=None) -> float:
         value = self.values.pop(0)
         if isinstance(value, Exception):
             raise value
@@ -561,7 +561,7 @@ class StewardEvaluatorFake:
     def check(self, workspace, command) -> None:
         self.checks.append(command)
 
-    def evaluate(self, workspace, command, metric) -> float:
+    def evaluate(self, workspace, command, metric, extra_env=None) -> float:
         return self.value
 
 

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -231,6 +231,55 @@ def test_rejected_solver_pr_notes_the_claim_is_held(review_run) -> None:
     assert "stays claimed" in body and "fresh" in body
 
 
+def test_followup_row_update_respects_the_cross_seed_floor(review_run) -> None:
+    """A follow-up re-measure runs under a FRESH seed: beating the recorded
+    best by less than min_delta is pool luck and must not ratchet the
+    ledger (round-1 finding) — while a clearing delta still moves the row
+    and records the seed it was measured under."""
+    import json as _json
+
+    root, _bare = review_run
+    ws = run_dir(root, "tsp-r1") / "ws"
+    floored = CONTRACT.replace(
+        "    direction: min\n",
+        "    direction: min\n    seed_env: PILOT_TSP_SEED\n    min_delta: 0.5\n",
+        1,
+    )
+    (ws / ".autoresearch.yaml").write_text(floored)
+    (ws / "results").mkdir(exist_ok=True)
+    prior_row = {
+        "tsp": {
+            "benchmark": "tsp",
+            "metric": "mean_tour_length",
+            "direction": "min",
+            "baseline": 13.876,
+            "best": 12.0,
+            "best_run": "r0",
+            "updated": "d",
+        }
+    }
+    (ws / "results" / "leader.json").write_text(_json.dumps(prior_row))
+    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "floor setup")
+
+    github = FakeGitHub(comments=[member(101, "try tightening the kick")])
+    harness = ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"})
+    outcome = respond(root, github, harness=harness, evaluator=QueueEvaluator(values=[11.8]))
+    assert outcome.action == "replied"
+    row = _json.loads((ws / "results" / "leader.json").read_text())["tsp"]
+    assert row["best"] == 12.0  # 0.2 inside the 0.5 floor: unchanged
+
+    # a second round that CLEARS the floor moves the row and records the seed
+    record = load_record(root, "tsp-r1")
+    save_record(root, replace(record, followup_job_id=""), NOW)
+    github2 = FakeGitHub(comments=[member(200, "one more push")])
+    harness2 = ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v3\n"})
+    outcome2 = respond(root, github2, harness=harness2, evaluator=QueueEvaluator(values=[11.4]))
+    assert outcome2.action == "replied"
+    row2 = _json.loads((ws / "results" / "leader.json").read_text())["tsp"]
+    assert row2["best"] == 11.4 and row2["run_seed"] > 0
+
+
 def test_session_outage_refunds_the_wake_attempt(review_run) -> None:
     """The tick bills a wake attempt at submit; a session the API refused
     gives it back and stamps the latch, so a dead key cannot burn a run's

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -268,6 +268,9 @@ def test_followup_row_update_respects_the_cross_seed_floor(review_run) -> None:
     assert outcome.action == "replied"
     row = _json.loads((ws / "results" / "leader.json").read_text())["tsp"]
     assert row["best"] == 12.0  # 0.2 inside the 0.5 floor: unchanged
+    # ...and the thread says WHY the row did not move (round-2 finding)
+    (reply,) = github.posted
+    assert "noise floor" in reply and "ledger row is unchanged" in reply
 
     # a second round that CLEARS the floor moves the row and records the seed
     record = load_record(root, "tsp-r1")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -53,9 +53,11 @@ class FakeEvaluator:
 
     values: list[float] = field(default_factory=list)
     calls: list[tuple[str, str]] = field(default_factory=list)
+    seen_env: list = field(default_factory=list)
 
-    def evaluate(self, workspace: Path, command: str, metric: str) -> float:
+    def evaluate(self, workspace: Path, command: str, metric: str, extra_env=None) -> float:
         self.calls.append((command, metric))
+        self.seen_env.append(dict(extra_env) if extra_env else None)
         value = self.values.pop(0)
         if isinstance(value, Exception):
             raise value
@@ -106,6 +108,54 @@ def test_direction_min_regression_is_no_improvement(tmp_path: Path) -> None:
 def test_noise_below_threshold_is_no_improvement(tmp_path: Path) -> None:
     result, _, _ = run_climb(tmp_path, [100.0, 99.9])  # 0.1% < 0.5% floor
     assert result.outcome == "no-improvement"
+
+
+SEEDED_CONTRACT = CONTRACT.replace(
+    "    direction: min\n",
+    "    direction: min\n    seed_env: PILOT_TSP_SEED\n    min_delta: 0.5\n",
+    1,
+)
+
+
+def test_seeded_benchmark_measures_both_sides_under_one_fresh_seed(tmp_path: Path) -> None:
+    """seed_env: the orchestrator draws ONE seed per climb, pins baseline
+    and candidate to it (paired), and reports it on the result for the
+    ledger — nothing about the pool was knowable when the solver wrote."""
+    harness = FakeHarness(result=ok_session())
+    evaluator = FakeEvaluator(values=[13.876, 13.10])
+    result = climb_once(
+        CONFIG,
+        SEEDED_CONTRACT,
+        tmp_path,
+        harness,
+        evaluator,
+        ruler="r",
+        changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+        created="2026-08-09T00:00:00Z",
+    )
+    assert result.outcome == "improved"
+    first, second = evaluator.seen_env
+    assert first is not None and set(first) == {"PILOT_TSP_SEED"}
+    assert first == second  # paired: common random numbers
+    assert result.run_seed == int(first["PILOT_TSP_SEED"]) > 0
+
+
+def test_unseeded_benchmark_injects_nothing(tmp_path: Path) -> None:
+    result, _, evaluator = run_climb(tmp_path, [13.876, 13.10])
+    assert evaluator.seen_env == [None, None]
+    assert result.run_seed == 0
+
+
+def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
+    from autoresearch.orchestrator import clears_min_delta
+
+    assert clears_min_delta(12.0, 11.4, "min", 0.5)  # 0.6 > 0.5
+    assert not clears_min_delta(12.0, 11.5, "min", 0.5)  # exactly at the floor
+    assert clears_min_delta(0.54, 0.65, "max", 0.10)
+    assert not clears_min_delta(0.54, 0.60, "max", 0.10)  # inside pool luck
+    assert clears_min_delta(12.0, 11.9, "min", None)  # no floor declared
+    assert clears_min_delta(12.0, 11.9, "min", 0)  # zero floor = no floor
+    assert not clears_min_delta(float("nan"), 11.9, "min", 0.5)
 
 
 def test_session_error_short_circuits_before_second_eval(tmp_path: Path) -> None:
@@ -216,6 +266,20 @@ def test_improved_rejects_nonfinite_and_zero_baseline_uses_absolute() -> None:
     assert not improved(1.0, float("inf"), "max", 0.005)
     assert not improved(0.0, 1e-12, "max", 0.005)  # absolute threshold at 0
     assert improved(0.0, 0.01, "max", 0.005)
+
+
+def test_subprocess_evaluator_injects_extra_env(tmp_path: Path) -> None:
+    """The seed reaches the eval subprocess (the base env is a scrubbed
+    allowlist, so injection must be explicit and is tested for real)."""
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    value = SubprocessEvaluator(timeout_s=30).evaluate(
+        tmp_path,
+        'printf \'{"m": %s}\\n\' "$PILOT_TSP_SEED"',
+        "m",
+        extra_env={"PILOT_TSP_SEED": "42"},
+    )
+    assert value == 42.0
 
 
 def test_subprocess_evaluator_real_run(tmp_path: Path) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -268,6 +268,29 @@ def test_improved_rejects_nonfinite_and_zero_baseline_uses_absolute() -> None:
     assert improved(0.0, 0.01, "max", 0.005)
 
 
+def test_draw_run_seed_never_returns_the_sentinel() -> None:
+    from autoresearch.orchestrator import draw_run_seed
+
+    for _ in range(64):
+        seed = draw_run_seed()
+        assert 1 <= seed <= 2**30  # 0 stays the "no seed recorded" sentinel
+
+
+def test_extra_env_cannot_override_managed_isolation_vars(tmp_path: Path) -> None:
+    """HOME/UV_* are the eval's isolation; a colliding injection is dropped
+    (the contract validator rejects such seed_env names — this is depth)."""
+    from autoresearch.orchestrator import SubprocessEvaluator
+
+    value = SubprocessEvaluator(timeout_s=30).evaluate(
+        tmp_path,
+        'if [ "$HOME" = "/tmp/hijack" ]; then printf \'{"m": 1}\'; '
+        'else printf \'{"m": %s}\' "$M_SEED"; fi',
+        "m",
+        extra_env={"HOME": "/tmp/hijack", "M_SEED": "7"},
+    )
+    assert value == 7.0
+
+
 def test_subprocess_evaluator_injects_extra_env(tmp_path: Path) -> None:
     """The seed reaches the eval subprocess (the base env is a scrubbed
     allowlist, so injection must be explicit and is tested for real)."""

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -25,3 +25,31 @@ def test_render_markdown_honors_per_benchmark_digits() -> None:
     assert "| 13.88 |" in md and "| 10.84 |" in md
     md_default = render_markdown(entries, "org/pilot")
     assert "13.8757" in md_default  # 6 sig figs
+
+
+def test_run_seed_round_trips_and_old_rows_load(tmp_path) -> None:
+    """New rows carry the seed they were measured under; ledgers written
+    before the field existed load with 0 (fixed pool / none recorded)."""
+    import json as _json
+
+    from autoresearch.progress import LEADER_FILE, load_leader, update_leader, write_progress
+
+    entries = update_leader(
+        {},
+        benchmark="reach",
+        metric="success_rate",
+        direction="max",
+        baseline=0.54,
+        candidate=0.54,
+        run_id="r1",
+        date="2026-08-09",
+        run_seed=123456789,
+    )
+    write_progress(tmp_path, entries, "org/pilot")
+    raw = _json.loads((tmp_path / LEADER_FILE).read_text())
+    assert raw["reach"]["run_seed"] == 123456789
+    assert load_leader(tmp_path)["reach"].run_seed == 123456789
+    # pre-field ledger: run_seed absent -> 0
+    del raw["reach"]["run_seed"]
+    (tmp_path / LEADER_FILE).write_text(_json.dumps(raw))
+    assert load_leader(tmp_path)["reach"].run_seed == 0

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -269,7 +269,7 @@ class CheckingEvaluator:
 
             raise EvalError(self.check_error)
 
-    def evaluate(self, workspace, command, metric) -> float:
+    def evaluate(self, workspace, command, metric, extra_env=None) -> float:
         return self.values.pop(0)
 
 
@@ -700,3 +700,28 @@ def test_orphaned_claims_are_released_for_dead_runs() -> None:
         )
         == 0
     )
+
+
+def test_rebase_row_records_the_measurement_seed(tmp_path) -> None:
+    """A re-based baseline on a resampled pool is re-derivable: the row
+    carries the seed the orchestrator measured under."""
+    import json as _json
+
+    from autoresearch.steward import rebase_leader_row
+
+    contract = load_contract(CONTRACT, "org/pilot")
+    bench = contract.benchmarks[0]
+    rebase_leader_row(
+        tmp_path,
+        contract,
+        bench.name,
+        bench,
+        14.9,
+        "steward-tsp-s",
+        "2026-08-09",
+        "org/pilot",
+        run_seed=987654321,
+    )
+    raw = _json.loads((tmp_path / "results" / "leader.json").read_text())
+    assert raw[bench.name]["run_seed"] == 987654321
+    assert raw[bench.name]["best_run"] == "baseline-steward-tsp-s"


### PR DESCRIPTION
Implements the verifier's measurement-gap finding on pilot #26 (the re-based reach baseline is a bare scalar nobody can reproduce, on a pool with ±0.051 stderr), generalized to every measurement path.

**`seed_env` (contract, per benchmark)** — names the env var the eval reads its run seed from (e.g. `PILOT_REACH_SEED`). The orchestrator draws one `secrets.randbits(31)` seed per measurement pass and pins both sides to it: climb baseline+candidate, both sides of the freshness re-measure, the steward re-base, and both follow-up re-measure paths. Paired comparisons (common random numbers) stay tight on resampled pools, the seed is unknowable at solver-authoring time, and the ledger row records it (`LeaderEntry.run_seed`) so the number is re-derivable. Injection is explicit — the eval env remains a scrubbed allowlist, with the seed mirrored via `APPTAINERENV_` when contained (tested for real through a subprocess).

**`min_delta` (contract, per benchmark, absolute units)** — the cross-seed noise floor, applied to the one comparison where two different seeds meet: candidate vs the *recorded* best. Inside the floor ends as `NoiseFloored` → an honest `no-improvement`/`negative-result` with the floor named in the note — not a PR, and pointedly not an abort. Direction-aware, strictly-greater; same-seed paired comparisons are exempt by construction.

After this merges, the pilot contract wants `seed_env: PILOT_REACH_SEED` + `min_delta: 0.10` on reach (per the steward's stated stderr ×2) — I'll prepare that contract PR separately; denoise's steward re-base from #25 can pick up seeds at its next touch.

Tests: paired-seed capture through `climb_once`, real subprocess env injection, live noise-floor negative (no PR, negative-result ending, floor in the note), seeded live climb writing `run_seed` into the pushed ledger, steward re-base row seed, contract validation (strict env-var shape — the string reaches a subprocess environment), ledger round-trip incl. pre-field rows. 422 pass; mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)