### PR TITLE
refactor: extract shared posting helpers into posting.py (de-mess the sunset)

### DIFF
--- a/src/autoresearch/posting.py
+++ b/src/autoresearch/posting.py
@@ -1,0 +1,133 @@
+"""Shared GitHub posting helpers for the reviewer and verifier.
+
+Round-numbered comments, inline reviews, and skip stubs — the machinery for
+getting a judge's findings onto a PR thread. Backend-agnostic on purpose: no
+model or completer dependency, so both the completer path and the agent path
+post through here. (Extracted from review_cli so that path can be sunset as a
+clean delete once the last repo migrates.)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from autoresearch.github import GitHubClient, GitHubError
+from autoresearch.harness import redact
+
+log = logging.getLogger(__name__)
+
+# Posting/transport failures an advisory role tolerates — logged, never fatal,
+# because an advisory reviewer or verifier must not turn a target repo's CI red.
+# Programming errors (AttributeError, KeyError, TypeError) deliberately
+# propagate. Model-call errors are NOT here: they arise only inside a completer
+# call, which catches them itself — posting has nothing to do with the model.
+EXPECTED_FAILURES = (
+    GitHubError,
+    ValueError,
+    OSError,
+    json.JSONDecodeError,
+)
+
+
+def post_round(
+    client: GitHubClient, repo: str, number: int, marker: str, body: str, pr_data: dict
+) -> str:
+    """Post one NEW comment per round — numbered, stamped with the reviewed
+    head — so every round notifies and stays visible (edits do neither).
+    Shared by the advisory reviewer and the verifier; each counts rounds by
+    ITS OWN marker. The old one-thread upsert guarded against
+    synchronize-triggered spam; runs are now only PR-open or an explicit
+    label request, so volume is human-bounded.
+    """
+    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
+    client.comment(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1))
+    return round_label
+
+
+def _round_stamp(
+    client: GitHubClient, repo: str, number: int, marker: str, pr_data: dict
+) -> tuple[str, str]:
+    """(stamp line, round label): prior rounds are counted across BOTH
+    issue comments and review bodies, so switching a role between posting
+    styles never resets its numbering."""
+    head = pr_data.get("head")
+    head_sha = str(head.get("sha", ""))[:8] if isinstance(head, dict) else ""
+    # The round number is cosmetic: an EXPECTED failure counting prior
+    # rounds must never cost the round itself. Programming errors still
+    # propagate, per this module's policy.
+    try:
+        bodies = [str(c.get("body", "")) for c in client.list_comments(repo, number)]
+        bodies += [str(r.get("body", "")) for r in client.list_pr_reviews(repo, number)]
+        # STARTS WITH the marker: a quote-reply prefixes every line with
+        # "> ", so it cannot match — and this stays true for any posting
+        # identity (Actions token, GitHub App, or a self-hoster's
+        # machine-user PAT, which posts as type User)
+        prior = [b for b in bodies if b.lstrip().startswith(marker)]
+        round_label = f"**Round {len(prior) + 1}**"
+        if head_sha and any(f"reviewed head `{head_sha}`" in b for b in prior):
+            round_label += " (re-run on the same head)"
+    except EXPECTED_FAILURES as exc:
+        log.warning("could not count prior rounds: %s", exc)
+        round_label = "**New round** (prior count unavailable)"
+    return f"{round_label} — reviewed head `{head_sha or 'unknown'}`.\n\n", round_label
+
+
+def post_round_review(
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    marker: str,
+    body: str,
+    inline: list[dict],
+    pr_data: dict,
+    fallback_body: str,
+) -> str:
+    """The Reviews-API sibling of post_round: body summary plus anchored
+    inline comments, event COMMENT always (the client hard-codes it). A
+    posting failure falls back to a plain issue comment carrying
+    fallback_body — the FULL single-comment rendering, because the review
+    body alone may say no more than "findings are attached" while the
+    findings live in the rejected inline payload."""
+    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
+    try:
+        client.create_pr_review(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1), inline)
+    except EXPECTED_FAILURES as exc:
+        log.warning("inline review failed (%s); falling back to a comment", exc)
+        client.comment(repo, number, fallback_body.replace(marker, f"{marker}\n{stamp}", 1))
+    return round_label
+
+
+SKIP_MARKER = "<!-- autoresearch:round-skipped -->"
+
+
+def post_skip_stub(client: GitHubClient, repo: str, number: int, role: str, exc: Exception) -> None:
+    """Silence is invisible: when the model API refuses a round (dead
+    credits, spend cap, auth), say so on the thread instead of leaving a
+    gap only the Actions tab can see. A DIFFERENT marker than a real
+    round, deliberately — a stub never counts toward round numbering and
+    never rides as follow-up wake context (both match on their own
+    markers)."""
+    # the reviewer/verifier keys are the only secrets this process holds;
+    # auth errors are exactly the class that can echo request material
+    secrets = tuple(
+        v
+        for v in (
+            os.environ.get("ANTHROPIC_REVIEWER_KEY", ""),
+            os.environ.get("ANTHROPIC_VERIFIER_KEY", ""),
+        )
+        if v
+    )
+    note = redact(str(exc), secrets)[:200]
+    try:
+        client.comment(
+            repo,
+            number,
+            f"{SKIP_MARKER}\n*The {role} round could not run — the model API "
+            f"refused the request ({type(exc).__name__}: {note}). Treat this "
+            f"as an outage, not a clean read; re-add the review label to "
+            f"re-request once the API recovers.*",
+        )
+    except EXPECTED_FAILURES as post_exc:
+        log.warning("could not post the skip stub: %s", post_exc)

--- a/src/autoresearch/posting.py
+++ b/src/autoresearch/posting.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 
 from autoresearch.github import GitHubClient, GitHubError
 from autoresearch.harness import redact
@@ -102,24 +101,28 @@ def post_round_review(
 SKIP_MARKER = "<!-- autoresearch:round-skipped -->"
 
 
-def post_skip_stub(client: GitHubClient, repo: str, number: int, role: str, exc: Exception) -> None:
+def post_skip_stub(
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    role: str,
+    exc: Exception,
+    secrets: tuple[str, ...] = (),
+) -> None:
     """Silence is invisible: when the model API refuses a round (dead
     credits, spend cap, auth), say so on the thread instead of leaving a
     gap only the Actions tab can see. A DIFFERENT marker than a real
     round, deliberately — a stub never counts toward round numbering and
     never rides as follow-up wake context (both match on their own
-    markers)."""
-    # the reviewer/verifier keys are the only secrets this process holds;
-    # auth errors are exactly the class that can echo request material
-    secrets = tuple(
-        v
-        for v in (
-            os.environ.get("ANTHROPIC_REVIEWER_KEY", ""),
-            os.environ.get("ANTHROPIC_VERIFIER_KEY", ""),
-        )
-        if v
-    )
-    note = redact(str(exc), secrets)[:200]
+    markers).
+
+    `secrets` are the model API key(s) the caller holds — an auth error is
+    exactly the class that can echo request material, so we scrub them from the
+    posted text. The caller supplies them (the harness's own key on the agent
+    path, the completer's key on the completer path) so posting stays
+    backend-agnostic — the key env var is provider-specific, this module is not.
+    """
+    note = redact(str(exc), tuple(s for s in secrets if s))[:200]
     try:
         client.comment(
             repo,

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -220,6 +220,9 @@ def run_agent_review(
             detail = role_result.error or role_result.session.stop_reason
             log.warning("agent review produced no verdict on %s#%s: %s", repo, number, detail)
             if outage(role_result.session) or budget_exhausted(role_result.session):
+                # `detail` is already api-key-redacted by the harness (it owns
+                # its own secret), so no secrets are passed here — unlike the
+                # completer path, whose CompleterError is not self-redacted.
                 post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
             return None
 

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -32,6 +32,12 @@ from autoresearch.harness import (
     budget_exhausted,
     outage,
 )
+from autoresearch.posting import (
+    EXPECTED_FAILURES,
+    post_round,
+    post_round_review,
+    post_skip_stub,
+)
 from autoresearch.review import (
     MARKER,
     PullRequest,
@@ -39,12 +45,6 @@ from autoresearch.review import (
     format_comment,
     format_review,
     skip_reason,
-)
-from autoresearch.review_cli import (
-    EXPECTED_FAILURES,
-    post_round,
-    post_round_review,
-    post_skip_stub,
 )
 from autoresearch.role_runner import run_role
 from autoresearch.roles import review_result_from_role, reviewer_spec

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -9,7 +9,6 @@ CI red.
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import sys
@@ -18,8 +17,15 @@ from dataclasses import replace
 from datetime import UTC, datetime
 
 from autoresearch.github import EnvTokenProvider, GitHubClient, GitHubError
-from autoresearch.harness import redact
 from autoresearch.llm import AnthropicCompleter, CompleterError, RefusalError, TruncatedError
+from autoresearch.posting import (
+    EXPECTED_FAILURES as _POSTING_FAILURES,
+)
+from autoresearch.posting import (
+    post_round,
+    post_round_review,
+    post_skip_stub,
+)
 from autoresearch.review import (
     MARKER,
     MAX_CONTEXT_FILES,
@@ -33,18 +39,11 @@ from autoresearch.review import (
 
 log = logging.getLogger(__name__)
 
-# Failures that mean "this run can't post" — logged, never fatal, because an
-# advisory reviewer must not turn a target repo's CI red. Programming errors
-# (AttributeError, KeyError, TypeError) deliberately propagate.
-EXPECTED_FAILURES = (
-    GitHubError,
-    RefusalError,
-    TruncatedError,
-    CompleterError,
-    ValueError,
-    OSError,
-    json.JSONDecodeError,
-)
+# The completer path catches the shared posting/transport failures PLUS the
+# model-call errors an AnthropicCompleter can raise — logged, never fatal,
+# because an advisory reviewer must not turn a target repo's CI red. Programming
+# errors (AttributeError, KeyError, TypeError) deliberately propagate.
+EXPECTED_FAILURES = (*_POSTING_FAILURES, RefusalError, TruncatedError, CompleterError)
 
 
 def _gather_context(
@@ -88,108 +87,6 @@ def _gather_context(
     except (GitHubError, ValueError) as exc:  # ValueError covers JSONDecodeError
         log.warning("reviewing without file context: %s", exc)
         return ()
-
-
-def post_round(
-    client: GitHubClient, repo: str, number: int, marker: str, body: str, pr_data: dict
-) -> str:
-    """Post one NEW comment per round — numbered, stamped with the reviewed
-    head — so every round notifies and stays visible (edits do neither).
-    Shared by the advisory reviewer and the verifier; each counts rounds by
-    ITS OWN marker. The old one-thread upsert guarded against
-    synchronize-triggered spam; runs are now only PR-open or an explicit
-    label request, so volume is human-bounded.
-    """
-    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
-    client.comment(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1))
-    return round_label
-
-
-def _round_stamp(
-    client: GitHubClient, repo: str, number: int, marker: str, pr_data: dict
-) -> tuple[str, str]:
-    """(stamp line, round label): prior rounds are counted across BOTH
-    issue comments and review bodies, so switching a role between posting
-    styles never resets its numbering."""
-    head = pr_data.get("head")
-    head_sha = str(head.get("sha", ""))[:8] if isinstance(head, dict) else ""
-    # The round number is cosmetic: an EXPECTED failure counting prior
-    # rounds must never cost the round itself. Programming errors still
-    # propagate, per this module's policy.
-    try:
-        bodies = [str(c.get("body", "")) for c in client.list_comments(repo, number)]
-        bodies += [str(r.get("body", "")) for r in client.list_pr_reviews(repo, number)]
-        # STARTS WITH the marker: a quote-reply prefixes every line with
-        # "> ", so it cannot match — and this stays true for any posting
-        # identity (Actions token, GitHub App, or a self-hoster's
-        # machine-user PAT, which posts as type User)
-        prior = [b for b in bodies if b.lstrip().startswith(marker)]
-        round_label = f"**Round {len(prior) + 1}**"
-        if head_sha and any(f"reviewed head `{head_sha}`" in b for b in prior):
-            round_label += " (re-run on the same head)"
-    except EXPECTED_FAILURES as exc:
-        log.warning("could not count prior rounds: %s", exc)
-        round_label = "**New round** (prior count unavailable)"
-    return f"{round_label} — reviewed head `{head_sha or 'unknown'}`.\n\n", round_label
-
-
-def post_round_review(
-    client: GitHubClient,
-    repo: str,
-    number: int,
-    marker: str,
-    body: str,
-    inline: list[dict],
-    pr_data: dict,
-    fallback_body: str,
-) -> str:
-    """The Reviews-API sibling of post_round: body summary plus anchored
-    inline comments, event COMMENT always (the client hard-codes it). A
-    posting failure falls back to a plain issue comment carrying
-    fallback_body — the FULL single-comment rendering, because the review
-    body alone may say no more than "findings are attached" while the
-    findings live in the rejected inline payload."""
-    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
-    try:
-        client.create_pr_review(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1), inline)
-    except EXPECTED_FAILURES as exc:
-        log.warning("inline review failed (%s); falling back to a comment", exc)
-        client.comment(repo, number, fallback_body.replace(marker, f"{marker}\n{stamp}", 1))
-    return round_label
-
-
-SKIP_MARKER = "<!-- autoresearch:round-skipped -->"
-
-
-def post_skip_stub(client: GitHubClient, repo: str, number: int, role: str, exc: Exception) -> None:
-    """Silence is invisible: when the model API refuses a round (dead
-    credits, spend cap, auth), say so on the thread instead of leaving a
-    gap only the Actions tab can see. A DIFFERENT marker than a real
-    round, deliberately — a stub never counts toward round numbering and
-    never rides as follow-up wake context (both match on their own
-    markers)."""
-    # the reviewer/verifier keys are the only secrets this process holds;
-    # auth errors are exactly the class that can echo request material
-    secrets = tuple(
-        v
-        for v in (
-            os.environ.get("ANTHROPIC_REVIEWER_KEY", ""),
-            os.environ.get("ANTHROPIC_VERIFIER_KEY", ""),
-        )
-        if v
-    )
-    note = redact(str(exc), secrets)[:200]
-    try:
-        client.comment(
-            repo,
-            number,
-            f"{SKIP_MARKER}\n*The {role} round could not run — the model API "
-            f"refused the request ({type(exc).__name__}: {note}). Treat this "
-            f"as an outage, not a clean read; re-add the review label to "
-            f"re-request once the API recovers.*",
-        )
-    except EXPECTED_FAILURES as post_exc:
-        log.warning("could not post the skip stub: %s", post_exc)
 
 
 def main() -> int:

--- a/src/autoresearch/review_cli.py
+++ b/src/autoresearch/review_cli.py
@@ -100,8 +100,10 @@ def main() -> int:
         log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot identify bot-authored PRs)")
         return 0
     # An unset secret arrives as an empty string; skip cleanly instead of
-    # crashing inside the API client.
-    if not os.environ.get("ANTHROPIC_REVIEWER_KEY", "").strip():
+    # crashing inside the API client. The completer is Anthropic by construction
+    # (the multi-backend path is the agent reviewer); read its key once.
+    reviewer_key = os.environ.get("ANTHROPIC_REVIEWER_KEY", "").strip()
+    if not reviewer_key:
         log.warning("ANTHROPIC_REVIEWER_KEY is unset or empty; skipping review")
         return 0
     client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
@@ -123,7 +125,7 @@ def main() -> int:
             ),
         )
         completer = AnthropicCompleter(
-            api_key=os.environ["ANTHROPIC_REVIEWER_KEY"],
+            api_key=reviewer_key,
             model=os.environ.get("REVIEW_MODEL") or "claude-opus-5",
             effort=os.environ.get("REVIEW_EFFORT") or "high",
         )
@@ -161,7 +163,7 @@ def main() -> int:
     except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
         log.warning("advisory review did not complete: %s: %s", type(exc).__name__, exc)
         if isinstance(exc, CompleterError):
-            post_skip_stub(client, repo, number, "advisory review", exc)
+            post_skip_stub(client, repo, number, "advisory review", exc, secrets=(reviewer_key,))
     return 0
 
 

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -25,6 +25,7 @@ import json
 import logging
 from typing import Any
 
+from autoresearch.github import GitHubClient
 from autoresearch.review import (
     CONFIDENCES,
     MAX_DETAIL_CHARS,
@@ -63,6 +64,63 @@ MAX_CLAIM_CHARS = 30_000
 # carried them) — most recent comments, bounded.
 MAX_THREAD_COMMENTS = 12
 MAX_THREAD_COMMENT_CHARS = 4_000
+
+# The verifier's own rounds post via the Actions workflow token — this
+# identity, which no ordinary account can assume. Marker text alone is
+# forgeable (it appears verbatim in every posted round); identity is not.
+ACTIONS_BOT_LOGIN = "github-actions[bot]"
+
+
+def _standing(comment: dict, bot_login: str) -> bool:
+    """Only voices with standing reach the verifier: maintainers by
+    association, the accused agent's own replies, and prior verifier
+    rounds identified by POSTING IDENTITY plus marker (marker alone can be
+    forged by any commenter on a public repo)."""
+    # QUALIFYING_ASSOCIATIONS lives in followup, which imports VERIFY_MARKER from
+    # this module; a function-level import avoids the module-level import cycle.
+    from autoresearch.followup import QUALIFYING_ASSOCIATIONS
+
+    body = str(comment.get("body") or "")
+    if not body.strip():
+        return False
+    login = str((comment.get("user") or {}).get("login", ""))
+    if str(comment.get("author_association", "")) in QUALIFYING_ASSOCIATIONS:
+        return True
+    if login.casefold() == bot_login.casefold():
+        return True
+    return login.casefold() == ACTIONS_BOT_LOGIN.casefold() and body.lstrip().startswith(
+        VERIFY_MARKER
+    )
+
+
+def gather_thread(
+    client: GitHubClient, repo: str, number: int, bot_login: str
+) -> tuple[tuple[str, str], ...]:
+    """The gated discussion, from ALL THREE places maintainers write —
+    issue comments, review bodies, inline review comments (the follow-up
+    lane learned this the hard way: independent collections, and feedback
+    lands in any of them)."""
+    sources = (
+        client.list_comments(repo, number),
+        client.list_pr_reviews(repo, number),
+        client.list_pr_review_comments(repo, number),
+    )
+    # Chronological across ALL sources: the prompt keeps the most recent
+    # tail, and a per-source concatenation would let a long inline-review
+    # thread silently evict the issue comments (rebuttals, prior rounds).
+    gated = [
+        (
+            str(c.get("submitted_at") or c.get("created_at") or ""),
+            str((c.get("user") or {}).get("login", "")),
+            str(c.get("body") or ""),
+        )
+        for comments in sources
+        for c in comments
+        if _standing(c, bot_login)
+    ]
+    gated.sort(key=lambda item: item[0])  # ISO-8601 sorts lexicographically
+    return tuple((author, body) for _, author, body in gated)
+
 
 CATEGORIES = (
     "harness-exploitation",

--- a/src/autoresearch/verifier_cli.py
+++ b/src/autoresearch/verifier_cli.py
@@ -20,13 +20,9 @@ from datetime import UTC, datetime
 from autoresearch.followup import QUALIFYING_ASSOCIATIONS
 from autoresearch.github import EnvTokenProvider, GitHubClient
 from autoresearch.llm import AnthropicCompleter, CompleterError
+from autoresearch.posting import post_round, post_skip_stub
 from autoresearch.review import PullRequest
-from autoresearch.review_cli import (
-    EXPECTED_FAILURES,
-    _gather_context,
-    post_round,
-    post_skip_stub,
-)
+from autoresearch.review_cli import EXPECTED_FAILURES, _gather_context
 from autoresearch.verifier import (
     MAX_RULER_FILES,
     VERIFY_MARKER,

--- a/src/autoresearch/verifier_cli.py
+++ b/src/autoresearch/verifier_cli.py
@@ -103,7 +103,10 @@ def main() -> int:
     if not bot_login:
         log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot identify bot-authored PRs)")
         return 0
-    if not os.environ.get("ANTHROPIC_VERIFIER_KEY", "").strip():
+    # The completer is Anthropic by construction (the multi-backend path is the
+    # agent verifier); read its key once and reuse it below.
+    verifier_key = os.environ.get("ANTHROPIC_VERIFIER_KEY", "").strip()
+    if not verifier_key:
         log.warning("ANTHROPIC_VERIFIER_KEY is unset or empty; skipping verification")
         return 0
     client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
@@ -149,7 +152,7 @@ def main() -> int:
                 log.warning("verifying without the discussion thread: %s", exc)
             pr = replace(pr, context_files=_gather_context(client, repo, number, pr_data))
         completer = AnthropicCompleter(
-            api_key=os.environ["ANTHROPIC_VERIFIER_KEY"],
+            api_key=verifier_key,
             model=os.environ.get("VERIFY_MODEL") or "claude-opus-5",
             effort=os.environ.get("VERIFY_EFFORT") or "high",
         )
@@ -165,7 +168,7 @@ def main() -> int:
     except EXPECTED_FAILURES as exc:  # advisory role: never fail the target's CI
         log.warning("verification did not complete: %s: %s", type(exc).__name__, exc)
         if isinstance(exc, CompleterError):
-            post_skip_stub(client, repo, number, "verification", exc)
+            post_skip_stub(client, repo, number, "verification", exc, secrets=(verifier_key,))
     return 0
 
 

--- a/src/autoresearch/verifier_cli.py
+++ b/src/autoresearch/verifier_cli.py
@@ -17,7 +17,6 @@ import sys
 from dataclasses import replace
 from datetime import UTC, datetime
 
-from autoresearch.followup import QUALIFYING_ASSOCIATIONS
 from autoresearch.github import EnvTokenProvider, GitHubClient
 from autoresearch.llm import AnthropicCompleter, CompleterError
 from autoresearch.posting import post_round, post_skip_stub
@@ -27,6 +26,7 @@ from autoresearch.verifier import (
     MAX_RULER_FILES,
     VERIFY_MARKER,
     format_verify_comment,
+    gather_thread,
     verify,
     verify_skip_reason,
 )
@@ -91,59 +91,6 @@ def gather_ruler(
     except EXPECTED_FAILURES as exc:
         log.warning("verifying with partial ruler context: %s", exc)
     return tuple(out)
-
-
-# The verifier's own rounds post via the Actions workflow token — this
-# identity, which no ordinary account can assume. Marker text alone is
-# forgeable (it appears verbatim in every posted round); identity is not.
-ACTIONS_BOT_LOGIN = "github-actions[bot]"
-
-
-def _standing(comment: dict, bot_login: str) -> bool:
-    """Only voices with standing reach the verifier: maintainers by
-    association, the accused agent's own replies, and prior verifier
-    rounds identified by POSTING IDENTITY plus marker (marker alone can be
-    forged by any commenter on a public repo)."""
-    body = str(comment.get("body") or "")
-    if not body.strip():
-        return False
-    login = str((comment.get("user") or {}).get("login", ""))
-    if str(comment.get("author_association", "")) in QUALIFYING_ASSOCIATIONS:
-        return True
-    if login.casefold() == bot_login.casefold():
-        return True
-    return login.casefold() == ACTIONS_BOT_LOGIN.casefold() and body.lstrip().startswith(
-        VERIFY_MARKER
-    )
-
-
-def gather_thread(
-    client: GitHubClient, repo: str, number: int, bot_login: str
-) -> tuple[tuple[str, str], ...]:
-    """The gated discussion, from ALL THREE places maintainers write —
-    issue comments, review bodies, inline review comments (the follow-up
-    lane learned this the hard way: independent collections, and feedback
-    lands in any of them)."""
-    sources = (
-        client.list_comments(repo, number),
-        client.list_pr_reviews(repo, number),
-        client.list_pr_review_comments(repo, number),
-    )
-    # Chronological across ALL sources: the prompt keeps the most recent
-    # tail, and a per-source concatenation would let a long inline-review
-    # thread silently evict the issue comments (rebuttals, prior rounds).
-    gated = [
-        (
-            str(c.get("submitted_at") or c.get("created_at") or ""),
-            str((c.get("user") or {}).get("login", "")),
-            str(c.get("body") or ""),
-        )
-        for comments in sources
-        for c in comments
-        if _standing(c, bot_login)
-    ]
-    gated.sort(key=lambda item: item[0])  # ISO-8601 sorts lexicographically
-    return tuple((author, body) for _, author, body in gated)
 
 
 def main() -> int:

--- a/src/autoresearch/verify_agent.py
+++ b/src/autoresearch/verify_agent.py
@@ -97,6 +97,9 @@ def run_agent_verify(
             detail = role_result.error or role_result.session.stop_reason
             log.warning("verification produced no verdict on %s#%s: %s", repo, number, detail)
             if outage(role_result.session) or budget_exhausted(role_result.session):
+                # `detail` is already api-key-redacted by the harness (it owns
+                # its own secret), so no secrets are passed here — unlike the
+                # completer path, whose CompleterError is not self-redacted.
                 post_skip_stub(client, repo, number, "verification", RuntimeError(detail))
             return None
 

--- a/src/autoresearch/verify_agent.py
+++ b/src/autoresearch/verify_agent.py
@@ -32,9 +32,9 @@ from autoresearch.verifier import (
     VERIFY_MARKER,
     build_verify_agent_brief,
     format_verify_comment,
+    gather_thread,
     verify_skip_reason,
 )
-from autoresearch.verifier_cli import gather_thread
 
 log = logging.getLogger(__name__)
 

--- a/src/autoresearch/verify_agent.py
+++ b/src/autoresearch/verify_agent.py
@@ -23,8 +23,8 @@ from pathlib import Path
 
 from autoresearch.github import GitHubClient
 from autoresearch.harness import Harness, budget_exhausted, outage
+from autoresearch.posting import EXPECTED_FAILURES, post_round, post_skip_stub
 from autoresearch.review_agent import _pull_request
-from autoresearch.review_cli import EXPECTED_FAILURES, post_round, post_skip_stub
 from autoresearch.role_runner import run_role
 from autoresearch.roles import verifier_spec, verify_result_from_role
 from autoresearch.rolespec import RoleSpec

--- a/tests/test_clis.py
+++ b/tests/test_clis.py
@@ -156,32 +156,16 @@ def test_review_cli_posts_a_skip_stub_when_the_model_api_refuses(monkeypatch) ->
     monkeypatch.setattr(cli, "review", fake_review)
     monkeypatch.setattr(cli, "AnthropicCompleter", lambda **kw: object())
     _cli_env(monkeypatch)
+    from autoresearch.posting import SKIP_MARKER
+
     assert cli.main() == 0  # still never fails the target's CI
     (stub,) = [c["body"] for c in fake_client.posted]
-    assert stub.lstrip().startswith(cli.SKIP_MARKER)
+    assert stub.lstrip().startswith(SKIP_MARKER)
     assert "could not run" in stub and "credit balance" in stub
     from autoresearch.review import MARKER
     from autoresearch.verifier import VERIFY_MARKER
 
     assert MARKER not in stub and VERIFY_MARKER not in stub
-
-
-def test_skip_stub_posting_failure_is_swallowed(monkeypatch, caplog) -> None:
-    import autoresearch.review_cli as cli
-    from autoresearch.github import GitHubError
-
-    class RefusingClient(FakeReviewClient):
-        def comment(self, repo, number, body):
-            raise GitHubError(403, "/repos/org/repo", "forbidden")
-
-    cli.post_skip_stub(
-        RefusingClient(),  # type: ignore[arg-type]
-        "org/repo",
-        1,
-        "advisory review",
-        CompleterError("x"),
-    )
-    assert "could not post the skip stub" in caplog.text
 
 
 def test_human_pr_review_is_inline_and_comment_event_only(monkeypatch) -> None:
@@ -270,28 +254,6 @@ def test_bot_pr_explicit_round_stays_an_issue_comment(monkeypatch) -> None:
     assert cli.main() == 0
     (posted,) = fake_client.posted
     assert posted.get("kind") != "review"  # plain comment: wake context reads these
-
-
-def test_round_numbering_spans_comments_and_reviews(monkeypatch) -> None:
-    """Switching posting styles must not reset the round counter."""
-    import autoresearch.review_cli as cli
-    from autoresearch.review import MARKER
-
-    fake_client = FakeReviewClient()
-    fake_client.posted.append(
-        {"body": f"{MARKER}\nold round", "user": {"type": "User"}}  # issue-comment round
-    )
-    fake_client.posted.append(
-        {"body": f"{MARKER}\nolder", "user": {"type": "User"}, "kind": "review", "inline": []}
-    )
-    _stamp, label = cli._round_stamp(
-        fake_client,  # type: ignore[arg-type]
-        "org/repo",
-        1,
-        MARKER,
-        {"head": {"sha": "abc"}},
-    )
-    assert label == "**Round 3**"
 
 
 def test_review_cli_threads_date_and_context(monkeypatch) -> None:

--- a/tests/test_posting.py
+++ b/tests/test_posting.py
@@ -1,0 +1,102 @@
+"""Shared posting helpers (`posting.py`): round numbering and the skip stub.
+
+These live here rather than in test_clis so they survive the completer sunset —
+`posting.py` outlives `review_cli`. The fake client is deliberately local (no
+completer/llm dependency), matching what the helpers actually call.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from autoresearch import posting
+from autoresearch.github import GitHubError
+
+_MARKER = "<!-- test-marker -->"
+
+
+class _FakeClient:
+    """Records posts and serves them back split by kind — the minimal surface
+    the posting helpers touch (list_comments, list_pr_reviews, comment)."""
+
+    def __init__(self) -> None:
+        self.posted: list[dict] = []
+
+    def list_comments(self, repo: str, number: int, max_pages: int = 20) -> list[dict]:
+        return [c for c in self.posted if c.get("kind") != "review"]
+
+    def list_pr_reviews(self, repo: str, number: int, max_pages: int = 10) -> list[dict]:
+        return [c for c in self.posted if c.get("kind") == "review"]
+
+    def comment(self, repo: str, number: int, body: str) -> None:
+        self.posted.append({"body": body, "kind": "comment"})
+
+    def create_pr_review(self, repo: str, number: int, body: str, comments: Any = None) -> None:
+        self.posted.append({"body": body, "kind": "review", "inline": comments or []})
+
+
+def test_round_numbering_spans_comments_and_reviews() -> None:
+    """Prior rounds are counted across BOTH issue comments and review bodies, so
+    switching a role between posting styles never resets its numbering."""
+    client = _FakeClient()
+    client.posted.append({"body": f"{_MARKER}\nold round", "kind": "comment"})
+    client.posted.append({"body": f"{_MARKER}\nolder", "kind": "review", "inline": []})
+    _stamp, label = posting._round_stamp(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        _MARKER,
+        {"head": {"sha": "abc"}},
+    )
+    assert label == "**Round 3**"
+
+
+def test_round_stamp_falls_back_when_count_fails(caplog: Any) -> None:
+    """A GitHub failure counting prior rounds must not cost the round itself —
+    it falls back to a labeled 'New round', never raises."""
+
+    class _Blind(_FakeClient):
+        def list_comments(self, repo: str, number: int, max_pages: int = 20) -> list[dict]:
+            raise GitHubError(500, "/repos/org/repo", "server error")
+
+    _stamp, label = posting._round_stamp(
+        _Blind(),  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        _MARKER,
+        {"head": {"sha": "abc"}},
+    )
+    assert "New round" in label
+    assert "could not count prior rounds" in caplog.text
+
+
+def test_skip_stub_posting_failure_is_swallowed(caplog: Any) -> None:
+    """post_skip_stub must never raise — a failed stub post is logged, not fatal
+    (an advisory role never reds the target's CI)."""
+
+    class _Refusing(_FakeClient):
+        def comment(self, repo: str, number: int, body: str) -> None:
+            raise GitHubError(403, "/repos/org/repo", "forbidden")
+
+    posting.post_skip_stub(
+        _Refusing(),  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        "advisory review",
+        ValueError("x"),
+    )
+    assert "could not post the skip stub" in caplog.text
+
+
+def test_skip_stub_carries_its_own_marker_and_reason() -> None:
+    client = _FakeClient()
+    posting.post_skip_stub(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        "advisory review",
+        ValueError("credit balance"),
+    )
+    (stub,) = [c["body"] for c in client.posted]
+    assert stub.lstrip().startswith(posting.SKIP_MARKER)
+    assert "could not run" in stub and "credit balance" in stub

--- a/tests/test_posting.py
+++ b/tests/test_posting.py
@@ -100,3 +100,57 @@ def test_skip_stub_carries_its_own_marker_and_reason() -> None:
     (stub,) = [c["body"] for c in client.posted]
     assert stub.lstrip().startswith(posting.SKIP_MARKER)
     assert "could not run" in stub and "credit balance" in stub
+
+
+def test_post_round_posts_one_numbered_stamped_comment() -> None:
+    client = _FakeClient()
+    label = posting.post_round(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        _MARKER,
+        f"{_MARKER}\nfindings",
+        {"head": {"sha": "abcd1234ef"}},
+    )
+    assert label == "**Round 1**"
+    (posted,) = client.posted
+    assert posted["body"].lstrip().startswith(_MARKER)
+    assert "reviewed head `abcd1234`" in posted["body"]  # 8-char stamp
+
+
+def test_post_round_review_posts_inline_on_success() -> None:
+    client = _FakeClient()
+    label = posting.post_round_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        _MARKER,
+        f"{_MARKER}\nsummary",
+        [{"path": "x.py", "line": 1, "body": "note"}],
+        {"head": {"sha": "abcd"}},
+        fallback_body=f"{_MARKER}\nfull findings",
+    )
+    assert label == "**Round 1**"
+    (posted,) = client.posted
+    assert posted["kind"] == "review" and posted["inline"]
+
+
+def test_post_round_review_falls_back_to_a_comment_carrying_full_findings() -> None:
+    class _NoInline(_FakeClient):
+        def create_pr_review(self, repo: str, number: int, body: str, comments: Any = None) -> None:
+            raise GitHubError(422, "/repos/org/repo", "unprocessable")
+
+    client = _NoInline()
+    label = posting.post_round_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        _MARKER,
+        f"{_MARKER}\nsummary only",
+        [{"path": "x.py", "line": 1}],
+        {"head": {"sha": "abcd"}},
+        fallback_body=f"{_MARKER}\nFULL findings in the fallback",
+    )
+    assert label == "**Round 1**"
+    (posted,) = client.posted  # the failed inline review fell back to an issue comment
+    assert posted["kind"] == "comment" and "FULL findings in the fallback" in posted["body"]

--- a/tests/test_posting.py
+++ b/tests/test_posting.py
@@ -154,3 +154,21 @@ def test_post_round_review_falls_back_to_a_comment_carrying_full_findings() -> N
     assert label == "**Round 1**"
     (posted,) = client.posted  # the failed inline review fell back to an issue comment
     assert posted["kind"] == "comment" and "FULL findings in the fallback" in posted["body"]
+
+
+def test_skip_stub_redacts_the_provided_key_any_provider() -> None:
+    # backend-agnostic: whatever key the caller passes (Anthropic on the
+    # completer path, the harness's own key on the agent path) is scrubbed
+    # before the error text — which can echo request material — is posted.
+    client = _FakeClient()
+    posting.post_skip_stub(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        "advisory review",
+        ValueError("401 Unauthorized: key sk-or-LEAK9 rejected"),
+        secrets=("sk-or-LEAK9",),
+    )
+    (stub,) = [c["body"] for c in client.posted]
+    assert "sk-or-LEAK9" not in stub
+    assert "[redacted]" in stub

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -11,6 +11,7 @@ from autoresearch.verifier import (
     VERIFY_MARKER,
     build_verify_prompt,
     format_verify_comment,
+    gather_thread,
     verify,
     verify_skip_reason,
 )
@@ -366,3 +367,45 @@ def test_thread_gate_excludes_unprivileged_voices(monkeypatch) -> None:
     idx_review = next(i for i, b in enumerate(bodies) if "review-body feedback" in b)
     idx_comment = next(i for i, b in enumerate(bodies) if "address the findings" in b)
     assert idx_review < idx_comment
+
+
+def test_gather_thread_gates_by_standing_and_orders_chronologically() -> None:
+    """Direct coverage of verifier.gather_thread — survives the completer
+    sunset (the vcli.main integration test above dies with verifier_cli)."""
+
+    class _Client:
+        def list_comments(self, repo, number, max_pages=20):
+            return [
+                {"created_at": "2026-01-02", "user": {"login": "drive-by"}, "body": "noise"},
+                {
+                    "created_at": "2026-01-01",
+                    "user": {"login": "maint"},
+                    "author_association": "OWNER",
+                    "body": "fix the seed",
+                },
+            ]
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return [{"submitted_at": "2026-01-03", "user": {"login": BOT}, "body": "my rebuttal"}]
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return [
+                {
+                    "created_at": "2026-01-04",
+                    "user": {"login": "github-actions[bot]"},
+                    "body": f"{VERIFY_MARKER}\nprior verifier round",
+                },
+                {
+                    "created_at": "2026-01-05",
+                    "user": {"login": "forger"},
+                    "body": f"{VERIFY_MARKER}\nmarker text alone must not admit",
+                },
+            ]
+
+    thread = gather_thread(_Client(), "org/repo", 1, BOT)  # type: ignore[arg-type]
+    authors = [a for a, _ in thread]
+    # gated & chronological: maintainer (OWNER, 01-01), the accused agent (01-03),
+    # the real prior round (Actions identity + marker, 01-04). Excluded: the
+    # drive-by, and the forger who copied the marker without the posting identity.
+    assert authors == ["maint", BOT, "github-actions[bot]"]
+    assert "drive-by" not in authors and "forger" not in authors


### PR DESCRIPTION
Pre-work for the completer sunset. Verifier migration is already complete (every caller routes to the agent verifier; the completer `verify.yml`/`verifier_cli.py` have zero callers), but the completer **couldn't be cleanly deleted** because `review_cli.py` was a *mixed* module.

**The mess:** `review_cli.py` held the shared posting helpers — `post_round`, `post_round_review`, `post_skip_stub`, `_round_stamp`, `SKIP_MARKER`, `EXPECTED_FAILURES` — that the **live agent path** (`review_agent`, `verify_agent`) imports. `EXPECTED_FAILURES` even bundled completer model-errors (`RefusalError`/`TruncatedError`/`CompleterError` from `llm.py`) with transport errors, transitively chaining the agent path to the completer.

**This PR:**
- new `posting.py` ← the posting helpers + `EXPECTED_FAILURES` scoped to the **transport** errors they actually catch (no `llm`/completer dependency).
- `review_cli` (completer) keeps its own broadened catch (`*posting.EXPECTED_FAILURES, RefusalError, TruncatedError, CompleterError`) → **completer behavior unchanged**.
- `review_agent`, `verify_agent`, `verifier_cli` repoint to `posting`.
- posting-helper tests move to `test_posting.py` so they **survive the sunset** (`test_clis` dies with `review_cli`).

**Result:** the agent path has zero code dependency on `review_cli`/`llm` (verified). Once jepa-agent #7 + egolearn #5 land, the completer sunset is a clean `rm` of `review_cli.py`, `verifier_cli.py`, `advisory-review.yml`, `verify.yml`, + `AnthropicCompleter`/`Completer` — no untangling.

Behavior-preserving except the agent path's `EXPECTED_FAILURES` drops the 3 completer model-errors it never raises. 532 tests green, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)