### PR TITLE
Stage 1: agent-session reviewer foundation (RoleSpec, Codex backend, role-runner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Review findings carry a `kind` — change, suggestion, question, or note —
+  saying what the reader is asked to do, separate from whether the finding
+  gates the merge. Placement follows it: actionable findings (a blocking
+  defect, a change, or a suggestion) anchor inline on their line; questions
+  and notes stay in the compact body list so local FYIs do not flood the
+  diff. Suggestions are marked as optional.
 - Reviews are shorter and lead with a verdict. Every advisory and
   verification round now opens with one line — blocking vs advisory
   counts — then shows blocking findings in full and the rest as a

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -564,6 +564,8 @@ class CodexHarness:
             path = _write_private(
                 workspace.parent, transcript_stem, ".jsonl", redact(stdout or "", (self.api_key,))
             )
+            with contextlib.suppress(OSError):
+                last_message_path.unlink()  # clean up on the timeout path too
             log.warning("codex session timed out after %ss in %s", self.timeout_s, workspace)
             return _error_result(
                 "timeout",

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -518,9 +518,11 @@ class CodexHarness:
         except OSError as exc:
             log.warning("could not create session home %s: %s", session_home, exc)
             return _error_result("workspace-error")
-        # --output-last-message target lives outside the clone and is cleared
-        # first, so a stale file can never be read as this run's result.
-        last_message_path = workspace.parent / f"{transcript_stem}-last.txt"
+        # --output-last-message target lives inside the per-run home (0700),
+        # not the shared parent, so model output is not exposed there while
+        # codex is writing it; cleared first so a stale file can never be read
+        # as this run's result, and deleted again after reading.
+        last_message_path = session_home / "codex-last-message.txt"
         with contextlib.suppress(OSError):
             last_message_path.unlink()
         command = _codex_command(
@@ -571,10 +573,12 @@ class CodexHarness:
         stdout = redact(stdout, (self.api_key,))
         transcript_path = _write_private(workspace.parent, transcript_stem, ".jsonl", stdout)
         last_message = ""
+        # errors="replace": a non-UTF-8 last-message file must not raise
+        # UnicodeDecodeError (not an OSError) and break the never-raises contract.
         with contextlib.suppress(OSError):
-            last_message = redact(last_message_path.read_text(), (self.api_key,))
+            last_message = redact(last_message_path.read_text(errors="replace"), (self.api_key,))
         # The final message is preserved in the 0600 transcript; drop the raw
-        # file so model output is not left behind with default permissions.
+        # file so model output is not left behind.
         with contextlib.suppress(OSError):
             last_message_path.unlink()
         return _parse_codex_result(stdout, last_message, process.returncode, transcript_path)

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -464,7 +464,9 @@ def _parse_codex_result(
             value = event.get(key)
             if not session_id and isinstance(value, str):
                 session_id = value
-        if str(event.get("type", "")).endswith("error") or "error" in event:
+        # A truthy `error` value or an error-typed event, not the mere presence
+        # of an "error" key — a benign event may carry `"error": null`.
+        if str(event.get("type", "")).endswith("error") or event.get("error"):
             saw_error = True
             message = event.get("message") or event.get("error")
             if isinstance(message, str):
@@ -571,6 +573,10 @@ class CodexHarness:
         last_message = ""
         with contextlib.suppress(OSError):
             last_message = redact(last_message_path.read_text(), (self.api_key,))
+        # The final message is preserved in the 0600 transcript; drop the raw
+        # file so model output is not left behind with default permissions.
+        with contextlib.suppress(OSError):
+            last_message_path.unlink()
         return _parse_codex_result(stdout, last_message, process.returncode, transcript_path)
 
 

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -402,6 +402,178 @@ def _parse_result(stdout: str) -> dict[str, Any] | None:
     return candidates[0] if candidates else None
 
 
+def _codex_command(
+    binary: str,
+    model: str,
+    sandbox: str,
+    workspace: Path,
+    last_message_path: Path,
+    resume_session_id: str | None,
+    extra_args: tuple[str, ...],
+) -> list[str]:
+    """Argv for one headless `codex exec` run.
+
+    The prompt is NOT an argument: `codex exec` reads it from stdin when no
+    positional prompt is given, keeping the brief out of world-readable /proc
+    argv (the same rule as the Claude adapter). Flags follow the Codex docs and
+    must be checked against `codex exec --help` on the cluster.
+    """
+    head = [binary, "exec", "resume", resume_session_id] if resume_session_id else [binary, "exec"]
+    return [
+        *head,
+        "--json",  # JSONL events on stdout (session id, usage)
+        "--model",
+        model,
+        "--sandbox",
+        sandbox,  # "read-only" for judge roles; "workspace-write" for authors
+        "--cd",
+        str(workspace),
+        "--output-last-message",  # final message -> file (reliable final_text)
+        str(last_message_path),
+        "--skip-git-repo-check",
+        *extra_args,
+    ]
+
+
+def _parse_codex_result(
+    stdout: str, last_message: str, returncode: int, transcript_path: str = ""
+) -> SessionResult:
+    """Best-effort SessionResult from `codex exec --json` output.
+
+    `final_text` comes from the --output-last-message file, which is reliable.
+    `session_id` is pulled from the JSONL events defensively; the exact event
+    schema must be confirmed against a live `--json` run, so until then resume
+    may be unavailable. Cost is left at 0 (these backends are subscription or
+    token metered; the budget layer meters them by a session/token proxy).
+    Never raises.
+    """
+    session_id = ""
+    saw_error = False
+    errors: list[str] = []
+    for line in stdout.splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        try:
+            event = json.loads(text)
+        except json.JSONDecodeError:
+            continue  # human-readable lines can interleave the JSONL; skip them
+        if not isinstance(event, dict):
+            continue
+        for key in ("session_id", "conversation_id"):
+            value = event.get(key)
+            if not session_id and isinstance(value, str):
+                session_id = value
+        if str(event.get("type", "")).endswith("error") or "error" in event:
+            saw_error = True
+            message = event.get("message") or event.get("error")
+            if isinstance(message, str):
+                errors.append(message)
+    is_error = returncode != 0 or saw_error
+    detail = "; ".join(errors)[:500]
+    return SessionResult(
+        stop_reason="error" if is_error else "completed",
+        is_error=is_error,
+        error_detail=detail if is_error else "",
+        cost_usd=0.0,
+        num_turns=0,
+        session_id=session_id,
+        final_text=last_message.strip(),
+        transcript_path=transcript_path,
+    )
+
+
+@dataclass
+class CodexHarness:
+    """Headless OpenAI Codex CLI (`codex exec`) — a second Harness backend.
+
+    Stage 1's swappability proof, first used for the read-only reviewer
+    (docs/design/consolidation.md): Codex's own `--sandbox read-only` plus a
+    judge RoleSpec's tool set. Flags and the JSONL event schema follow the Codex
+    docs and MUST be verified against `codex exec --help` and a live `--json`
+    run on the cluster before production; `session_id` and cost parsing are
+    best-effort until then. No apptainer wrapper yet (the reviewer runs
+    read-only); the author-on-Codex path adds one later.
+
+    `run` never raises: every failure comes back as an error SessionResult.
+    """
+
+    api_key: str
+    binary: str = "codex"
+    model: str = "gpt-5-codex"  # verify the available model id on the cluster
+    sandbox: str = "read-only"  # judge default; authors pass "workspace-write"
+    timeout_s: int = DEFAULT_TIMEOUT_S
+    extra_args: tuple[str, ...] = field(default_factory=tuple)
+
+    def run(
+        self, brief_text: str, workspace: Path, resume_session_id: str | None = None
+    ) -> SessionResult:
+        transcript_stem = f"{workspace.name}-codex"
+        session_home = workspace.parent / f"{workspace.name}-home"
+        try:
+            session_home.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(session_home, 0o700)
+        except OSError as exc:
+            log.warning("could not create session home %s: %s", session_home, exc)
+            return _error_result("workspace-error")
+        # --output-last-message target lives outside the clone and is cleared
+        # first, so a stale file can never be read as this run's result.
+        last_message_path = workspace.parent / f"{transcript_stem}-last.txt"
+        with contextlib.suppress(OSError):
+            last_message_path.unlink()
+        command = _codex_command(
+            self.binary,
+            self.model,
+            self.sandbox,
+            workspace,
+            last_message_path,
+            resume_session_id,
+            self.extra_args,
+        )
+        try:
+            env = session_env(self.api_key, "OPENAI_API_KEY", session_home)
+            process = subprocess.Popen(
+                command,
+                cwd=workspace,
+                env=env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                start_new_session=True,
+            )
+        except OSError as exc:
+            log.warning("could not spawn %s: %s", self.binary, exc)
+            return _error_result("spawn-error")
+        try:
+            stdout, _ = process.communicate(input=brief_text, timeout=self.timeout_s)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(process.pid, signal.SIGKILL)
+            try:
+                stdout, _ = process.communicate(timeout=10)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                stdout = ""
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    stdout, _ = process.communicate(timeout=5)
+            path = _write_private(
+                workspace.parent, transcript_stem, ".jsonl", redact(stdout or "", (self.api_key,))
+            )
+            log.warning("codex session timed out after %ss in %s", self.timeout_s, workspace)
+            return _error_result(
+                "timeout",
+                path,
+                detail=f"session hit its {self.timeout_s}s walltime and was killed",
+            )
+        stdout = redact(stdout, (self.api_key,))
+        transcript_path = _write_private(workspace.parent, transcript_stem, ".jsonl", stdout)
+        last_message = ""
+        with contextlib.suppress(OSError):
+            last_message = redact(last_message_path.read_text(), (self.api_key,))
+        return _parse_codex_result(stdout, last_message, process.returncode, transcript_path)
+
+
 @dataclass
 class FakeHarness:
     """Deterministic in-process harness for tests and dry runs."""

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -393,8 +393,28 @@ def verdict_line(findings: list[Finding], clean_text: str = "no defects found") 
     return f"**Verdict: {blocking} blocking, {advisory} advisory.**"
 
 
+# Findings that anchor inline: the ones the reader can act on right at the
+# line. Blocking findings anchor too (they gate the merge, so they are always
+# actionable), which keeps them inline regardless of `kind`.
+_INLINE_KINDS = ("change", "suggestion")
+# Body-bullet labels that surface intent for the kinds kept in the body.
+_BRIEF_LABEL = {"question": "Question: ", "suggestion": "Suggestion: "}
+
+
+def _inlines(finding: Finding) -> bool:
+    return finding.blocking or finding.kind in _INLINE_KINDS
+
+
+def _inline_comment(finding: Finding) -> str:
+    """The inline thread body for a local, actionable finding. A suggestion is
+    marked as optional; a change (or blocking defect) reads as itself."""
+    paragraph = _finding_paragraph(finding, with_ref=False)
+    lead = "**Suggestion.** " if finding.kind == "suggestion" and not finding.blocking else ""
+    return f"{lead}{paragraph}\n\n*({finding.confidence} confidence)*"
+
+
 def _finding_brief(finding: Finding) -> str:
-    """A compact one-line bullet for a non-blocking finding. Summary is
+    """A compact one-line bullet for a finding kept in the body. Summary is
     model text shaped by the diff, so an odd backtick must be balanced or
     it pairs with the reference's opening backtick and spills the path."""
     safe_file = finding.file.replace("`", "")
@@ -402,7 +422,8 @@ def _finding_brief(finding: Finding) -> str:
     summary = finding.summary.rstrip(".!?…")
     if summary.count("`") % 2:
         summary += "`"
-    return f"- {summary} ({where}; {finding.confidence})"
+    label = _BRIEF_LABEL.get(finding.kind, "")
+    return f"- {label}{summary} ({where}; {finding.confidence})"
 
 
 def _render_body(
@@ -423,7 +444,7 @@ def _render_body(
     lines = [marker, header, "", verdict, ""]
     if inline_count:
         n = inline_count
-        lines.append(f"{n} blocking finding{'s' if n != 1 else ''} attached to the lines below.")
+        lines.append(f"{n} finding{'s' if n != 1 else ''} attached to the lines below.")
         lines.append("")
     for f in blocking:  # only the ones not shown inline reach here
         lines.append(_finding_paragraph(f))
@@ -450,17 +471,17 @@ def format_review(result: ReviewResult, diff: str) -> tuple[str, list[dict[str, 
     anchors = commentable_lines(diff)
     inline: list[dict[str, Any]] = []
     remaining: list[Finding] = []
-    # Only blocking findings anchor inline (they are what the reader must
-    # act on); advisory findings stay as a compact list in the body.
+    # Actionable findings (blocking, or kind change/suggestion) anchor inline
+    # where the reader acts; questions and notes stay a compact body list, so
+    # local FYI findings do not flood the diff with threads.
     for finding in sorted(result.findings, key=lambda f: _CONFIDENCE_ORDER[f.confidence]):
-        if finding.blocking and finding.line and finding.line in anchors.get(finding.file, ()):
+        if _inlines(finding) and finding.line and finding.line in anchors.get(finding.file, ()):
             inline.append(
                 {
                     "path": finding.file,
                     "line": finding.line,
                     "side": "RIGHT",
-                    "body": f"{_finding_paragraph(finding, with_ref=False)}\n\n"
-                    f"*({finding.confidence} confidence)*",
+                    "body": _inline_comment(finding),
                 }
             )
         else:

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -271,7 +271,15 @@ def review(
         return ReviewResult(findings=[], notes="", skipped=skip)
 
     raw = completer.complete(SYSTEM_PROMPT, build_prompt(pr, today), FINDINGS_SCHEMA)
-    data = json.loads(raw)
+    return result_from_data(json.loads(raw))
+
+
+def result_from_data(data: dict[str, Any]) -> ReviewResult:
+    """Build a ReviewResult from a validated findings object. Shared by the
+    one-shot completer path and the agent-session path — both hand back the
+    same schema, so both must sanitize identically: every string here is
+    untrusted model output bound for a GitHub comment, and the caps guard the
+    render (`sanitize` also neutralizes markdown/HTML injection)."""
     findings = [
         Finding(
             file=sanitize(item["file"], 200),

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -225,6 +225,26 @@ def _fence(text: str) -> str:
     return "`" * max(3, longest + 1)
 
 
+# Prepended to the shared rubric for the agent-session reviewer: it has a
+# read-only checkout and the read tools, unlike the one-shot completer that
+# only sees the diff and a bounded context slice.
+AGENT_INVESTIGATION = (
+    "The repository is checked out read-only in your working directory. Use Read, "
+    "Grep, and Glob to investigate beyond the diff: the surrounding code, callers, "
+    "and tests. The checked-out code is part of your evidence, so you may cite file "
+    "contents you read. You have no execute or write tools; do not run code.\n\n"
+    "When done, reply with ONLY the JSON object of findings (keys: `findings`, "
+    "`notes`) and nothing else."
+)
+
+
+def build_agent_brief(pr: PullRequest, today: str | None = None) -> str:
+    """The reviewer brief for an agent session: the shared rubric, the
+    investigation instruction, and the PR itself. Reuses the completer's
+    prompt so both paths judge by the same rules."""
+    return f"{SYSTEM_PROMPT}\n\n{AGENT_INVESTIGATION}\n\n{build_prompt(pr, today)}"
+
+
 def build_prompt(pr: PullRequest, today: str | None = None) -> str:
     diff = pr.diff
     truncated = ""

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -406,10 +406,16 @@ def _inlines(finding: Finding) -> bool:
 
 
 def _inline_comment(finding: Finding) -> str:
-    """The inline thread body for a local, actionable finding. A suggestion is
-    marked as optional; a change (or blocking defect) reads as itself."""
+    """The inline thread body for a local, actionable finding. A lead word says
+    which it is: a blocking defect (gates the merge), an optional suggestion, or
+    a plain change."""
+    if finding.blocking:
+        lead = "**Blocking.** "
+    elif finding.kind == "suggestion":
+        lead = "**Suggestion.** "
+    else:
+        lead = ""
     paragraph = _finding_paragraph(finding, with_ref=False)
-    lead = "**Suggestion.** " if finding.kind == "suggestion" and not finding.blocking else ""
     return f"{lead}{paragraph}\n\n*({finding.confidence} confidence)*"
 
 

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -88,11 +88,16 @@ or gaming defect with a concrete failure. Edge cases, missing docs,
 wording, and anything low-confidence are advisory: `blocking` false. Most
 findings are advisory.
 
+Set `kind` to what you want the reader to do: `change` (fix this),
+`suggestion` (an optional improvement), `question` (you need an answer), or
+`note` (just flagging). A blocking finding is almost always `change`.
+
 Never instruct the reader to merge, approve, or reject. You are advisory."""
 )
 
 
 CONFIDENCES = ("low", "medium", "high")
+KINDS = ("change", "suggestion", "question", "note")
 
 
 class Completer(Protocol):
@@ -124,6 +129,9 @@ class Finding:
     detail: str
     category: str = ""  # verifier-only (gaming taxonomy); "" for advisory
     blocking: bool = False  # a confirmed defect that should gate merge
+    # What the reader is asked to do — the speech act, separate from blocking
+    # (does it gate) and line (is it local). Governs how a finding renders.
+    kind: Literal["change", "suggestion", "question", "note"] = "note"
 
 
 @dataclass(frozen=True)
@@ -147,8 +155,9 @@ FINDINGS_SCHEMA: dict[str, Any] = {
                     "summary": {"type": "string"},
                     "detail": {"type": "string"},
                     "blocking": {"type": "boolean"},
+                    "kind": {"type": "string", "enum": list(KINDS)},
                 },
-                "required": ["file", "line", "confidence", "summary", "detail", "blocking"],
+                "required": ["file", "line", "confidence", "summary", "detail", "blocking", "kind"],
                 "additionalProperties": False,
             },
         },
@@ -308,6 +317,7 @@ def result_from_data(data: dict[str, Any]) -> ReviewResult:
             summary=sanitize(item["summary"], MAX_SUMMARY_CHARS),
             detail=sanitize(item["detail"], MAX_DETAIL_CHARS),
             blocking=bool(item.get("blocking")),
+            kind=item["kind"] if item.get("kind") in KINDS else "note",
         )
         for item in list(data.get("findings", []))[:MAX_FINDINGS]
     ]

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -242,8 +242,10 @@ AGENT_INVESTIGATION = (
     "Grep, and Glob to investigate beyond the diff: the surrounding code, callers, "
     "and tests. The checked-out code is part of your evidence, so you may cite file "
     "contents you read. You have no execute or write tools; do not run code.\n\n"
-    "When done, reply with ONLY the JSON object of findings (keys: `findings`, "
-    "`notes`) and nothing else."
+    "When done, reply with ONLY a JSON object and nothing else: `findings` (a "
+    "list) and `notes` (a string). Each finding has `file`, `line` (or null), "
+    "`confidence` (low, medium, or high), `summary`, `detail`, `blocking` (true "
+    "or false), and `kind` (change, suggestion, question, or note)."
 )
 
 
@@ -313,8 +315,10 @@ def result_from_data(data: dict[str, Any]) -> ReviewResult:
     the item schema, but the agent path validates only the top-level shape, so
     an item may be a non-dict or miss a key. A finding needs at least a file, a
     summary, and a detail; anything short of that is skipped."""
+    raw = data.get("findings")
+    items = raw if isinstance(raw, list) else []  # null / non-list -> no findings
     findings: list[Finding] = []
-    for item in list(data.get("findings", []))[:MAX_FINDINGS]:
+    for item in items[:MAX_FINDINGS]:
         if not isinstance(item, dict):
             continue
         file, summary, detail = item.get("file"), item.get("summary"), item.get("detail")

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -304,24 +304,38 @@ def review(
 
 
 def result_from_data(data: dict[str, Any]) -> ReviewResult:
-    """Build a ReviewResult from a validated findings object. Shared by the
-    one-shot completer path and the agent-session path — both hand back the
-    same schema, so both must sanitize identically: every string here is
-    untrusted model output bound for a GitHub comment, and the caps guard the
-    render (`sanitize` also neutralizes markdown/HTML injection)."""
-    findings = [
-        Finding(
-            file=sanitize(item["file"], 200),
-            line=item["line"] if isinstance(item.get("line"), int) else None,
-            confidence=item["confidence"] if item.get("confidence") in CONFIDENCES else "low",
-            summary=sanitize(item["summary"], MAX_SUMMARY_CHARS),
-            detail=sanitize(item["detail"], MAX_DETAIL_CHARS),
-            blocking=bool(item.get("blocking")),
-            kind=item["kind"] if item.get("kind") in KINDS else "note",
+    """Build a ReviewResult from a findings object. Shared by the one-shot
+    completer path and the agent-session path — both sanitize identically:
+    every string here is untrusted model output bound for a GitHub comment, and
+    the caps guard the render (`sanitize` also neutralizes markdown/HTML).
+
+    Malformed items are dropped, never raised on: the completer path enforces
+    the item schema, but the agent path validates only the top-level shape, so
+    an item may be a non-dict or miss a key. A finding needs at least a file, a
+    summary, and a detail; anything short of that is skipped."""
+    findings: list[Finding] = []
+    for item in list(data.get("findings", []))[:MAX_FINDINGS]:
+        if not isinstance(item, dict):
+            continue
+        file, summary, detail = item.get("file"), item.get("summary"), item.get("detail")
+        if not (isinstance(file, str) and isinstance(summary, str) and isinstance(detail, str)):
+            continue
+        findings.append(
+            Finding(
+                file=sanitize(file, 200),
+                line=item["line"] if isinstance(item.get("line"), int) else None,
+                confidence=item["confidence"] if item.get("confidence") in CONFIDENCES else "low",
+                summary=sanitize(summary, MAX_SUMMARY_CHARS),
+                detail=sanitize(detail, MAX_DETAIL_CHARS),
+                blocking=bool(item.get("blocking")),
+                kind=item["kind"] if item.get("kind") in KINDS else "note",
+            )
         )
-        for item in list(data.get("findings", []))[:MAX_FINDINGS]
-    ]
-    return ReviewResult(findings=findings, notes=sanitize(data.get("notes", ""), MAX_DETAIL_CHARS))
+    notes = data.get("notes", "")
+    return ReviewResult(
+        findings=findings,
+        notes=sanitize(notes if isinstance(notes, str) else "", MAX_DETAIL_CHARS),
+    )
 
 
 def commentable_lines(diff: str) -> dict[str, set[int]]:

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -1,0 +1,115 @@
+"""Agent-session reviewer: the deployment path that runs the reviewer as an
+agent over a read-only PR-head checkout, instead of the one-shot completer.
+
+`run_agent_review` is the orchestration core, testable with a fake harness and
+client. It reuses everything the completer path already has: the same skip
+rules, the same rubric (via `build_agent_brief`), the same result-policy
+(`review_result_from_role`), and the same inline-posting path (`format_review`
+-> `post_round_review`). The only new thing is *how the verdict is produced* —
+an agent session with read tools — not how it is judged or posted.
+
+This lives beside `review_cli` (the completer path), which stays the live
+default until this path is validated on a real runner. When the workflow swaps
+to this path, the SAME change sunsets the completer path — the completer branch
+in `review_cli`, `llm.AnthropicCompleter` and `review.review`/`build_prompt` if
+then unused, and their tests — so `main` never carries two reviewer
+implementations. The workflow swap and its CHANGELOG entry come with that
+validation.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+
+from autoresearch.github import GitHubClient
+from autoresearch.harness import Harness, outage
+from autoresearch.review import (
+    MARKER,
+    PullRequest,
+    build_agent_brief,
+    format_comment,
+    format_review,
+    skip_reason,
+)
+from autoresearch.review_cli import EXPECTED_FAILURES, post_round_review, post_skip_stub
+from autoresearch.role_runner import run_role
+from autoresearch.roles import review_result_from_role, reviewer_spec
+from autoresearch.rolespec import RoleSpec
+
+log = logging.getLogger(__name__)
+
+
+def _pull_request(client: GitHubClient, repo: str, number: int) -> tuple[PullRequest, dict]:
+    pr_data = client.get_pull_request(repo, number)
+    diff = client.get_pull_request_diff(repo, number)
+    pr = PullRequest(
+        repo=repo,
+        number=number,
+        title=str(pr_data.get("title", "")),
+        body=str(pr_data.get("body") or ""),
+        diff=diff,
+        author=str((pr_data.get("user") or {}).get("login", "")),
+        labels=tuple(
+            str(label.get("name", ""))
+            for label in pr_data.get("labels", [])
+            if isinstance(label, dict)
+        ),
+    )
+    return pr, pr_data
+
+
+def run_agent_review(
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    harness: Harness,
+    workspace: Path,
+    *,
+    bot_login: str,
+    spec: RoleSpec | None = None,
+    explicit: bool = False,
+    today: str | None = None,
+) -> str | None:
+    """Review PR #`number` as an agent session over `workspace` (a read-only
+    PR-head checkout the caller prepared). Post the findings inline via the
+    Reviews API. Returns the round label, or None when it skipped or could not
+    produce a verdict. Advisory: never raises the expected failures, so it can
+    never turn a target repo's CI red.
+    """
+    spec = spec or reviewer_spec()
+    today = today or datetime.now(UTC).date().isoformat()
+    try:
+        pr, pr_data = _pull_request(client, repo, number)
+        skip = skip_reason(pr, bot_login, explicit)
+        if skip is not None:
+            log.info("skipping agent review of %s#%s: %s", repo, number, skip)
+            return None
+
+        role_result = run_role(spec, harness, build_agent_brief(pr, today), workspace)
+        review = review_result_from_role(role_result)
+        if review is None:
+            # No verdict: an errored or refused session, not a clean read.
+            # Say so on the thread only for an outage (API refused us); other
+            # failures are logged, advisory-silent.
+            detail = role_result.error or role_result.session.stop_reason
+            log.warning("agent review produced no verdict on %s#%s: %s", repo, number, detail)
+            if outage(role_result.session):
+                post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
+            return None
+
+        rendered = format_review(review, pr.diff)
+        full = format_comment(review)
+        if rendered is None or full is None:
+            log.info("nothing to post")
+            return None
+        body, inline = rendered
+        round_label = post_round_review(
+            client, repo, number, MARKER, body, inline, pr_data, fallback_body=full
+        )
+        log.info("posted agent review (%s) on %s#%s", round_label, repo, number)
+        return round_label
+    except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
+        log.warning("agent review did not complete: %s: %s", type(exc).__name__, exc)
+        return None

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -51,9 +51,10 @@ def _pull_request(client: GitHubClient, repo: str, number: int) -> tuple[PullReq
         body=str(pr_data.get("body") or ""),
         diff=diff,
         author=str((pr_data.get("user") or {}).get("login", "")),
+        # `or []`: the labels field may be null in the payload, not just absent
         labels=tuple(
             str(label.get("name", ""))
-            for label in pr_data.get("labels", [])
+            for label in (pr_data.get("labels") or [])
             if isinstance(label, dict)
         ),
     )

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -81,6 +81,14 @@ def run_role(
 
     A judge whose first message is malformed is asked once (per `max_repairs`)
     to resend just the JSON, resuming the same session so it keeps its context.
+
+    The `harness` is assumed already constructed for this role — its tools,
+    execution sandbox, and budget set to match `spec`. That construction (map
+    spec.tools to the backend's native tool flags vs harness-provided MCP
+    tools, spec.execution to the sandbox, spec.budget to turns/walltime) is the
+    deployment wiring, done where the harness is built for the role — the same
+    way climb builds its harness from effective_limits. run_role does not
+    reconcile a mismatched harness; it runs what it is given.
     """
     session = harness.run(brief_text, workspace, resume_session_id)
     if session.is_error:
@@ -92,13 +100,17 @@ def run_role(
     data, error = _validate_output(session.final_text, spec.output_schema)
     repairs = 0
     while data is None and repairs < max_repairs:
+        # A repair prompt only works if it resumes the session that holds the
+        # investigation context. With no session to resume, a fresh session
+        # would see only "resend the JSON" and produce nothing useful — fail
+        # instead of burning a context-less turn.
+        resume_target = session.session_id or resume_session_id
+        if not resume_target:
+            log.info("role %s: cannot repair structured output without a session", spec.name)
+            break
         repairs += 1
         log.info("role %s: repairing structured output (%s)", spec.name, error)
-        session = harness.run(
-            _repair_prompt(error),
-            workspace,
-            resume_session_id=session.session_id or resume_session_id,
-        )
+        session = harness.run(_repair_prompt(error), workspace, resume_session_id=resume_target)
         if session.is_error:
             return RoleResult(
                 ok=False, session=session, error=session.error_detail or session.stop_reason

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -1,0 +1,109 @@
+"""The role-runner: run one role session and validate its output.
+
+One loop replaces the per-role driver modules (docs/design/consolidation.md). It
+runs a RoleSpec on a Harness, and for a role that declares an `output_schema`
+(the judges) it parses and validates the session's final message into structured
+data, repairing once if the model returned malformed output. It does NOT judge,
+gate, measure, or post — the result-policy (kernel) acts on the RoleResult.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from autoresearch.harness import Harness, SessionResult
+from autoresearch.rolespec import RoleSpec
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MAX_REPAIRS = 1
+
+
+@dataclass(frozen=True)
+class RoleResult:
+    """The outcome of one role run: the session plus, for judge roles, the
+    validated structured payload. `ok` is False when the session errored or the
+    output never validated; `data` is the validated object (None for an editing
+    role, whose artifact is the workspace diff, or on failure)."""
+
+    ok: bool
+    session: SessionResult
+    data: dict[str, Any] | None = None
+    error: str = ""
+
+
+def _extract_json(text: str) -> str:
+    """The JSON object inside a final message, tolerating code fences and prose
+    around it: the substring from the first `{` to the last `}`."""
+    stripped = text.strip()
+    start, end = stripped.find("{"), stripped.rfind("}")
+    if start != -1 and end > start:
+        return stripped[start : end + 1]
+    return stripped
+
+
+def _validate_output(text: str, schema: dict[str, Any]) -> tuple[dict[str, Any] | None, str]:
+    """Parse `text` as the schema's top-level object. Dep-free: a JSON object
+    with the schema's `required` keys present. Deeper validation is the
+    backend's native structured output or a later jsonschema pass."""
+    try:
+        data = json.loads(_extract_json(text))
+    except json.JSONDecodeError as exc:
+        return None, f"final message is not valid JSON: {exc}"
+    if not isinstance(data, dict):
+        return None, "final message is not a JSON object"
+    missing = [key for key in schema.get("required", []) if key not in data]
+    if missing:
+        return None, f"missing required keys: {missing}"
+    return data, ""
+
+
+def _repair_prompt(error: str) -> str:
+    return (
+        f"Your last message was not the structured output this task requires: {error}. "
+        "Reply with ONLY the JSON object — no prose, no code fences."
+    )
+
+
+def run_role(
+    spec: RoleSpec,
+    harness: Harness,
+    brief_text: str,
+    workspace: Path,
+    resume_session_id: str | None = None,
+    max_repairs: int = DEFAULT_MAX_REPAIRS,
+) -> RoleResult:
+    """Run one role session; validate structured output for judge roles.
+
+    A judge whose first message is malformed is asked once (per `max_repairs`)
+    to resend just the JSON, resuming the same session so it keeps its context.
+    """
+    session = harness.run(brief_text, workspace, resume_session_id)
+    if session.is_error:
+        return RoleResult(
+            ok=False, session=session, error=session.error_detail or session.stop_reason
+        )
+    if spec.output_schema is None:
+        return RoleResult(ok=True, session=session)  # editing role: artifact is the diff
+    data, error = _validate_output(session.final_text, spec.output_schema)
+    repairs = 0
+    while data is None and repairs < max_repairs:
+        repairs += 1
+        log.info("role %s: repairing structured output (%s)", spec.name, error)
+        session = harness.run(
+            _repair_prompt(error),
+            workspace,
+            resume_session_id=session.session_id or resume_session_id,
+        )
+        if session.is_error:
+            return RoleResult(
+                ok=False, session=session, error=session.error_detail or session.stop_reason
+            )
+        data, error = _validate_output(session.final_text, spec.output_schema)
+    if data is None:
+        return RoleResult(ok=False, session=session, error=f"invalid structured output: {error}")
+    return RoleResult(ok=True, session=session, data=data)

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -7,7 +7,8 @@ result-policy — no kernel change (docs/design/consolidation.md).
 
 from __future__ import annotations
 
-from autoresearch.review import FINDINGS_SCHEMA
+from autoresearch.review import FINDINGS_SCHEMA, ReviewResult, result_from_data
+from autoresearch.role_runner import RoleResult
 from autoresearch.rolespec import Environment, Execution, RoleSpec, SessionBudget
 
 # Read-only investigation: repo-read plus the harness-provided pr-context and
@@ -38,3 +39,16 @@ def reviewer_spec(
         skills=("kernel-primer", "plain-style", "review-rubric", "read-only-investigation"),
         output_schema=FINDINGS_SCHEMA,
     )
+
+
+def review_result_from_role(result: RoleResult) -> ReviewResult | None:
+    """The reviewer result-policy: turn a role run into a postable ReviewResult,
+    or None when the session did not hand back a verdict (error/outage — the
+    caller posts a skip stub, never a clean read). The agent hands back data;
+    the kernel sanitizes it (`result_from_data`) and posts it. The findings
+    carry line anchors, so the same `format_review` path the completer used
+    still places inline comments — the agent directs the anchor, the kernel
+    places it."""
+    if not result.ok or result.data is None:
+        return None
+    return result_from_data(result.data)

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -1,0 +1,40 @@
+"""Concrete RoleSpecs — the per-role manifests the role-runner consumes.
+
+Each is data: instructions, skills, tools, key, scope, execution, budget, and
+(for judges) an output_schema. Adding a role is a new factory here plus a
+result-policy — no kernel change (docs/design/consolidation.md).
+"""
+
+from __future__ import annotations
+
+from autoresearch.review import FINDINGS_SCHEMA
+from autoresearch.rolespec import Environment, Execution, RoleSpec, SessionBudget
+
+# Read-only investigation: repo-read plus the harness-provided pr-context and
+# retriever. No Write/Edit/Bash — a judge never executes untrusted PR code.
+_JUDGE_TOOLS = ("Read", "Grep", "Glob", "pr-context-read", "retriever")
+
+
+def reviewer_spec(
+    *, environment: Environment = "gh-runner", max_turns: int = 40, walltime_s: int = 1800
+) -> RoleSpec:
+    """The advisory reviewer as a read-only agent session.
+
+    Investigates the PR head with the read tools and returns findings validated
+    against `review.FINDINGS_SCHEMA`. Read-only by construction — the RoleSpec
+    invariant rejects any mutating tool or write scope.
+    """
+    return RoleSpec(
+        name="reviewer",
+        instructions=(
+            "Review the pull request for correctness and clarity. Investigate "
+            "beyond the diff with the read tools; do not execute code. Return the "
+            "findings as the required JSON object."
+        ),
+        key="reviewer",
+        tools=_JUDGE_TOOLS,
+        execution=Execution(environment=environment, can_execute=False),
+        budget=SessionBudget(max_turns=max_turns, walltime_s=walltime_s),
+        skills=("kernel-primer", "plain-style", "review-rubric", "read-only-investigation"),
+        output_schema=FINDINGS_SCHEMA,
+    )

--- a/src/autoresearch/rolespec.py
+++ b/src/autoresearch/rolespec.py
@@ -1,0 +1,73 @@
+"""RoleSpec: the manifest that turns the generic harness into one role.
+
+Data, not code. Adding a role is a new RoleSpec plus its skills and a
+result-policy — no kernel change (docs/design/consolidation.md). The kernel
+reads a RoleSpec to decide what a session sees (skills, tools), how it is
+constrained (key, scope, execution), and how its output is checked
+(`output_schema`).
+
+The one hard invariant here is the read-only judge boundary: a reviewer or
+verifier investigates a PR but never executes untrusted code, so it may not
+hold a mutating tool or a write scope (docs/design/reviewer-infra.md).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+RoleName = Literal["author", "reviewer", "verifier", "steward", "followup"]
+KeyFamily = Literal["author", "reviewer", "verifier", "steward"]
+Environment = Literal["apptainer", "gh-runner", "local"]
+
+# Tools that change files or run code. A read-only judge is granted none of
+# these: the security boundary is the tool set, not a prompt asking nicely.
+MUTATING_TOOLS: frozenset[str] = frozenset({"Write", "Edit", "Bash"})
+
+
+class RoleSpecError(ValueError):
+    """A RoleSpec violates a hard invariant."""
+
+
+@dataclass(frozen=True)
+class Execution:
+    environment: Environment
+    can_execute: bool  # may the session run code (Bash)?
+
+
+@dataclass(frozen=True)
+class SessionBudget:
+    max_turns: int
+    walltime_s: int
+    cost_cap_usd: float | None = None
+
+
+@dataclass(frozen=True)
+class RoleSpec:
+    name: RoleName
+    instructions: str  # standing role text; skills add know-how on top
+    key: KeyFamily  # credential family (isolation)
+    tools: tuple[str, ...]  # allowed tool ids (native + harness-provided)
+    execution: Execution
+    budget: SessionBudget
+    skills: tuple[str, ...] = ()
+    # Judges only: the final artifact must validate against this JSON schema.
+    # None for editing roles, whose artifact is a workspace diff, not a verdict.
+    output_schema: dict[str, Any] | None = None
+    # Editing roles only: repo-relative write allowlist. None for read-only
+    # judges — declared here for legibility, enforced by the tool set too.
+    scope: tuple[str, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.tools:
+            raise RoleSpecError(f"role {self.name!r} has no tools")
+        if not self.execution.can_execute:
+            mutating = MUTATING_TOOLS.intersection(self.tools)
+            if mutating:
+                raise RoleSpecError(
+                    f"read-only role {self.name!r} may not hold mutating tools {sorted(mutating)}"
+                )
+            if self.scope is not None:
+                raise RoleSpecError(
+                    f"read-only role {self.name!r} edits nothing; scope must be None"
+                )

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -1,0 +1,60 @@
+"""CodexHarness command construction and output parsing.
+
+The Codex CLI is not run here (no binary in CI); these tests pin the argv shape
+and the defensive JSONL parsing. The exact flag spellings and event schema are
+verified on the cluster — see CodexHarness.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autoresearch.harness import _codex_command, _parse_codex_result
+
+
+def test_command_reads_prompt_from_stdin_not_argv() -> None:
+    cmd = _codex_command("codex", "m", "read-only", Path("/w"), Path("/w-last.txt"), None, ())
+    assert cmd[:2] == ["codex", "exec"]
+    # the brief travels on stdin, never as an argument
+    assert all(part != "brief_text" for part in cmd)
+    assert "--output-last-message" in cmd and "/w-last.txt" in cmd
+    assert "--sandbox" in cmd and "read-only" in cmd
+    assert "--cd" in cmd and "/w" in cmd
+
+
+def test_command_resume_uses_resume_subcommand() -> None:
+    cmd = _codex_command("codex", "m", "read-only", Path("/w"), Path("/l"), "sess-123", ())
+    assert cmd[:4] == ["codex", "exec", "resume", "sess-123"]
+
+
+def test_parse_success_pulls_session_and_final_text() -> None:
+    stdout = "\n".join(
+        [
+            json.dumps({"type": "session.created", "session_id": "sess-9"}),
+            json.dumps({"type": "item.completed"}),
+        ]
+    )
+    result = _parse_codex_result(stdout, "final answer\n", 0, "t.jsonl")
+    assert result.is_error is False
+    assert result.session_id == "sess-9"
+    assert result.final_text == "final answer"
+    assert result.transcript_path == "t.jsonl"
+
+
+def test_parse_flags_error_on_nonzero_returncode() -> None:
+    assert _parse_codex_result("", "", 1).is_error is True
+
+
+def test_parse_flags_error_event_with_message() -> None:
+    stdout = json.dumps({"type": "error", "message": "model unavailable"})
+    result = _parse_codex_result(stdout, "", 0)
+    assert result.is_error is True
+    assert "model unavailable" in result.error_detail
+
+
+def test_parse_tolerates_non_json_lines() -> None:
+    stdout = "starting up...\n" + json.dumps({"session_id": "s"}) + "\nbye"
+    result = _parse_codex_result(stdout, "ok", 0)
+    assert result.session_id == "s"
+    assert result.is_error is False

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -9,18 +9,42 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
-from autoresearch.harness import _codex_command, _parse_codex_result
+import autoresearch.harness as harness_mod
+from autoresearch.harness import CodexHarness, _codex_command, _parse_codex_result
 
 
-def test_command_reads_prompt_from_stdin_not_argv() -> None:
+def test_command_has_expected_flags() -> None:
     cmd = _codex_command("codex", "m", "read-only", Path("/w"), Path("/w-last.txt"), None, ())
     assert cmd[:2] == ["codex", "exec"]
-    # the brief travels on stdin, never as an argument
-    assert all(part != "brief_text" for part in cmd)
     assert "--output-last-message" in cmd and "/w-last.txt" in cmd
     assert "--sandbox" in cmd and "read-only" in cmd
     assert "--cd" in cmd and "/w" in cmd
+
+
+def test_brief_goes_to_stdin_never_argv(monkeypatch: Any, tmp_path: Path) -> None:
+    """The real guarantee: the brief is fed on stdin (argv is world-readable in
+    /proc), so it must never appear in the spawned command."""
+    seen: dict[str, Any] = {}
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, command: list[str], **_: Any) -> None:
+            seen["argv"] = command
+
+        def communicate(
+            self, input: str | None = None, timeout: float | None = None
+        ) -> tuple[str, str]:
+            seen["stdin"] = input
+            return json.dumps({"session_id": "s"}), ""
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    brief = "SENTINEL_BRIEF_9x7 please review this pull request"
+    CodexHarness(api_key="k").run(brief, tmp_path)
+    assert seen["stdin"] == brief
+    assert not any("SENTINEL_BRIEF_9x7" in str(part) for part in seen["argv"])
 
 
 def test_command_resume_uses_resume_subcommand() -> None:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -59,11 +59,21 @@ ONE_FINDING = {
 def test_result_from_data_parses_and_defaults_kind() -> None:
     from autoresearch.review import result_from_data
 
-    data = {
+    def item(**extra: Any) -> dict[str, Any]:
+        return {
+            "file": "x.py",
+            "line": 1,
+            "confidence": "low",
+            "summary": "s",
+            "detail": "d",
+            **extra,
+        }
+
+    data: dict[str, Any] = {
         "findings": [
-            {**ONE_FINDING["findings"][0], "kind": "change"},
-            {**ONE_FINDING["findings"][0], "kind": "bogus"},  # invalid -> note
-            {**ONE_FINDING["findings"][0]},  # missing -> note
+            item(kind="change"),
+            item(kind="bogus"),  # invalid -> note
+            item(),  # missing -> note
         ],
         "notes": "",
     }
@@ -340,8 +350,53 @@ def test_format_review_splits_anchored_from_body() -> None:
     # advisory findings stay in the body as a compact list, references intact
     assert "Stale doc" in body and "`src/other.py`:5" in body
     assert "Global" in body and "Bad add" not in body
-    assert "1 blocking finding attached to the lines below." in body
+    assert "1 finding attached to the lines below." in body
     assert "Verdict:" in body and body.lstrip().startswith(MARKER)
+
+
+def test_nonblocking_suggestion_anchors_inline_with_label() -> None:
+    from autoresearch.review import Finding, ReviewResult, format_review
+
+    sugg = Finding(
+        file="src/x.py",
+        line=11,
+        confidence="medium",
+        summary="Rename for clarity",
+        detail="`tmp` hides intent.",
+        blocking=False,
+        kind="suggestion",
+    )
+    _body, inline = format_review(ReviewResult([sugg], notes=""), DIFF)  # type: ignore[misc]
+    (item,) = inline
+    assert item["line"] == 11
+    assert item["body"].startswith("**Suggestion.**")
+
+
+def test_local_question_and_note_stay_in_body() -> None:
+    from autoresearch.review import Finding, ReviewResult, format_review
+
+    question = Finding(
+        file="src/x.py",
+        line=11,
+        confidence="low",
+        summary="Why drop the guard",
+        detail="The old code checked n.",
+        blocking=False,
+        kind="question",
+    )
+    note = Finding(
+        file="src/x.py",
+        line=12,
+        confidence="low",
+        summary="Uses tabs here",
+        detail="Rest of file is spaces.",
+        blocking=False,
+        kind="note",
+    )
+    body, inline = format_review(ReviewResult([question, note], notes=""), DIFF)  # type: ignore[misc]
+    assert inline == []  # neither floods the diff
+    assert "Question: Why drop the guard" in body
+    assert "Uses tabs here" in body
 
 
 def test_commentable_lines_survives_header_lookalike_content() -> None:
@@ -379,7 +434,7 @@ def test_format_review_all_anchored_says_so() -> None:
     assert rendered is not None
     body, inline = rendered
     assert len(inline) == 1
-    assert "1 blocking finding attached to the lines below." in body
+    assert "1 finding attached to the lines below." in body
 
 
 def test_commentable_lines_stops_at_file_boundaries() -> None:

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -372,6 +372,33 @@ def test_nonblocking_suggestion_anchors_inline_with_label() -> None:
     assert item["body"].startswith("**Suggestion.**")
 
 
+def test_inline_lead_distinguishes_blocking_from_change() -> None:
+    from autoresearch.review import Finding, ReviewResult, format_review
+
+    blocking = Finding(
+        file="src/x.py",
+        line=11,
+        confidence="high",
+        summary="Bug",
+        detail="Crashes.",
+        blocking=True,
+        kind="change",
+    )
+    change = Finding(
+        file="src/x.py",
+        line=12,
+        confidence="medium",
+        summary="Tidy",
+        detail="Clearer name.",
+        blocking=False,
+        kind="change",
+    )
+    _body, inline = format_review(ReviewResult([blocking, change], notes=""), DIFF)  # type: ignore[misc]
+    by_line = {c["line"]: c["body"] for c in inline}
+    assert by_line[11].startswith("**Blocking.**")
+    assert not by_line[12].startswith("**Blocking.**")
+
+
 def test_local_question_and_note_stay_in_body() -> None:
     from autoresearch.review import Finding, ReviewResult, format_review
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -106,6 +106,11 @@ def test_result_from_data_drops_malformed_items_without_crashing() -> None:
     assert [f.file for f in result.findings] == ["x.py"]
     assert result.notes == ""
 
+    # findings null or a non-list must not raise, either
+    assert result_from_data({"findings": None, "notes": ""}).findings == []
+    assert result_from_data({"findings": 7, "notes": ""}).findings == []
+    assert result_from_data({}).findings == []
+
 
 def test_bot_authored_prs_are_never_reviewed() -> None:
     pr = make_pr(author=BOT)

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -81,6 +81,32 @@ def test_result_from_data_parses_and_defaults_kind() -> None:
     assert kinds == ["change", "note", "note"]
 
 
+def test_result_from_data_drops_malformed_items_without_crashing() -> None:
+    from autoresearch.review import result_from_data
+
+    good = {
+        "file": "x.py",
+        "line": 1,
+        "confidence": "high",
+        "summary": "ok",
+        "detail": "d",
+        "blocking": False,
+        "kind": "note",
+    }
+    data: dict[str, Any] = {
+        "findings": [
+            good,
+            {"file": "y.py"},  # missing summary/detail -> dropped
+            "not a dict",  # non-dict -> dropped
+            {"summary": "no file", "detail": "d"},  # missing file -> dropped
+        ],
+        "notes": None,  # non-string notes must not crash
+    }
+    result = result_from_data(data)
+    assert [f.file for f in result.findings] == ["x.py"]
+    assert result.notes == ""
+
+
 def test_bot_authored_prs_are_never_reviewed() -> None:
     pr = make_pr(author=BOT)
     assert skip_reason(pr, BOT) is not None

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -56,6 +56,21 @@ ONE_FINDING = {
 }
 
 
+def test_result_from_data_parses_and_defaults_kind() -> None:
+    from autoresearch.review import result_from_data
+
+    data = {
+        "findings": [
+            {**ONE_FINDING["findings"][0], "kind": "change"},
+            {**ONE_FINDING["findings"][0], "kind": "bogus"},  # invalid -> note
+            {**ONE_FINDING["findings"][0]},  # missing -> note
+        ],
+        "notes": "",
+    }
+    kinds = [f.kind for f in result_from_data(data).findings]
+    assert kinds == ["change", "note", "note"]
+
+
 def test_bot_authored_prs_are_never_reviewed() -> None:
     pr = make_pr(author=BOT)
     assert skip_reason(pr, BOT) is not None

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 from autoresearch.harness import SessionResult
 from autoresearch.review import build_agent_brief
@@ -63,8 +64,12 @@ class _Harness:
 class _Client:
     """Minimal GitHubClient stand-in recording posts."""
 
-    def __init__(self, *, author: str = "alice", labels: list[dict] | None = None) -> None:
-        self._author, self._labels = author, labels or []
+    _UNSET = object()
+
+    def __init__(self, *, author: str = "alice", labels: Any = _UNSET) -> None:
+        # labels passed as None models the API returning "labels": null
+        self._author = author
+        self._labels = [] if labels is _Client._UNSET else labels
         self.reviews: list[tuple[str, list[dict]]] = []
         self.comments: list[str] = []
 
@@ -109,6 +114,19 @@ def test_clean_review_posts_inline() -> None:
     assert any(c.get("path") == "models/encoder.py" for c in inline)
     # the brief carried the read-only investigation instruction
     assert "checked out read-only" in harness.briefs[0]
+
+
+def test_null_labels_do_not_crash() -> None:
+    client, harness = _Client(labels=None), _Harness(_FINDINGS)
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+    )
+    assert label is not None  # posts normally; null labels are not a crash
 
 
 def test_bot_authored_pr_is_skipped() -> None:

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -1,0 +1,168 @@
+"""Agent-review orchestration (run_agent_review) with a fake harness and a fake
+GitHub client — no real session, no network."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autoresearch.harness import SessionResult
+from autoresearch.review import build_agent_brief
+from autoresearch.review_agent import run_agent_review
+
+_WORKSPACE = Path("/tmp/checkout")
+
+_FINDINGS = json.dumps(
+    {
+        "findings": [
+            {
+                "file": "models/encoder.py",
+                "line": 2,
+                "confidence": "high",
+                "summary": "smells like a per-layer LR",
+                "detail": "belongs in the initializer seam",
+                "blocking": True,
+            }
+        ],
+        "notes": "one finding",
+    }
+)
+
+_DIFF = (
+    "diff --git a/models/encoder.py b/models/encoder.py\n"
+    "--- a/models/encoder.py\n"
+    "+++ b/models/encoder.py\n"
+    "@@ -1,2 +1,3 @@\n"
+    " class TanhMLP:\n"
+    "+    input_gain = 4.0\n"
+    "     pass\n"
+)
+
+
+class _Harness:
+    def __init__(self, final_text: str, *, is_error: bool = False, detail: str = "") -> None:
+        self._text, self._err, self._detail = final_text, is_error, detail
+        self.briefs: list[str] = []
+
+    def run(
+        self, brief_text: str, workspace: Path, resume_session_id: str | None = None
+    ) -> SessionResult:
+        self.briefs.append(brief_text)
+        return SessionResult(
+            stop_reason="error" if self._err else "completed",
+            is_error=self._err,
+            cost_usd=0.0,
+            num_turns=1,
+            session_id="s",
+            final_text=self._text,
+            transcript_path="",
+            error_detail=self._detail,
+        )
+
+
+class _Client:
+    """Minimal GitHubClient stand-in recording posts."""
+
+    def __init__(self, *, author: str = "alice", labels: list[dict] | None = None) -> None:
+        self._author, self._labels = author, labels or []
+        self.reviews: list[tuple[str, list[dict]]] = []
+        self.comments: list[str] = []
+
+    def get_pull_request(self, repo: str, number: int) -> dict:
+        return {
+            "title": "improve encoder",
+            "body": "raise the probe",
+            "user": {"login": self._author},
+            "labels": self._labels,
+            "head": {"sha": "deadbeef1234"},
+        }
+
+    def get_pull_request_diff(self, repo: str, number: int) -> str:
+        return _DIFF
+
+    def list_comments(self, repo: str, number: int) -> list[dict]:
+        return []
+
+    def list_pr_reviews(self, repo: str, number: int) -> list[dict]:
+        return []
+
+    def create_pr_review(self, repo: str, number: int, body: str, inline: list[dict]) -> None:
+        self.reviews.append((body, inline))
+
+    def comment(self, repo: str, number: int, body: str) -> None:
+        self.comments.append(body)
+
+
+def test_clean_review_posts_inline() -> None:
+    client, harness = _Client(), _Harness(_FINDINGS)
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+    )
+    assert label is not None
+    assert len(client.reviews) == 1
+    _body, inline = client.reviews[0]
+    assert any(c.get("path") == "models/encoder.py" for c in inline)
+    # the brief carried the read-only investigation instruction
+    assert "checked out read-only" in harness.briefs[0]
+
+
+def test_bot_authored_pr_is_skipped() -> None:
+    client, harness = _Client(author="autoresearch-bot"), _Harness(_FINDINGS)
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+    )
+    assert label is None
+    assert client.reviews == [] and client.comments == []
+    assert harness.briefs == []  # skipped before the session ran
+
+
+def test_outage_posts_skip_stub_no_review() -> None:
+    client = _Client()
+    harness = _Harness("", is_error=True, detail="rate_limit_error: slow down")
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+    )
+    assert label is None
+    assert client.reviews == []
+    assert len(client.comments) == 1
+    assert "could not run" in client.comments[0]
+
+
+def test_malformed_output_posts_nothing() -> None:
+    client = _Client()
+    harness = _Harness("not json, no verdict")
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+    )
+    assert label is None
+    assert client.reviews == [] and client.comments == []
+
+
+def test_build_agent_brief_reuses_rubric_and_diff() -> None:
+    from autoresearch.review import PullRequest
+
+    pr = PullRequest("org/repo", 1, "t", "b", _DIFF, "alice")
+    brief = build_agent_brief(pr, today="2026-08-13")
+    assert "reviewing a pull request" in brief.lower()
+    assert "input_gain" in brief  # the diff is embedded
+    assert "2026-08-13" in brief

--- a/tests/test_review_policy.py
+++ b/tests/test_review_policy.py
@@ -1,0 +1,93 @@
+"""The reviewer result-policy end to end (faked harness): an agent hands back
+findings JSON, the kernel turns it into a ReviewResult and renders inline
+comments — proving "hand back data; kernel posts inline" without a live session
+or GitHub."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from autoresearch.harness import SessionResult
+from autoresearch.review import format_review
+from autoresearch.role_runner import RoleResult, run_role
+from autoresearch.roles import review_result_from_role, reviewer_spec
+
+_WORKSPACE = Path("/tmp/does-not-matter")
+
+# a diff whose new side has an anchorable line in models/encoder.py
+_DIFF = (
+    "diff --git a/models/encoder.py b/models/encoder.py\n"
+    "--- a/models/encoder.py\n"
+    "+++ b/models/encoder.py\n"
+    "@@ -1,2 +1,3 @@\n"
+    " class TanhMLP:\n"
+    "+    input_gain = 4.0\n"
+    "     pass\n"
+)
+
+_AGENT_FINDINGS = json.dumps(
+    {
+        "findings": [
+            {
+                "file": "models/encoder.py",
+                "line": 2,
+                "confidence": "high",
+                "summary": "input_gain is a per-layer LR in disguise",
+                "detail": "This belongs in the initializer/LR seam, not forward().",
+                "blocking": True,
+            }
+        ],
+        "notes": "one blocking finding",
+    }
+)
+
+
+class _Harness:
+    def __init__(self, final_text: str) -> None:
+        self._final_text = final_text
+
+    def run(
+        self, brief_text: str, workspace: Path, resume_session_id: str | None = None
+    ) -> SessionResult:
+        return SessionResult(
+            stop_reason="completed",
+            is_error=False,
+            cost_usd=0.0,
+            num_turns=1,
+            session_id="s",
+            final_text=self._final_text,
+            transcript_path="",
+        )
+
+
+def test_agent_findings_flow_to_inline_review_payload() -> None:
+    role_result = run_role(reviewer_spec(), _Harness(_AGENT_FINDINGS), "brief", _WORKSPACE)
+    review = review_result_from_role(role_result)
+    assert review is not None
+    assert len(review.findings) == 1
+    assert review.findings[0].blocking is True
+
+    rendered = format_review(review, _DIFF)
+    assert rendered is not None
+    body, inline = rendered
+    # the blocking finding anchors inline on the diff line the kernel posts
+    assert any(c.get("path") == "models/encoder.py" for c in inline)
+    assert "Verdict" in body
+
+
+def test_failed_role_yields_no_review() -> None:
+    failed = RoleResult(
+        ok=False,
+        session=SessionResult("error", True, 0.0, 0, "", "", "", error_detail="boom"),
+        error="boom",
+    )
+    assert review_result_from_role(failed) is None
+
+
+def test_malformed_agent_output_yields_no_review() -> None:
+    # never validates -> run_role fails -> policy returns None (post a skip stub)
+    role_result = run_role(
+        reviewer_spec(), _Harness("not json"), "brief", _WORKSPACE, max_repairs=0
+    )
+    assert review_result_from_role(role_result) is None

--- a/tests/test_role_runner.py
+++ b/tests/test_role_runner.py
@@ -1,0 +1,115 @@
+"""Role-runner: structured-output validation, the repair loop, and the reviewer
+RoleSpec. The harness is faked; no session is actually run."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from autoresearch.harness import SessionResult
+from autoresearch.review import FINDINGS_SCHEMA
+from autoresearch.role_runner import run_role
+from autoresearch.roles import reviewer_spec
+from autoresearch.rolespec import Execution, RoleSpec, SessionBudget
+
+_WORKSPACE = Path("/tmp/does-not-matter")
+_FINDINGS = json.dumps({"findings": [], "notes": "looks fine"})
+
+
+def _session(
+    final_text: str = "", *, is_error: bool = False, error_detail: str = ""
+) -> SessionResult:
+    return SessionResult(
+        stop_reason="error" if is_error else "completed",
+        is_error=is_error,
+        cost_usd=0.0,
+        num_turns=1,
+        session_id="sess-1",
+        final_text=final_text,
+        transcript_path="",
+        error_detail=error_detail,
+    )
+
+
+@dataclass
+class _SeqHarness:
+    """Returns queued results in order; records each call's resume id."""
+
+    results: list[SessionResult]
+    calls: list[str | None] = field(default_factory=list)
+
+    def run(
+        self, brief_text: str, workspace: Path, resume_session_id: str | None = None
+    ) -> SessionResult:
+        self.calls.append(resume_session_id)
+        return self.results.pop(0)
+
+
+def _author_spec() -> RoleSpec:
+    return RoleSpec(
+        name="author",
+        instructions="improve",
+        key="author",
+        tools=("Read", "Edit", "Bash"),
+        execution=Execution(environment="apptainer", can_execute=True),
+        budget=SessionBudget(max_turns=10, walltime_s=60),
+    )
+
+
+def test_reviewer_spec_is_read_only_and_uses_findings_schema() -> None:
+    spec = reviewer_spec()
+    assert spec.execution.can_execute is False
+    assert spec.scope is None
+    assert spec.output_schema is FINDINGS_SCHEMA
+
+
+def test_happy_path_returns_validated_data() -> None:
+    harness = _SeqHarness([_session(_FINDINGS)])
+    result = run_role(reviewer_spec(), harness, "brief", _WORKSPACE)
+    assert result.ok is True
+    assert result.data == {"findings": [], "notes": "looks fine"}
+
+
+def test_tolerates_code_fenced_json() -> None:
+    fenced = f"Here are my findings:\n```json\n{_FINDINGS}\n```\n"
+    result = run_role(reviewer_spec(), _SeqHarness([_session(fenced)]), "brief", _WORKSPACE)
+    assert result.ok is True
+    assert result.data is not None
+
+
+def test_repairs_once_then_succeeds() -> None:
+    harness = _SeqHarness([_session("not json at all"), _session(_FINDINGS)])
+    result = run_role(reviewer_spec(), harness, "brief", _WORKSPACE)
+    assert result.ok is True
+    # the repair call resumed the first session
+    assert harness.calls == [None, "sess-1"]
+
+
+def test_exhausts_repairs_and_fails() -> None:
+    harness = _SeqHarness([_session("nope"), _session("still nope")])
+    result = run_role(reviewer_spec(), harness, "brief", _WORKSPACE, max_repairs=1)
+    assert result.ok is False
+    assert "invalid structured output" in result.error
+
+
+def test_missing_required_key_is_invalid() -> None:
+    partial = json.dumps({"findings": []})  # no "notes"
+    result = run_role(
+        reviewer_spec(), _SeqHarness([_session(partial)]), "brief", _WORKSPACE, max_repairs=0
+    )
+    assert result.ok is False
+    assert "notes" in result.error
+
+
+def test_session_error_propagates() -> None:
+    harness = _SeqHarness([_session(is_error=True, error_detail="boom")])
+    result = run_role(reviewer_spec(), harness, "brief", _WORKSPACE)
+    assert result.ok is False
+    assert result.error == "boom"
+
+
+def test_editing_role_needs_no_schema() -> None:
+    result = run_role(_author_spec(), _SeqHarness([_session("done")]), "brief", _WORKSPACE)
+    assert result.ok is True
+    assert result.data is None

--- a/tests/test_rolespec.py
+++ b/tests/test_rolespec.py
@@ -1,0 +1,77 @@
+"""RoleSpec invariants — the read-only judge boundary especially."""
+
+from __future__ import annotations
+
+import pytest
+
+from autoresearch.rolespec import Execution, RoleSpec, RoleSpecError, SessionBudget
+
+
+def _author() -> RoleSpec:
+    return RoleSpec(
+        name="author",
+        instructions="Improve the method to raise the benchmark.",
+        key="author",
+        tools=("Read", "Grep", "Glob", "Edit", "Write", "Bash"),
+        execution=Execution(environment="apptainer", can_execute=True),
+        budget=SessionBudget(max_turns=120, walltime_s=5400),
+        skills=("kernel-primer", "hypothesis-discipline"),
+        scope=("models/",),
+    )
+
+
+def _reviewer() -> RoleSpec:
+    return RoleSpec(
+        name="reviewer",
+        instructions="Review the PR and report findings.",
+        key="reviewer",
+        tools=("Read", "Grep", "Glob", "pr-context-read", "retriever"),
+        execution=Execution(environment="gh-runner", can_execute=False),
+        budget=SessionBudget(max_turns=40, walltime_s=1800),
+        skills=("review-rubric", "read-only-investigation"),
+        output_schema={"type": "object"},
+    )
+
+
+def test_author_and_reviewer_are_valid() -> None:
+    assert _author().name == "author"
+    reviewer = _reviewer()
+    assert reviewer.scope is None
+    assert reviewer.execution.can_execute is False
+
+
+def test_read_only_role_rejects_mutating_tools() -> None:
+    with pytest.raises(RoleSpecError, match="mutating tools"):
+        RoleSpec(
+            name="reviewer",
+            instructions="x",
+            key="reviewer",
+            tools=("Read", "Bash"),
+            execution=Execution(environment="gh-runner", can_execute=False),
+            budget=SessionBudget(max_turns=40, walltime_s=1800),
+        )
+
+
+def test_read_only_role_rejects_scope() -> None:
+    with pytest.raises(RoleSpecError, match="scope must be None"):
+        RoleSpec(
+            name="verifier",
+            instructions="x",
+            key="verifier",
+            tools=("Read", "Grep"),
+            execution=Execution(environment="gh-runner", can_execute=False),
+            budget=SessionBudget(max_turns=40, walltime_s=1800),
+            scope=("models/",),
+        )
+
+
+def test_empty_tools_rejected() -> None:
+    with pytest.raises(RoleSpecError, match="no tools"):
+        RoleSpec(
+            name="author",
+            instructions="x",
+            key="author",
+            tools=(),
+            execution=Execution(environment="apptainer", can_execute=True),
+            budget=SessionBudget(max_turns=10, walltime_s=60),
+        )


### PR DESCRIPTION
Stage 1 of the consolidation (design: #71). Runs the reviewer as a read-only **agent session** on a swappable backend, and reshapes the finding model.

## Foundations
- **`RoleSpec`** (`rolespec.py`) — the app manifest (name, instructions, skills, tools, key, scope, execution, budget, output_schema). Frozen dataclass; enforces the read-only judge boundary (a `can_execute=False` role can't hold `Write`/`Edit`/`Bash` or a write scope).
- **`CodexHarness`** (`harness.py`) — a second backend behind the `Harness` seam (`codex exec`). ⚠️ Flag spellings and the JSONL event schema still need a `codex exec --help` / live check on the cluster; parsing is unit-tested against assumed shapes.
- **role-runner** (`role_runner.py`) — `run_role`: run a RoleSpec on a Harness, validate a judge's structured output, repair once on malformed output. The harness is assumed already constructed for the role (tools/sandbox/budget from the RoleSpec) — that construction is the deployment wiring, like climb building from effective_limits.
- **reviewer RoleSpec + result-policy** (`roles.py`) — the reviewer as a read-only session; `review_result_from_role` turns its output into a postable `ReviewResult`.
- **agent-review orchestration** (`review_agent.py`) — `run_agent_review`: fetch PR → run the session over a read-only checkout → post inline via the existing path. This IS the result-policy wiring end to end (tested with fakes). It runs **beside** the completer path (`review_cli`), which stays the live default until validated on a real runner; the workflow swap sunsets the completer path in the same change.

## Finding model (affects the LIVE reviewer now)
- Findings carry a **`kind`** (change / suggestion / question / note) — what the reader is asked to do, separate from `blocking` (gate) and `line` (locality). `FINDINGS_SCHEMA` now requires it.
- **Rendering by (locality, gate, kind):** actionable findings (blocking, or change/suggestion) anchor inline; questions and notes stay in the compact body so local FYIs don't flood the diff. Inline leads with Blocking./Suggestion. Shared by both paths, so the live completer reviewer improves too. CHANGELOG updated.

## Tested
Full suite green (481), mypy clean. Round-2 advisory findings addressed in 62d0dfa.

## Not here (rides with the runner swap)
`review.yml` (read-only checkout + agent CLI), the `record_finding` incremental tool + one-click GitHub suggestion blocks, and the completer sunset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)