### PR TITLE
Every flight has a snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,7 @@ Versions follow [SemVer](https://semver.org).
   it was at submit time instead of the shared checkout the deploy step
   resets every tick — no more code swaps under queued jobs, and crashed
   flights leave their exact tree for forensics. Expired flights are
-  reaped after 72 h; snapshot failure falls back to the shared checkout.
-
-### Changed
+  reaped after 24 h; snapshot failure falls back to the shared checkout.
 
 - The advisory reviewer posts human PRs as a GitHub review: findings
   anchored to diff lines become resolvable inline threads (auto-marked

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Every flight has a snapshot: submitted jobs (climbs, stewardships,
+  intake, follow-ups) run from a detached worktree of the checkout as
+  it was at submit time instead of the shared checkout the deploy step
+  resets every tick — no more code swaps under queued jobs, and crashed
+  flights leave their exact tree for forensics. Expired flights are
+  reaped after 72 h; snapshot failure falls back to the shared checkout.
+
+### Changed
+
 - The advisory reviewer posts human PRs as a GitHub review: findings
   anchored to diff lines become resolvable inline threads (auto-marked
   outdated on push), the marker/header/notes and any un-anchorable

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -227,6 +227,15 @@ refused posts a skip stub on the thread under its own marker — an
 outage notice, not a round — because silence only visible in the
 Actions tab is not a defensible way to miss a verification.
 
+**Every flight has a snapshot.** Submitted jobs do not run from the
+shared checkout — the deploy step resets it at every tick, so a queued
+job could have its code swapped mid-flight. Each submission gets a
+detached worktree of the checkout as it was at submit time (`flights/`,
+beside the checkout); the job runs exactly the tree that submitted it,
+the tree survives for forensics after a crash or kill, and expired
+flights are reaped on a TTL. Snapshot failure falls back to the shared
+checkout — a snapshot must never ground the fleet.
+
 **The loop itself has no end state.** It pauses (sentinel) and resumes.
 Offboarding a target has a graceful path and a hard path: *graceful* — remove
 the contract; intake stops and in-flight runs drain to their natural endings

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -169,6 +169,20 @@ class SlurmCompute:
         state = result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
         return state if state else GONE
 
+    def active_commands(self) -> list[str]:
+        """The submit commands of this user's PENDING and RUNNING jobs.
+        Raises SlurmQueryError on failure — callers that delete things
+        keyed on this must treat blindness as "delete nothing"."""
+        try:
+            result = self.runner(
+                ["squeue", "--me", "--noheader", "-o", "%o"], self.command_timeout_s
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SlurmQueryError(f"squeue did not run: {exc}") from exc
+        if result.returncode != 0:
+            raise SlurmQueryError(f"squeue failed ({result.returncode}): {result.stderr.strip()}")
+        return [line for line in result.stdout.splitlines() if line.strip()]
+
     def cancel(self, job_id: str) -> None:
         """Cancel; idempotent (cancelling a finished job is not an error)."""
         if not job_id.isdigit():

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -169,19 +169,21 @@ class SlurmCompute:
         state = result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
         return state if state else GONE
 
-    def active_commands(self) -> list[str]:
-        """The submit commands of this user's PENDING and RUNNING jobs.
-        Raises SlurmQueryError on failure — callers that delete things
-        keyed on this must treat blindness as "delete nothing"."""
+    def active_job_names(self) -> list[str]:
+        """The names of this user's PENDING and RUNNING jobs. Names, not
+        commands: squeue's Command field is not guaranteed to carry --wrap
+        strings, while %j is always the submitted name. Raises
+        SlurmQueryError on failure — callers that delete things keyed on
+        this must treat blindness as "delete nothing"."""
         try:
             result = self.runner(
-                ["squeue", "--me", "--noheader", "-o", "%o"], self.command_timeout_s
+                ["squeue", "--me", "--noheader", "-o", "%j"], self.command_timeout_s
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
             raise SlurmQueryError(f"squeue did not run: {exc}") from exc
         if result.returncode != 0:
             raise SlurmQueryError(f"squeue failed ({result.returncode}): {result.stderr.strip()}")
-        return [line for line in result.stdout.splitlines() if line.strip()]
+        return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
     def cancel(self, job_id: str) -> None:
         """Cancel; idempotent (cancelling a finished job is not an error)."""

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -178,9 +178,15 @@ def flight_checkout(home: Path, name: str, now: float) -> Path:
         return home
 
 
-def _flight_command(home: Path, name: str, now: float, argv: list[str]) -> str:
-    """The job's shell command, cd'ing into a fresh flight snapshot."""
-    flight = flight_checkout(home, name, now)
+def _flight_command(home: Path, job_name: str, now: float, argv: list[str]) -> str:
+    """The job's shell command, cd'ing into a fresh flight snapshot.
+
+    The flight is named FROM the job name (one truncation rule, here) so
+    the reaper's pending-job immunity — live job name prefixes flight
+    name — holds by construction at every submit site. argv must contain
+    absolute paths only; every spec path is absolute by construction, and
+    a relative path would resolve inside a tree that is reaped later."""
+    flight = flight_checkout(home, job_name[:40], now)
     return f"cd {quote_command([str(flight)])} && {quote_command(argv)}"
 
 
@@ -220,8 +226,25 @@ def reap_flights(
                 timeout=60,
             )
             reaped += 1
-        except (OSError, subprocess.SubprocessError) as exc:
-            log.warning("could not reap flight %s: %s", entry.name, exc)
+        except (OSError, subprocess.SubprocessError):
+            # not a registered worktree (a half-created flight, or debris):
+            # remove the directory itself and prune the registry, or the
+            # entry warns forever without ever going away
+            import shutil
+
+            shutil.rmtree(entry, ignore_errors=True)
+            with contextlib.suppress(OSError, subprocess.SubprocessError):
+                subprocess.run(
+                    ["git", "-C", str(home), "worktree", "prune"],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=60,
+                )
+            if not entry.exists():
+                reaped += 1
+            else:
+                log.warning("could not reap flight %s", entry.name)
     return reaped
 
 
@@ -341,7 +364,7 @@ def service_in_review(
                     account=spec.account,
                     partition=spec.partition,
                     time_minutes=spec.time_minutes,
-                    command=_flight_command(spec.home, f"followup-{record.run_id}"[:40], now, argv),
+                    command=_flight_command(spec.home, f"followup-{record.run_id}"[:60], now, argv),
                     cpus=4,
                     mem="8G",
                 )
@@ -743,14 +766,19 @@ def tick(
         # expired flight snapshots die with their TTL, not with a human.
         # One home suffices: every lane's spec derives from followup_spec
         # via replace(), so all flights share this checkout's flights/ dir.
-        # Blind means delete nothing: if Slurm cannot list live jobs, no
-        # flight is reaped this tick.
-        with contextlib.suppress(Exception):
-            reaped = reap_flights(
-                followup_spec.home, now, live_job_names=compute.active_job_names()
-            )
-            if reaped:
-                log.info("reaped %d expired flight snapshot(s)", reaped)
+        # Blind means delete nothing — but only QUERY failures count as
+        # blindness; a compute backend missing the method is a programming
+        # error and propagates.
+        try:
+            live_names = compute.active_job_names()
+        except SlurmQueryError as exc:
+            log.warning("cannot list live jobs (%s); reaping no flights this tick", exc)
+            live_names = None
+        if live_names is not None:
+            with contextlib.suppress(Exception):
+                reaped = reap_flights(followup_spec.home, now, live_job_names=live_names)
+                if reaped:
+                    log.info("reaped %d expired flight snapshot(s)", reaped)
         # ONE contract fetch per tick feeds every lane: the requested and
         # self-initiated lanes need its benchmarks, and all three lanes now
         # take their session/job limits from its budgets — clamped by our
@@ -1015,7 +1043,7 @@ def service_self_initiated(
                 account=spec.account,
                 partition=spec.partition,
                 time_minutes=limits.climb_job_minutes,
-                command=_flight_command(spec.home, f"climb-{benchmark}"[:40], now, argv),
+                command=_flight_command(spec.home, f"climb-{benchmark}"[:60], now, argv),
                 cpus=4,
                 mem="8G",
             )
@@ -1128,7 +1156,7 @@ def service_steward(
                     account=spec.account,
                     partition=spec.partition,
                     time_minutes=limits.climb_job_minutes,
-                    command=_flight_command(spec.home, f"steward-{task.benchmark}"[:40], now, argv),
+                    command=_flight_command(spec.home, f"steward-issue-{task.number}", now, argv),
                     cpus=4,
                     mem="8G",
                 )
@@ -1234,7 +1262,7 @@ def service_intake(
                 account=spec.account,
                 partition=spec.partition,
                 time_minutes=limits.climb_job_minutes,
-                command=_flight_command(spec.home, f"issue-{task.number}", now, argv),
+                command=_flight_command(spec.home, f"climb-issue-{task.number}", now, argv),
                 cpus=4,
                 mem="8G",
             )

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -144,12 +144,14 @@ FLIGHT_TTL_S = 24 * 3600
 
 
 def flight_checkout(home: Path, name: str, now: float) -> Path:
-    """A detached git worktree of the checkout as it is RIGHT NOW, for one
-    submitted job to run from. The shared checkout is reset --hard at every
-    tick's deploy, so a queued job that cd's into it can have its code
-    swapped mid-flight; a flight runs the exact tree that submitted it, and
-    the tree survives for forensics after a crash. Failures fall back to
-    the shared checkout — a snapshot must never ground the fleet."""
+    """A detached git worktree of the checkout's HEAD commit, for one
+    submitted job to run from. The shared checkout is reset --hard at
+    every tick's deploy, so a queued job that cd's into it can have its
+    code swapped mid-flight; a flight pins the deployed commit, and the
+    tree survives for forensics after a crash. HEAD, deliberately:
+    uncommitted hand-edits in the shared checkout do not fly — only
+    deployed code does. Failures fall back to the shared checkout — a
+    snapshot must never ground the fleet."""
     flights = home.parent / "flights"
     try:
         flights.mkdir(parents=True, exist_ok=True)
@@ -186,31 +188,28 @@ def reap_flights(
     home: Path,
     now: float,
     ttl_s: float = FLIGHT_TTL_S,
-    live_commands: Sequence[str] = (),
+    live_job_names: Sequence[str] = (),
 ) -> int:
-    """Remove flight worktrees older than the TTL (their timestamp is in
-    the directory name) — UNLESS a pending or running job still references
-    the flight in its command. Queue wait is unbounded (GPU partitions can
-    pend for days), so age alone must never delete a tree a job will cd
-    into; the TTL is purely the forensics-retention window for flights no
-    job references anymore. Best-effort: a stubborn flight is logged, not
-    fatal."""
+    """Remove flight worktrees older than the TTL — age by directory
+    mtime, no name parsing — UNLESS a pending or running job's NAME
+    prefixes the flight's (flights are named after their job). Queue wait
+    is unbounded (GPU partitions can pend for days), so age alone must
+    never delete a tree a job will cd into; the TTL is purely the
+    forensics-retention window for flights whose job is gone. Name
+    matching is conservative: one live job name protects every flight it
+    prefixes. Best-effort: a stubborn flight is logged, not fatal."""
     flights = home.parent / "flights"
     if not flights.is_dir():
         return 0
     reaped = 0
     for entry in flights.iterdir():
-        if any(str(entry) in cmd for cmd in live_commands):
+        if any(name and entry.name.startswith(name[:40]) for name in live_job_names):
             continue  # a queued or running job still needs this tree
-        # name is <label>-<stamp> or <label>-<stamp>-<n>: the collision
-        # suffix is a single digit (2..5), so when the last two pieces are
-        # both numeric the larger-form second-to-last is the stamp
-        parts = entry.name.split("-")
-        digits = [piece for piece in parts if piece.isdigit()]
-        if not digits:
+        try:
+            age = now - entry.stat().st_mtime
+        except OSError:
             continue
-        stamp = int(digits[-2]) if len(digits) >= 2 and int(digits[-1]) < 100 else int(digits[-1])
-        if now - stamp < ttl_s:
+        if age < ttl_s:
             continue
         try:
             subprocess.run(
@@ -747,7 +746,9 @@ def tick(
         # Blind means delete nothing: if Slurm cannot list live jobs, no
         # flight is reaped this tick.
         with contextlib.suppress(Exception):
-            reaped = reap_flights(followup_spec.home, now, live_commands=compute.active_commands())
+            reaped = reap_flights(
+                followup_spec.home, now, live_job_names=compute.active_job_names()
+            )
             if reaped:
                 log.info("reaped %d expired flight snapshot(s)", reaped)
         # ONE contract fetch per tick feeds every lane: the requested and

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -19,9 +19,11 @@ import logging
 import os
 import socket
 import subprocess
+from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Protocol
+from uuid import uuid4
 
 from autoresearch.compute import (
     GONE,
@@ -153,12 +155,14 @@ def flight_checkout(home: Path, name: str, now: float) -> Path:
         flights.mkdir(parents=True, exist_ok=True)
         # same name in the same tick (e.g. two orders on one benchmark, or
         # truncation collisions) must get its own tree, not a silent
-        # fallback: suffix until free
+        # fallback: suffix until free, with a unique tail as the backstop
         target = flights / f"{name}-{int(now)}"
         for attempt in range(2, 6):
             if not target.exists():
                 break
             target = flights / f"{name}-{int(now)}-{attempt}"
+        if target.exists():
+            target = flights / f"{name}-{int(now)}-{uuid4().hex[:8]}"
         subprocess.run(
             ["git", "-C", str(home), "worktree", "add", "--detach", str(target)],
             check=True,
@@ -178,14 +182,26 @@ def _flight_command(home: Path, name: str, now: float, argv: list[str]) -> str:
     return f"cd {quote_command([str(flight)])} && {quote_command(argv)}"
 
 
-def reap_flights(home: Path, now: float, ttl_s: float = FLIGHT_TTL_S) -> int:
-    """Remove flight worktrees older than the TTL (their timestamp is in the
-    directory name). Best-effort: a stubborn flight is logged, not fatal."""
+def reap_flights(
+    home: Path,
+    now: float,
+    ttl_s: float = FLIGHT_TTL_S,
+    live_commands: Sequence[str] = (),
+) -> int:
+    """Remove flight worktrees older than the TTL (their timestamp is in
+    the directory name) — UNLESS a pending or running job still references
+    the flight in its command. Queue wait is unbounded (GPU partitions can
+    pend for days), so age alone must never delete a tree a job will cd
+    into; the TTL is purely the forensics-retention window for flights no
+    job references anymore. Best-effort: a stubborn flight is logged, not
+    fatal."""
     flights = home.parent / "flights"
     if not flights.is_dir():
         return 0
     reaped = 0
     for entry in flights.iterdir():
+        if any(str(entry) in cmd for cmd in live_commands):
+            continue  # a queued or running job still needs this tree
         # name is <label>-<stamp> or <label>-<stamp>-<n>: the collision
         # suffix is a single digit (2..5), so when the last two pieces are
         # both numeric the larger-form second-to-last is the stamp
@@ -728,8 +744,10 @@ def tick(
         # expired flight snapshots die with their TTL, not with a human.
         # One home suffices: every lane's spec derives from followup_spec
         # via replace(), so all flights share this checkout's flights/ dir.
+        # Blind means delete nothing: if Slurm cannot list live jobs, no
+        # flight is reaped this tick.
         with contextlib.suppress(Exception):
-            reaped = reap_flights(followup_spec.home, now)
+            reaped = reap_flights(followup_spec.home, now, live_commands=compute.active_commands())
             if reaped:
                 log.info("reaped %d expired flight snapshot(s)", reaped)
         # ONE contract fetch per tick feeds every lane: the requested and

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -18,6 +18,7 @@ import json
 import logging
 import os
 import socket
+import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any, Protocol
@@ -134,6 +135,67 @@ class FollowupSpec:
     steward_key_file: str = ""
 
 
+FLIGHT_TTL_S = 72 * 3600
+
+
+def flight_checkout(home: Path, name: str, now: float) -> Path:
+    """A detached git worktree of the checkout as it is RIGHT NOW, for one
+    submitted job to run from. The shared checkout is reset --hard at every
+    tick's deploy, so a queued job that cd's into it can have its code
+    swapped mid-flight; a flight runs the exact tree that submitted it, and
+    the tree survives for forensics after a crash. Failures fall back to
+    the shared checkout — a snapshot must never ground the fleet."""
+    flights = home.parent / "flights"
+    target = flights / f"{name}-{int(now)}"
+    try:
+        flights.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "-C", str(home), "worktree", "add", "--detach", str(target)],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        return target
+    except (OSError, subprocess.SubprocessError) as exc:
+        log.warning("flight snapshot failed for %s (%s); using the shared checkout", name, exc)
+        return home
+
+
+def _flight_command(home: Path, name: str, now: float, argv: list[str]) -> str:
+    """The job's shell command, cd'ing into a fresh flight snapshot."""
+    flight = flight_checkout(home, name, now)
+    return f"cd {quote_command([str(flight)])} && {quote_command(argv)}"
+
+
+def reap_flights(home: Path, now: float, ttl_s: float = FLIGHT_TTL_S) -> int:
+    """Remove flight worktrees older than the TTL (their timestamp is in the
+    directory name). Best-effort: a stubborn flight is logged, not fatal."""
+    flights = home.parent / "flights"
+    if not flights.is_dir():
+        return 0
+    reaped = 0
+    for entry in flights.iterdir():
+        try:
+            stamp = int(entry.name.rsplit("-", 1)[-1])
+        except ValueError:
+            continue
+        if now - stamp < ttl_s:
+            continue
+        try:
+            subprocess.run(
+                ["git", "-C", str(home), "worktree", "remove", "--force", str(entry)],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            reaped += 1
+        except (OSError, subprocess.SubprocessError) as exc:
+            log.warning("could not reap flight %s: %s", entry.name, exc)
+    return reaped
+
+
 def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: Any) -> FollowupSpec:
     """Clamp the operator's follow-up spec by the contract's effective
     limits. Both knobs clamp only when the contract EXPLICITLY sets them:
@@ -244,14 +306,13 @@ def service_in_review(
             key_file = spec.steward_key_file if is_steward else spec.key_file
             if key_file:
                 argv += ["--key-file", key_file]
-            command = quote_command(argv)
             job_id = compute.submit(
                 JobSpec(
                     job_name=f"followup-{record.run_id}"[:60],
                     account=spec.account,
                     partition=spec.partition,
                     time_minutes=spec.time_minutes,
-                    command=f"cd {quote_command([str(spec.home)])} && {command}",
+                    command=_flight_command(spec.home, f"followup-{record.run_id}"[:40], now, argv),
                     cpus=4,
                     mem="8G",
                 )
@@ -650,6 +711,11 @@ def tick(
     if not launch_ok:
         log.warning("disk preflight failed; launch lanes are OFF this tick")
     if github is not None and followup_spec is not None:
+        # expired flight snapshots die with their TTL, not with a human
+        with contextlib.suppress(Exception):
+            reaped = reap_flights(followup_spec.home, now)
+            if reaped:
+                log.info("reaped %d expired flight snapshot(s)", reaped)
         # ONE contract fetch per tick feeds every lane: the requested and
         # self-initiated lanes need its benchmarks, and all three lanes now
         # take their session/job limits from its budgets — clamped by our
@@ -914,7 +980,7 @@ def service_self_initiated(
                 account=spec.account,
                 partition=spec.partition,
                 time_minutes=limits.climb_job_minutes,
-                command=f"cd {quote_command([str(spec.home)])} && {quote_command(argv)}",
+                command=_flight_command(spec.home, f"climb-{benchmark}"[:40], now, argv),
                 cpus=4,
                 mem="8G",
             )
@@ -1027,7 +1093,7 @@ def service_steward(
                     account=spec.account,
                     partition=spec.partition,
                     time_minutes=limits.climb_job_minutes,
-                    command=f"cd {quote_command([str(spec.home)])} && {quote_command(argv)}",
+                    command=_flight_command(spec.home, f"steward-{task.benchmark}"[:40], now, argv),
                     cpus=4,
                     mem="8G",
                 )
@@ -1133,7 +1199,7 @@ def service_intake(
                 account=spec.account,
                 partition=spec.partition,
                 time_minutes=limits.climb_job_minutes,
-                command=f"cd {quote_command([str(spec.home)])} && {quote_command(argv)}",
+                command=_flight_command(spec.home, f"issue-{task.number}", now, argv),
                 cpus=4,
                 mem="8G",
             )

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -135,7 +135,10 @@ class FollowupSpec:
     steward_key_file: str = ""
 
 
-FLIGHT_TTL_S = 72 * 3600
+# Generous vs the ~2 h job walltimes plus queue wait, tight enough that
+# full trees + per-flight venvs cannot pile up for days (review finding);
+# same-day forensics is the norm, and the disk preflight is the backstop.
+FLIGHT_TTL_S = 24 * 3600
 
 
 def flight_checkout(home: Path, name: str, now: float) -> Path:
@@ -146,9 +149,16 @@ def flight_checkout(home: Path, name: str, now: float) -> Path:
     the tree survives for forensics after a crash. Failures fall back to
     the shared checkout — a snapshot must never ground the fleet."""
     flights = home.parent / "flights"
-    target = flights / f"{name}-{int(now)}"
     try:
         flights.mkdir(parents=True, exist_ok=True)
+        # same name in the same tick (e.g. two orders on one benchmark, or
+        # truncation collisions) must get its own tree, not a silent
+        # fallback: suffix until free
+        target = flights / f"{name}-{int(now)}"
+        for attempt in range(2, 6):
+            if not target.exists():
+                break
+            target = flights / f"{name}-{int(now)}-{attempt}"
         subprocess.run(
             ["git", "-C", str(home), "worktree", "add", "--detach", str(target)],
             check=True,
@@ -176,10 +186,14 @@ def reap_flights(home: Path, now: float, ttl_s: float = FLIGHT_TTL_S) -> int:
         return 0
     reaped = 0
     for entry in flights.iterdir():
-        try:
-            stamp = int(entry.name.rsplit("-", 1)[-1])
-        except ValueError:
+        # name is <label>-<stamp> or <label>-<stamp>-<n>: the collision
+        # suffix is a single digit (2..5), so when the last two pieces are
+        # both numeric the larger-form second-to-last is the stamp
+        parts = entry.name.split("-")
+        digits = [piece for piece in parts if piece.isdigit()]
+        if not digits:
             continue
+        stamp = int(digits[-2]) if len(digits) >= 2 and int(digits[-1]) < 100 else int(digits[-1])
         if now - stamp < ttl_s:
             continue
         try:
@@ -711,7 +725,9 @@ def tick(
     if not launch_ok:
         log.warning("disk preflight failed; launch lanes are OFF this tick")
     if github is not None and followup_spec is not None:
-        # expired flight snapshots die with their TTL, not with a human
+        # expired flight snapshots die with their TTL, not with a human.
+        # One home suffices: every lane's spec derives from followup_spec
+        # via replace(), so all flights share this checkout's flights/ dir.
         with contextlib.suppress(Exception):
             reaped = reap_flights(followup_spec.home, now)
             if reaped:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -998,9 +998,23 @@ def test_reap_flights_removes_only_expired(tmp_path: Path) -> None:
     old_flight = flight_checkout(home, "old", NOW - FLIGHT_TTL_S - 10)
     old_collided = flight_checkout(home, "old", NOW - FLIGHT_TTL_S - 10)  # -2 suffix
     fresh = flight_checkout(home, "fresh", NOW)
+    queued = flight_checkout(home, "queued", NOW - FLIGHT_TTL_S - 999)
     (home.parent / "flights" / "not-a-flight").mkdir()  # bad name: ignored
-    assert reap_flights(home, NOW) == 2
-    assert not old_flight.exists() and not old_collided.exists() and fresh.exists()
+    # a PENDING/RUNNING job's flight is immune regardless of age: GPU
+    # queues can pend past any TTL, and age alone must never strand a job
+    live = [f"cd {queued} && uv run python -m autoresearch.climb ..."]
+    assert reap_flights(home, NOW, live_commands=live) == 2
+    assert not old_flight.exists() and not old_collided.exists()
+    assert fresh.exists() and queued.exists()
+
+
+def test_flight_name_exhaustion_still_gets_a_unique_tree(tmp_path: Path) -> None:
+    from autoresearch.tick import flight_checkout
+
+    home = _git_home(tmp_path)
+    made = [flight_checkout(home, "same", NOW) for _ in range(7)]
+    assert len({str(m) for m in made}) == 7  # no silent fallback to home
+    assert all(m != home for m in made)
 
 
 def test_shape_followup_spec_clamps_strictly_downward() -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -995,15 +995,19 @@ def test_reap_flights_removes_only_expired(tmp_path: Path) -> None:
     from autoresearch.tick import FLIGHT_TTL_S, flight_checkout, reap_flights
 
     home = _git_home(tmp_path)
-    old_flight = flight_checkout(home, "old", NOW - FLIGHT_TTL_S - 10)
-    old_collided = flight_checkout(home, "old", NOW - FLIGHT_TTL_S - 10)  # -2 suffix
+    import os as _os
+
+    old_flight = flight_checkout(home, "old", NOW)
+    old_collided = flight_checkout(home, "old", NOW)  # -2 suffix
     fresh = flight_checkout(home, "fresh", NOW)
-    queued = flight_checkout(home, "queued", NOW - FLIGHT_TTL_S - 999)
-    (home.parent / "flights" / "not-a-flight").mkdir()  # bad name: ignored
+    queued = flight_checkout(home, "climb-nav", NOW)
+    stale = NOW - FLIGHT_TTL_S - 10
+    for d in (old_flight, old_collided, queued):
+        _os.utime(d, (stale, stale))  # age is mtime, not name parsing
+    (home.parent / "flights" / "not-a-flight").mkdir()  # ignored: fresh mtime
     # a PENDING/RUNNING job's flight is immune regardless of age: GPU
     # queues can pend past any TTL, and age alone must never strand a job
-    live = [f"cd {queued} && uv run python -m autoresearch.climb ..."]
-    assert reap_flights(home, NOW, live_commands=live) == 2
+    assert reap_flights(home, NOW, live_job_names=["climb-nav"]) == 2
     assert not old_flight.exists() and not old_collided.exists()
     assert fresh.exists() and queued.exists()
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -982,6 +982,9 @@ def test_flight_snapshot_survives_a_deploy_reset(tmp_path: Path) -> None:
         check=True,
     )
     assert (flight / "marker.txt").read_text() == "v1\n"
+    # a same-tick name collision gets its own tree, not a silent fallback
+    second = flight_checkout(home, "climb-tsp", NOW)
+    assert second != flight and second.name.endswith("-2") and second.exists()
     # and failure falls back to the shared checkout, never grounding the job
     bare = tmp_path / "notarepo"
     bare.mkdir()
@@ -993,10 +996,11 @@ def test_reap_flights_removes_only_expired(tmp_path: Path) -> None:
 
     home = _git_home(tmp_path)
     old_flight = flight_checkout(home, "old", NOW - FLIGHT_TTL_S - 10)
+    old_collided = flight_checkout(home, "old", NOW - FLIGHT_TTL_S - 10)  # -2 suffix
     fresh = flight_checkout(home, "fresh", NOW)
     (home.parent / "flights" / "not-a-flight").mkdir()  # bad name: ignored
-    assert reap_flights(home, NOW) == 1
-    assert not old_flight.exists() and fresh.exists()
+    assert reap_flights(home, NOW) == 2
+    assert not old_flight.exists() and not old_collided.exists() and fresh.exists()
 
 
 def test_shape_followup_spec_clamps_strictly_downward() -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -45,6 +45,8 @@ class FakeSlurm:
         if argv[0] == "scancel":
             self.cancelled.append(argv[1])
             return CommandResult(0, "", "")
+        if argv[0] == "squeue":
+            return CommandResult(0, "", "")  # no live jobs
         raise AssertionError(f"unexpected command {argv}")
 
     def compute(self) -> SlurmCompute:
@@ -503,6 +505,8 @@ def test_service_in_review_ends_merged_runs(tmp_path: Path) -> None:
     )
 
     def unused_runner(argv, timeout_s):
+        if argv[0] == "squeue":  # the flight reaper's liveness query
+            return CommandResult(0, "", "")
         raise AssertionError("no slurm calls expected")
 
     ended, _submitted = service_in_review(
@@ -661,6 +665,8 @@ def test_disk_preflight_gates_launch_lanes(tmp_path: Path) -> None:
     )
 
     def unused_runner(argv, timeout_s):
+        if argv[0] == "squeue":  # the flight reaper's liveness query
+            return CommandResult(0, "", "")
         raise AssertionError("no slurm calls expected")
 
     report = tick(
@@ -1010,6 +1016,22 @@ def test_reap_flights_removes_only_expired(tmp_path: Path) -> None:
     assert reap_flights(home, NOW, live_job_names=["climb-nav"]) == 2
     assert not old_flight.exists() and not old_collided.exists()
     assert fresh.exists() and queued.exists()
+
+
+def test_reap_clears_non_worktree_debris(tmp_path: Path) -> None:
+    """A half-created flight (not a registered worktree) must still go
+    away instead of warning forever."""
+    import os as _os
+
+    from autoresearch.tick import FLIGHT_TTL_S, reap_flights
+
+    home = _git_home(tmp_path)
+    debris = home.parent / "flights" / "climb-x-123"
+    debris.mkdir(parents=True)
+    stale = NOW - FLIGHT_TTL_S - 10
+    _os.utime(debris, (stale, stale))
+    assert reap_flights(home, NOW) == 1
+    assert not debris.exists()
 
 
 def test_flight_name_exhaustion_still_gets_a_unique_tree(tmp_path: Path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 
@@ -935,6 +936,67 @@ def test_followup_jobs_carry_the_session_turn_budget(tmp_path: Path) -> None:
         tmp_path, G(), SlurmCompute(runner=runner), replace(spec, max_turns=25), NOW
     )
     assert followups and "--max-turns 25" in submitted[0][-1]
+
+
+def _git_home(tmp_path: Path) -> Path:
+    home = tmp_path / "checkout"
+    home.mkdir()
+    (home / "marker.txt").write_text("v1\n")
+    subprocess.run(["git", "-C", str(home), "init", "-q", "-b", "main"], check=True)
+    subprocess.run(
+        ["git", "-C", str(home), "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(home), "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "s"],
+        check=True,
+    )
+    return home
+
+
+def test_flight_snapshot_survives_a_deploy_reset(tmp_path: Path) -> None:
+    """A submitted job runs the tree that SUBMITTED it: the shared checkout
+    is reset --hard at every deploy, and the flight must not move with it."""
+    from autoresearch.tick import _flight_command, flight_checkout
+
+    home = _git_home(tmp_path)
+    cmd = _flight_command(home, "climb-tsp", NOW, ["echo", "hi"])
+    assert "flights/climb-tsp-" in cmd and "echo hi" in cmd
+    flight = next((home.parent / "flights").iterdir())
+    assert (flight / "marker.txt").read_text() == "v1\n"
+    # deploy rewrites the shared checkout; the flight keeps its tree
+    (home / "marker.txt").write_text("v2\n")
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(home),
+            "-c",
+            "user.name=t",
+            "-c",
+            "user.email=t@t",
+            "commit",
+            "-aqm",
+            "d",
+        ],
+        check=True,
+    )
+    assert (flight / "marker.txt").read_text() == "v1\n"
+    # and failure falls back to the shared checkout, never grounding the job
+    bare = tmp_path / "notarepo"
+    bare.mkdir()
+    assert flight_checkout(bare, "x", NOW) == bare
+
+
+def test_reap_flights_removes_only_expired(tmp_path: Path) -> None:
+    from autoresearch.tick import FLIGHT_TTL_S, flight_checkout, reap_flights
+
+    home = _git_home(tmp_path)
+    old_flight = flight_checkout(home, "old", NOW - FLIGHT_TTL_S - 10)
+    fresh = flight_checkout(home, "fresh", NOW)
+    (home.parent / "flights" / "not-a-flight").mkdir()  # bad name: ignored
+    assert reap_flights(home, NOW) == 1
+    assert not old_flight.exists() and fresh.exists()
 
 
 def test_shape_followup_spec_clamps_strictly_downward() -> None:


### PR DESCRIPTION
Maintainer-endorsed ("every flight has a snapshot just in case"). All four submit sites route through `_flight_command`: a detached git worktree of the checkout's HEAD at submit time, so a queued job can't have its code swapped by the next tick's deploy and a crashed flight leaves its exact tree behind. Reaping is job-aware and conservative: a flight whose job name is still PENDING/RUNNING is immune regardless of age (GPU queues can pend past any TTL); unreferenced flights age out by directory mtime after 24 h (the forensics window); if Slurm can't be queried, nothing is reaped. Same-tick name collisions get suffixed trees with a unique-tail backstop. Creation failure falls back to the shared checkout — degraded to today's behavior, never grounded.

Note: flights build their own `.venv` on first `uv run`, consistent with one-writer-per-environment; warm-cache cost is seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)