### PR TITLE
Relative cross-seed noise floor (min_delta_rel)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Benchmarks can declare a relative cross-seed noise floor
+  (`min_delta_rel`), a fraction of the recorded level, alongside or
+  instead of the absolute `min_delta`. This is the right floor for an
+  unbounded metric such as wall-clock timing, whose level drifts with
+  hardware so a fixed absolute number goes stale. Both set means the
+  more conservative applies.
+
+### Added
+
 - Persistent contract failure alarms on GitHub: after three consecutive
   ticks unable to load the target's `.autoresearch.yaml`, the tick opens
   one issue on the target repo with the loader's error (marker-deduped,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ Versions follow [SemVer](https://semver.org).
   hardware so a fixed absolute number goes stale. Both set means the
   more conservative applies.
 
-### Added
-
 - Persistent contract failure alarms on GitHub: after three consecutive
   ticks unable to load the target's `.autoresearch.yaml`, the tick opens
   one issue on the target repo with the loader's error (marker-deduped,

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -136,8 +136,9 @@ vs candidate, and both sides of the freshness re-measure), and records it
 in the ledger row (`run_seed` in results/leader.json), so the recorded
 number is re-derivable instead of pool luck. Comparisons against the
 RECORDED best are the one place two different seeds meet, so on a
-benchmark that declares `min_delta` — an absolute cross-seed noise floor
-(the steward's stated stderr, times a safety factor) — EVERY sub-floor
+benchmark that declares a noise floor — `min_delta` in absolute units for
+a bounded metric, or `min_delta_rel` as a fraction of the level for an
+unbounded one like wall-clock timing — EVERY sub-floor
 delta over the recorded best, including one below the relative
 threshold, is an honest negative result ("does not clear the noise
 floor"), never a PR and never an abort; the stale-clone abort remains

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -457,10 +457,14 @@ def live_climb(
                         prior.best, candidate, bench.direction, bench.min_delta, bench.min_delta_rel
                     ):
                         floor = benchmark_floor(prior.best, bench.min_delta, bench.min_delta_rel)
+                        reason = (
+                            f"the cross-seed noise floor ({floor:.6g})"
+                            if floor > 0
+                            else "the relative-improvement threshold"
+                        )
                         raise NoiseFloored(
                             f"candidate {candidate} does not clear the recorded "
-                            f"best {prior.best} beyond the cross-seed noise "
-                            f"floor ({floor:.6g})"
+                            f"best {prior.best} beyond {reason}"
                         )
                 elif not rel_ok:
                     # fixed pool: the ledger says this run's own baseline

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -42,6 +42,7 @@ from autoresearch.orchestrator import (
 from autoresearch.orchestrator import improved as orch_improved
 from autoresearch.progress import (
     PROGRESS_PATHS,
+    fmt_metric,
     load_leader,
     update_leader,
     write_progress,
@@ -461,7 +462,8 @@ def live_climb(
                         # whichever floor happens to exist
                         floor = benchmark_floor(prior.best, bench.min_delta, bench.min_delta_rel)
                         if floored and floor > 0:
-                            why = f"the cross-seed noise floor ({floor:.6g})"
+                            shown = fmt_metric(floor, bench.display_digits)
+                            why = f"the cross-seed noise floor ({shown})"
                         elif floored:
                             why = f"a usable baseline (recorded best {prior.best})"
                         else:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -453,18 +453,22 @@ def live_climb(
                     # one below the relative threshold — is an expected
                     # honest negative, never an anomaly (round-4 review
                     # finding: the abort band contradicted the promise).
-                    if not rel_ok or not clears_min_delta(
+                    floored = not clears_min_delta(
                         prior.best, candidate, bench.direction, bench.min_delta, bench.min_delta_rel
-                    ):
+                    )
+                    if not rel_ok or floored:
+                        # name the check that actually failed, not just
+                        # whichever floor happens to exist
                         floor = benchmark_floor(prior.best, bench.min_delta, bench.min_delta_rel)
-                        reason = (
-                            f"the cross-seed noise floor ({floor:.6g})"
-                            if floor > 0
-                            else "the relative-improvement threshold"
-                        )
+                        if floored and floor > 0:
+                            why = f"the cross-seed noise floor ({floor:.6g})"
+                        elif floored:
+                            why = f"a usable baseline (recorded best {prior.best})"
+                        else:
+                            why = "the relative-improvement threshold"
                         raise NoiseFloored(
                             f"candidate {candidate} does not clear the recorded "
-                            f"best {prior.best} beyond {reason}"
+                            f"best {prior.best} beyond {why}"
                         )
                 elif not rel_ok:
                     # fixed pool: the ledger says this run's own baseline

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -33,6 +33,7 @@ from autoresearch.orchestrator import (
     ClimbConfig,
     Evaluator,
     SubprocessEvaluator,
+    benchmark_floor,
     clears_min_delta,
     climb_once,
     out_of_scope,
@@ -446,19 +447,20 @@ def live_climb(
                 rel_ok = orch_improved(
                     prior.best, candidate, bench.direction, config.min_relative_improvement
                 )
-                if bench.min_delta:
+                if bench.min_delta or bench.min_delta_rel:
                     # A resampled pool re-rolls between runs, so ANY
                     # sub-floor delta over the recorded best — including
                     # one below the relative threshold — is an expected
                     # honest negative, never an anomaly (round-4 review
                     # finding: the abort band contradicted the promise).
                     if not rel_ok or not clears_min_delta(
-                        prior.best, candidate, bench.direction, bench.min_delta
+                        prior.best, candidate, bench.direction, bench.min_delta, bench.min_delta_rel
                     ):
+                        floor = benchmark_floor(prior.best, bench.min_delta, bench.min_delta_rel)
                         raise NoiseFloored(
                             f"candidate {candidate} does not clear the recorded "
                             f"best {prior.best} beyond the cross-seed noise "
-                            f"floor (min_delta={bench.min_delta})"
+                            f"floor ({floor:.6g})"
                         )
                 elif not rel_ok:
                     # fixed pool: the ledger says this run's own baseline

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -104,7 +104,12 @@ class Benchmark(_StrictModel):
     # drifts with hardware, so an absolute number goes stale. Set either or
     # both; both means the more conservative of the two applies.
     min_delta: float | None = Field(default=None, ge=0)
-    min_delta_rel: float | None = Field(default=None, ge=0)
+    # capped at 1.0: a noise floor is a small fraction (e.g. 0.13), so a
+    # value above the level itself is a typo (13 meaning 13%), and a floor
+    # of 13x would freeze the benchmark. A relative floor assumes a
+    # non-zero level; pair it with a small absolute min_delta as a backstop
+    # for a metric that can reach 0.
+    min_delta_rel: float | None = Field(default=None, ge=0, le=1.0)
 
 
 class SuiteAggregate(_StrictModel):

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -95,12 +95,16 @@ class Benchmark(_StrictModel):
             )
         return value
 
-    # Cross-seed noise floor in ABSOLUTE metric units (a resampled pool
-    # re-rolls between runs; the steward's stated stderr belongs here,
-    # e.g. ~2x). Comparisons against the RECORDED best — measured under a
-    # different seed — must clear it on top of the relative threshold;
-    # same-seed paired comparisons are exempt by construction.
+    # Cross-seed noise floor. A comparison against the RECORDED best was
+    # measured under a different seed, so a delta inside the floor is noise,
+    # not progress; same-seed paired comparisons are exempt by construction.
+    # Two forms. min_delta is absolute metric units, right for a bounded
+    # metric (a success rate). min_delta_rel is a fraction of the recorded
+    # level, right for an unbounded metric (wall-clock timing) whose level
+    # drifts with hardware, so an absolute number goes stale. Set either or
+    # both; both means the more conservative of the two applies.
     min_delta: float | None = Field(default=None, ge=0)
+    min_delta_rel: float | None = Field(default=None, ge=0)
 
 
 class SuiteAggregate(_StrictModel):

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -515,9 +515,13 @@ def _respond(
                             floor = benchmark_floor(
                                 prior.best, bench.min_delta, bench.min_delta_rel
                             )
+                            where = (
+                                f"the cross-seed noise floor ({floor:.6g})"
+                                if floor > 0
+                                else "the relative-improvement threshold"
+                            )
                             floor_note = (
-                                f" — within the cross-seed noise floor "
-                                f"({floor:.6g}) of the recorded "
+                                f" — within {where} of the recorded "
                                 f"best {prior.best}, so the ledger row is unchanged"
                             )
                         if not floor_note:

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -24,6 +24,7 @@ from autoresearch.github import GitHubClient, Workspace
 from autoresearch.harness import Harness, outage, redact
 from autoresearch.orchestrator import (
     Evaluator,
+    benchmark_floor,
     clears_min_delta,
     draw_run_seed,
     out_of_scope,
@@ -501,15 +502,22 @@ def _respond(
                             prior is not None
                             and beats_prior
                             and not clears_min_delta(
-                                prior.best, candidate, bench.direction, bench.min_delta
+                                prior.best,
+                                candidate,
+                                bench.direction,
+                                bench.min_delta,
+                                bench.min_delta_rel,
                             )
                         ):
                             # named on the thread, like the climb's ending
                             # note — a silently unchanged ledger row reads
                             # as a bug (review finding)
+                            floor = benchmark_floor(
+                                prior.best, bench.min_delta, bench.min_delta_rel
+                            )
                             floor_note = (
                                 f" — within the cross-seed noise floor "
-                                f"(min_delta={bench.min_delta}) of the recorded "
+                                f"({floor:.6g}) of the recorded "
                                 f"best {prior.best}, so the ledger row is unchanged"
                             )
                         if not floor_note:

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -518,7 +518,7 @@ def _respond(
                             where = (
                                 f"the cross-seed noise floor ({floor:.6g})"
                                 if floor > 0
-                                else "the relative-improvement threshold"
+                                else f"a usable baseline (recorded best {prior.best})"
                             )
                             floor_note = (
                                 f" — within {where} of the recorded "

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -516,7 +516,8 @@ def _respond(
                                 prior.best, bench.min_delta, bench.min_delta_rel
                             )
                             where = (
-                                f"the cross-seed noise floor ({floor:.6g})"
+                                f"the cross-seed noise floor "
+                                f"({fmt_metric(floor, bench.display_digits)})"
                                 if floor > 0
                                 else f"a usable baseline (recorded best {prior.best})"
                             )

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -460,7 +460,13 @@ def benchmark_floor(
     """The effective absolute cross-seed floor for a comparison against the
     recorded best. The larger of the absolute floor and the relative floor
     scaled to the level, so a benchmark that sets both gets the more
-    conservative one. Returns 0.0 when no floor is declared."""
+    conservative one. Returns 0.0 when no floor is declared.
+
+    A relative-only floor scales to 0 at a recorded level of 0, which means
+    no floor. That is a real limit of a relative floor, not a bug: a metric
+    that can sit at 0 should pair min_delta_rel with a small absolute
+    min_delta as a backstop. Unbounded metrics that use a relative floor
+    (wall-clock timing) do not reach 0."""
     floors = []
     if min_delta:
         floors.append(min_delta)

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -454,19 +454,39 @@ def draw_run_seed() -> int:
     return 1 + randbits(30)
 
 
+def benchmark_floor(
+    prior_best: float, min_delta: float | None, min_delta_rel: float | None
+) -> float:
+    """The effective absolute cross-seed floor for a comparison against the
+    recorded best. The larger of the absolute floor and the relative floor
+    scaled to the level, so a benchmark that sets both gets the more
+    conservative one. Returns 0.0 when no floor is declared."""
+    floors = []
+    if min_delta:
+        floors.append(min_delta)
+    if min_delta_rel and math.isfinite(prior_best):
+        floors.append(min_delta_rel * abs(prior_best))
+    return max(floors) if floors else 0.0
+
+
 def clears_min_delta(
-    prior_best: float, candidate: float, direction: str, min_delta: float | None
+    prior_best: float,
+    candidate: float,
+    direction: str,
+    min_delta: float | None,
+    min_delta_rel: float | None = None,
 ) -> bool:
     """Cross-seed comparisons on a resampled pool must clear the
-    benchmark's ABSOLUTE noise floor: the recorded best was measured under
-    a different seed, so a delta inside the floor is pool luck, not
-    progress. Same-seed paired comparisons never call this."""
-    if not min_delta:
+    benchmark's noise floor: the recorded best was measured under a
+    different seed, so a delta inside the floor is pool luck, not progress.
+    Same-seed paired comparisons never call this."""
+    floor = benchmark_floor(prior_best, min_delta, min_delta_rel)
+    if not floor:
         return True
     if not (math.isfinite(prior_best) and math.isfinite(candidate)):
         return False
     delta = candidate - prior_best if direction == "max" else prior_best - candidate
-    return delta > min_delta
+    return delta > floor
 
 
 def improved(baseline: float, candidate: float, direction: str, min_rel: float) -> bool:

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -480,11 +480,11 @@ def clears_min_delta(
     benchmark's noise floor: the recorded best was measured under a
     different seed, so a delta inside the floor is pool luck, not progress.
     Same-seed paired comparisons never call this."""
-    floor = benchmark_floor(prior_best, min_delta, min_delta_rel)
-    if not floor:
-        return True
+    if not (min_delta or min_delta_rel):
+        return True  # no floor declared
     if not (math.isfinite(prior_best) and math.isfinite(candidate)):
-        return False
+        return False  # a declared floor with non-finite inputs fails closed
+    floor = benchmark_floor(prior_best, min_delta, min_delta_rel)
     delta = candidate - prior_best if direction == "max" else prior_best - candidate
     return delta > floor
 

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -591,7 +591,7 @@ def test_within_noise_floor_is_an_honest_negative(tmp_path, target_repo) -> None
     assert github.prs == []
     record = load_record(tmp_path / "state", "tsp-floor")
     assert record.ending == "negative-result"
-    assert "noise floor" in record.ending_note and "min_delta" in record.ending_note
+    assert "noise floor" in record.ending_note and "0.5" in record.ending_note
 
 
 def test_sub_threshold_delta_on_floored_benchmark_is_negative_not_abort(

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -201,3 +201,5 @@ roadmap: docs/roadmap.md
 
     with pytest.raises(ValueError):
         load_contract(base % "-0.1", "org/pilot")
+    with pytest.raises(ValueError):
+        load_contract(base % "13", "org/pilot")  # 13 meaning 13% is a typo, not 13x

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -184,3 +184,20 @@ roadmap: docs/roadmap.md
     ):
         with pytest.raises(ValueError):
             load_contract(base % managed, "org/pilot")
+
+
+def test_min_delta_rel_is_optional_and_non_negative() -> None:
+    from autoresearch.contract import load_contract
+
+    base = """
+benchmarks:
+  - {name: speedup, command: c, metric: m, direction: max, min_delta_rel: %s}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    assert load_contract(base % "0.13", "org/pilot").benchmarks[0].min_delta_rel == 0.13
+    import pytest
+
+    with pytest.raises(ValueError):
+        load_contract(base % "-0.1", "org/pilot")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -161,6 +161,9 @@ def test_relative_floor_scales_with_the_level() -> None:
     # neither: no floor
     assert benchmark_floor(500.0, None, None) == 0.0
     assert clears_min_delta(500.0, 500.001, "max", None, None)
+    # a declared floor with a non-finite recorded best fails closed, not open
+    assert not clears_min_delta(float("nan"), 600.0, "max", None, 0.13)
+    assert not clears_min_delta(float("inf"), 600.0, "max", 5.0, None)
 
 
 def test_clears_min_delta_is_direction_aware_and_absolute() -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -146,6 +146,23 @@ def test_unseeded_benchmark_injects_nothing(tmp_path: Path) -> None:
     assert result.run_seed == 0
 
 
+def test_relative_floor_scales_with_the_level() -> None:
+    from autoresearch.orchestrator import benchmark_floor, clears_min_delta
+
+    # 13% relative floor: at level 500 the floor is 65, at 550 it is 71.5
+    assert benchmark_floor(500.0, None, 0.13) == 65.0
+    assert benchmark_floor(550.0, None, 0.13) == 71.5
+    # a max benchmark must beat the recorded best by more than the scaled floor
+    assert clears_min_delta(500.0, 566.0, "max", None, 0.13)  # +66 > 65
+    assert not clears_min_delta(500.0, 564.0, "max", None, 0.13)  # +64 < 65
+    # both set: the more conservative (max) applies
+    assert benchmark_floor(500.0, 100.0, 0.13) == 100.0  # abs 100 > rel 65
+    assert benchmark_floor(500.0, 40.0, 0.13) == 65.0  # rel 65 > abs 40
+    # neither: no floor
+    assert benchmark_floor(500.0, None, None) == 0.0
+    assert clears_min_delta(500.0, 500.001, "max", None, None)
+
+
 def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
     from autoresearch.orchestrator import clears_min_delta
 


### PR DESCRIPTION
The speedup verifier keeps flagging that the record has no floor, and the fix exposed a design gap: `min_delta` is absolute, but speedup is our first unbounded metric and its floor is fundamentally relative (a fraction of a level that drifts with hardware). An absolute number goes stale every re-measure.

Adds `min_delta_rel` to the contract. `benchmark_floor(prior_best, min_delta, min_delta_rel)` returns the effective absolute floor: the larger of the absolute floor and the relative floor scaled to the level, so a benchmark can set either or both. Both callers (climb, follow-up) pass both and report the effective floor value. Bounded metrics (reach 0.15, probe 0.04) keep absolute; timing will use relative.

After this merges, the pilot's speedup contract entry gets `seed_env: PILOT_SPEEDUP_SEED` and `min_delta_rel: 0.13`, which closes the verifier's ungated-record and run_seed-0 findings on #35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)