### PR TITLE
Follow-up jobs get the real turn budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Follow-up sessions now receive the raised turn budget: the tick passes
+  `--max-turns` (clamped by the contract's `session_max_turns`) to
+  follow-up jobs, and the CLI's fallback follows the harness ceiling
+  instead of a stale 40. A live steward follow-up burned its whole
+  session against the old default and produced nothing.
+
 ### Changed
 
 - Ledger numbers on resampled pools are re-derivable and noise-honest

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -626,7 +626,7 @@ def main() -> int:
     import time
 
     from autoresearch.github import FileTokenProvider
-    from autoresearch.harness import ClaudeCodeHarness
+    from autoresearch.harness import DEFAULT_MAX_TURNS, ClaudeCodeHarness
     from autoresearch.orchestrator import SubprocessEvaluator
 
     parser = argparse.ArgumentParser(description="Service one in-review run.")
@@ -636,7 +636,10 @@ def main() -> int:
     parser.add_argument("--uncontained", action="store_true")
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument("--model", default="claude-opus-5")
-    parser.add_argument("--max-turns", type=int, default=40)
+    # the tick passes the effective limit explicitly; this fallback follows
+    # the harness ceiling so a bare CLI run is never silently starved (a
+    # 40-turn default cost a live steward follow-up its whole session)
+    parser.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS)
     parser.add_argument("--bot-login", default="agentic-learning-bot")
     parser.add_argument(
         "--job-minutes",

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -33,6 +33,7 @@ from autoresearch.compute import (
     quote_command,
 )
 from autoresearch.disk import DEFAULT_MIN_FREE_BYTES, check_disk
+from autoresearch.harness import DEFAULT_MAX_TURNS
 from autoresearch.limits import EffectiveLimits, effective_limits
 from autoresearch.runstate import (
     ABORTED,
@@ -124,13 +125,23 @@ class FollowupSpec:
     home: Path  # AUTORESEARCH_HOME: cwd for the submitted job
     bot_login: str = "agentic-learning-bot"
     time_minutes: int = 90  # min()'d with the contract's followup_job_minutes
-    max_turns: int = 120  # session turn budget for follow-up jobs
+    max_turns: int = DEFAULT_MAX_TURNS  # session turn budget for follow-up jobs
     pat_file: str = ""  # forwarded to the job; "" = the followup CLI default
     key_file: str = ""
     target: str = ""  # the repo the intake pass scans for requested-lane issues
     # the STEWARD'S OWN key (role separation): the steward lane stays off
     # until the operator provisions it
     steward_key_file: str = ""
+
+
+def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: Any) -> FollowupSpec:
+    """Clamp the operator's follow-up spec by the contract's effective
+    limits. Turn budget clamps unconditionally (strictly-downward, like
+    all limits); walltime keeps its explicit-only override semantics."""
+    spec = replace(spec, max_turns=min(spec.max_turns, limits.session_max_turns))
+    if contract is not None and getattr(contract.budgets, "followup_job_minutes", None) is not None:
+        spec = replace(spec, time_minutes=min(spec.time_minutes, limits.followup_job_minutes))
+    return spec
 
 
 def service_in_review(
@@ -653,17 +664,7 @@ def tick(
         # set — and only DOWNWARD from the operator's spec value: strictly-
         # downward shaping must hold against operator config too, not just
         # against the module defaults.
-        # turn budget clamps unconditionally (strictly-downward, like all
-        # limits); walltime keeps its explicit-only override semantics
-        spec = replace(
-            followup_spec,
-            max_turns=min(followup_spec.max_turns, limits.session_max_turns),
-        )
-        if contract is not None and contract.budgets.followup_job_minutes is not None:
-            spec = replace(
-                spec,
-                time_minutes=min(spec.time_minutes, limits.followup_job_minutes),
-            )
+        spec = shape_followup_spec(followup_spec, limits, contract)
         ended, submitted = service_in_review(
             root,
             github,

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -140,9 +140,13 @@ def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: A
     a contract shapes spend downward, but an operator's deliberate config
     is never silently reduced by defaults (raising budgets is operator
     territory)."""
-    if contract is not None and getattr(contract.budgets, "session_max_turns", None) is not None:
+    if contract is None:
+        return spec
+    # direct attribute access: Budgets is our typed model, and a rename
+    # must fail loudly here, not silently stop shaping spend downward
+    if contract.budgets.session_max_turns is not None:
         spec = replace(spec, max_turns=min(spec.max_turns, limits.session_max_turns))
-    if contract is not None and getattr(contract.budgets, "followup_job_minutes", None) is not None:
+    if contract.budgets.followup_job_minutes is not None:
         spec = replace(spec, time_minutes=min(spec.time_minutes, limits.followup_job_minutes))
     return spec
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -136,9 +136,12 @@ class FollowupSpec:
 
 def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: Any) -> FollowupSpec:
     """Clamp the operator's follow-up spec by the contract's effective
-    limits. Turn budget clamps unconditionally (strictly-downward, like
-    all limits); walltime keeps its explicit-only override semantics."""
-    spec = replace(spec, max_turns=min(spec.max_turns, limits.session_max_turns))
+    limits. Both knobs clamp only when the contract EXPLICITLY sets them:
+    a contract shapes spend downward, but an operator's deliberate config
+    is never silently reduced by defaults (raising budgets is operator
+    territory)."""
+    if contract is not None and getattr(contract.budgets, "session_max_turns", None) is not None:
+        spec = replace(spec, max_turns=min(spec.max_turns, limits.session_max_turns))
     if contract is not None and getattr(contract.budgets, "followup_job_minutes", None) is not None:
         spec = replace(spec, time_minutes=min(spec.time_minutes, limits.followup_job_minutes))
     return spec

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -124,6 +124,7 @@ class FollowupSpec:
     home: Path  # AUTORESEARCH_HOME: cwd for the submitted job
     bot_login: str = "agentic-learning-bot"
     time_minutes: int = 90  # min()'d with the contract's followup_job_minutes
+    max_turns: int = 120  # session turn budget for follow-up jobs
     pat_file: str = ""  # forwarded to the job; "" = the followup CLI default
     key_file: str = ""
     target: str = ""  # the repo the intake pass scans for requested-lane issues
@@ -217,6 +218,8 @@ def service_in_review(
                 spec.bot_login,
                 "--job-minutes",
                 str(spec.time_minutes),
+                "--max-turns",
+                str(spec.max_turns),
             ]
             if spec.pat_file:
                 argv += ["--pat-file", spec.pat_file]
@@ -650,11 +653,16 @@ def tick(
         # set — and only DOWNWARD from the operator's spec value: strictly-
         # downward shaping must hold against operator config too, not just
         # against the module defaults.
-        spec = followup_spec
+        # turn budget clamps unconditionally (strictly-downward, like all
+        # limits); walltime keeps its explicit-only override semantics
+        spec = replace(
+            followup_spec,
+            max_turns=min(followup_spec.max_turns, limits.session_max_turns),
+        )
         if contract is not None and contract.budgets.followup_job_minutes is not None:
             spec = replace(
-                followup_spec,
-                time_minutes=min(followup_spec.time_minutes, limits.followup_job_minutes),
+                spec,
+                time_minutes=min(spec.time_minutes, limits.followup_job_minutes),
             )
         ended, submitted = service_in_review(
             root,

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -860,6 +860,83 @@ roadmap: docs/roadmap.md
     assert "--job-minutes 120" in wrap  # the job's own walltime, for the alarm
 
 
+def test_followup_jobs_carry_the_session_turn_budget(tmp_path: Path) -> None:
+    """The 40-turn CLI default silently starved a live steward follow-up
+    ($6 of session, zero output): the tick now passes --max-turns
+    explicitly, clamped by the contract's session_max_turns."""
+    from autoresearch.followup import REPLY_MARKER  # noqa: F401 (import sanity)
+    from autoresearch.tick import FollowupSpec, service_in_review
+
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="rev-t",
+            target="org/pilot",
+            task_title="t",
+            state="in-review",
+            pr_url="https://github.com/org/pilot/pull/9",
+        ),
+        now=NOW - 5000,
+    )
+
+    class G:
+        def get_pull_request(self, repo, number):
+            return {"state": "open", "merged": False}
+
+        def list_comments(self, repo, number, max_pages: int = 20):
+            return [
+                {
+                    "id": 101,
+                    "body": "please fix",
+                    "user": {"login": "renmengye"},
+                    "author_association": "OWNER",
+                }
+            ]
+
+        def list_pr_reviews(self, repo, number, max_pages: int = 10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages: int = 10):
+            return []
+
+    submitted: list[list[str]] = []
+
+    def runner(argv, timeout_s):
+        submitted.append(list(argv))
+        return CommandResult(0, "55\n", "")
+
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="a",
+        partition="p",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+        key_file="/k",
+    )
+    _, followups = service_in_review(tmp_path, G(), SlurmCompute(runner=runner), spec, NOW)
+    assert followups
+    wrap = submitted[0][-1]
+    assert "--max-turns 120" in wrap  # spec default = harness ceiling
+    # a spec shrunk by the tick's clamp is what lands in argv
+    submitted.clear()
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="rev-t",
+            target="org/pilot",
+            task_title="t",
+            state="in-review",
+            pr_url="https://github.com/org/pilot/pull/9",
+        ),
+        now=NOW - 5000,
+    )
+    _, followups = service_in_review(
+        tmp_path, G(), SlurmCompute(runner=runner), replace(spec, max_turns=25), NOW
+    )
+    assert followups and "--max-turns 25" in submitted[0][-1]
+
+
 def test_contract_followup_walltime_never_raises_operator_config(tmp_path: Path) -> None:
     """Strictly-downward holds against the OPERATOR's spec too: a contract
     asking for more follow-up walltime than the spec grants gets the spec."""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -963,6 +963,10 @@ roadmap: docs/roadmap.md
     greedy = load_contract(base % ", session_max_turns: 100000", "org/pilot")
     shaped = shape_followup_spec(spec, effective_limits(greedy.budgets), greedy)
     assert shaped.max_turns == 120 and shaped.time_minutes == 90
+    # a contract SILENT on turns never reduces deliberate operator config
+    silent = load_contract(base % "", "org/pilot")
+    raised = replace(spec, max_turns=200)
+    assert shape_followup_spec(raised, effective_limits(silent.budgets), silent).max_turns == 200
     # contract shrinking turns shrinks follow-ups too, walltime untouched
     frugal = load_contract(base % ", session_max_turns: 15", "org/pilot")
     shaped = shape_followup_spec(spec, effective_limits(frugal.budgets), frugal)

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -937,6 +937,45 @@ def test_followup_jobs_carry_the_session_turn_budget(tmp_path: Path) -> None:
     assert followups and "--max-turns 25" in submitted[0][-1]
 
 
+def test_shape_followup_spec_clamps_strictly_downward() -> None:
+    """The clamp itself, against untrusted contract values (round-1
+    finding: the argv test alone left the tick's clamp unverified)."""
+    from autoresearch.contract import load_contract
+    from autoresearch.limits import effective_limits
+    from autoresearch.tick import FollowupSpec, shape_followup_spec
+
+    base = """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets: {gpu_hours_per_run: 0, runs_per_week: 20%s}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="a",
+        partition="p",
+        run_root=Path("/tmp"),
+        image="i",
+        home=Path("/tmp"),
+    )
+    # contract asking for MORE turns than the ceiling gets the ceiling
+    greedy = load_contract(base % ", session_max_turns: 100000", "org/pilot")
+    shaped = shape_followup_spec(spec, effective_limits(greedy.budgets), greedy)
+    assert shaped.max_turns == 120 and shaped.time_minutes == 90
+    # contract shrinking turns shrinks follow-ups too, walltime untouched
+    frugal = load_contract(base % ", session_max_turns: 15", "org/pilot")
+    shaped = shape_followup_spec(spec, effective_limits(frugal.budgets), frugal)
+    assert shaped.max_turns == 15 and shaped.time_minutes == 90
+    # explicit followup walltime shrinks walltime
+    tight = load_contract(base % ", followup_job_minutes: 30", "org/pilot")
+    shaped = shape_followup_spec(spec, effective_limits(tight.budgets), tight)
+    assert shaped.time_minutes == 30
+    # no contract at all: pure defaults, nothing raised
+    shaped = shape_followup_spec(spec, effective_limits(None), None)
+    assert shaped.max_turns == 120 and shaped.time_minutes == 90
+
+
 def test_contract_followup_walltime_never_raises_operator_config(tmp_path: Path) -> None:
     """Strictly-downward holds against the OPERATOR's spec too: a contract
     asking for more follow-up walltime than the spec grants gets the spec."""


### PR DESCRIPTION
Found live: the steward follow-up on pilot #28 died at `error_max_turns` after 40 turns — the tick never passed `--max-turns` to follow-up jobs, so the followup CLI's `default=40` silently overrode everything #61 raised. Fix: `FollowupSpec.max_turns` (derived from `DEFAULT_MAX_TURNS`), passed in argv; `shape_followup_spec()` clamps both knobs when — and only when — the contract explicitly sets them, so a silent contract never reduces deliberate operator config. Tested from the spec through `service_in_review` to the sbatch argv, plus the clamp directly against greedy/frugal/silent/absent contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)