### PR TITLE
Reviewer deployment wiring + fixes from live validation

### DIFF
--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -449,28 +449,38 @@ def _parse_codex_result(
     at 0 (these backends are subscription or token metered; the budget layer
     meters them by a session/token proxy). Never raises.
     """
+    # Event schema verified against codex-cli 0.130.0 (cluster0):
+    #   thread.started -> thread_id (the session id)
+    #   error          -> message
+    #   turn.failed    -> error.message
+    #   turn.completed -> success (usage carries tokens)
     session_id = ""
     saw_error = False
     errors: list[str] = []
     for line in stdout.splitlines():
         text = line.strip()
-        if not text:
-            continue
+        if not text.startswith("{"):
+            continue  # timestamped log lines interleave the JSONL; skip them
         try:
             event = json.loads(text)
         except json.JSONDecodeError:
-            continue  # human-readable lines can interleave the JSONL; skip them
+            continue
         if not isinstance(event, dict):
             continue
-        for key in ("session_id", "conversation_id"):
-            value = event.get(key)
-            if not session_id and isinstance(value, str):
-                session_id = value
-        # A truthy `error` value or an error-typed event, not the mere presence
-        # of an "error" key — a benign event may carry `"error": null`.
-        if str(event.get("type", "")).endswith("error") or event.get("error"):
+        etype = str(event.get("type", ""))
+        if etype == "thread.started" and not session_id:
+            thread_id = event.get("thread_id")
+            if isinstance(thread_id, str):
+                session_id = thread_id
+        elif etype == "error":
             saw_error = True
-            message = event.get("message") or event.get("error")
+            message = event.get("message")
+            if isinstance(message, str):
+                errors.append(message)
+        elif etype == "turn.failed":
+            saw_error = True
+            err = event.get("error")
+            message = err.get("message") if isinstance(err, dict) else None
             if isinstance(message, str):
                 errors.append(message)
     is_error = returncode != 0 or saw_error
@@ -507,10 +517,35 @@ class CodexHarness:
 
     api_key: str
     binary: str = "codex"
-    model: str = "gpt-5-codex"  # verify the available model id on the cluster
+    model: str = "gpt-5-codex"  # codex-cli flagship; overridable per call
     sandbox: str = "read-only"  # judge default; authors pass "workspace-write"
     timeout_s: int = DEFAULT_TIMEOUT_S
     extra_args: tuple[str, ...] = field(default_factory=tuple)
+
+    def _login(self, session_home: Path) -> SessionResult | None:
+        """Write auth.json into the per-run HOME. None on success, an error
+        SessionResult on failure. The key travels on stdin, never argv."""
+        env = session_env(self.api_key, "OPENAI_API_KEY", session_home)
+        try:
+            proc = subprocess.run(
+                [self.binary, "login", "--with-api-key"],
+                input=self.api_key,
+                cwd=session_home,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+        except OSError as exc:
+            log.warning("could not spawn codex login: %s", exc)
+            return _error_result("codex-login-error", detail=str(exc)[:200])
+        except subprocess.TimeoutExpired:
+            return _error_result("codex-login-error", detail="codex login timed out")
+        if proc.returncode != 0:
+            detail = redact((proc.stderr or proc.stdout or "").strip(), (self.api_key,))[-300:]
+            log.warning("codex login failed: %s", detail)
+            return _error_result("codex-login-error", detail=detail or "codex login failed")
+        return None
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
@@ -523,6 +558,13 @@ class CodexHarness:
         except OSError as exc:
             log.warning("could not create session home %s: %s", session_home, exc)
             return _error_result("workspace-error")
+        # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
+        # (verified: the responses endpoint 401s on env-only). Write auth.json
+        # into the scrubbed per-run HOME with `codex login --with-api-key`
+        # (key on stdin, never argv) before exec.
+        login_error = self._login(session_home)
+        if login_error is not None:
+            return login_error
         # --output-last-message target lives inside the per-run home (0700),
         # not the shared parent, so model output is not exposed there while
         # codex is writing it; cleared first so a stale file can never be read

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -436,7 +436,7 @@ def _codex_command(
 
 
 def _parse_codex_result(
-    stdout: str, last_message: str, returncode: int, transcript_path: str = ""
+    stdout: str, last_message: str, returncode: int, transcript_path: str = "", stderr: str = ""
 ) -> SessionResult:
     """Best-effort SessionResult from `codex exec --json` output.
 
@@ -473,6 +473,10 @@ def _parse_codex_result(
                 errors.append(message)
     is_error = returncode != 0 or saw_error
     detail = "; ".join(errors)[:500]
+    # Fall back to stderr so a failed run (e.g. a bad flag, no matching event)
+    # carries some cause instead of an empty detail.
+    if is_error and not detail and stderr.strip():
+        detail = stderr.strip()[-500:]
     return SessionResult(
         stop_reason="error" if is_error else "completed",
         is_error=is_error,
@@ -550,7 +554,7 @@ class CodexHarness:
             log.warning("could not spawn %s: %s", self.binary, exc)
             return _error_result("spawn-error")
         try:
-            stdout, _ = process.communicate(input=brief_text, timeout=self.timeout_s)
+            stdout, stderr = process.communicate(input=brief_text, timeout=self.timeout_s)
         except subprocess.TimeoutExpired:
             with contextlib.suppress(ProcessLookupError, PermissionError):
                 os.killpg(process.pid, signal.SIGKILL)
@@ -583,7 +587,13 @@ class CodexHarness:
         # file so model output is not left behind.
         with contextlib.suppress(OSError):
             last_message_path.unlink()
-        return _parse_codex_result(stdout, last_message, process.returncode, transcript_path)
+        return _parse_codex_result(
+            stdout,
+            last_message,
+            process.returncode,
+            transcript_path,
+            stderr=redact(stderr, (self.api_key,)),
+        )
 
 
 @dataclass

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -421,11 +421,13 @@ def _codex_command(
     and the stdin prompt behavior.
     """
     head = [binary, "exec", "resume", resume_session_id] if resume_session_id else [binary, "exec"]
+    # --model is omitted when empty so codex uses its configured default; a
+    # wrong model id is a 404 ("Model not found"), so only pin a verified one.
+    model_flag = ["--model", model] if model else []
     return [
         *head,
         "--json",  # JSONL events on stdout (session id, usage)
-        "--model",
-        model,
+        *model_flag,
         "--sandbox",
         sandbox,  # "read-only" for judge roles; "workspace-write" for authors
         "--cd",
@@ -517,7 +519,8 @@ class CodexHarness:
 
     api_key: str
     binary: str = "codex"
-    model: str = "gpt-5-codex"  # codex-cli flagship; overridable per call
+    # empty -> codex's configured default (a wrong id 404s); pin only a verified one
+    model: str = ""
     sandbox: str = "read-only"  # judge default; authors pass "workspace-write"
     timeout_s: int = DEFAULT_TIMEOUT_S
     extra_args: tuple[str, ...] = field(default_factory=tuple)

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -415,8 +415,10 @@ def _codex_command(
 
     The prompt is NOT an argument: `codex exec` reads it from stdin when no
     positional prompt is given, keeping the brief out of world-readable /proc
-    argv (the same rule as the Claude adapter). Flags follow the Codex docs and
-    must be checked against `codex exec --help` on the cluster.
+    argv (the same rule as the Claude adapter). Flags verified against
+    codex-cli 0.130.0 (`codex exec --help`): exec/resume, --json, --model,
+    --sandbox read-only, --cd, --output-last-message, --skip-git-repo-check,
+    and the stdin prompt behavior.
     """
     head = [binary, "exec", "resume", resume_session_id] if resume_session_id else [binary, "exec"]
     return [
@@ -441,11 +443,11 @@ def _parse_codex_result(
     """Best-effort SessionResult from `codex exec --json` output.
 
     `final_text` comes from the --output-last-message file, which is reliable.
-    `session_id` is pulled from the JSONL events defensively; the exact event
-    schema must be confirmed against a live `--json` run, so until then resume
-    may be unavailable. Cost is left at 0 (these backends are subscription or
-    token metered; the budget layer meters them by a session/token proxy).
-    Never raises.
+    `session_id` is pulled from the JSONL events defensively; the CLI flags are
+    verified (codex-cli 0.130.0), but the exact `--json` event field names still
+    need a live authed run, so resume may be unavailable until then. Cost is left
+    at 0 (these backends are subscription or token metered; the budget layer
+    meters them by a session/token proxy). Never raises.
     """
     session_id = ""
     saw_error = False
@@ -495,11 +497,10 @@ class CodexHarness:
 
     Stage 1's swappability proof, first used for the read-only reviewer
     (docs/design/consolidation.md): Codex's own `--sandbox read-only` plus a
-    judge RoleSpec's tool set. Flags and the JSONL event schema follow the Codex
-    docs and MUST be verified against `codex exec --help` and a live `--json`
-    run on the cluster before production; `session_id` and cost parsing are
-    best-effort until then. No apptainer wrapper yet (the reviewer runs
-    read-only); the author-on-Codex path adds one later.
+    judge RoleSpec's tool set. CLI flags are verified against codex-cli 0.130.0;
+    the `--json` event field names still need a live authed run, so `session_id`
+    and cost parsing are best-effort until then. No apptainer wrapper yet (the
+    reviewer runs read-only); the author-on-Codex path adds one later.
 
     `run` never raises: every failure comes back as an error SessionResult.
     """

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -245,6 +245,11 @@ class ClaudeCodeHarness:
         except OSError as exc:
             log.warning("could not create session home %s: %s", session_home, exc)
             return _error_result("workspace-error")
+        # A read-only session (no mutating tool) gets a permission mode that
+        # denies edits rather than auto-accepting them — defense in depth
+        # behind the tool allowlist, so a stray edit tool cannot auto-apply.
+        mutating = {"Write", "Edit", "Bash"}.intersection(self.allowed_tools)
+        permission_mode = "acceptEdits" if mutating else "default"
         claude_argv = [
             self.CONTAINER_CLAUDE if self.container_image else self.binary,
             "-p",
@@ -260,7 +265,7 @@ class ClaudeCodeHarness:
             "--allowedTools",
             ",".join(self.allowed_tools),
             "--permission-mode",
-            "acceptEdits",
+            permission_mode,
             *self.extra_args,
         ]
         if resume_session_id:
@@ -550,6 +555,12 @@ class CodexHarness:
             return _error_result("codex-login-error", detail=detail or "codex login failed")
         return None
 
+    def _purge_auth(self, session_home: Path) -> None:
+        """Delete the API key that `codex login` wrote to auth.json, so it does
+        not persist on disk past the session."""
+        with contextlib.suppress(OSError):
+            (session_home / ".codex" / "auth.json").unlink()
+
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
     ) -> SessionResult:
@@ -598,6 +609,7 @@ class CodexHarness:
             )
         except OSError as exc:
             log.warning("could not spawn %s: %s", self.binary, exc)
+            self._purge_auth(session_home)
             return _error_result("spawn-error")
         try:
             stdout, stderr = process.communicate(input=brief_text, timeout=self.timeout_s)
@@ -616,6 +628,7 @@ class CodexHarness:
             )
             with contextlib.suppress(OSError):
                 last_message_path.unlink()  # clean up on the timeout path too
+            self._purge_auth(session_home)
             log.warning("codex session timed out after %ss in %s", self.timeout_s, workspace)
             return _error_result(
                 "timeout",
@@ -633,6 +646,7 @@ class CodexHarness:
         # file so model output is not left behind.
         with contextlib.suppress(OSError):
             last_message_path.unlink()
+        self._purge_auth(session_home)
         return _parse_codex_result(
             stdout,
             last_message,

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -324,10 +324,14 @@ def result_from_data(data: dict[str, Any]) -> ReviewResult:
         file, summary, detail = item.get("file"), item.get("summary"), item.get("detail")
         if not (isinstance(file, str) and isinstance(summary, str) and isinstance(detail, str)):
             continue
+        # bool is an int subclass, so `line: true` would slip through an
+        # `isinstance(..., int)` check and become line 1.
+        line = item.get("line")
+        line = line if isinstance(line, int) and not isinstance(line, bool) else None
         findings.append(
             Finding(
                 file=sanitize(file, 200),
-                line=item["line"] if isinstance(item.get("line"), int) else None,
+                line=line,
                 confidence=item["confidence"] if item.get("confidence") in CONFIDENCES else "low",
                 summary=sanitize(summary, MAX_SUMMARY_CHARS),
                 detail=sanitize(detail, MAX_DETAIL_CHARS),

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -33,7 +33,12 @@ from autoresearch.review import (
     format_review,
     skip_reason,
 )
-from autoresearch.review_cli import EXPECTED_FAILURES, post_round_review, post_skip_stub
+from autoresearch.review_cli import (
+    EXPECTED_FAILURES,
+    post_round,
+    post_round_review,
+    post_skip_stub,
+)
 from autoresearch.role_runner import run_role
 from autoresearch.roles import review_result_from_role, reviewer_spec
 from autoresearch.rolespec import RoleSpec
@@ -133,15 +138,26 @@ def run_agent_review(
                 post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
             return None
 
-        rendered = format_review(review, pr.diff)
-        full = format_comment(review)
-        if rendered is None or full is None:
-            log.info("nothing to post")
-            return None
-        body, inline = rendered
-        round_label = post_round_review(
-            client, repo, number, MARKER, body, inline, pr_data, fallback_body=full
-        )
+        # Human PRs get inline findings. Explicit rounds on BOT PRs stay issue
+        # comments: those ride into follow-up wakes as context, and the wake
+        # plumbing reads the issue-comment collection (matches review_cli).
+        bot_authored = pr.author.strip().casefold() == bot_login.strip().casefold()
+        if bot_authored:
+            body = format_comment(review)
+            if body is None:
+                log.info("nothing to post")
+                return None
+            round_label = post_round(client, repo, number, MARKER, body, pr_data)
+        else:
+            rendered = format_review(review, pr.diff)
+            full = format_comment(review)
+            if rendered is None or full is None:
+                log.info("nothing to post")
+                return None
+            body, inline = rendered
+            round_label = post_round_review(
+                client, repo, number, MARKER, body, inline, pr_data, fallback_body=full
+            )
         log.info("posted agent review (%s) on %s#%s", round_label, repo, number)
         return round_label
     except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -24,7 +24,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from autoresearch.github import GitHubClient
-from autoresearch.harness import Harness, outage
+from autoresearch.harness import ClaudeCodeHarness, Harness, outage
 from autoresearch.review import (
     MARKER,
     PullRequest,
@@ -39,6 +39,39 @@ from autoresearch.roles import review_result_from_role, reviewer_spec
 from autoresearch.rolespec import RoleSpec
 
 log = logging.getLogger(__name__)
+
+# Native Claude Code tools a judge session uses. The RoleSpec's other tools
+# (pr-context-read, retriever) are harness-provided MCP tools, wired separately;
+# they are not passed as native CLI tools here.
+_NATIVE_READ_TOOLS = ("Read", "Grep", "Glob")
+
+
+def build_reviewer_harness(
+    api_key: str,
+    spec: RoleSpec | None = None,
+    *,
+    binary: str = "claude",
+    model: str | None = None,
+    container_image: str = "",
+) -> ClaudeCodeHarness:
+    """Construct a read-only Claude Code harness for the reviewer from its
+    RoleSpec — the deployment wiring the role-runner assumes (docs: "the harness
+    is assumed already constructed for the role"). Only native read tools are
+    granted (no Write/Edit/Bash), so the read-only boundary binds the session,
+    and the RoleSpec's budget sets turns and walltime."""
+    spec = spec or reviewer_spec()
+    if spec.execution.can_execute:
+        raise ValueError("build_reviewer_harness is for read-only judge roles")
+    allowed = tuple(tool for tool in spec.tools if tool in _NATIVE_READ_TOOLS)
+    return ClaudeCodeHarness(
+        api_key=api_key,
+        binary=binary,
+        model=model or "claude-opus-5",
+        max_turns=spec.budget.max_turns,
+        timeout_s=spec.budget.walltime_s,
+        allowed_tools=allowed,
+        container_image=container_image,
+    )
 
 
 def _pull_request(client: GitHubClient, repo: str, number: int) -> tuple[PullRequest, dict]:

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -23,8 +23,14 @@ log = logging.getLogger(__name__)
 
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
-    repo = os.environ["PR_REPO"]
-    number = int(os.environ["PR_NUMBER"])
+    # Fail closed on a missing/invalid PR reference too, so a misconfigured
+    # workflow skips cleanly rather than exiting nonzero (never red the CI).
+    repo = os.environ.get("PR_REPO", "").strip()
+    number_raw = os.environ.get("PR_NUMBER", "").strip()
+    if not repo or not number_raw.isdigit():
+        log.warning("PR_REPO/PR_NUMBER unset or invalid; skipping")
+        return 0
+    number = int(number_raw)
     # Fail closed: without the bot login we cannot honor "never review
     # bot-authored PRs", so we do not review at all.
     bot_login = os.environ.get("REVIEW_BOT_LOGIN", "").strip()

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -35,9 +35,15 @@ def main() -> int:
     if not api_key:
         log.warning("ANTHROPIC_REVIEWER_KEY is unset or empty; skipping review")
         return 0
-    # The workflow checks out the PR head read-only into this directory; the
-    # agent reads it but never executes it (read-only tool set).
-    workspace = Path(os.environ.get("REVIEW_CHECKOUT", ".")).resolve()
+    # The workflow checks out the PR head read-only into REVIEW_CHECKOUT; the
+    # agent reads it but never executes it (read-only tool set). Fail closed:
+    # defaulting to cwd would silently review the wrong tree (the reviewer's
+    # own repo) if the checkout step were misconfigured.
+    checkout = os.environ.get("REVIEW_CHECKOUT", "").strip()
+    if not checkout:
+        log.warning("REVIEW_CHECKOUT is unset; skipping (won't review the wrong tree)")
+        return 0
+    workspace = Path(checkout).resolve()
     explicit = os.environ.get("REVIEW_EXPLICIT_REQUEST", "").strip().lower() == "true"
 
     client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -1,0 +1,62 @@
+"""Entry point for the agent-session advisory reviewer.
+
+Runs the reviewer as a read-only agent over a PR-head checkout the workflow
+prepared (REVIEW_CHECKOUT), and posts the findings inline. Exits 0 even on skip
+or failure — an advisory reviewer must never turn a target repo's CI red.
+
+Lives beside review_cli (the completer entry point) during validation; the
+workflow swap that makes this the default sunsets the completer path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from pathlib import Path
+
+from autoresearch.github import EnvTokenProvider, GitHubClient
+from autoresearch.review_agent import build_reviewer_harness, run_agent_review
+
+log = logging.getLogger(__name__)
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    repo = os.environ["PR_REPO"]
+    number = int(os.environ["PR_NUMBER"])
+    # Fail closed: without the bot login we cannot honor "never review
+    # bot-authored PRs", so we do not review at all.
+    bot_login = os.environ.get("REVIEW_BOT_LOGIN", "").strip()
+    if not bot_login:
+        log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot identify bot-authored PRs)")
+        return 0
+    api_key = os.environ.get("ANTHROPIC_REVIEWER_KEY", "").strip()
+    if not api_key:
+        log.warning("ANTHROPIC_REVIEWER_KEY is unset or empty; skipping review")
+        return 0
+    # The workflow checks out the PR head read-only into this directory; the
+    # agent reads it but never executes it (read-only tool set).
+    workspace = Path(os.environ.get("REVIEW_CHECKOUT", ".")).resolve()
+    explicit = os.environ.get("REVIEW_EXPLICIT_REQUEST", "").strip().lower() == "true"
+
+    client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
+    harness = build_reviewer_harness(
+        api_key,
+        binary=os.environ.get("CLAUDE_BINARY", "claude"),
+        model=os.environ.get("REVIEW_MODEL") or None,
+    )
+    run_agent_review(
+        client,
+        repo,
+        number,
+        harness,
+        workspace,
+        bot_login=bot_login,
+        explicit=explicit,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -21,6 +21,12 @@ def test_command_has_expected_flags() -> None:
     assert "--output-last-message" in cmd and "/w-last.txt" in cmd
     assert "--sandbox" in cmd and "read-only" in cmd
     assert "--cd" in cmd and "/w" in cmd
+    assert cmd[cmd.index("--model") + 1] == "m"
+
+
+def test_command_omits_model_when_empty() -> None:
+    cmd = _codex_command("codex", "", "read-only", Path("/w"), Path("/l"), None, ())
+    assert "--model" not in cmd  # codex uses its configured default
 
 
 def test_brief_goes_to_stdin_never_argv(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -41,6 +41,8 @@ def test_brief_goes_to_stdin_never_argv(monkeypatch: Any, tmp_path: Path) -> Non
             return json.dumps({"session_id": "s"}), ""
 
     monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    # stub the login pre-step (its own subprocess) so this test isolates exec
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, home: None)
     brief = "SENTINEL_BRIEF_9x7 please review this pull request"
     CodexHarness(api_key="k").run(brief, tmp_path)
     assert seen["stdin"] == brief
@@ -52,16 +54,18 @@ def test_command_resume_uses_resume_subcommand() -> None:
     assert cmd[:4] == ["codex", "exec", "resume", "sess-123"]
 
 
-def test_parse_success_pulls_session_and_final_text() -> None:
+def test_parse_success_pulls_thread_id_and_final_text() -> None:
+    # schema verified against codex-cli 0.130.0: thread.started -> thread_id
     stdout = "\n".join(
         [
-            json.dumps({"type": "session.created", "session_id": "sess-9"}),
-            json.dumps({"type": "item.completed"}),
+            json.dumps({"type": "thread.started", "thread_id": "019ff8f0-abc"}),
+            json.dumps({"type": "turn.started"}),
+            json.dumps({"type": "turn.completed", "usage": {"output_tokens": 29}}),
         ]
     )
     result = _parse_codex_result(stdout, "final answer\n", 0, "t.jsonl")
     assert result.is_error is False
-    assert result.session_id == "sess-9"
+    assert result.session_id == "019ff8f0-abc"
     assert result.final_text == "final answer"
     assert result.transcript_path == "t.jsonl"
 
@@ -77,8 +81,18 @@ def test_parse_flags_error_event_with_message() -> None:
     assert "model unavailable" in result.error_detail
 
 
-def test_parse_tolerates_non_json_lines() -> None:
-    stdout = "starting up...\n" + json.dumps({"session_id": "s"}) + "\nbye"
+def test_parse_flags_turn_failed_with_nested_message() -> None:
+    stdout = json.dumps({"type": "turn.failed", "error": {"message": "401 Unauthorized"}})
+    result = _parse_codex_result(stdout, "", 0)
+    assert result.is_error is True
+    assert "401 Unauthorized" in result.error_detail
+
+
+def test_parse_skips_timestamped_log_lines() -> None:
+    # codex interleaves "2026-... ERROR ..." log lines that are not JSON
+    stdout = "2026-08-13T02:25:06Z ERROR codex_api: failed to connect\n" + json.dumps(
+        {"type": "thread.started", "thread_id": "t1"}
+    )
     result = _parse_codex_result(stdout, "ok", 0)
-    assert result.session_id == "s"
+    assert result.session_id == "t1"
     assert result.is_error is False

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -112,6 +112,19 @@ def test_result_from_data_drops_malformed_items_without_crashing() -> None:
     assert result_from_data({}).findings == []
 
 
+def test_boolean_line_is_not_treated_as_a_line_number() -> None:
+    from autoresearch.review import result_from_data
+
+    data: dict[str, Any] = {
+        "findings": [
+            {"file": "x.py", "line": True, "confidence": "low", "summary": "s", "detail": "d"}
+        ],
+        "notes": "",
+    }
+    # bool is an int subclass; `line: true` must not become line 1
+    assert result_from_data(data).findings[0].line is None
+
+
 def test_bot_authored_prs_are_never_reviewed() -> None:
     pr = make_pr(author=BOT)
     assert skip_reason(pr, BOT) is not None

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -176,6 +176,36 @@ def test_malformed_output_posts_nothing() -> None:
     assert client.reviews == [] and client.comments == []
 
 
+def test_build_reviewer_harness_is_read_only() -> None:
+    from autoresearch.review_agent import build_reviewer_harness
+
+    harness = build_reviewer_harness("k")
+    # the read-only boundary binds the session: no execute/write tools
+    assert "Bash" not in harness.allowed_tools
+    assert "Write" not in harness.allowed_tools and "Edit" not in harness.allowed_tools
+    assert set(harness.allowed_tools) == {"Read", "Grep", "Glob"}
+    # budget comes from the RoleSpec
+    assert harness.max_turns == 40 and harness.timeout_s == 1800
+
+
+def test_build_reviewer_harness_rejects_execute_role() -> None:
+    import pytest
+
+    from autoresearch.review_agent import build_reviewer_harness
+    from autoresearch.rolespec import Execution, RoleSpec, SessionBudget
+
+    author = RoleSpec(
+        name="author",
+        instructions="x",
+        key="author",
+        tools=("Read", "Edit", "Bash"),
+        execution=Execution(environment="apptainer", can_execute=True),
+        budget=SessionBudget(max_turns=10, walltime_s=60),
+    )
+    with pytest.raises(ValueError, match="read-only"):
+        build_reviewer_harness("k", author)
+
+
 def test_build_agent_brief_reuses_rubric_and_diff() -> None:
     from autoresearch.review import PullRequest
 

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -233,10 +233,27 @@ def test_build_agent_brief_reuses_rubric_and_diff() -> None:
     assert "2026-08-13" in brief
 
 
-def test_reviewer_harness_uses_read_only_permission_mode() -> None:
-    # defense in depth: a read-only harness must not auto-accept edits
+def test_reviewer_harness_uses_read_only_permission_mode(monkeypatch: Any, tmp_path: Path) -> None:
+    # defense in depth: a read-only harness passes --permission-mode default
+    # (edits denied), not acceptEdits. Inspect the actual spawned argv.
+    import autoresearch.harness as harness_mod
     from autoresearch.review_agent import build_reviewer_harness
 
-    h = build_reviewer_harness("k")
-    mutating = {"Write", "Edit", "Bash"}.intersection(h.allowed_tools)
-    assert not mutating  # sanity: it's read-only
+    seen: dict[str, Any] = {}
+
+    class FakePopen:
+        returncode = 0
+
+        def __init__(self, command: list[str], **_: Any) -> None:
+            seen["argv"] = command
+
+        def communicate(
+            self, input: str | None = None, timeout: float | None = None
+        ) -> tuple[str, str]:
+            return json.dumps({"result": "{}", "session_id": "s"}), ""
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    build_reviewer_harness("k").run("brief", tmp_path)
+    argv = seen["argv"]
+    assert argv[argv.index("--permission-mode") + 1] == "default"
+    assert "Bash" not in argv[argv.index("--allowedTools") + 1]

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -129,6 +129,23 @@ def test_null_labels_do_not_crash() -> None:
     assert label is not None  # posts normally; null labels are not a crash
 
 
+def test_explicit_bot_pr_posts_issue_comment_not_inline() -> None:
+    # a bot PR reviewed on explicit re-request stays an issue comment, so it
+    # rides into follow-up wakes (the wake plumbing reads issue comments)
+    client, harness = _Client(author="autoresearch-bot"), _Harness(_FINDINGS)
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+        explicit=True,
+    )
+    assert label is not None
+    assert client.comments and client.reviews == []  # issue comment, not inline review
+
+
 def test_bot_authored_pr_is_skipped() -> None:
     client, harness = _Client(author="autoresearch-bot"), _Harness(_FINDINGS)
     label = run_agent_review(

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -231,3 +231,12 @@ def test_build_agent_brief_reuses_rubric_and_diff() -> None:
     assert "reviewing a pull request" in brief.lower()
     assert "input_gain" in brief  # the diff is embedded
     assert "2026-08-13" in brief
+
+
+def test_reviewer_harness_uses_read_only_permission_mode() -> None:
+    # defense in depth: a read-only harness must not auto-accept edits
+    from autoresearch.review_agent import build_reviewer_harness
+
+    h = build_reviewer_harness("k")
+    mutating = {"Write", "Edit", "Bash"}.intersection(h.allowed_tools)
+    assert not mutating  # sanity: it's read-only

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -1,0 +1,57 @@
+"""review_agent_cli.main: env reading, fail-closed skips, and the wired call."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import autoresearch.review_agent_cli as cli
+
+
+def _base_env() -> dict[str, str]:
+    return {
+        "PR_REPO": "org/repo",
+        "PR_NUMBER": "7",
+        "REVIEW_BOT_LOGIN": "autoresearch-bot",
+        "ANTHROPIC_REVIEWER_KEY": "sk-test",
+        "REVIEW_CHECKOUT": "/tmp/pr-head",
+    }
+
+
+def _patch(monkeypatch: Any, env: dict[str, str]) -> dict[str, Any]:
+    monkeypatch.setattr(cli.os, "environ", env)
+    monkeypatch.setattr(cli, "GitHubClient", lambda auth: "client")
+    monkeypatch.setattr(cli, "build_reviewer_harness", lambda *a, **k: "harness")
+    calls: dict[str, Any] = {}
+    monkeypatch.setattr(
+        cli,
+        "run_agent_review",
+        lambda *a, **k: calls.update(args=a, kwargs=k) or "Round 1",
+    )
+    return calls
+
+
+def test_configured_run_calls_through(monkeypatch: Any) -> None:
+    calls = _patch(monkeypatch, _base_env())
+    assert cli.main() == 0
+    # (client, repo, number, harness, workspace)
+    assert calls["args"][1] == "org/repo"
+    assert calls["args"][2] == 7
+    assert calls["args"][4] == Path("/tmp/pr-head").resolve()
+    assert calls["kwargs"]["bot_login"] == "autoresearch-bot"
+
+
+def test_missing_bot_login_skips(monkeypatch: Any) -> None:
+    env = _base_env()
+    del env["REVIEW_BOT_LOGIN"]
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert calls == {}  # never reached run_agent_review
+
+
+def test_missing_key_skips(monkeypatch: Any) -> None:
+    env = _base_env()
+    env["ANTHROPIC_REVIEWER_KEY"] = "  "
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert calls == {}

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -55,3 +55,11 @@ def test_missing_key_skips(monkeypatch: Any) -> None:
     calls = _patch(monkeypatch, env)
     assert cli.main() == 0
     assert calls == {}
+
+
+def test_missing_checkout_fails_closed(monkeypatch: Any) -> None:
+    env = _base_env()
+    del env["REVIEW_CHECKOUT"]  # would otherwise default to cwd (wrong tree)
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert calls == {}


### PR DESCRIPTION
Makes the agent-session reviewer runnable, and fixes three real bugs found by running it.

## Wiring
- **`build_reviewer_harness`** — construct a read-only Claude Code harness from `reviewer_spec`: only native read tools (Read/Grep/Glob, no Write/Edit/Bash), budget from the RoleSpec. This is the "construct the harness for the role" step the role-runner assumes.
- **`review_agent_cli`** — the entry point: reads env, builds the harness, runs `run_agent_review` over a read-only PR-head checkout (`REVIEW_CHECKOUT`). Exits 0 always (advisory).

## Validated live (local, dry-run)
Ran the agent reviewer against #72 with the local `claude` binary — read-only, no posting. It ran headless in the scrubbed env (no onboarding issue), investigated over 15 turns ($1.30), and returned 4 valid findings using the new `kind` taxonomy. Three were **real bugs the completer's five rounds missed** — because the agent read the code, not just the diff:

- `run_agent_review` always posted inline; explicit rounds on **bot PRs** must stay issue comments so they feed follow-up wakes (as `review_cli` does). Fixed.
- `line: true` became line 1 — **bool is an int subclass**, so the `isinstance(int)` check needed a not-bool guard. Fixed.
- **CodexHarness discarded stderr** on the normal path, so a failed run had no error detail. Fixed (capture + fall back to it).

(A fourth finding — a design doc "missing" — was a #72-branch checkout artifact; the doc is on main. That the agent flagged it confirms it read the real tree.)

This is the value proposition, dogfooded: an agentic reviewer that investigates the checkout finds real defects a diff-only completer can't.

## Not here
`review.yml` swap + the agent-review workflow (the only remaining unvalidated piece is the CLI-install step on a runner) and the completer sunset. Codex-adapter validation stays on CI/Linux — the local codex binary is quarantined by macOS.

Full suite green (490), mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)