### PR TITLE
Advisory findings land inline on human PRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- The advisory reviewer posts human PRs as a GitHub review: findings
+  anchored to diff lines become resolvable inline threads (auto-marked
+  outdated on push), the marker/header/notes and any un-anchorable
+  findings stay in the review body, and the event is hard-coded COMMENT
+  — the client cannot approve or request changes. Explicit rounds on
+  bot PRs remain issue comments so they can ride into follow-up wakes;
+  round numbering spans both styles. REVIEW_INLINE=false restores the
+  single-comment style.
+
 ### Fixed
 
 - Follow-up sessions now receive the raised turn budget: the tick passes

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -544,6 +544,38 @@ class GitHubClient:
                 return
         self.comment(repo, issue_number, body)
 
+    def create_pr_review(
+        self,
+        repo: str,
+        number: int,
+        body: str,
+        comments: list[dict[str, Any]] | None = None,
+    ) -> None:
+        """Post a PR review with optional inline comments.
+
+        The event is hard-coded to COMMENT: this client must never be able
+        to approve or request changes — a Write-role bot review that blocks
+        or endorses would hand a model role the exact powers the
+        constitution denies it.
+        """
+        if self.dry_run:
+            log.info(
+                "[dry-run] review on %s#%s (%d chars, %d inline)",
+                repo,
+                number,
+                len(body),
+                len(comments or []),
+            )
+            return
+        payload: dict[str, Any] = {"body": body, "event": "COMMENT"}
+        if comments:
+            payload["comments"] = comments
+        self._request(
+            "POST",
+            f"/repos/{urllib.parse.quote(repo)}/pulls/{number}/reviews",
+            payload,
+        )
+
     def comment(self, repo: str, issue_number: int, body: str) -> None:
         if self.dry_run:
             log.info("[dry-run] comment on %s#%s (%d chars)", repo, issue_number, len(body))

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -283,24 +283,31 @@ def commentable_lines(diff: str) -> dict[str, set[int]]:
     lines: dict[str, set[int]] = {}
     current: str | None = None
     new_line = 0
+    remaining = 0  # new-side lines left in the open hunk: counting stops
+    # when the hunk is consumed, so inter-file headers ("diff --git",
+    # "index ...") can never inflate the previous file's anchor set
     for raw in diff.splitlines():
-        if raw.startswith("+++ b/"):
+        if raw.startswith("diff --git"):
+            current = None
+            remaining = 0
+        elif raw.startswith("+++ b/"):
             current = raw[6:]
             lines.setdefault(current, set())
+            remaining = 0
         elif raw.startswith("+++ "):
             current = None  # /dev/null (deleted file): no new side
         elif raw.startswith("@@") and current is not None:
             try:
-                new_line = int(raw.split("+", 1)[1].split(",")[0].split(" ")[0])
+                seg = raw.split("+", 1)[1].split(" ", 1)[0]
+                new_line = int(seg.split(",")[0])
+                remaining = int(seg.split(",")[1]) if "," in seg else 1
             except (IndexError, ValueError):
                 current = None
-                continue
-        elif current is not None and raw.startswith("+"):
-            lines[current].add(new_line)
+                remaining = 0
+        elif current is not None and remaining > 0 and not raw.startswith(("-", "\\")):
+            lines[current].add(new_line)  # added and context lines alike
             new_line += 1
-        elif current is not None and not raw.startswith(("-", "\\")):
-            lines[current].add(new_line)  # context lines are commentable too
-            new_line += 1
+            remaining -= 1
     return lines
 
 

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -287,13 +287,21 @@ def commentable_lines(diff: str) -> dict[str, set[int]]:
     # when the hunk is consumed, so inter-file headers ("diff --git",
     # "index ...") can never inflate the previous file's anchor set
     for raw in diff.splitlines():
+        if current is not None and remaining > 0:
+            # INSIDE a hunk every line is +/-/context/backslash, so headers
+            # are parsed only between hunks — an added line whose content
+            # begins with "++ b/" (arriving as "+++ b/...") cannot rebind
+            # the file mid-hunk (review finding: contributor-controlled)
+            if not raw.startswith(("-", "\\")):
+                lines[current].add(new_line)  # added and context lines alike
+                new_line += 1
+                remaining -= 1
+            continue
         if raw.startswith("diff --git"):
             current = None
-            remaining = 0
         elif raw.startswith("+++ b/"):
             current = raw[6:]
             lines.setdefault(current, set())
-            remaining = 0
         elif raw.startswith("+++ "):
             current = None  # /dev/null (deleted file): no new side
         elif raw.startswith("@@") and current is not None:
@@ -304,10 +312,6 @@ def commentable_lines(diff: str) -> dict[str, set[int]]:
             except (IndexError, ValueError):
                 current = None
                 remaining = 0
-        elif current is not None and remaining > 0 and not raw.startswith(("-", "\\")):
-            lines[current].add(new_line)  # added and context lines alike
-            new_line += 1
-            remaining -= 1
     return lines
 
 
@@ -357,8 +361,11 @@ def format_review(result: ReviewResult, diff: str) -> tuple[str, list[dict[str, 
     if not result.findings:
         lines.append("No defects found in this diff.")
         lines.append("")
-    elif inline and not body_findings:
-        lines.append("Findings are attached to the lines they concern.")
+    elif inline:
+        n = len(inline)
+        note = f"{n} finding{'s are' if n != 1 else ' is'} attached inline to the lines concerned"
+        note += "; the rest follow." if body_findings else "."
+        lines.append(note)
         lines.append("")
     for finding in body_findings:
         lines.append(_finding_paragraph(finding))

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -276,6 +276,91 @@ def review(
     return ReviewResult(findings=findings, notes=sanitize(data.get("notes", ""), MAX_DETAIL_CHARS))
 
 
+def commentable_lines(diff: str) -> dict[str, set[int]]:
+    """(file -> new-side line numbers present in the diff's hunks): the only
+    positions GitHub accepts inline review comments on. Findings outside
+    this map fall back to the review body instead of 422-ing the round."""
+    lines: dict[str, set[int]] = {}
+    current: str | None = None
+    new_line = 0
+    for raw in diff.splitlines():
+        if raw.startswith("+++ b/"):
+            current = raw[6:]
+            lines.setdefault(current, set())
+        elif raw.startswith("+++ "):
+            current = None  # /dev/null (deleted file): no new side
+        elif raw.startswith("@@") and current is not None:
+            try:
+                new_line = int(raw.split("+", 1)[1].split(",")[0].split(" ")[0])
+            except (IndexError, ValueError):
+                current = None
+                continue
+        elif current is not None and raw.startswith("+"):
+            lines[current].add(new_line)
+            new_line += 1
+        elif current is not None and not raw.startswith(("-", "\\")):
+            lines[current].add(new_line)  # context lines are commentable too
+            new_line += 1
+    return lines
+
+
+def _finding_paragraph(finding: Finding, with_ref: bool = True) -> str:
+    # backticks stripped: a file value containing one would close the code
+    # span and render attacker markdown inline
+    safe_file = finding.file.replace("`", "")
+    where = f"`{safe_file}`" + (f":{finding.line}" if finding.line else "")
+    ref = f" ({where}; {finding.confidence} confidence)" if with_ref else ""
+    summary = finding.summary.rstrip(".!?…")  # the template owns the period
+    # an odd backtick in the detail would pair with the reference's opening
+    # backtick and spill the path out of its code span
+    detail = finding.detail + ("`" if finding.detail.count("`") % 2 else "")
+    return f"**{summary}.** {detail}{ref}"
+
+
+_CONFIDENCE_ORDER = {"high": 0, "medium": 1, "low": 2}
+
+
+def format_review(result: ReviewResult, diff: str) -> tuple[str, list[dict[str, Any]]] | None:
+    """(review body, inline comments) for the Reviews API, or None.
+
+    Findings that anchor to a (file, line) present in the diff become
+    inline comments — resolvable threads that GitHub marks outdated when
+    the line changes; the rest stay in the body with their reference. The
+    body always carries the marker, header, and notes.
+    """
+    if result.skipped is not None:
+        return None
+    anchors = commentable_lines(diff)
+    inline: list[dict[str, Any]] = []
+    body_findings: list[Finding] = []
+    for finding in sorted(result.findings, key=lambda f: _CONFIDENCE_ORDER[f.confidence]):
+        if finding.line and finding.line in anchors.get(finding.file, ()):
+            inline.append(
+                {
+                    "path": finding.file,
+                    "line": finding.line,
+                    "side": "RIGHT",
+                    "body": f"{_finding_paragraph(finding, with_ref=False)}\n\n"
+                    f"*({finding.confidence} confidence)*",
+                }
+            )
+        else:
+            body_findings.append(finding)
+    lines = [MARKER, ADVISORY_HEADER, ""]
+    if not result.findings:
+        lines.append("No defects found in this diff.")
+        lines.append("")
+    elif inline and not body_findings:
+        lines.append("Findings are attached to the lines they concern.")
+        lines.append("")
+    for finding in body_findings:
+        lines.append(_finding_paragraph(finding))
+        lines.append("")
+    if result.notes:
+        lines += [result.notes]
+    return "\n".join(lines).rstrip() + "\n", inline
+
+
 def format_comment(result: ReviewResult) -> str | None:
     """Render the comment body, or None when there is nothing to post."""
     if result.skipped is not None:
@@ -288,18 +373,8 @@ def format_comment(result: ReviewResult) -> str | None:
         # Prose paragraphs, not bullet fragments (maintainer preference,
         # 2026-08-08): the human is the reader who needs readability; a
         # model relocating references does not.
-        order = {"high": 0, "medium": 1, "low": 2}
-        for finding in sorted(result.findings, key=lambda f: order[f.confidence]):
-            # backticks stripped: a file value containing one would close
-            # the code span and render attacker markdown inline
-            safe_file = finding.file.replace("`", "")
-            where = f"`{safe_file}`" + (f":{finding.line}" if finding.line else "")
-            ref = f"({where}; {finding.confidence} confidence)"
-            summary = finding.summary.rstrip(".!?…")  # the template owns the period
-            # an odd backtick in the detail would pair with the reference's
-            # opening backtick and spill the path out of its code span
-            detail = finding.detail + ("`" if finding.detail.count("`") % 2 else "")
-            lines.append(f"**{summary}.** {detail} {ref}")
+        for finding in sorted(result.findings, key=lambda f: _CONFIDENCE_ORDER[f.confidence]):
+            lines.append(_finding_paragraph(finding))
             lines.append("")
     if result.notes:
         lines += [result.notes]

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -141,18 +141,20 @@ def post_round_review(
     body: str,
     inline: list[dict],
     pr_data: dict,
+    fallback_body: str,
 ) -> str:
     """The Reviews-API sibling of post_round: body summary plus anchored
     inline comments, event COMMENT always (the client hard-codes it). A
-    posting failure falls back to a plain issue comment — anchor problems
-    must not cost the round."""
+    posting failure falls back to a plain issue comment carrying
+    fallback_body — the FULL single-comment rendering, because the review
+    body alone may say no more than "findings are attached" while the
+    findings live in the rejected inline payload."""
     stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
-    stamped = body.replace(marker, f"{marker}\n{stamp}", 1)
     try:
-        client.create_pr_review(repo, number, stamped, inline)
+        client.create_pr_review(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1), inline)
     except EXPECTED_FAILURES as exc:
         log.warning("inline review failed (%s); falling back to a comment", exc)
-        client.comment(repo, number, stamped)
+        client.comment(repo, number, fallback_body.replace(marker, f"{marker}\n{stamp}", 1))
     return round_label
 
 
@@ -250,11 +252,14 @@ def main() -> int:
             round_label = post_round(client, repo, number, MARKER, body, pr_data)
         else:
             rendered = format_review(result, diff)
-            if rendered is None:
+            full = format_comment(result)
+            if rendered is None or full is None:
                 log.info("nothing to post")
                 return 0
             body, inline = rendered
-            round_label = post_round_review(client, repo, number, MARKER, body, inline, pr_data)
+            round_label = post_round_review(
+                client, repo, number, MARKER, body, inline, pr_data, fallback_body=full
+            )
         log.info("posted advisory review (%s) on %s#%s", round_label, repo, number)
     except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
         log.warning("advisory review did not complete: %s: %s", type(exc).__name__, exc)

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -25,6 +25,7 @@ from autoresearch.review import (
     MAX_CONTEXT_FILES,
     PullRequest,
     format_comment,
+    format_review,
     pick_context_files,
     review,
     skip_reason,
@@ -99,29 +100,59 @@ def post_round(
     synchronize-triggered spam; runs are now only PR-open or an explicit
     label request, so volume is human-bounded.
     """
+    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
+    client.comment(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1))
+    return round_label
+
+
+def _round_stamp(
+    client: GitHubClient, repo: str, number: int, marker: str, pr_data: dict
+) -> tuple[str, str]:
+    """(stamp line, round label): prior rounds are counted across BOTH
+    issue comments and review bodies, so switching a role between posting
+    styles never resets its numbering."""
     head = pr_data.get("head")
     head_sha = str(head.get("sha", ""))[:8] if isinstance(head, dict) else ""
     # The round number is cosmetic: an EXPECTED failure counting prior
     # rounds must never cost the round itself. Programming errors still
     # propagate, per this module's policy.
     try:
-        prior = [
-            str(c.get("body", ""))
-            for c in client.list_comments(repo, number)
-            # STARTS WITH the marker: a quote-reply prefixes every line
-            # with "> ", so it cannot match — and this stays true for
-            # any posting identity (Actions token, GitHub App, or a
-            # self-hoster's machine-user PAT, which posts as type User)
-            if str(c.get("body", "")).lstrip().startswith(marker)
-        ]
+        bodies = [str(c.get("body", "")) for c in client.list_comments(repo, number)]
+        bodies += [str(r.get("body", "")) for r in client.list_pr_reviews(repo, number)]
+        # STARTS WITH the marker: a quote-reply prefixes every line with
+        # "> ", so it cannot match — and this stays true for any posting
+        # identity (Actions token, GitHub App, or a self-hoster's
+        # machine-user PAT, which posts as type User)
+        prior = [b for b in bodies if b.lstrip().startswith(marker)]
         round_label = f"**Round {len(prior) + 1}**"
         if head_sha and any(f"reviewed head `{head_sha}`" in b for b in prior):
             round_label += " (re-run on the same head)"
     except EXPECTED_FAILURES as exc:
         log.warning("could not count prior rounds: %s", exc)
         round_label = "**New round** (prior count unavailable)"
-    stamp = f"{round_label} — reviewed head `{head_sha or 'unknown'}`.\n\n"
-    client.comment(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1))
+    return f"{round_label} — reviewed head `{head_sha or 'unknown'}`.\n\n", round_label
+
+
+def post_round_review(
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    marker: str,
+    body: str,
+    inline: list[dict],
+    pr_data: dict,
+) -> str:
+    """The Reviews-API sibling of post_round: body summary plus anchored
+    inline comments, event COMMENT always (the client hard-codes it). A
+    posting failure falls back to a plain issue comment — anchor problems
+    must not cost the round."""
+    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
+    stamped = body.replace(marker, f"{marker}\n{stamp}", 1)
+    try:
+        client.create_pr_review(repo, number, stamped, inline)
+    except EXPECTED_FAILURES as exc:
+        log.warning("inline review failed (%s); falling back to a comment", exc)
+        client.comment(repo, number, stamped)
     return round_label
 
 
@@ -205,13 +236,25 @@ def main() -> int:
         if skip_reason(pr, bot_login, explicit) is None:
             pr = replace(pr, context_files=_gather_context(client, repo, number, pr_data))
         today = datetime.now(UTC).date().isoformat()
-        body = format_comment(
-            review(pr, completer, bot_login, today=today, explicit_request=explicit)
-        )
-        if body is None:
-            log.info("nothing to post")
-            return 0
-        round_label = post_round(client, repo, number, MARKER, body, pr_data)
+        result = review(pr, completer, bot_login, today=today, explicit_request=explicit)
+        # Human PRs get inline findings (resolvable threads, auto-outdated
+        # on push). Explicit rounds on BOT PRs stay issue comments: those
+        # ride into follow-up wakes as context, and the wake plumbing
+        # reads the issue-comment collection.
+        bot_authored = pr.author.strip().casefold() == bot_login.strip().casefold()
+        if bot_authored or os.environ.get("REVIEW_INLINE", "").strip().lower() == "false":
+            body = format_comment(result)
+            if body is None:
+                log.info("nothing to post")
+                return 0
+            round_label = post_round(client, repo, number, MARKER, body, pr_data)
+        else:
+            rendered = format_review(result, diff)
+            if rendered is None:
+                log.info("nothing to post")
+                return 0
+            body, inline = rendered
+            round_label = post_round_review(client, repo, number, MARKER, body, inline, pr_data)
         log.info("posted advisory review (%s) on %s#%s", round_label, repo, number)
     except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
         log.warning("advisory review did not complete: %s: %s", type(exc).__name__, exc)

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -210,6 +210,37 @@ def test_human_pr_review_is_inline_and_comment_event_only(monkeypatch) -> None:
     assert "Round 1" in posted["body"]
 
 
+def test_review_fallback_carries_the_full_findings(monkeypatch) -> None:
+    """If the Reviews API rejects the post, the fallback comment must carry
+    the findings themselves — not a body that says they are attached to
+    lines they never reached (round-1 finding)."""
+    import autoresearch.review_cli as cli
+    from autoresearch.github import GitHubError
+    from autoresearch.review import Finding, ReviewResult
+
+    class RefusingReviews(FakeReviewClient):
+        def create_pr_review(self, repo, number, body, comments=None):
+            raise GitHubError(422, "/reviews", "line outside diff")
+
+    fake_client = RefusingReviews()
+
+    def fake_review(pr, completer, bot_login, today=None, explicit_request=False):
+        return ReviewResult(
+            [Finding(file="x.py", line=2, confidence="high", summary="Bug", detail="Real.")],
+            notes="",
+        )
+
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
+    monkeypatch.setattr(cli, "review", fake_review)
+    monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
+    _cli_env(monkeypatch)
+    assert cli.main() == 0
+    (posted,) = fake_client.posted
+    assert posted.get("kind") != "review"  # plain comment fallback
+    assert "Bug" in posted["body"] and "`x.py`:2" in posted["body"]
+    assert "attached to the lines" not in posted["body"]
+
+
 def test_bot_pr_explicit_round_stays_an_issue_comment(monkeypatch) -> None:
     import autoresearch.review_cli as cli
     from autoresearch.review import Finding, ReviewResult

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -100,7 +100,7 @@ class FakeReviewClient:
         }
 
     def get_pull_request_diff(self, repo: str, number: int) -> str:
-        return "--- a/x.py\n+++ b/x.py\n"
+        return "--- a/x.py\n+++ b/x.py\n@@ -1,2 +1,3 @@\n line1\n+line2\n line3\n"
 
     def get_pull_request_files(self, repo: str, number: int, max_pages: int = 5) -> list[dict]:
         return [{"filename": "x.py", "status": "modified"}]
@@ -110,12 +110,25 @@ class FakeReviewClient:
         return "def f(): pass"
 
     def list_comments(self, repo: str, number: int, max_pages: int = 20) -> list[dict]:
-        return list(self.posted)
+        return [c for c in self.posted if c.get("kind") != "review"]
+
+    def list_pr_reviews(self, repo: str, number: int, max_pages: int = 10) -> list[dict]:
+        return [c for c in self.posted if c.get("kind") == "review"]
 
     def comment(self, repo: str, number: int, body: str) -> None:
         # deliberately type User: round counting must be identity-agnostic
         # (self-hosters post reviews with machine-user PATs)
         self.posted.append({"body": body, "user": {"type": "User"}})
+
+    def create_pr_review(self, repo: str, number: int, body: str, comments=None) -> None:
+        self.posted.append(
+            {
+                "body": body,
+                "user": {"type": "User"},
+                "kind": "review",
+                "inline": list(comments or []),
+            }
+        )
 
 
 def _cli_env(monkeypatch) -> None:
@@ -169,6 +182,76 @@ def test_skip_stub_posting_failure_is_swallowed(monkeypatch, caplog) -> None:
         CompleterError("x"),
     )
     assert "could not post the skip stub" in caplog.text
+
+
+def test_human_pr_review_is_inline_and_comment_event_only(monkeypatch) -> None:
+    """Human PRs get the Reviews-API round (body summary + anchored inline
+    findings); bot PRs under an explicit label stay issue comments so the
+    round can ride into follow-up wakes as context."""
+    import autoresearch.review_cli as cli
+    from autoresearch.review import Finding, ReviewResult
+
+    fake_client = FakeReviewClient()
+
+    def fake_review(pr, completer, bot_login, today=None, explicit_request=False):
+        return ReviewResult(
+            [Finding(file="x.py", line=2, confidence="high", summary="Bug", detail="Real.")],
+            notes="",
+        )
+
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
+    monkeypatch.setattr(cli, "review", fake_review)
+    monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
+    _cli_env(monkeypatch)
+    assert cli.main() == 0
+    (posted,) = fake_client.posted
+    assert posted["kind"] == "review"  # Reviews API, event hard-coded COMMENT
+    assert posted["inline"] and posted["inline"][0]["path"] == "x.py"
+    assert "Round 1" in posted["body"]
+
+
+def test_bot_pr_explicit_round_stays_an_issue_comment(monkeypatch) -> None:
+    import autoresearch.review_cli as cli
+    from autoresearch.review import Finding, ReviewResult
+
+    fake_client = FakeReviewClient(author="some-bot")  # PR author == bot login
+
+    def fake_review(pr, completer, bot_login, today=None, explicit_request=False):
+        return ReviewResult(
+            [Finding(file="x.py", line=2, confidence="high", summary="Bug", detail="Real.")],
+            notes="",
+        )
+
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: fake_client)
+    monkeypatch.setattr(cli, "review", fake_review)
+    monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
+    _cli_env(monkeypatch)
+    monkeypatch.setenv("REVIEW_EXPLICIT_REQUEST", "true")
+    assert cli.main() == 0
+    (posted,) = fake_client.posted
+    assert posted.get("kind") != "review"  # plain comment: wake context reads these
+
+
+def test_round_numbering_spans_comments_and_reviews(monkeypatch) -> None:
+    """Switching posting styles must not reset the round counter."""
+    import autoresearch.review_cli as cli
+    from autoresearch.review import MARKER
+
+    fake_client = FakeReviewClient()
+    fake_client.posted.append(
+        {"body": f"{MARKER}\nold round", "user": {"type": "User"}}  # issue-comment round
+    )
+    fake_client.posted.append(
+        {"body": f"{MARKER}\nolder", "user": {"type": "User"}, "kind": "review", "inline": []}
+    )
+    _stamp, label = cli._round_stamp(
+        fake_client,  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        MARKER,
+        {"head": {"sha": "abc"}},
+    )
+    assert label == "**Round 3**"
 
 
 def test_review_cli_threads_date_and_context(monkeypatch) -> None:

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -238,7 +238,7 @@ def test_review_fallback_carries_the_full_findings(monkeypatch) -> None:
     (posted,) = fake_client.posted
     assert posted.get("kind") != "review"  # plain comment fallback
     assert "Bug" in posted["body"] and "`x.py`:2" in posted["body"]
-    assert "attached to the lines" not in posted["body"]
+    assert "attached inline" not in posted["body"]
 
 
 def test_bot_pr_explicit_round_stays_an_issue_comment(monkeypatch) -> None:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -248,7 +248,28 @@ def test_format_review_splits_anchored_from_body() -> None:
     # the un-anchorable findings stay in the body, references intact
     assert "Stale doc" in body and "`src/other.py`:5" in body
     assert "Global" in body and "Bad add" not in body
+    assert "1 finding is attached inline to the lines concerned; the rest follow." in body
     assert body.lstrip().startswith(MARKER)
+
+
+def test_commentable_lines_survives_header_lookalike_content() -> None:
+    """An added line whose CONTENT starts with '++ b/' arrives as
+    '+++ b/...' and must not rebind the file mid-hunk (review finding:
+    file content is contributor-controlled)."""
+    from autoresearch.review import commentable_lines
+
+    tricky = (
+        "diff --git a/real.py b/real.py\n"
+        "--- a/real.py\n"
+        "+++ b/real.py\n"
+        "@@ -1,1 +1,3 @@\n"
+        " kept\n"
+        "+++ b/fake.py\n"  # added content: '++ b/fake.py'
+        "+normal\n"
+    )
+    lines = commentable_lines(tricky)
+    assert lines == {"real.py": {1, 2, 3}}
+    assert "fake.py" not in lines
 
 
 def test_format_review_all_anchored_says_so() -> None:
@@ -259,7 +280,7 @@ def test_format_review_all_anchored_says_so() -> None:
     assert rendered is not None
     body, inline = rendered
     assert len(inline) == 1
-    assert "attached to the lines they concern" in body
+    assert "1 finding is attached inline to the lines concerned." in body
 
 
 def test_commentable_lines_stops_at_file_boundaries() -> None:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -205,3 +205,58 @@ def test_backticked_filename_cannot_break_the_reference_span() -> None:
     # whatever remains of the path renders as inert code-span text
     assert "a](http://evil).py" in body  # inside the span, backtick-free
     assert "`a](http://evil).py`" in body
+
+
+DIFF = """\
+--- a/src/x.py
++++ b/src/x.py
+@@ -10,3 +10,4 @@
+ context_line_ten
+-removed_eleven
++added_eleven
++added_twelve
+ context_thirteen
+"""
+
+
+def test_commentable_lines_maps_the_new_side() -> None:
+    from autoresearch.review import commentable_lines
+
+    lines = commentable_lines(DIFF)
+    # new side: 10 (context), 11-12 (added), 13 (context); nothing else
+    assert lines == {"src/x.py": {10, 11, 12, 13}}
+
+
+def test_format_review_splits_anchored_from_body() -> None:
+    from autoresearch.review import Finding, ReviewResult, format_review
+
+    anchored = Finding(
+        file="src/x.py", line=11, confidence="high", summary="Bad add", detail="It breaks."
+    )
+    off_diff = Finding(
+        file="src/other.py", line=5, confidence="low", summary="Stale doc", detail="Old text."
+    )
+    no_line = Finding(
+        file="src/x.py", line=None, confidence="medium", summary="Global", detail="Everywhere."
+    )
+    rendered = format_review(ReviewResult([anchored, off_diff, no_line], notes=""), DIFF)
+    assert rendered is not None
+    body, inline = rendered
+    (item,) = inline
+    assert item["path"] == "src/x.py" and item["line"] == 11 and item["side"] == "RIGHT"
+    assert "Bad add" in item["body"] and "high confidence" in item["body"]
+    # the un-anchorable findings stay in the body, references intact
+    assert "Stale doc" in body and "`src/other.py`:5" in body
+    assert "Global" in body and "Bad add" not in body
+    assert body.lstrip().startswith(MARKER)
+
+
+def test_format_review_all_anchored_says_so() -> None:
+    from autoresearch.review import Finding, ReviewResult, format_review
+
+    f = Finding(file="src/x.py", line=12, confidence="low", summary="Nit", detail="Tiny.")
+    rendered = format_review(ReviewResult([f], notes=""), DIFF)
+    assert rendered is not None
+    body, inline = rendered
+    assert len(inline) == 1
+    assert "attached to the lines they concern" in body

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -260,3 +260,26 @@ def test_format_review_all_anchored_says_so() -> None:
     body, inline = rendered
     assert len(inline) == 1
     assert "attached to the lines they concern" in body
+
+
+def test_commentable_lines_stops_at_file_boundaries() -> None:
+    """Inter-file headers must not inflate the previous file's anchors
+    (review finding: they read as context lines past the last hunk)."""
+    from autoresearch.review import commentable_lines
+
+    two_files = (
+        "diff --git a/a.py b/a.py\n"
+        "--- a/a.py\n"
+        "+++ b/a.py\n"
+        "@@ -1,1 +1,2 @@\n"
+        " kept\n"
+        "+added\n"
+        "diff --git a/b.py b/b.py\n"
+        "index 123..456 100644\n"
+        "--- a/b.py\n"
+        "+++ b/b.py\n"
+        "@@ -5,1 +5,1 @@\n"
+        "+only\n"
+    )
+    lines = commentable_lines(two_files)
+    assert lines == {"a.py": {1, 2}, "b.py": {5}}  # headers counted nowhere


### PR DESCRIPTION
Maintainer request ("inline COMMENT + general body summary for now"). `format_review` splits findings by anchorability against a parsed diff line-map (new-side lines only — the positions GitHub accepts); anchored ones become inline comments with confidence tags, un-anchorable ones stay in the body with their usual references. `create_pr_review` hard-codes `event: COMMENT` so the client is structurally incapable of approving or blocking. `post_round_review` shares the round-stamp logic with `post_round`, counts prior rounds across issue comments *and* review bodies (style switches never reset numbering), and falls back to a plain comment if the Reviews API rejects the post. Scope: human PRs only — explicit rounds on bot PRs stay issue comments because follow-up wakes read that collection. Kill-switch: `REVIEW_INLINE=false`.

Verifier unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)