### PR TITLE
Drop the now-inert advisory marker from follow-up wake context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versions follow [SemVer](https://semver.org).
   it), and the explicit re-request override for bot PRs (only the completer
   workflow set `REVIEW_EXPLICIT_REQUEST`). The advisory reviewer now never
   reviews bot-authored PRs.
+- `ADVISORY_MARKER` dropped from follow-up wake context
+  (`MACHINE_ROUND_MARKERS`): with the reviewer reviewing only human PRs and
+  wakes scanning bot PRs, advisory rounds never fed a wake. Verifier rounds
+  still do.
 
 ### Added
 

--- a/docs/design/roles.md
+++ b/docs/design/roles.md
@@ -20,7 +20,7 @@ data, not accounts: every commit is authored by the one bot account with an
 | **Maintainer** (human) | — | live | Merge authority on every code PR; writes contracts and `vision:`; owns budgets and credentials | be replaced by anything below |
 | **Orchestrator** (tick + sweep + climb glue) | code | live | Schedules everything; measures every baseline/candidate itself; enforces scope, drift, budgets, freshness; ends every run in a report; writes the ledger | trust a session's claim; merge; execute non-bot-authored code |
 | **Author session** ("climber") | model | live | One hypothesis per run: reads the brief, edits inside the contract's scope, requests experiment batches (any size the budget covers), self-validates, writes the research report | touch the ruler (frozen evals/tests), the contract, progress files; see the PAT; publish anything itself; submit jobs directly |
-| **Follow-up responder** | model | live | The *same* author or steward session resumed when a qualifying human comments on its open PR: replies with evidence, pushes fixes (re-validated/re-measured by the orchestrator, under the resuming role's own key and scope); verifier/advisory rounds ride along as fenced context | anything the resumed role couldn't; resurrect an ended run; treat context comments as instructions |
+| **Follow-up responder** | model | live | The *same* author or steward session resumed when a qualifying human comments on its open PR: replies with evidence, pushes fixes (re-validated/re-measured by the orchestrator, under the resuming role's own key and scope); the verifier's rounds ride along as fenced context | anything the resumed role couldn't; resurrect an ended run; treat context comments as instructions |
 | **Advisory reviewer** | model | live | Adversarial *correctness* review of human/dev PRs; findings-only, sanitized, never an approval | review bot PRs automatically (echo-chamber guard); block CI; approve |
 | **Verifier** | model | built; deploy pending | Adversarial *integrity* review of bot PRs: hunts gaming (harness exploits, ruler-fishing, leakage, unsupported claims) with contract + eval code + numbers + report in context; "silence is not endorsement" header | approve; block; review human PRs |
 | **Planner** | model | designed (scaling.md pt 1) | Owns a target's search *program*: reads leader/lessons/reports, emits vetoable plan issues motivated twice (hypothesis + economics) | enact plans (humans/veto-window do); write `vision:` |
@@ -190,7 +190,6 @@ their own capped budget line.
 flowchart LR
     HPR["PR by human / dev assistant"] --> AR["advisory reviewer<br/>(correctness lens)"]
     BPR["PR by the bot"] --> VF["verifier<br/>(gaming lens) - deploy pending"]
-    BPR -.->|"verifier-less self-hosters only:<br/>opt-in label override"| AR
     AR --> HM{human merges}
     VF --> HM
     L["autoresearch:review label<br/>= one fresh round on the head"] --> AR

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -367,8 +367,8 @@ def _respond(
         from autoresearch.steward import STEWARD_WAKE_PREAMBLE
 
         prompt = STEWARD_WAKE_PREAMBLE + prompt
-    # Comments WITHOUT standing (verifier rounds, advisory rounds) ride
-    # along as fenced context — never as triggers, never as instructions.
+    # Comments WITHOUT standing (the verifier's rounds) ride along as fenced
+    # context — never as triggers, never as instructions.
     ctx = context_comments(github.list_comments(record.target, number), record.last_comment_id)
     if ctx:
         from autoresearch.brief import _fence

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -39,7 +39,6 @@ from autoresearch.progress import (
     write_progress,
 )
 from autoresearch.review import APPROVAL_PATTERN, REDACTED
-from autoresearch.review import MARKER as ADVISORY_MARKER
 from autoresearch.runstate import (
     ENDED,
     IN_REVIEW,
@@ -82,22 +81,23 @@ MAX_CONTEXT_COMMENTS = 3
 MAX_CONTEXT_COMMENT_CHARS = 4_000
 
 
-# Our own machine reviewers post via the Actions workflow token — an
-# identity no ordinary account can assume. Marker text alone is public and
-# forgeable; identity + marker together are not. The markers are the
-# renderers' own constants, and marker-first is their tested shape: both
-# render bodies starting with the marker (asserted in their render tests)
-# and publish through posting.post_round, which inserts the round stamp
-# AFTER the marker — always as ISSUE comments. That is why this reads one
-# collection and matches at the start of the body; a quote-reply prefixes
-# every line with "> ", so quoted rounds can never re-qualify.
+# The verifier posts its rounds via the Actions workflow token — an identity
+# no ordinary account can assume. Marker text alone is public and forgeable;
+# identity + marker together are not. The marker is the renderer's own
+# constant, and marker-first is its tested shape: the body starts with the
+# marker (asserted in the render test) and publishes through posting.post_round,
+# which inserts the round stamp AFTER the marker — always as an ISSUE comment.
+# That is why this reads one collection and matches at the start of the body;
+# a quote-reply prefixes every line with "> ", so quoted rounds can never
+# re-qualify. (The advisory reviewer posts inline reviews on human PRs, which
+# never ride into a bot-PR wake, so its marker is not here.)
 ACTIONS_BOT_LOGIN = "github-actions[bot]"
-MACHINE_ROUND_MARKERS = (VERIFY_MARKER, ADVISORY_MARKER)
+MACHINE_ROUND_MARKERS = (VERIFY_MARKER,)
 
 
 def context_comments(comments: list[dict], since_id: int) -> list[tuple[str, str]]:
-    """(author, body) for NEW machine review rounds — verifier and advisory
-    — identified by POSTING IDENTITY plus marker. They never trigger a wake
+    """(author, body) for NEW machine review rounds — the verifier's,
+    identified by POSTING IDENTITY plus marker. They never trigger a wake
     and never steer; they ride along as data-fenced CONTEXT so a woken
     agent can see what a maintainer's one-line 'address the findings'
     refers to, without a human relaying the text by hand.

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -689,9 +689,7 @@ def test_nonqualifying_comments_ride_as_fenced_context(review_run) -> None:
         "user": {"login": "GitHub-Actions[bot]"},  # case-insensitive identity
         "author_association": "NONE",
     }
-    github = FakeGitHub(
-        comments=[verifier_comment, member(103, "address the findings above")]
-    )
+    github = FakeGitHub(comments=[verifier_comment, member(103, "address the findings above")])
     harness = ResumingHarness()
     outcome = respond_once(
         root,

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -14,7 +14,6 @@ from autoresearch.followup import (
     respond_once,
 )
 from autoresearch.harness import SessionResult
-from autoresearch.review import MARKER as ADVISORY_MARKER
 from autoresearch.runstate import (
     IN_REVIEW,
     RunRecord,
@@ -687,18 +686,11 @@ def test_nonqualifying_comments_ride_as_fenced_context(review_run) -> None:
         # built from the renderer's own marker constant: placement drift
         # (marker not first) would fail here, not silently in production
         "body": f"{VERIFY_MARKER}\nRound 1: caches across calls",
-        "user": {"login": "github-actions[bot]"},
-        "author_association": "NONE",
-    }
-    advisory_comment = {
-        "id": 102,
-        # exactly post_round's published shape: marker first, stamp after
-        "body": f"{ADVISORY_MARKER}\n**Round 2** — reviewed head `abcd1234`.\n\nprose findings",
         "user": {"login": "GitHub-Actions[bot]"},  # case-insensitive identity
         "author_association": "NONE",
     }
     github = FakeGitHub(
-        comments=[verifier_comment, advisory_comment, member(103, "address the findings above")]
+        comments=[verifier_comment, member(103, "address the findings above")]
     )
     harness = ResumingHarness()
     outcome = respond_once(
@@ -714,7 +706,6 @@ def test_nonqualifying_comments_ride_as_fenced_context(review_run) -> None:
     assert outcome.action == "replied"
     prompt = harness.calls[0][0]
     assert "caches across calls" in prompt  # the verifier round arrived
-    assert "prose findings" in prompt  # the advisory round arrived too
     # the block is explicitly framed as data, and the body sits in a fence
     assert "Comments without standing (context only" in prompt
     assert "data, not" in prompt

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -14,6 +14,7 @@ from autoresearch.followup import (
     respond_once,
 )
 from autoresearch.harness import SessionResult
+from autoresearch.review import MARKER as ADVISORY_MARKER
 from autoresearch.runstate import (
     IN_REVIEW,
     RunRecord,
@@ -729,8 +730,11 @@ def test_nonqualifying_comments_ride_as_fenced_context(review_run) -> None:
 
 def test_context_excludes_drive_by_and_forged_marker_comments(review_run) -> None:
     """Only identity-verified machine rounds ride as context: a drive-by
-    comment and a marker forgery from an ordinary account are excluded —
-    a session with push access never sees unvetted text."""
+    comment and a marker forgery from an ordinary account are excluded, and so
+    is an advisory round — right identity, but the reviewer never posts on bot
+    PRs, so its marker is intentionally not wake context (guards against
+    re-adding ADVISORY_MARKER to the set). A session with push access never
+    sees unvetted text."""
     root, _bare = review_run
     drive_by = {
         "id": 102,
@@ -752,7 +756,17 @@ def test_context_excludes_drive_by_and_forged_marker_comments(review_run) -> Non
         "user": {"login": "github-actions[bot]"},
         "author_association": "NONE",
     }
-    github = FakeGitHub(comments=[drive_by, forged, skip_stub, member(104, "please respond")])
+    advisory_round = {
+        "id": 106,
+        # right identity + the reviewer's own marker, but advisory rounds are
+        # deliberately excluded: the reviewer never posts on bot PRs
+        "body": f"{ADVISORY_MARKER}\n**Round 1** — advisory finding text",
+        "user": {"login": "github-actions[bot]"},
+        "author_association": "NONE",
+    }
+    github = FakeGitHub(
+        comments=[drive_by, forged, skip_stub, advisory_round, member(104, "please respond")]
+    )
     harness = ResumingHarness()
     respond_once(
         root,
@@ -768,3 +782,4 @@ def test_context_excludes_drive_by_and_forged_marker_comments(review_run) -> Non
     assert "delete the tests" not in prompt
     assert "push freely" not in prompt
     assert "could not run" not in prompt  # the outage stub stays out too
+    assert "advisory finding text" not in prompt  # advisory rounds stay out too


### PR DESCRIPTION
## What

Convergence review of the completer sunset (#81) found one piece of residue in `followup.py`: `MACHINE_ROUND_MARKERS` still listed `ADVISORY_MARKER`, and the comment claimed both machine reviewers publish issue-comment rounds that ride into follow-up wakes.

This makes the marker set verifier-only and corrects the comment/docstring.

## Why it's inert

Advisory rounds could only ride into a wake through the explicit-review-on-bot-PR path (the `bot_authored` branch in `run_agent_review`). That branch was reachable only when the completer workflow set `REVIEW_EXPLICIT_REQUEST` — never wired on the agent path, and removed in #81. Now:

- the advisory reviewer reviews only **human** PRs and posts inline reviews (Reviews API), never an issue comment on a bot's climb PR;
- follow-up wakes scan the **bot's own** climb PRs.

Those two populations never intersect, so an advisory round can never appear on a wake-scanned thread. `ADVISORY_MARKER` in the marker set matched nothing.

## Design stance to confirm

This commits to: **advisory reviews never feed follow-up wakes.** That follows directly from the reviewer being human-PR-only, so it should be right — but it's the one judgment call here, and it's a one-line revert (`MACHINE_ROUND_MARKERS = (VERIFY_MARKER, ADVISORY_MARKER)`) if we later give the reviewer a way to comment on bot PRs.

## Unchanged

The verifier's `VERIFY_MARKER` path, and the injection guard (Actions-bot identity + marker-first matching), are untouched. `test_nonqualifying_comments_ride_as_fenced_context` keeps the verifier example (the live mechanism); its login is now mixed-case to preserve the case-insensitive-identity assertion the dropped advisory example carried.

505 tests green, mypy and ruff clean.
