### PR TITLE
Design: kernel/role consolidation + agent substrate

### DIFF
--- a/docs/design/agent-substrate.md
+++ b/docs/design/agent-substrate.md
@@ -1,0 +1,189 @@
+# Agent substrate: tools, skills, memory
+
+Status: proposal (2026-08-12). Companion to `consolidation.md`. This lays out
+*what exists in the agentic layer* — the catalog — and how the harness loads it.
+
+**Living document.** The catalog is not fixed. We discover feedback in real runs
+and harden it into memory and skills (see *Hardening: the living loop*); expect
+this list to grow.
+
+Three axes, kept distinct:
+
+- **Tool** — a capability the harness grants (a callable function).
+- **Skill** — authored know-how: how and when to do a task. A file, not code.
+- **Memory** — what persists across sessions and gets recalled into a brief.
+
+Skills and tools pair up (a tool is a hand; a skill is knowing when to use it).
+Skills are also the *procedural layer of memory* — see the memory table.
+
+## Tools (capabilities)
+
+| Tool | Who | Notes |
+| --- | --- | --- |
+| repo-read (Read/Grep/Glob) | all agentic roles | native; the read surface |
+| execute / bash | author, steward | inside apptainer; **never** reviewer/verifier |
+| pr-context-read | reviewer, verifier | read-only, **tokenless** — the harness fetches PR/issue text; the bot PAT never enters a session |
+| retriever | opt-in per RoleSpec | curated egress for best-practice/reference lookups (the retriever-in-harness seam) |
+
+GitHub **writes** (open PR, comment, update ledger), the **eval run**, and
+**sbatch** are kernel syscalls, not agent tools. The agent proposes; the kernel
+acts. This is the credential boundary.
+
+## Skills (know-how)
+
+Three scopes: global (every role), role, target. Curated on purpose — a skill
+per tiny thing is the accretion trap in a new costume.
+
+**Global**
+- `kernel-primer` — how autoresearch works: the contract (scope/budgets/benchmark);
+  **your metric is re-measured by the kernel, so gaming it is pointless**; the six
+  honest endings; humans hold merge authority.
+- `experiment-lifecycle` — launch a long job, record what you wait for, end the
+  session; you will be woken with results. Don't block.
+- `plain-style` — the house writing style (today's `PLAIN_STYLE`).
+- `research-report` — hypothesis, what moved, negatives, one next step; a clean
+  negative is a success.
+
+**Role**
+- author: `hypothesis-discipline` (one hypothesis, one expected movement,
+  done-criteria; don't chase small things) · `honest-method` (express a finding
+  in its natural abstraction — the init/LR seam, not a `forward` hack — and check
+  transfer, not just the sweep)
+- reviewer: `review-rubric` (verdict-led, blocking vs advisory, "materially
+  sound" bar, close cycles fast) · `read-only-investigation` (use the checkout +
+  retriever to look past the diff, never execute)
+- verifier: `integrity-lens` (gaming / overfit / scope-evasion; is the change a
+  real mechanism or a benchmark hack?) · shares `read-only-investigation`
+- steward: `ruler-hardening` (when/how to make the metric harder once it's gamed —
+  add a transfer split, harder cells) · `benchmark-design` (noise floors, seeds,
+  why a sweep beats a single point)
+- follow-up: `respond-to-review` (address maintainer comments; which task
+  instruction a wake supersedes; honest scope)
+
+**Target (e.g. `yolo-jepa`)**
+- `codebase-map` — `models/` (encoder/predictor/regularizers) is yours; `run_sweep.py`
+  (the frozen SGD optimizer, the task tuple), `bench_eval.py`, `data/` are the ruler.
+- `method-notes` — the JEPA method, the variance floor, the curves, the probe,
+  known headroom (spiral/decay near 0), the oracle ceiling (~0.81).
+- `eval-and-env` — `uv run python bench_eval.py`, the CPU-torch env, the budget.
+
+## Memory (layers)
+
+| # | Layer | Holds | Lifetime | Scope | Writer | Reader |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | session / resume | working context, agent notes | one run | one run | the session | the session |
+| 2 | run reports (episodic) | hypothesis + outcome per run | persistent | per target | role session | brief (recent N) |
+| 3 | lessons (semantic) | distilled do / don't | persistent, curated | per target | curator role | brief |
+| 4 | **human feedback (new)** | maintainer comments + the merge/close **delta** | persistent → distilled | per target | capture step | brief |
+| 5 | ledger / leaderboard (factual) | verified best, seeds, floor | persistent | per benchmark | **kernel only** | brief + humans |
+| 6 | skills store (procedural) | the skills above | persistent, versioned | global/role/target | humans (PR-gated) | brief |
+
+Layer 7 (later): a retrieval index over 2 and 3 for relevance recall
+(Hermes-style FTS), once the store is big enough to need it.
+
+The gap today is **layer 4** — the notebook carries the agent's own reports
+forward, but maintainer feedback and the merge/close decision feed nothing. The
+highest-value signal there is the *delta*: what a human changed before merging,
+not the prose comment.
+
+## Hardening: the living loop
+
+Feedback is not an authored set fixed up front — it is discovered in runs and
+hardened. A promotion ladder, each rung more general and more permanent, every
+rung human-gated:
+
+1. **Observe** — a maintainer comment, a correction, an observed failure (a gamed
+   metric, a banal PR).
+2. **Capture** — into human-feedback memory (layer 4): the comment plus the
+   merge/close delta.
+3. **Distill** — the curator turns it into a per-target lesson (layer 3). Small,
+   deduped.
+4. **Promote** — a lesson that recurs across runs or targets graduates to a skill
+   (layer 6) or a global standing rule. This is where a one-off correction
+   becomes house policy.
+5. **Pin + version** — skills and lessons are versioned; a run records what it
+   saw, so the ladder never breaks reproducibility.
+
+Promotion is a human-reviewed PR, never a silent self-edit. The affordance rule
+still applies: if a lesson keeps recurring because the environment makes the
+wrong thing easy, fix the environment (add a seam) instead of adding another
+rule.
+
+## Boundaries (hold across all layers)
+
+- **Cross-target separation** — a brief sees only its target's memory. No leakage
+  between targets (`architecture.md`, brief builder).
+- **No raw transcripts in memory** — distill into reports/lessons; transcripts
+  stay on disk, secret-scanned, out of briefs.
+- **No maintainer-private text** in anything an agent reads.
+- **Reproducibility pin** — a run records which lessons-version it saw, so runs
+  stay comparable (same caveat as pinning a self-improving backend).
+- **Authored, then gated** — skills and lessons are human-authored now; an agent
+  may *propose* one, but it lands through a human-reviewed PR, never silent
+  self-modification.
+
+## Harness: the loading substrate
+
+Extends `architecture.md` ("Harness and context engineering", "The backend
+seam"). The harness runs one role session on a swappable backend and returns a
+result. It does **not** judge, gate, measure, or write to GitHub — those are the
+role-runner and kernel.
+
+**Capability contract.** A backend adapter provides, or synthesizes:
+
+| Capability | Native | Synthesized fallback |
+| --- | --- | --- |
+| resume | wake a session with its context | replay distilled context into a fresh session |
+| structured output | schema-constrained final artifact | role-runner parses → validates → repairs `final_text` |
+| tool restriction | honor `allowed_tools` | if it can't restrict, it's ineligible for read-only judge roles |
+| cost / turn accounting | from backend output | session/token proxy |
+
+**Tools: native vs harness-provided.**
+- *native* (from the backend): repo-read, edit, bash — gated by `allowed_tools`.
+- *harness-provided* (one MCP surface, uniform across backends): retriever,
+  pr-context-read. The security-sensitive tools live here so the kernel owns
+  them. `allowed_tools` is the single security surface.
+
+**Two orthogonal axes.** Backend (what drives the session: Claude Code / Codex /
+Hermes) is separate from execution environment (where it runs: apptainer on Torch
+/ GH runner / local / Docker). The RoleSpec picks both. Reviewer = Claude Code on
+a GH runner, read-only; author = Claude Code or Codex in apptainer on Torch.
+Hermes's Singularity backend maps onto apptainer directly.
+
+**One seam.** The old one-shot `Completer` becomes a degenerate RoleSpec — no
+tools, no edit, `output_schema` set — a one-turn session on the same adapter.
+Cheap fast-pass, no second seam.
+
+## RoleSpec: the app manifest
+
+Data, not code. Adding a role is a new RoleSpec + its skills + a result-policy —
+zero kernel change (the invariant).
+
+| Field | Meaning |
+| --- | --- |
+| `name` | role id (author, reviewer, verifier, steward, followup) |
+| `instructions` | standing role prompt, composed from skills |
+| `skills` | skill ids to load (global + role + target) |
+| `tools` | allowed tools (native + harness-provided) |
+| `output_schema` | schema the final artifact must meet (judges); none for authors |
+| `key` | credential family (isolation) |
+| `scope` | path allowlist (editing roles) |
+| `memory_scope` | which target and layers this role reads/writes |
+| `execution` | where it runs + whether execute is allowed |
+| `budget` | turns, walltime, cost cap |
+
+## The role-runner: one loop replaces five drivers
+
+Replaces `climb`, `steward`, `followup`, `review_cli`, `verifier_cli`. Kernel
+code; it calls into the agentic realm at step 2, and everything trust-critical is
+deterministic.
+
+1. **prep** — build the workspace (editable for author, read-only for judge);
+   `brief.build(RoleSpec, task, memory)`; pick the backend adapter.
+2. **run** — `harness.run(...)` with the RoleSpec's tools, key, scope, execution,
+   schema.
+3. **collect + validate** — capture the SessionResult and the diff; validate the
+   structured output (bounded repair).
+4. **result-policy** — deterministic, per role: author = measure + floor + PR;
+   reviewer = post findings, blocking gates the merge; steward = validate + PR.
+5. **persist** — run report, memory, ledger (verified numbers only).

--- a/docs/design/agent-substrate.md
+++ b/docs/design/agent-substrate.md
@@ -30,7 +30,7 @@ GitHub **writes** (open PR, comment, update ledger), the **eval run**, and
 **experiment submission** are `act` syscalls, not agent tools: the agent directs
 them, the kernel performs them so the guarantee holds — the PAT never enters a
 session, and a launched experiment always gets its paired wake job
-(consolidation.md, "Syscalls: sync, yield, and no interrupt"). The agent drafts;
+(consolidation.md, "Syscalls"). The agent drafts;
 the kernel opens the bot PR; a human merges.
 
 ## Skills (know-how)

--- a/docs/design/agent-substrate.md
+++ b/docs/design/agent-substrate.md
@@ -73,7 +73,7 @@ per tiny thing is the accretion trap in a new costume.
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | session / resume | working context, agent notes | one run | one run | the session | the session |
 | 2 | run reports (episodic) | hypothesis + outcome per run | persistent | per target | role session | brief (recent N) |
-| 3 | lessons (semantic) | distilled do / don't | persistent, curated | per target | curator role | brief |
+| 3 | lessons (semantic) | distilled do / don't | persistent, curated | per target | curator drafts → human PR | brief |
 | 4 | **human feedback (new)** | maintainer comments + the merge/close **delta** | persistent → distilled | per target | capture step | brief |
 | 5 | ledger / leaderboard (factual) | verified best, seeds, floor | persistent | per benchmark | **kernel only** | brief + humans |
 | 6 | skills store (procedural) | the skills above | persistent, versioned | global/role/target | humans (PR-gated) | brief |
@@ -96,8 +96,9 @@ rung human-gated:
    metric, a banal PR).
 2. **Capture** — into human-feedback memory (layer 4): the comment plus the
    merge/close delta.
-3. **Distill** — the curator turns it into a per-target lesson (layer 3). Small,
-   deduped.
+3. **Distill** — the curator *drafts* a per-target lesson (layer 3), small and
+   deduped, which lands through a human-reviewed PR — never auto-applied (see
+   Boundaries).
 4. **Promote** — a lesson that recurs across runs or targets graduates to a skill
    (layer 6) or a global standing rule. This is where a one-off correction
    becomes house policy.
@@ -121,6 +122,12 @@ rule.
 - **Authored, then gated** — skills and lessons are human-authored now; an agent
   may *propose* one, but it lands through a human-reviewed PR, never silent
   self-modification.
+- **Untrusted content is data, not instructions** — PR/issue text, retriever
+  results, and the target's own files are untrusted. The harness data-fences
+  them and a role treats them as material to judge, never as commands. This is
+  the prompt-injection boundary for the read tools (pr-context-read, retriever)
+  and for anything a session reads in the workspace (`architecture.md` already
+  data-fences wake prompts by the same rule).
 
 ## Harness: the loading substrate
 
@@ -138,6 +145,12 @@ role-runner and kernel.
 | tool restriction | honor `allowed_tools` | if it can't restrict, it's ineligible for read-only judge roles |
 | cost / turn accounting | from backend output | session/token proxy |
 
+Editing-role **scope** (the write allowlist) is not a backend capability: the
+kernel enforces it on the captured diff after the session, rejecting any write
+outside `scope` regardless of backend (`contract.path_is_forbidden`). Tool
+restriction above is the read-only *judge* boundary; scope is the *editing*
+boundary. Both are kernel-owned.
+
 **Tools: native vs harness-provided.**
 - *native* (from the backend): repo-read, edit, bash — gated by `allowed_tools`.
 - *harness-provided* (one MCP surface, uniform across backends): retriever,
@@ -146,9 +159,10 @@ role-runner and kernel.
 
 **Two orthogonal axes.** Backend (what drives the session: Claude Code / Codex /
 Hermes) is separate from execution environment (where it runs: apptainer on Torch
-/ GH runner / local / Docker). The RoleSpec picks both. Reviewer = Claude Code on
-a GH runner, read-only; author = Claude Code or Codex in apptainer on Torch.
-Hermes's Singularity backend maps onto apptainer directly.
+/ GH runner / local / Docker). The RoleSpec picks both. The read-only
+reviewer on a GH runner is where we first prove an alternate backend (Codex) —
+a judge that never executes is the safe place to swap; the author runs in
+apptainer on Torch. Hermes's Singularity backend maps onto apptainer directly.
 
 **One seam.** The old one-shot `Completer` becomes a degenerate RoleSpec — no
 tools, no edit, `output_schema` set — a one-turn session on the same adapter.
@@ -156,8 +170,9 @@ Cheap fast-pass, no second seam.
 
 ## RoleSpec: the app manifest
 
-Data, not code. Adding a role is a new RoleSpec + its skills + a result-policy —
-zero kernel change (the invariant).
+Data, not code. Adding a role is a new RoleSpec + its skills, reusing an existing
+result-policy — zero kernel change (the invariant; a genuinely new result-policy
+is the rare exception).
 
 | Field | Meaning |
 | --- | --- |

--- a/docs/design/agent-substrate.md
+++ b/docs/design/agent-substrate.md
@@ -24,10 +24,14 @@ Skills are also the *procedural layer of memory* — see the memory table.
 | execute / bash | author, steward | inside apptainer; **never** reviewer/verifier |
 | pr-context-read | reviewer, verifier | read-only, **tokenless** — the harness fetches PR/issue text; the bot PAT never enters a session |
 | retriever | opt-in per RoleSpec | curated egress for best-practice/reference lookups (the retriever-in-harness seam) |
+| subagent (fan-out) | author, steward | inherits the parent RoleSpec's tools/scope/key; spend counts against the session budget |
 
 GitHub **writes** (open PR, comment, update ledger), the **eval run**, and
-**sbatch** are kernel syscalls, not agent tools. The agent proposes; the kernel
-acts. This is the credential boundary.
+**experiment submission** are `act` syscalls, not agent tools: the agent directs
+them, the kernel performs them so the guarantee holds — the PAT never enters a
+session, and a launched experiment always gets its paired wake job
+(consolidation.md, "Syscalls: sync, yield, and no interrupt"). The agent drafts;
+the kernel opens the bot PR; a human merges.
 
 ## Skills (know-how)
 
@@ -73,7 +77,7 @@ per tiny thing is the accretion trap in a new costume.
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | session / resume | working context, agent notes | one run | one run | the session | the session |
 | 2 | run reports (episodic) | hypothesis + outcome per run | persistent | per target | role session | brief (recent N) |
-| 3 | lessons (semantic) | distilled do / don't | persistent, curated | per target | curator drafts → human PR | brief |
+| 3 | lessons (semantic) | distilled do / don't | persistent, curated | per target | curator role → bot PR → human merge | brief |
 | 4 | **human feedback (new)** | maintainer comments + the merge/close **delta** | persistent → distilled | per target | capture step | brief |
 | 5 | ledger / leaderboard (factual) | verified best, seeds, floor | persistent | per benchmark | **kernel only** | brief + humans |
 | 6 | skills store (procedural) | the skills above | persistent, versioned | global/role/target | humans (PR-gated) | brief |
@@ -119,9 +123,9 @@ rule.
 - **No maintainer-private text** in anything an agent reads.
 - **Reproducibility pin** — a run records which lessons-version it saw, so runs
   stay comparable (same caveat as pinning a self-improving backend).
-- **Authored, then gated** — skills and lessons are human-authored now; an agent
-  may *propose* one, but it lands through a human-reviewed PR, never silent
-  self-modification.
+- **Proposed by agents, gated at merge** — an agent (the curator, like any role)
+  drafts a skill or lesson as a bot PR; it lands only on a human merge, never a
+  silent self-edit. Drafting is agentic; merge authority is the human gate.
 - **Untrusted content is data, not instructions** — PR/issue text, retriever
   results, and the target's own files are untrusted. The harness data-fences
   them and a role treats them as material to judge, never as commands. This is

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -70,6 +70,32 @@ So: measure (kernel) + judge (invoked role) + gate (policy) + execute (plumbing)
 what — the kernel doesn't; it wakes the session. Every time real judgment is
 required, it is a role, not the kernel.
 
+## Syscalls: sync, yield, and no interrupt
+
+Agents don't touch the trust-critical machinery directly — they call syscalls,
+and the kernel mediates only where a guarantee depends on it. `act` is every
+outward effect the kernel performs for a role: open a bot PR, post a comment,
+update the ledger, and **launch an experiment**. So agents already draft PRs
+(the kernel opens them; humans **merge**) and already launch experiments (the
+kernel submits them, with the paired wake job so no run is stranded). A role can
+also **fan out subagents** inside its session; they inherit its RoleSpec (tools,
+scope, key), and their spend counts against its budget.
+
+**Our OS is single-threaded, cooperative, and non-preemptive.** The tick is the
+scheduler: it runs each lane to completion and exits, and run state on the shared
+filesystem is the context switch. There is one blocking syscall —
+launch-experiment, which runs for hours — and it is a **yield**, not a preemptive
+block: the session ends, the kernel records the continuation (what it waits for,
+plus resume state), and a later tick wakes it. The wake cycle is coroutine
+yield/resume, which is why no agent is ever a long-lived process.
+
+**Nothing is interrupted mid-flight.** There are no signals into a running
+session. You steer at yield boundaries — a wake prompt can supersede a
+task-level instruction — or you cancel the job (the coarse `kill`). Between
+yields the agent honors its standing brief. A single-threaded OS that can't be
+interrupted is a real constraint; it is also what makes every step recoverable
+from a file on disk.
+
 ## What is kernel, what is app
 
 | Now | Fate |

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -38,15 +38,21 @@ data + skills:
   scope, output schema
 - a **result-policy** — what the kernel does with the role's output (author:
   measure+floor+PR; reviewer: post findings, blocking gates merge; steward:
-  validate+PR). Trust-critical policies are deterministic by design.
+  validate+PR). These are trust-critical *kernel* code and form a small, reused
+  set — see the invariant below.
 
 ## The design invariant
 
-> Adding a new role, backend, or benchmark requires **zero kernel changes.**
+> Adding a new role, backend, or benchmark requires **zero kernel changes** —
+> as long as it reuses an existing result-policy.
 
-If any of them forces a kernel edit, an app has leaked into the OS — which is
-exactly how the accretion happened. This is the health check for every change
-under this plan.
+Most new roles do: another judge reuses "post findings, blocking gates merge";
+another climb-like role reuses "measure + floor + PR". A role that needs a
+genuinely *new* result-policy is the honest exception — a result-policy is
+trust-critical kernel code (it measures, gates, acts), so a new one is a new
+kernel primitive, added deliberately and rarely. The health check still bites:
+if a *routine* new role, backend, or benchmark forces a kernel edit, an app has
+leaked into the OS — which is exactly how the accretion happened.
 
 ## The kernel never judges
 

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -1,0 +1,147 @@
+# Consolidation: the kernel as a multi-agent OS
+
+Status: proposal (2026-08-12). Staged; each stage stops for review.
+
+## Why
+
+The system grew by accretion. Each recent pain — session budgets, outages,
+review length, noise floors — was fixed by adding a module or a flag. Every fix
+was defensible; the sum is over-fragmented. Reading it now, a lot of the weight
+is bespoke Python re-implementing what an agent harness already does: the loop,
+tools, context management, resume, structured output, skills, memory.
+
+The good news is the hard part is already right. The backend seam exists
+(`architecture.md`, "The backend seam"): `Harness` takes a brief + workspace and
+returns a `SessionResult`; `brief.build` owns context policy, shared by all
+backends. So this is not a rewrite. It is finishing a separation the design
+already started.
+
+## The two layers
+
+**Kernel — the multi-agent OS.** The deterministic core that earns trust: it
+must be ungameable and reproducible. It exposes a small, stable surface and
+nothing more:
+
+- **run-a-role** — dispatch one role session to a backend (the `Harness` seam)
+- **measure** — re-run the contract eval on the candidate tree; the number is
+  never the agent's claim
+- **gate** — apply an explicit policy (floor, scope-clean, no-regression) to a
+  measurement or a verdict
+- **act** — mechanical I/O: open a PR, post a comment, update the ledger
+- **isolate** — per-role key and scope; scrubbed session env
+- **persist** — run state, notebook, memory on the shared filesystem
+
+**Roles — the apps.** Everything that thinks. A role is not a module; it is
+data + skills:
+
+- a **RoleSpec** — instructions, skill set, allowed tools, key, scope, memory
+  scope, output schema
+- a **result-policy** — what the kernel does with the role's output (author:
+  measure+floor+PR; reviewer: post findings, blocking gates merge; steward:
+  validate+PR). Trust-critical policies are deterministic by design.
+
+## The design invariant
+
+> Adding a new role, backend, or benchmark requires **zero kernel changes.**
+
+If any of them forces a kernel edit, an app has leaked into the OS — which is
+exactly how the accretion happened. This is the health check for every change
+under this plan.
+
+## The kernel never judges
+
+"Interpret → act" hides two kinds of interpretation. Only one is the kernel's.
+
+- *Measurement* ("did the number move, is the diff in scope") is arithmetic on a
+  re-run eval. Deterministic — the trust anchor.
+- *Judgment* ("is this sound, interesting, overfit, what next") is agentic. The
+  kernel never does it. When judgment is needed it **calls a role** — that is
+  what the reviewer and verifier are — and applies a mechanical policy to the
+  role's structured verdict.
+
+So: measure (kernel) + judge (invoked role) + gate (policy) + execute (plumbing)
++ human merge. When the author must interpret mid-run — experiment done, now
+what — the kernel doesn't; it wakes the session. Every time real judgment is
+required, it is a role, not the kernel.
+
+## What is kernel, what is app
+
+| Now | Fate |
+| --- | --- |
+| `climb`, `steward`, `followup`, `review_cli`, `verifier_cli` | Five copies of "prep → run a role → act on the result." Collapse into **one role-runner + a RoleSpec + a result-policy** each. The measure/gate/PR halves stay kernel; the brief/skills halves become app config. |
+| `review`, `verifier` (rendering, verdict/blocking machinery) | Move onto the agent-session path; shared finding-rendering becomes a skill. |
+| `harness`, `llm`, `brief` | The seam. Keep. Add adapters. |
+| `orchestrator`, `contract`, `github`, `compute`, `runstate`, `disk`, `limits`, `intake` | Kernel. Barely moves — the point. |
+| `tick` | Kernel, but bloated from the same accretion. Its own diet, later. |
+
+Rough size: ~2.5–2.8k of ~8.7k LOC is role-layer that collapses toward ~1k of
+plumbing plus skill/instruction files. The kernel (~5k) is intentionally
+untouched — you do not refactor the part that earns trust.
+
+## Backends (the seam)
+
+Any backend must meet a capability contract, or its adapter synthesizes the
+gap:
+
+- **resume** (wake a session with its working context)
+- **structured output** (schema-constrained verdict for judge roles)
+- **tool restriction** (read-only toolset for the reviewer boundary)
+- **cost / turn accounting**
+
+Lineup: **Claude Code** (primary), **Codex** (second, confirmed), **Hermes
+Agent** (Nous, MIT, full CLI harness, model-agnostic, Singularity/apptainer
+backend, native skills + learning loop) as the open-source candidate. Bench
+honestly — same brief, same task pool, diff the outcomes — never rewrite around
+one. A self-improving backend (Hermes) must be pinned for controlled roles so
+runs stay comparable.
+
+## Reviewer and verifier are this consolidation
+
+Today they sit on the one-shot `Completer` seam: read a diff, emit findings, no
+tools, no checkout. The planned upgrade — make them agentic — *is* moving them
+onto the agent-session path with a read-only checkout of the PR head (Read,
+Grep, Glob; no Bash, no Write; egress limited to the model API plus the curated
+retriever). The two seams collapse to one substrate; roles differ only by
+RoleSpec.
+
+Two tracked upgrades fall out for free: **inline verifier findings** (same
+render path as the reviewer) and **the retriever seam** (a tool in the reviewer's
+RoleSpec, not a bolted-on API context). The security boundary becomes
+`allowed_tools` — kernel-enforced by the toolset, not asked for in a prompt.
+See `reviewer-infra.md`.
+
+## Learning
+
+Skills, memory, and the notebook are how roles learn — the native substrate, not
+a bolt-on. Two levers:
+
+- **Capture.** The notebook carries the agent's own reports forward; maintainer
+  PR feedback and the merge/close decision currently do not feed it. Add a step
+  that distills a closed/merged PR's review thread + outcome into one short,
+  per-target lesson. The strongest signal is the *delta* — what a maintainer
+  changed before merging — not the prose comment.
+- **Affordance.** Prefer shaping the environment over instructing. Give `models/`
+  a real init/LR seam and µP-type findings land there, instead of being smuggled
+  into `forward` — no rule required. Affordances teach more reliably than
+  instructions, and a frozen model only "learns" in-context anyway.
+
+## Staged plan
+
+1. **Reviewer/verifier onto the agent-session path, Codex as the proving
+   backend.** Lowest-stakes place to validate a second backend (a read-only judge
+   is far safer to run on an alternate stack than a file-editing author), and it
+   ships the agentic-review upgrade at the same time.
+2. **Introduce `RoleSpec` + the role-runner**; move author, steward, follow-up
+   onto it; fold prompt content into skills; wire the lesson-capture step.
+3. **Diet `tick`.**
+
+## Costs and non-goals
+
+- An agentic review is a session — slower and pricier than one completion. Keep a
+  no-tools RoleSpec as a cheap fast-pass.
+- Keep the trust story *legible*: a reviewer must still be able to point at
+  "measured here, gated there." Do not trade auditability for brevity.
+- Going lighter deepens harness coupling; the seam and honest backend benching
+  are the hedge.
+- Not in scope: touching the measure/gate/isolate core, or the scheduler's
+  fail-safety (`architecture.md`, "Wake delivery and fail-safety").

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -105,7 +105,7 @@ So: measure (kernel) + judge (invoked role) + gate (policy) + execute (plumbing)
 what — the kernel doesn't; it wakes the session. Every time real judgment is
 required, it is a role, not the kernel.
 
-## Syscalls: sync, yield, and no interrupt
+## Syscalls
 
 Agents don't touch the trust-critical machinery directly — they call syscalls,
 and the kernel mediates only where a guarantee depends on it. `act` is every
@@ -115,21 +115,6 @@ update the ledger, and **launch an experiment**. So agents already draft PRs
 kernel submits them, with the paired wake job so no run is stranded). A role can
 also **fan out subagents** inside its session; they inherit its RoleSpec (tools,
 scope, key), and their spend counts against its budget.
-
-**Our OS is single-threaded, cooperative, and non-preemptive.** The tick is the
-scheduler: it runs each lane to completion and exits, and run state on the shared
-filesystem is the context switch. There is one blocking syscall —
-launch-experiment, which runs for hours — and it is a **yield**, not a preemptive
-block: the session ends, the kernel records the continuation (what it waits for,
-plus resume state), and a later tick wakes it. The wake cycle is coroutine
-yield/resume, which is why no agent is ever a long-lived process.
-
-**Nothing is interrupted mid-flight.** There are no signals into a running
-session. You steer at yield boundaries — a wake prompt can supersede a
-task-level instruction — or you cancel the job (the coarse `kill`). Between
-yields the agent honors its standing brief. A single-threaded OS that can't be
-interrupted is a real constraint; it is also what makes every step recoverable
-from a file on disk.
 
 ## What is kernel, what is app
 

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -2,6 +2,41 @@
 
 Status: proposal (2026-08-12). Staged; each stage stops for review.
 
+## Principle
+
+**Everything is an agent except the smallest set of mechanisms that make an
+agent's output trustworthy.** The kernel is a thin, verifiable boundary *around*
+untrusted intelligence, never a manager *of* it — the microkernel idea applied to
+intelligence: a minimal privileged core, everything smart in userspace.
+
+Only four mechanisms are irreducible, because an agent cannot provide them about
+itself:
+
+1. **Disinterested verification** (measure + gate) — the graded thing can't
+   produce its own grade.
+2. **Outside-enforced isolation** (credentials, scope) — you can't ask the
+   guarded to guard itself; the agent is the untrusted party.
+3. **Crash-proof liveness** (the wake guarantee) — an agent can't guarantee its
+   own progress if it hangs or dies.
+4. **Reproducible audit** — a fixed, replayable procedure is what makes an
+   autonomous PR mergeable at all.
+
+Everything else is an agent. The compass:
+
+- **Agents by default, mechanism by exception.** If you can't name the guarantee,
+  it isn't kernel.
+- **Minimize the trusted base.** The kernel is the TCB — every line is attack
+  surface and audit burden. Small enough to hold in your head.
+- **Mechanism, not policy.** The kernel only says *no*; it never says *do this
+  next*. Decisions are agentic.
+- **Guarantees, not guardrails.** Don't make agents *correct*; make their output
+  *verifiable, contained, recoverable*.
+
+The bound that keeps it honest: as agentic as possible *while every autonomous
+action stays verifiable, contained, and recoverable*. The one place a mechanism
+must exist is exactly where you otherwise couldn't verify, contain, or recover
+what an agent did.
+
 ## Why
 
 The system grew by accretion. Each recent pain — session budgets, outages,


### PR DESCRIPTION
Design proposals for the lighter architecture (no code changes). Bundled so the design can be reviewed and settled before stage 1 moves any code.

## `consolidation.md`
The system is two layers, and only one should be fragmented.
- **Kernel = a multi-agent OS** with a minimal syscall surface: run-a-role, measure, gate, act, isolate, persist.
- **Roles = apps**: a `RoleSpec` + a result-policy. The five role-driver modules (`climb`, `steward`, `followup`, `review_cli`, `verifier_cli`) collapse into one role-runner.
- **Invariant:** adding a new role, backend, or benchmark requires zero kernel changes.
- The kernel never judges — it calls a role and applies a mechanical policy to the structured verdict.

## `agent-substrate.md`
- **Tools / skills / memory** catalog, kept on three distinct axes (capability / know-how / recall).
- **Hardening loop** — how discovered feedback becomes memory then skill: observe → capture → distill → promote → pin, human-gated. A living document.
- **Harness / RoleSpec / role-runner** — the capability contract for swappable backends (Claude Code, Codex, Hermes), the native-vs-harness tool split, and the one-loop role-runner.

## Not in scope
The measure/gate/isolate core and the scheduler's fail-safety are untouched by this plan.

## Next
Stage 1 (separate PR): a Codex adapter behind `Harness` + the read-only reviewer as the first RoleSpec on the agent-session path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)