### PR TITLE
Add manual agent-reviewer workflow (validation)

### DIFF
--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -21,10 +21,11 @@ permissions:
   contents: read
   pull-requests: write
 
-# One review at a time per PR (avoid a duplicate comment or a duplicate bill).
+# One review at a time per PR. Do NOT cancel in progress: a running session is a
+# paid model call, so queue a second dispatch behind it rather than kill it.
 concurrency:
   group: advisory-review-agent-${{ inputs.pr_number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   agent-review:
@@ -61,8 +62,13 @@ jobs:
       # on Linux. Either way the binary lands on PATH, which the harness passes
       # through to the scrubbed session env.
       - name: Install the ${{ inputs.backend }} CLI
+        env:
+          # via env, not interpolated into the script (avoids the injection shape)
+          BACKEND: ${{ inputs.backend }}
+        # pipefail so a failed curl fails the step instead of piping empty to bash
         run: |
-          if [ "${{ inputs.backend }}" = "codex" ]; then
+          set -euo pipefail
+          if [ "$BACKEND" = "codex" ]; then
             npm install -g @openai/codex@0.130.0
           else
             curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.229

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -1,0 +1,63 @@
+name: advisory-review-agent
+# The agent-session reviewer, run manually (workflow_dispatch) to validate it on
+# a real runner beside the live completer (review.yml). It checks out the PR head
+# READ-ONLY and never executes it — the reviewer's tool set has no Bash/Write, so
+# untrusted PR code is only read. Non-destructive: this does not replace
+# review.yml. The swap + completer sunset is a later change once this is proven.
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: PR number to review
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+# One review at a time per PR (avoid a duplicate comment or a duplicate bill).
+concurrency:
+  group: advisory-review-agent-${{ inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  agent-review:
+    runs-on: ubuntu-latest
+    # Advisory: an infrastructure failure here must never turn a PR red.
+    continue-on-error: true
+    steps:
+      # The reviewer code runs from here; the PR head is only ever read.
+      - name: Check out the reviewer
+        uses: actions/checkout@v4
+        with:
+          path: .autoresearch
+          persist-credentials: false
+      - name: Check out the PR head (read-only; never executed)
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ inputs.pr_number }}/head
+          path: pr-head
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      # Native binary, not npm: the npm wrapper's native-binary spawn is
+      # fragile (macOS quarantines it); the standalone install is what the
+      # cluster0 validation used. Adds ~/.local/bin to PATH for the run step,
+      # which the harness passes through to the scrubbed session env.
+      - name: Install the Claude Code CLI
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Run the agent review
+        working-directory: .autoresearch
+        env:
+          ANTHROPIC_REVIEWER_KEY: ${{ secrets.REVIEWER_API_KEY }}
+          # The workflow token, not the bot PAT — the PAT never reaches a session.
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REVIEW_BOT_LOGIN: agentic-learning-bot
+          REVIEW_CHECKOUT: ${{ github.workspace }}/pr-head
+        run: uv run --extra review python -m autoresearch.review_agent_cli

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -29,8 +29,11 @@ concurrency:
 jobs:
   agent-review:
     runs-on: ubuntu-latest
-    # Advisory: an infrastructure failure here must never turn a PR red.
-    continue-on-error: true
+    # Backstop a hung session so it cannot burn the 360-min default runner
+    # budget; the harness kills the session at its own walltime well before
+    # this. No continue-on-error: this is a manual workflow, not a PR check, so
+    # a failure never reds a PR — and masking install failures would hide them.
+    timeout-minutes: 40
     steps:
       # The reviewer code runs from here; the PR head is only ever read.
       - name: Check out the reviewer
@@ -47,17 +50,22 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      # Claude installs as a native binary (the npm wrapper's native-binary
-      # spawn is fragile — macOS quarantines it — and the standalone install is
-      # what the cluster0 validation used). Codex ships via npm on Linux.
-      # Either way the binary lands on PATH, which the harness passes through to
-      # the scrubbed session env.
+          # the reviewer is checked out under a dot-path; point the cache key at
+          # its lockfile or the default glob would miss it and never invalidate
+          cache-dependency-glob: .autoresearch/uv.lock
+      # Both CLIs are PINNED to the versions validated on cluster0 — bump them
+      # deliberately (and re-validate), since the codex adapter in particular
+      # parses codex-cli's --json event schema. Claude installs as a native
+      # binary (the npm wrapper's native-binary spawn is fragile — macOS
+      # quarantines it); its installer takes a version arg. Codex ships via npm
+      # on Linux. Either way the binary lands on PATH, which the harness passes
+      # through to the scrubbed session env.
       - name: Install the ${{ inputs.backend }} CLI
         run: |
           if [ "${{ inputs.backend }}" = "codex" ]; then
-            npm install -g @openai/codex
+            npm install -g @openai/codex@0.130.0
           else
-            curl -fsSL https://claude.ai/install.sh | bash
+            curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.229
             echo "$HOME/.local/bin" >> "$GITHUB_PATH"
           fi
       - name: Run the agent review
@@ -65,7 +73,7 @@ jobs:
         env:
           REVIEW_BACKEND: ${{ inputs.backend }}
           # The CLI reads only the key for the chosen backend; the other is unset.
-          ANTHROPIC_REVIEWER_KEY: ${{ secrets.REVIEWER_API_KEY }}
+          ANTHROPIC_REVIEWER_KEY: ${{ secrets.ANTHROPIC_REVIEWER_KEY }}
           OPENAI_REVIEWER_KEY: ${{ secrets.OPENAI_REVIEWER_KEY }}
           # The workflow token, not the bot PAT — the PAT never reaches a session.
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -11,6 +11,11 @@ on:
         description: PR number to review
         type: string
         required: true
+      backend:
+        description: Which agent backend drives the review
+        type: choice
+        options: [claude, codex]
+        default: claude
 
 permissions:
   contents: read
@@ -42,18 +47,26 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-      # Native binary, not npm: the npm wrapper's native-binary spawn is
-      # fragile (macOS quarantines it); the standalone install is what the
-      # cluster0 validation used. Adds ~/.local/bin to PATH for the run step,
-      # which the harness passes through to the scrubbed session env.
-      - name: Install the Claude Code CLI
+      # Claude installs as a native binary (the npm wrapper's native-binary
+      # spawn is fragile — macOS quarantines it — and the standalone install is
+      # what the cluster0 validation used). Codex ships via npm on Linux.
+      # Either way the binary lands on PATH, which the harness passes through to
+      # the scrubbed session env.
+      - name: Install the ${{ inputs.backend }} CLI
         run: |
-          curl -fsSL https://claude.ai/install.sh | bash
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          if [ "${{ inputs.backend }}" = "codex" ]; then
+            npm install -g @openai/codex
+          else
+            curl -fsSL https://claude.ai/install.sh | bash
+            echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          fi
       - name: Run the agent review
         working-directory: .autoresearch
         env:
+          REVIEW_BACKEND: ${{ inputs.backend }}
+          # The CLI reads only the key for the chosen backend; the other is unset.
           ANTHROPIC_REVIEWER_KEY: ${{ secrets.REVIEWER_API_KEY }}
+          OPENAI_REVIEWER_KEY: ${{ secrets.OPENAI_REVIEWER_KEY }}
           # The workflow token, not the bot PAT — the PAT never reaches a session.
           GITHUB_TOKEN: ${{ github.token }}
           PR_REPO: ${{ github.repository }}

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -24,7 +24,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from autoresearch.github import GitHubClient
-from autoresearch.harness import ClaudeCodeHarness, Harness, outage
+from autoresearch.harness import ClaudeCodeHarness, CodexHarness, Harness, outage
 from autoresearch.review import (
     MARKER,
     PullRequest,
@@ -55,22 +55,34 @@ def build_reviewer_harness(
     api_key: str,
     spec: RoleSpec | None = None,
     *,
-    binary: str = "claude",
+    backend: str = "claude",
+    binary: str | None = None,
     model: str | None = None,
     container_image: str = "",
-) -> ClaudeCodeHarness:
-    """Construct a read-only Claude Code harness for the reviewer from its
-    RoleSpec — the deployment wiring the role-runner assumes (docs: "the harness
-    is assumed already constructed for the role"). Only native read tools are
-    granted (no Write/Edit/Bash), so the read-only boundary binds the session,
-    and the RoleSpec's budget sets turns and walltime."""
+) -> Harness:
+    """Construct a read-only harness for the reviewer from its RoleSpec, for the
+    chosen backend — the deployment wiring the role-runner assumes (docs: "the
+    harness is assumed already constructed for the role"). The read-only
+    boundary binds the session regardless of backend: Claude via a native
+    read-only tool set (no Write/Edit/Bash), Codex via --sandbox read-only. The
+    RoleSpec's budget sets turns/walltime."""
     spec = spec or reviewer_spec()
     if spec.execution.can_execute:
         raise ValueError("build_reviewer_harness is for read-only judge roles")
+    if backend == "codex":
+        return CodexHarness(
+            api_key=api_key,
+            binary=binary or "codex",
+            model=model or "",  # codex's configured default
+            sandbox="read-only",
+            timeout_s=spec.budget.walltime_s,
+        )
+    if backend != "claude":
+        raise ValueError(f"unknown reviewer backend: {backend!r}")
     allowed = tuple(tool for tool in spec.tools if tool in _NATIVE_READ_TOOLS)
     return ClaudeCodeHarness(
         api_key=api_key,
-        binary=binary,
+        binary=binary or "claude",
         model=model or "claude-opus-5",
         max_turns=spec.budget.max_turns,
         timeout_s=spec.budget.walltime_s,

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -64,8 +64,9 @@ def build_reviewer_harness(
     chosen backend — the deployment wiring the role-runner assumes (docs: "the
     harness is assumed already constructed for the role"). The read-only
     boundary binds the session regardless of backend: Claude via a native
-    read-only tool set (no Write/Edit/Bash), Codex via --sandbox read-only. The
-    RoleSpec's budget sets turns/walltime."""
+    read-only tool set (no Write/Edit/Bash), Codex via --sandbox read-only.
+    Budget: Claude gets max_turns and walltime; Codex is bounded by walltime
+    only (no per-turn cap yet) and does not use container_image."""
     spec = spec or reviewer_spec()
     if spec.execution.can_execute:
         raise ValueError("build_reviewer_harness is for read-only judge roles")

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -37,9 +37,16 @@ def main() -> int:
     if not bot_login:
         log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot identify bot-authored PRs)")
         return 0
-    api_key = os.environ.get("ANTHROPIC_REVIEWER_KEY", "").strip()
+    # Backend is a deployment choice, not baked in: pick the harness and its
+    # key by REVIEW_BACKEND (claude | codex), consistent with the Harness seam.
+    backend = os.environ.get("REVIEW_BACKEND", "claude").strip().lower()
+    key_var = {"claude": "ANTHROPIC_REVIEWER_KEY", "codex": "OPENAI_REVIEWER_KEY"}.get(backend)
+    if key_var is None:
+        log.warning("unknown REVIEW_BACKEND %r; skipping review", backend)
+        return 0
+    api_key = os.environ.get(key_var, "").strip()
     if not api_key:
-        log.warning("ANTHROPIC_REVIEWER_KEY is unset or empty; skipping review")
+        log.warning("%s is unset or empty; skipping review", key_var)
         return 0
     # The workflow checks out the PR head read-only into REVIEW_CHECKOUT; the
     # agent reads it but never executes it (read-only tool set). Fail closed:
@@ -55,7 +62,8 @@ def main() -> int:
     client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
     harness = build_reviewer_harness(
         api_key,
-        binary=os.environ.get("CLAUDE_BINARY", "claude"),
+        backend=backend,
+        binary=os.environ.get("REVIEW_BINARY") or None,  # else the backend default on PATH
         model=os.environ.get("REVIEW_MODEL") or None,
     )
     run_agent_review(

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -194,15 +194,35 @@ def test_malformed_output_posts_nothing() -> None:
 
 
 def test_build_reviewer_harness_is_read_only() -> None:
+    from autoresearch.harness import ClaudeCodeHarness
     from autoresearch.review_agent import build_reviewer_harness
 
     harness = build_reviewer_harness("k")
+    assert isinstance(harness, ClaudeCodeHarness)  # default backend
     # the read-only boundary binds the session: no execute/write tools
     assert "Bash" not in harness.allowed_tools
     assert "Write" not in harness.allowed_tools and "Edit" not in harness.allowed_tools
     assert set(harness.allowed_tools) == {"Read", "Grep", "Glob"}
     # budget comes from the RoleSpec
     assert harness.max_turns == 40 and harness.timeout_s == 1800
+
+
+def test_build_reviewer_harness_codex_backend() -> None:
+    from autoresearch.harness import CodexHarness
+    from autoresearch.review_agent import build_reviewer_harness
+
+    h = build_reviewer_harness("k", backend="codex")
+    assert isinstance(h, CodexHarness)
+    assert h.sandbox == "read-only"  # read-only judge boundary via the sandbox
+
+
+def test_build_reviewer_harness_rejects_unknown_backend() -> None:
+    import pytest
+
+    from autoresearch.review_agent import build_reviewer_harness
+
+    with pytest.raises(ValueError, match="unknown reviewer backend"):
+        build_reviewer_harness("k", backend="hermes")
 
 
 def test_build_reviewer_harness_rejects_execute_role() -> None:

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -21,8 +21,14 @@ def _base_env() -> dict[str, str]:
 def _patch(monkeypatch: Any, env: dict[str, str]) -> dict[str, Any]:
     monkeypatch.setattr(cli.os, "environ", env)
     monkeypatch.setattr(cli, "GitHubClient", lambda auth: "client")
-    monkeypatch.setattr(cli, "build_reviewer_harness", lambda *a, **k: "harness")
     calls: dict[str, Any] = {}
+    # capture what the CLI passes to the harness builder (backend + key), so a
+    # test can assert the backend is actually forwarded
+    monkeypatch.setattr(
+        cli,
+        "build_reviewer_harness",
+        lambda api_key, **k: calls.update(build_key=api_key, build_kwargs=k) or "harness",
+    )
     monkeypatch.setattr(
         cli,
         "run_agent_review",
@@ -64,7 +70,9 @@ def test_codex_backend_reads_openai_key(monkeypatch: Any) -> None:
     del env["ANTHROPIC_REVIEWER_KEY"]  # wrong key for this backend; must be ignored
     calls = _patch(monkeypatch, env)
     assert cli.main() == 0
-    assert calls.get("args")  # reached run_agent_review with the openai key
+    # the codex backend AND its openai key are forwarded to the harness builder
+    assert calls["build_kwargs"]["backend"] == "codex"
+    assert calls["build_key"] == "sk-openai"
 
 
 def test_unknown_backend_skips(monkeypatch: Any) -> None:

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -57,6 +57,24 @@ def test_missing_key_skips(monkeypatch: Any) -> None:
     assert calls == {}
 
 
+def test_codex_backend_reads_openai_key(monkeypatch: Any) -> None:
+    env = _base_env()
+    env["REVIEW_BACKEND"] = "codex"
+    env["OPENAI_REVIEWER_KEY"] = "sk-openai"
+    del env["ANTHROPIC_REVIEWER_KEY"]  # wrong key for this backend; must be ignored
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert calls.get("args")  # reached run_agent_review with the openai key
+
+
+def test_unknown_backend_skips(monkeypatch: Any) -> None:
+    env = _base_env()
+    env["REVIEW_BACKEND"] = "hermes"
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert calls == {}
+
+
 def test_missing_checkout_fails_closed(monkeypatch: Any) -> None:
     env = _base_env()
     del env["REVIEW_CHECKOUT"]  # would otherwise default to cwd (wrong tree)


### PR DESCRIPTION
Adds `review-agent.yml` — the agent-session reviewer on a real runner, triggered manually (`workflow_dispatch`), **beside** the live completer (`review.yml`), not replacing it.

## What it does
- Checks out the **reviewer** code and the **PR head read-only** (the reviewer has no Bash/Write, so untrusted PR code is only read, never executed).
- Installs the **native Claude binary** (`claude.ai/install.sh`), not npm — matching what the cluster0 validation used.
- Runs `review_agent_cli` with `REVIEW_CHECKOUT` pointed at the PR-head checkout.
- capped by `timeout-minutes` and manually dispatched (not a PR check), so it never reds a PR.

## Why dormant/manual
`workflow_dispatch` requires the file on the default branch to be triggerable, and it must not disturb the live completer. So this merges dormant; I then trigger it on a test PR to validate on the runner (the pipeline itself is already proven end-to-end on Mac + cluster0, both backends). The only runner-specific unknown is the CLI-install step, which cluster0 already exercised.

## Next (separate PR, once proven)
Swap `review.yml` to this path and sunset the completer (`review_cli` branch, `AnthropicCompleter`, `review()`/`build_prompt` and their tests) — no two reviewer implementations on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)