### PR TITLE
Persistent contract failure opens an issue on the target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Persistent contract failure alarms on GitHub: after three consecutive
+  ticks unable to load the target's `.autoresearch.yaml`, the tick opens
+  one issue on the target repo with the loader's error (marker-deduped,
+  survives state loss); the next successful load comments and closes it.
+  A rejected contract silently idled every launch lane for 36 hours once
+  — the only signal was a log line on the cluster.
+
 ### Changed
 
 - Every flight has a snapshot: submitted jobs (climbs, stewardships,

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -576,6 +576,28 @@ class GitHubClient:
             payload,
         )
 
+    def create_issue(self, repo: str, title: str, body: str) -> int:
+        """Open an issue; returns its number (0 in dry-run)."""
+        if self.dry_run:
+            log.info("[dry-run] issue on %s: %s", repo, title)
+            return 0
+        data = self._request(
+            "POST",
+            f"/repos/{urllib.parse.quote(repo)}/issues",
+            {"title": title, "body": body},
+        )
+        return int(data.get("number", 0)) if isinstance(data, dict) else 0
+
+    def close_issue(self, repo: str, number: int) -> None:
+        if self.dry_run:
+            log.info("[dry-run] close issue %s#%s", repo, number)
+            return
+        self._request(
+            "PATCH",
+            f"/repos/{urllib.parse.quote(repo)}/issues/{number}",
+            {"state": "closed"},
+        )
+
     def comment(self, repo: str, issue_number: int, body: str) -> None:
         if self.dry_run:
             log.info("[dry-run] comment on %s#%s (%d chars)", repo, issue_number, len(body))

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -248,6 +248,65 @@ def reap_flights(
     return reaped
 
 
+CONTRACT_ALARM_MARKER = "<!-- autoresearch:contract-alarm -->"
+CONTRACT_ALARM_AFTER = 3  # consecutive failing ticks (~1.5 h) before alarming
+
+
+def contract_alarm(root: Path, github: Any, target: str, error: str | None, now: float) -> None:
+    """Persistent contract failure must surface where humans look.
+
+    A rejected or unfetchable contract silently idles every launch lane
+    (this cost 36 hours once — the only signal was a log line on the
+    cluster). After CONTRACT_ALARM_AFTER consecutive failing ticks this
+    opens ONE issue on the target repo; the next successful load closes
+    it and says so. Alarm plumbing is best-effort by construction: it
+    must never break the tick it reports for."""
+    state_path = root / "contract-alarm.json"
+    try:
+        state = json.loads(state_path.read_text())
+    except (OSError, ValueError):
+        state = {}
+    if error is None:
+        if state.get("issue"):
+            with contextlib.suppress(Exception):
+                github.comment(
+                    target,
+                    int(state["issue"]),
+                    "The contract loads again; launch lanes resume this tick.",
+                )
+                github.close_issue(target, int(state["issue"]))
+        if state:
+            with contextlib.suppress(OSError):
+                state_path.unlink()
+        return
+    count = int(state.get("count", 0)) + 1
+    state["count"] = count
+    if count >= CONTRACT_ALARM_AFTER and not state.get("issue"):
+        # search open issues first: state loss must not spawn duplicates
+        with contextlib.suppress(Exception):
+            existing = next(
+                (
+                    int(issue.get("number", 0))
+                    for issue in github.list_open_issues(target)
+                    if CONTRACT_ALARM_MARKER in str(issue.get("body", ""))
+                ),
+                0,
+            )
+            state["issue"] = existing or github.create_issue(
+                target,
+                "autoresearch: contract rejected — launch lanes are paused",
+                f"{CONTRACT_ALARM_MARKER}\nThe orchestrator has failed to load "
+                f"`.autoresearch.yaml` for {count} consecutive ticks; intake, "
+                f"steward, and self-initiated lanes sit out until it loads.\n\n"
+                f"Loader says:\n\n```\n{error[:600]}\n```\n\n"
+                f"This issue closes itself when the contract loads again.",
+            )
+    with contextlib.suppress(OSError):
+        tmp = state_path.with_suffix(f".{os.getpid()}.tmp")
+        tmp.write_text(json.dumps(state))
+        os.replace(tmp, state_path)
+
+
 def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: Any) -> FollowupSpec:
     """Clamp the operator's follow-up spec by the contract's effective
     limits. Both knobs clamp only when the contract EXPLICITLY sets them:
@@ -787,14 +846,19 @@ def tick(
         # the launch lanes need the contract and sit out this tick.
         contract = None
         if followup_spec.target:
+            contract_error: str | None = "contract file missing on main"
             try:
                 from autoresearch.contract import load_contract
 
                 raw = github.get_file_content(followup_spec.target, ".autoresearch.yaml", "main")
                 if raw is not None:
                     contract = load_contract(raw, followup_spec.target)
+                    contract_error = None
             except Exception as exc:
                 log.warning("contract fetch failed for %s: %s", followup_spec.target, exc)
+                contract_error = f"{type(exc).__name__}: {exc}"
+            with contextlib.suppress(Exception):
+                contract_alarm(root, github, followup_spec.target, contract_error, now)
         limits = effective_limits(contract.budgets if contract is not None else None)
         # The contract's followup walltime only overrides when EXPLICITLY
         # set — and only DOWNWARD from the operator's spec value: strictly-

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -17,6 +17,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import socket
 import subprocess
 from collections.abc import Sequence
@@ -36,7 +37,7 @@ from autoresearch.compute import (
     quote_command,
 )
 from autoresearch.disk import DEFAULT_MIN_FREE_BYTES, check_disk
-from autoresearch.harness import DEFAULT_MAX_TURNS
+from autoresearch.harness import DEFAULT_MAX_TURNS, redact
 from autoresearch.limits import EffectiveLimits, effective_limits
 from autoresearch.runstate import (
     ABORTED,
@@ -252,7 +253,14 @@ CONTRACT_ALARM_MARKER = "<!-- autoresearch:contract-alarm -->"
 CONTRACT_ALARM_AFTER = 3  # consecutive failing ticks (~1.5 h) before alarming
 
 
-def contract_alarm(root: Path, github: Any, target: str, error: str | None, now: float) -> None:
+def contract_alarm(
+    root: Path,
+    github: Any,
+    target: str,
+    error: str | None,
+    now: float,
+    bot_login: str = "agentic-learning-bot",
+) -> None:
     """Persistent contract failure must surface where humans look.
 
     A rejected or unfetchable contract silently idles every launch lane
@@ -268,33 +276,42 @@ def contract_alarm(root: Path, github: Any, target: str, error: str | None, now:
         state = {}
     if error is None:
         open_alarm = int(state.get("issue", 0))
-        if not open_alarm and state.get("count", 0) >= CONTRACT_ALARM_AFTER:
+        if not open_alarm and state:
             # creation may have landed without a recorded number (dry-run,
-            # odd response): search so recovery can still close it
+            # odd response, lost state file): search so recovery can still
+            # close it. Only ticks that follow SOME failure signal pay the
+            # search; total state loss + instant recovery leaves the issue
+            # for the next alarm cycle's search to adopt and close.
             with contextlib.suppress(Exception):
-                open_alarm = _find_alarm_issue(github, target)
+                open_alarm = _find_alarm_issue(github, target, bot_login)
         if open_alarm:
-            with contextlib.suppress(Exception):
-                github.comment(
-                    target, open_alarm, "The contract loads again; launch lanes resume this tick."
-                )
             try:
                 github.close_issue(target, open_alarm)
             except Exception as exc:
                 # keep the state so the NEXT healthy tick retries the close;
-                # unlinking here would orphan the open alarm forever
+                # unlinking here would orphan the open alarm forever — and
+                # no comment yet, or every retry would repeat it
                 log.warning("could not close contract alarm #%s: %s", open_alarm, exc)
                 return
+            with contextlib.suppress(Exception):
+                github.comment(
+                    target, open_alarm, "The contract loads again; launch lanes resume this tick."
+                )
         if state:
             with contextlib.suppress(OSError):
                 state_path.unlink()
         return
     count = int(state.get("count", 0)) + 1
     state["count"] = count
+    # redacted (the client's own token is the one secret this process
+    # holds) and fenced with a run longer than any backtick run inside —
+    # transport errors can echo request material, loader errors can echo
+    # contract content, and both are untrusted for a public issue body
+    safe_error = redact(error, _client_secrets(github))[:600]
     if count >= CONTRACT_ALARM_AFTER and not state.get("issue"):
         # search open issues first: state loss must not spawn duplicates
         try:
-            number = _find_alarm_issue(github, target) or github.create_issue(
+            number = _find_alarm_issue(github, target, bot_login) or github.create_issue(
                 target,
                 "autoresearch: contract failed to load — launch lanes are paused",
                 f"{CONTRACT_ALARM_MARKER}\nThe orchestrator has been unable to "
@@ -302,7 +319,7 @@ def contract_alarm(root: Path, github: Any, target: str, error: str | None, now:
                 f"intake, steward, and self-initiated lanes sit out until it "
                 f"loads. The error below says whether the contract itself was "
                 f"rejected or the fetch is failing.\n\n"
-                f"```\n{error[:600]}\n```\n\n"
+                f"{_fence(safe_error)}\n{safe_error}\n{_fence(safe_error)}\n\n"
                 f"This issue closes itself when the contract loads again.",
             )
             if number:
@@ -315,12 +332,29 @@ def contract_alarm(root: Path, github: Any, target: str, error: str | None, now:
         os.replace(tmp, state_path)
 
 
-def _find_alarm_issue(github: Any, target: str) -> int:
+def _client_secrets(github: Any) -> tuple[str, ...]:
+    with contextlib.suppress(Exception):
+        token = github.auth.token()
+        if token:
+            return (token,)
+    return ()
+
+
+def _fence(content: str) -> str:
+    longest = max((len(run) for run in re.findall(r"`+", content)), default=0)
+    return "`" * max(3, longest + 1)
+
+
+def _find_alarm_issue(github: Any, target: str, bot_login: str) -> int:
+    """Only the BOT'S own marker'd issue counts: the marker is a public
+    string, and adopting a stranger's issue would let anyone suppress the
+    real alarm or get their issue closed by the bot."""
     return next(
         (
             int(issue.get("number", 0))
             for issue in github.list_open_issues(target)
             if CONTRACT_ALARM_MARKER in str(issue.get("body", ""))
+            and str((issue.get("user") or {}).get("login", "")).casefold() == bot_login.casefold()
         ),
         0,
     )
@@ -877,7 +911,14 @@ def tick(
                 log.warning("contract fetch failed for %s: %s", followup_spec.target, exc)
                 contract_error = f"{type(exc).__name__}: {exc}"
             try:
-                contract_alarm(root, github, followup_spec.target, contract_error, now)
+                contract_alarm(
+                    root,
+                    github,
+                    followup_spec.target,
+                    contract_error,
+                    now,
+                    bot_login=followup_spec.bot_login,
+                )
             except Exception as exc:
                 log.warning("contract alarm failed: %s", exc)
         limits = effective_limits(contract.budgets if contract is not None else None)

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -267,14 +267,24 @@ def contract_alarm(root: Path, github: Any, target: str, error: str | None, now:
     except (OSError, ValueError):
         state = {}
     if error is None:
-        if state.get("issue"):
+        open_alarm = int(state.get("issue", 0))
+        if not open_alarm and state.get("count", 0) >= CONTRACT_ALARM_AFTER:
+            # creation may have landed without a recorded number (dry-run,
+            # odd response): search so recovery can still close it
+            with contextlib.suppress(Exception):
+                open_alarm = _find_alarm_issue(github, target)
+        if open_alarm:
             with contextlib.suppress(Exception):
                 github.comment(
-                    target,
-                    int(state["issue"]),
-                    "The contract loads again; launch lanes resume this tick.",
+                    target, open_alarm, "The contract loads again; launch lanes resume this tick."
                 )
-                github.close_issue(target, int(state["issue"]))
+            try:
+                github.close_issue(target, open_alarm)
+            except Exception as exc:
+                # keep the state so the NEXT healthy tick retries the close;
+                # unlinking here would orphan the open alarm forever
+                log.warning("could not close contract alarm #%s: %s", open_alarm, exc)
+                return
         if state:
             with contextlib.suppress(OSError):
                 state_path.unlink()
@@ -283,28 +293,37 @@ def contract_alarm(root: Path, github: Any, target: str, error: str | None, now:
     state["count"] = count
     if count >= CONTRACT_ALARM_AFTER and not state.get("issue"):
         # search open issues first: state loss must not spawn duplicates
-        with contextlib.suppress(Exception):
-            existing = next(
-                (
-                    int(issue.get("number", 0))
-                    for issue in github.list_open_issues(target)
-                    if CONTRACT_ALARM_MARKER in str(issue.get("body", ""))
-                ),
-                0,
-            )
-            state["issue"] = existing or github.create_issue(
+        try:
+            number = _find_alarm_issue(github, target) or github.create_issue(
                 target,
-                "autoresearch: contract rejected — launch lanes are paused",
-                f"{CONTRACT_ALARM_MARKER}\nThe orchestrator has failed to load "
-                f"`.autoresearch.yaml` for {count} consecutive ticks; intake, "
-                f"steward, and self-initiated lanes sit out until it loads.\n\n"
-                f"Loader says:\n\n```\n{error[:600]}\n```\n\n"
+                "autoresearch: contract failed to load — launch lanes are paused",
+                f"{CONTRACT_ALARM_MARKER}\nThe orchestrator has been unable to "
+                f"load `.autoresearch.yaml` for {count} consecutive ticks; "
+                f"intake, steward, and self-initiated lanes sit out until it "
+                f"loads. The error below says whether the contract itself was "
+                f"rejected or the fetch is failing.\n\n"
+                f"```\n{error[:600]}\n```\n\n"
                 f"This issue closes itself when the contract loads again.",
             )
+            if number:
+                state["issue"] = number
+        except Exception as exc:
+            log.warning("contract alarm could not post to %s: %s", target, exc)
     with contextlib.suppress(OSError):
         tmp = state_path.with_suffix(f".{os.getpid()}.tmp")
         tmp.write_text(json.dumps(state))
         os.replace(tmp, state_path)
+
+
+def _find_alarm_issue(github: Any, target: str) -> int:
+    return next(
+        (
+            int(issue.get("number", 0))
+            for issue in github.list_open_issues(target)
+            if CONTRACT_ALARM_MARKER in str(issue.get("body", ""))
+        ),
+        0,
+    )
 
 
 def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: Any) -> FollowupSpec:
@@ -857,8 +876,10 @@ def tick(
             except Exception as exc:
                 log.warning("contract fetch failed for %s: %s", followup_spec.target, exc)
                 contract_error = f"{type(exc).__name__}: {exc}"
-            with contextlib.suppress(Exception):
+            try:
                 contract_alarm(root, github, followup_spec.target, contract_error, now)
+            except Exception as exc:
+                log.warning("contract alarm failed: %s", exc)
         limits = effective_limits(contract.budgets if contract is not None else None)
         # The contract's followup walltime only overrides when EXPLICITLY
         # set — and only DOWNWARD from the operator's spec value: strictly-

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -308,6 +308,9 @@ def contract_alarm(
     # transport errors can echo request material, loader errors can echo
     # contract content, and both are untrusted for a public issue body
     safe_error = redact(error, _client_secrets(github))[:600]
+    # A recorded issue a human closed by hand stays closed: closing the
+    # alarm is the maintainer's "I know" — re-opening or re-creating it
+    # every threshold would be alarm spam, and recovery still clears state.
     if count >= CONTRACT_ALARM_AFTER and not state.get("issue"):
         # search open issues first: state loss must not spawn duplicates
         try:
@@ -333,10 +336,14 @@ def contract_alarm(
 
 
 def _client_secrets(github: Any) -> tuple[str, ...]:
-    with contextlib.suppress(Exception):
+    try:
         token = github.auth.token()
         if token:
             return (token,)
+    except Exception as exc:
+        # degraded redaction must not be silent: the error text goes to a
+        # public issue, and a renamed auth surface would no-op the redact
+        log.warning("alarm redaction has no client token (%s)", exc)
     return ()
 
 
@@ -352,7 +359,7 @@ def _find_alarm_issue(github: Any, target: str, bot_login: str) -> int:
     return next(
         (
             int(issue.get("number", 0))
-            for issue in github.list_open_issues(target)
+            for issue in github.list_open_issues(target, max_pages=10)
             if CONTRACT_ALARM_MARKER in str(issue.get("body", ""))
             and str((issue.get("user") or {}).get("login", "")).casefold() == bot_login.casefold()
         ),

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1092,6 +1092,55 @@ def test_contract_alarm_opens_once_and_closes_on_recovery(tmp_path: Path) -> Non
     assert g.closed == [7] and len(g.comments) == 1
 
 
+def test_contract_alarm_close_failure_keeps_state_for_retry(tmp_path: Path) -> None:
+    """A failed close must not orphan the open alarm: state survives so
+    the next healthy tick retries — and a lost issue number is recovered
+    by the marker search."""
+    from autoresearch.tick import contract_alarm
+
+    class G:
+        def __init__(self):
+            self.issues: list[dict] = []
+            self.closed: list[int] = []
+            self.refuse_close = True
+            self.next = 9
+
+        def list_open_issues(self, repo, max_pages: int = 3):
+            return [i for i in self.issues if i["number"] not in self.closed]
+
+        def create_issue(self, repo, title, body):
+            self.issues.append({"number": self.next, "title": title, "body": body})
+            return self.next
+
+        def comment(self, repo, number, body):
+            pass
+
+        def close_issue(self, repo, number):
+            if self.refuse_close:
+                raise RuntimeError("403")
+            self.closed.append(number)
+
+    g = G()
+    for _ in range(3):
+        contract_alarm(tmp_path, g, "org/pilot", "boom", NOW)
+    assert len(g.issues) == 1
+    contract_alarm(tmp_path, g, "org/pilot", None, NOW)  # close refused
+    assert g.closed == [] and (tmp_path / "contract-alarm.json").exists()
+    g.refuse_close = False
+    contract_alarm(tmp_path, g, "org/pilot", None, NOW)  # retried and closed
+    assert g.closed == [9] and not (tmp_path / "contract-alarm.json").exists()
+
+    # lost issue number (e.g. dry-run created nothing recordable): the
+    # recovery path still finds an open alarm by marker and closes it
+    g2 = G()
+    g2.refuse_close = False
+    for _ in range(3):
+        contract_alarm(tmp_path, g2, "org/pilot", "boom", NOW)
+    (tmp_path / "contract-alarm.json").write_text('{"count": 3}')  # number lost
+    contract_alarm(tmp_path, g2, "org/pilot", None, NOW)
+    assert g2.closed == [9]
+
+
 def test_shape_followup_spec_clamps_strictly_downward() -> None:
     """The clamp itself, against untrusted contract values (round-1
     finding: the argv test alone left the tick's clamp unverified)."""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1043,6 +1043,55 @@ def test_flight_name_exhaustion_still_gets_a_unique_tree(tmp_path: Path) -> None
     assert all(m != home for m in made)
 
 
+def test_contract_alarm_opens_once_and_closes_on_recovery(tmp_path: Path) -> None:
+    """Three consecutive failures open ONE issue on the target; recovery
+    comments and closes it. State loss must not spawn duplicates."""
+    from autoresearch.tick import CONTRACT_ALARM_MARKER, contract_alarm
+
+    class G:
+        def __init__(self):
+            self.issues: list[dict] = []
+            self.comments: list[tuple[int, str]] = []
+            self.closed: list[int] = []
+            self.next = 7
+
+        def list_open_issues(self, repo, max_pages: int = 3):
+            return [i for i in self.issues if i["number"] not in self.closed]
+
+        def create_issue(self, repo, title, body):
+            self.issues.append({"number": self.next, "title": title, "body": body})
+            return self.next
+
+        def comment(self, repo, number, body):
+            self.comments.append((number, body))
+
+        def close_issue(self, repo, number):
+            self.closed.append(number)
+
+    g = G()
+    contract_alarm(tmp_path, g, "org/pilot", "ScopeError: overlaps forbidden", NOW)
+    contract_alarm(tmp_path, g, "org/pilot", "ScopeError: overlaps forbidden", NOW)
+    assert g.issues == []  # below the threshold: log-only
+    contract_alarm(tmp_path, g, "org/pilot", "ScopeError: overlaps forbidden", NOW)
+    (issue,) = g.issues
+    assert CONTRACT_ALARM_MARKER in issue["body"] and "overlaps forbidden" in issue["body"]
+    contract_alarm(tmp_path, g, "org/pilot", "ScopeError: overlaps forbidden", NOW)
+    assert len(g.issues) == 1  # never a duplicate while open
+    # state loss: the open-issue search still prevents a duplicate
+    (tmp_path / "contract-alarm.json").unlink()
+    for _ in range(3):
+        contract_alarm(tmp_path, g, "org/pilot", "ScopeError: overlaps forbidden", NOW)
+    assert len(g.issues) == 1
+    # recovery: comment + close + state cleared
+    contract_alarm(tmp_path, g, "org/pilot", None, NOW)
+    assert g.closed == [7]
+    assert any("loads again" in body for _, body in g.comments)
+    assert not (tmp_path / "contract-alarm.json").exists()
+    # healthy steady state: no writes at all
+    contract_alarm(tmp_path, g, "org/pilot", None, NOW)
+    assert g.closed == [7] and len(g.comments) == 1
+
+
 def test_shape_followup_spec_clamps_strictly_downward() -> None:
     """The clamp itself, against untrusted contract values (round-1
     finding: the argv test alone left the tick's clamp unverified)."""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1059,7 +1059,14 @@ def test_contract_alarm_opens_once_and_closes_on_recovery(tmp_path: Path) -> Non
             return [i for i in self.issues if i["number"] not in self.closed]
 
         def create_issue(self, repo, title, body):
-            self.issues.append({"number": self.next, "title": title, "body": body})
+            self.issues.append(
+                {
+                    "number": self.next,
+                    "title": title,
+                    "body": body,
+                    "user": {"login": "agentic-learning-bot"},
+                }
+            )
             return self.next
 
         def comment(self, repo, number, body):
@@ -1109,7 +1116,14 @@ def test_contract_alarm_close_failure_keeps_state_for_retry(tmp_path: Path) -> N
             return [i for i in self.issues if i["number"] not in self.closed]
 
         def create_issue(self, repo, title, body):
-            self.issues.append({"number": self.next, "title": title, "body": body})
+            self.issues.append(
+                {
+                    "number": self.next,
+                    "title": title,
+                    "body": body,
+                    "user": {"login": "agentic-learning-bot"},
+                }
+            )
             return self.next
 
         def comment(self, repo, number, body):
@@ -1139,6 +1153,67 @@ def test_contract_alarm_close_failure_keeps_state_for_retry(tmp_path: Path) -> N
     (tmp_path / "contract-alarm.json").write_text('{"count": 3}')  # number lost
     contract_alarm(tmp_path, g2, "org/pilot", None, NOW)
     assert g2.closed == [9]
+
+    # a stranger's issue carrying the (public) marker is never adopted:
+    # the bot must not close third-party issues or let them suppress the
+    # real alarm
+    g3 = G()
+    g3.refuse_close = False
+    g3.issues.append(
+        {
+            "number": 1,
+            "title": "spoof",
+            "body": "<!-- autoresearch:contract-alarm -->\nmine now",
+            "user": {"login": "stranger"},
+        }
+    )
+    for _ in range(3):
+        contract_alarm(tmp_path, g3, "org/pilot", "boom", NOW)
+    assert [i["number"] for i in g3.issues] == [1, 9]  # real alarm created
+    contract_alarm(tmp_path, g3, "org/pilot", None, NOW)
+    assert g3.closed == [9]  # the stranger's issue is untouched
+
+
+def test_contract_alarm_redacts_and_fences_the_error(tmp_path: Path) -> None:
+    """Transport errors can echo request material; loader errors echo
+    contract content. Neither may leak a token or escape the fence."""
+    from autoresearch.tick import contract_alarm
+
+    class Auth:
+        def token(self):
+            return "tok-fixture-98765"
+
+    class G:
+        def __init__(self):
+            self.auth = Auth()
+            self.issues: list[dict] = []
+            self.next = 3
+
+        def list_open_issues(self, repo, max_pages: int = 3):
+            return self.issues
+
+        def create_issue(self, repo, title, body):
+            self.issues.append(
+                {
+                    "number": self.next,
+                    "title": title,
+                    "body": body,
+                    "user": {"login": "agentic-learning-bot"},
+                }
+            )
+            return self.next
+
+    g = G()
+    nasty = "401 fetching contract; request carried tok-fixture-98765\n```\nescape attempt"
+    for _ in range(3):
+        contract_alarm(tmp_path, g, "org/pilot", nasty, NOW)
+    (issue,) = g.issues
+    assert "tok-fixture-98765" not in issue["body"]
+    # the fence around the error is longer than any backtick run inside
+    import re as _re
+
+    runs = sorted(_re.findall(r"`+", issue["body"]), key=len, reverse=True)
+    assert len(runs[0]) >= 4  # widened past the embedded ```
 
 
 def test_shape_followup_spec_clamps_strictly_downward() -> None:


### PR DESCRIPTION
First half of the hardening bought by the roadmap/README incident: a contract that will not load pauses every launch lane fail-closed, and that state must be visible where humans look, not in a cluster log. After 3 consecutive failing ticks (~1.5 h), one issue opens on the target repo with the loader's exact error; it is marker-deduped against state loss, and the next successful load comments and closes it. All alarm plumbing is wrapped best-effort so it can never break the tick.

Second half (pilot CI validating the contract with this repo's loader) follows as a pilot-side PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)