### PR TITLE
Design note: reviewer and verifier infrastructure

### DIFF
--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -80,8 +80,10 @@ API call.
 ## The broker
 
 The `retrieve` tool does not reach the internet directly. It calls a broker
-we run. The runner can reach the broker and nothing else. The broker fetches
-only from an allowlist of destinations.
+we run. Where egress can be enforced, the runner should reach the broker and
+nothing else. On a GitHub-hosted runner that cannot be enforced, so there
+the containment leans on the other two defenses below rather than on network
+isolation. The broker fetches only from an allowlist of destinations.
 
 An allowlist narrows where requests go. It does not by itself stop data from
 leaving, because a fetch still carries agent-chosen bytes outbound in the
@@ -151,12 +153,13 @@ runs anything.
 Second, the split workflow keeps the blast radius small, not zero. The agent
 runs sandboxed with no write token and no secret beyond a spend-capped API
 key. It writes findings to an artifact, and a separate minimal step with the
-write token posts them. Two residual risks remain, and both are bounded. The
-spend-capped key is still a credential; if it leaks, the loss is capped and
-the fix is to rotate it. And the artifact is posted through a trusted
-channel, so injected text can reach a repo comment. The posting step must
-treat the artifact as data, not instructions, and findings are read by a
-human, so the worst case is a wrong comment, not a merge or a real leak.
+write token posts them. Two residual risks remain, and each has a bounded
+worst case. If the spend-capped key leaks, the worst case is capped spend
+until we rotate it, not an open-ended credential loss. If the agent is
+prompt-injected, the injected text reaches a repo comment through the
+posting step, so the worst case there is a wrong comment, not a merge. The
+posting step must treat the artifact as data, not instructions, and findings
+are read by a human.
 
 What is safe today, precisely. `verify.yml` runs only on same-repo,
 bot-authored branches, so no fork PR reaches the reviewer. That makes an

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -38,11 +38,25 @@ other.
 
 ### 3. The tools
 
-Define the agent's tools as MCP servers, not as harness-specific code. The
-tools are `grep`, `read`, and `retrieve`. If they are MCP, they keep working
-when we change the model or the harness. If we write them against one
-harness's tool API instead, we have traded model lock-in for harness
-lock-in.
+Split tools by whether they cross a trust boundary.
+
+Standard local operations are not custom tools. Reading a file, grep, find,
+and listing directories are the harness's built-in file tools, or a single
+sandboxed shell over the base tree. Every harness ships these, so there is
+no portability problem to solve and no reason to wrap them in MCP.
+
+Custom tools are the ones no harness ships and that cross a boundary. There
+are two. `retrieve` reaches outside the runner, through the broker.
+`run-candidate` runs PR code in an isolated runner, and comes later. Give
+these a stable contract, MCP if convenient, so they survive a change of
+model or harness.
+
+For the local work, give the agent one sandboxed shell over the base tree:
+read-only, no network. That covers grep, find, and sed without listing them.
+It is safe because the base tree is trusted code. The two things the shell
+must not do are handled outside it. It has no network, so the broker is the
+only outward path. And it never runs the PR's code, which stays on the
+split-workflow path.
 
 ## Retrieval is a tool, not context
 
@@ -119,12 +133,12 @@ after the repo goes public. See `public-surface.md` for that threat model.
 
 ## Sequencing
 
-1. Define the MCP tool contracts: `grep`, `read`, `retrieve`.
-2. Stand up the harness with the read-only base-tree tools only. These need
-   no broker, because reading the trusted base is safe.
-3. Add the `retrieve` tool and the broker later, without changing the
-   harness.
-4. Before making the agentic reviewer the default, score it against the
+1. Stand up the harness with a sandboxed, read-only shell over the base
+   tree. This needs no broker and no custom tools, because reading the
+   trusted base is safe.
+2. Define the `retrieve` tool contract and the broker, and add them without
+   changing the harness.
+3. Before making the agentic reviewer the default, score it against the
    single-pass version on the meta-benchmark. The metric is whether it
    catches more seeded gaming per dollar. "Feels better" and "is better,
    safely" can differ, so measure it.

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -104,6 +104,29 @@ corpus of the papers and specs the benchmarks cite gives us three things:
 no egress, reproducible results, and no page-injection surface. Live search
 through the broker is the fallback for things outside the corpus.
 
+## Where it runs
+
+The reviewer and verifier are event-driven, not scheduled. They are GitHub
+Actions workflows that fire on a PR event: opened, or the review label
+applied. There is no cadence. A PR gets a response when it arrives.
+
+This is a separate system from the tick. The tick runs on Torch, polls on
+the :00/:30 grid, submits research jobs, and makes no model calls. The
+reviewer runs on a GitHub runner, fires on PR events, and is the model call.
+Do not merge them. Putting the reviewer on the tick would add polling
+latency, put model calls inside the model-free scheduler, and mix the
+research path with the review path.
+
+The runner can be GitHub-hosted or self-hosted. Both are event-driven. A
+self-hosted runner could sit on lab hardware for tighter egress control, but
+it still picks up jobs on PR events, not on the tick's clock.
+
+Torch enters only for deep verification that re-runs an eval to check a
+measurement claim, for a GPU benchmark. That is a job submitted per PR,
+triggered by the event. For untrusted fork PRs it must not run on Torch at
+all, only on a throwaway GitHub runner. For trusted internal PRs it may
+submit to Torch, still event-driven.
+
 ## Security
 
 The danger is not running untrusted code. It is running untrusted code next

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -81,12 +81,19 @@ API call.
 
 The `retrieve` tool does not reach the internet directly. It calls a broker
 we run. The runner can reach the broker and nothing else. The broker fetches
-from an allowlist of permitted destinations and refuses to send data
-outward.
+only from an allowlist of destinations.
 
-This keeps the property we want. The agent can search, but the runner has no
-open path to exfiltrate a secret. The control lives at the tool boundary,
-which is cleaner than trusting a step that runs before the agent.
+An allowlist narrows where requests go. It does not by itself stop data from
+leaving, because a fetch still carries agent-chosen bytes outbound in the
+query string, the URL path, or the search terms. An injected agent could
+encode a secret into a Brave query or an allowlisted URL. So the broker's
+job is two-sided: limit the destinations, and constrain and log the outbound
+request contents. State the guarantee that way, not as "no egress," or an
+implementer will build the weaker thing and believe it is the stronger one.
+
+The other half of the defense is that the agent holds nothing worth
+exfiltrating in the first place (see Security). The broker limits the
+channel; the split workflow limits what is on the runner to leak.
 
 Owning the broker has a cost. It is a service we run and secure. If it is
 compromised, it is an egress hole. This is the price of not depending on a
@@ -136,23 +143,30 @@ the key.
 
 Two facts make this manageable.
 
-First, reading the base tree is safe. The base is what the workflow already
-checks out and trusts. An agent that greps and reads the base to trace a
-claim runs no untrusted code. Only running the PR's own code is dangerous,
-and that is a small part of what a reviewer does.
+First, reading is not running. Reading the base tree is safe: it is code the
+workflow already checks out and trusts. Running code is the dangerous act,
+and it is a small part of what a reviewer does. The read-only reviewer never
+runs anything.
 
-Second, the agent holds no write token. In the split-workflow pattern, the
-agent runs sandboxed with no secrets beyond a spend-capped API key and
-writes its findings to an artifact. A separate, minimal step with the write
-token posts them. If the agent is prompt-injected, there is nothing
-privileged to steal, and a poisoned result can at most produce a wrong
-finding that a human filters out.
+Second, the split workflow keeps the blast radius small, not zero. The agent
+runs sandboxed with no write token and no secret beyond a spend-capped API
+key. It writes findings to an artifact, and a separate minimal step with the
+write token posts them. Two residual risks remain, and both are bounded. The
+spend-capped key is still a credential; if it leaks, the loss is capped and
+the fix is to rotate it. And the artifact is posted through a trusted
+channel, so injected text can reach a repo comment. The posting step must
+treat the artifact as data, not instructions, and findings are read by a
+human, so the worst case is a wrong comment, not a merge or a real leak.
 
-Today this is not even active. `verify.yml` only runs on same-repo,
-bot-authored branches, so no untrusted PR reaches the reviewer. An agentic
-reviewer that reads files and runs the eval is safe right now for internal
-PRs. The sandbox and split-workflow work is what gates accepting fork PRs
-after the repo goes public. See `public-surface.md` for that threat model.
+What is safe today, precisely. `verify.yml` runs only on same-repo,
+bot-authored branches, so no fork PR reaches the reviewer. That makes an
+agentic reviewer that only reads safe to run now. It does not make running
+the PR's code safe. Bot-authored code is model-generated, which is the exact
+thing this note says not to run next to a secret. So even on internal PRs,
+executing the eval uses the guarded `run-candidate` path, never a direct
+run. Reading is what today's setup licenses; running is always guarded. The
+sandbox and split-workflow work is what gates accepting fork PRs after the
+repo goes public. See `public-surface.md` for that threat model.
 
 ## Sequencing
 

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -1,0 +1,140 @@
+# Reviewer and verifier infrastructure
+
+This note records how we intend to build the reviewer and verifier agents.
+The goal is to be able to change the model, the harness, or the search
+provider later without a rewrite. It is written before we build so the
+seams are agreed first. Nothing here is deployed yet.
+
+## Where we are now
+
+Both roles are one API call. We gather a fixed bundle of context (the diff,
+the contract, the eval modules, the tests, the PR thread), send it in a
+single request, and post the reply. This is cheap, fast, and safe: the
+model runs no tools and executes nothing.
+
+It has one limit. A single call cannot explore the code. It cannot open a
+file the diff refers to but does not include, follow a caller, or run the
+tests to check that a finding reproduces. On the pilot this is fine. On a
+larger target it will miss things.
+
+## The three seams
+
+We keep three things independent so each can change on its own.
+
+### 1. The model
+
+The reviewer already talks to a `Completer` interface. `AnthropicCompleter`
+is one implementation. Swapping the model is a config change, not a rewrite:
+Claude on Bedrock, Vertex, or Foundry, an OpenAI-compatible endpoint, or a
+local model all fit behind the same interface. Keep it that way. No code
+outside the completer should depend on Anthropic-specific response shapes.
+
+### 2. The harness
+
+The reviewer should become an agent that calls tools in a loop, not a
+single call. This is the same decision as adding retrieval (see below):
+retrieval is only useful inside a loop, so we cannot have one without the
+other.
+
+### 3. The tools
+
+Define the agent's tools as MCP servers, not as harness-specific code. The
+tools are `grep`, `read`, and `retrieve`. If they are MCP, they keep working
+when we change the model or the harness. If we write them against one
+harness's tool API instead, we have traded model lock-in for harness
+lock-in.
+
+## Retrieval is a tool, not context
+
+There are two ways to give an agent web access, and only one is useful.
+
+The weak way is to search first and paste the results into the prompt. This
+does not work well. You have to guess what to search before you have read
+the diff. You cannot follow a citation you find while reasoning. You cannot
+search again when a result raises a new question. The context ends up large
+and mostly irrelevant.
+
+The useful way is a tool the agent calls when it decides it needs to. For
+example: the report cites a paper for its method, so the agent fetches the
+paper and checks that the code does what the paper describes. This
+retrieve-then-reason-then-retrieve loop is the whole point, and it only
+exists when the model drives the tool calls.
+
+So retrieval belongs in the harness as a tool. It is not extra context on an
+API call.
+
+## The broker
+
+The `retrieve` tool does not reach the internet directly. It calls a broker
+we run. The runner can reach the broker and nothing else. The broker fetches
+from an allowlist of permitted destinations and refuses to send data
+outward.
+
+This keeps the property we want. The agent can search, but the runner has no
+open path to exfiltrate a secret. The control lives at the tool boundary,
+which is cleaner than trusting a step that runs before the agent.
+
+Owning the broker has a cost. It is a service we run and secure. If it is
+compromised, it is an egress hole. This is the price of not depending on a
+provider's built-in web tool.
+
+## Backends are pluggable
+
+Behind the broker, the search backend is swappable: a search API such as
+Brave or Tavily, a self-hosted SearxNG, or an offline corpus.
+
+For the main use case, an offline corpus is often better than live search.
+The main use case is checking a cited claim, such as whether a paper the
+report names actually says what the report claims. A curated, versioned
+corpus of the papers and specs the benchmarks cite gives us three things:
+no egress, reproducible results, and no page-injection surface. Live search
+through the broker is the fallback for things outside the corpus.
+
+## Security
+
+The danger is not running untrusted code. It is running untrusted code next
+to a secret and a write token. A workflow that holds the reviewer's API key
+and can post comments must not run code from the PR, or that code can steal
+the key.
+
+Two facts make this manageable.
+
+First, reading the base tree is safe. The base is what the workflow already
+checks out and trusts. An agent that greps and reads the base to trace a
+claim runs no untrusted code. Only running the PR's own code is dangerous,
+and that is a small part of what a reviewer does.
+
+Second, the agent holds no write token. In the split-workflow pattern, the
+agent runs sandboxed with no secrets beyond a spend-capped API key and
+writes its findings to an artifact. A separate, minimal step with the write
+token posts them. If the agent is prompt-injected, there is nothing
+privileged to steal, and a poisoned result can at most produce a wrong
+finding that a human filters out.
+
+Today this is not even active. `verify.yml` only runs on same-repo,
+bot-authored branches, so no untrusted PR reaches the reviewer. An agentic
+reviewer that reads files and runs the eval is safe right now for internal
+PRs. The sandbox and split-workflow work is what gates accepting fork PRs
+after the repo goes public. See `public-surface.md` for that threat model.
+
+## Sequencing
+
+1. Define the MCP tool contracts: `grep`, `read`, `retrieve`.
+2. Stand up the harness with the read-only base-tree tools only. These need
+   no broker, because reading the trusted base is safe.
+3. Add the `retrieve` tool and the broker later, without changing the
+   harness.
+4. Before making the agentic reviewer the default, score it against the
+   single-pass version on the meta-benchmark. The metric is whether it
+   catches more seeded gaming per dollar. "Feels better" and "is better,
+   safely" can differ, so measure it.
+
+## Open decisions
+
+- **Cost and determinism.** An agentic verifier costs far more per PR and
+  its output can drift, especially with web search. Likely make web search a
+  deep-verification toggle rather than always on, so routine rounds stay
+  cheap and reproducible.
+- **Runner choice.** GitHub-hosted runners cannot be egress-firewalled as
+  tightly as a container we control. Self-hosted runners give more control
+  but bring back "our hardware." Decide per role and per trust level.


### PR DESCRIPTION
Writes down the reviewer/verifier design decisions from the discussion so the seams are agreed before anyone builds against a backend. Covers: the three independent seams (model behind Completer, agentic harness, tools split by trust boundary), why local operations are the harness's sandboxed shell and only boundary-crossing capabilities get a custom contract, why retrieval must be a tool the agent drives rather than pre-fetched context, the broker that constrains and logs outbound content, pluggable and offline backends, where it runs (event-driven on GitHub, not on the tick's cadence), the security boundary (read the base freely, never run PR code next to secrets, split-workflow poster), and the build order.

Build order per the Sequencing section: read-only sandboxed shell over the base first (no broker, no custom tools), then the retrieve tool and broker, then score agentic vs single-pass on the meta-benchmark before defaulting to it.

Docs-only, so one review round with nits batched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)