### PR TITLE
Remove dead ruler_files path from verifier prompt; reconcile roadmap

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,10 +149,9 @@ open-ended sweep space.
 - [x] Verification agent CODE (scaling.md Part 2d): verifier on the review
       chassis — bot-PRs only, gaming prompt with contract + ruler source in
       context, own capped key, silence-is-not-endorsement header; label
-      routes by author (the #48 interim advisory override is now opt-in for
-      verifier-less self-hosters). DEPLOY still pending: pilot caller
-      workflow + `VERIFIER_API_KEY` org secret (maintainer) — required
-      before any statistically-verifiable target onboards
+      routes by author. DEPLOY still pending: pilot caller workflow +
+      `ANTHROPIC_VERIFIER_KEY` org secret (maintainer) — required before any
+      statistically-verifiable target onboards
 - [x] Benchmark steward CODE (maintainer direction 2026-08-08/09: the
       steward agent does env work, not hand edits): separate identity
       (`steward-01`, own key), territory = the contract's `steward.allowed`

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -50,11 +50,6 @@ VERIFY_HEADER = (
     "the result.*"
 )
 
-# Verifier-specific context caps: the ruler's source is the load-bearing
-# extra input, bounded the same way the reviewer bounds file context.
-MAX_RULER_FILES = 6
-MAX_RULER_FILE_CHARS = 20_000
-MAX_RULER_CHARS = 60_000
 MAX_CONTRACT_CHARS = 10_000
 MAX_CLAIM_CHARS = 30_000
 # The discussion is context the verifier must not be blind to (found live:
@@ -243,20 +238,15 @@ def _fenced(text: str) -> str:
     return f"{fence}\n{text}\n{fence}"
 
 
-def _safe_path(path: str) -> str:
-    """Git allows newlines and backticks in filenames; a raw path could
-    forge prompt structure even with fenced content."""
-    return " ".join(str(path).split()).replace("`", "")[:300]
-
-
 def build_verify_prompt(
     pr: PullRequest,
     contract_text: str,
-    ruler_files: tuple[tuple[str, str], ...] = (),
     today: str | None = None,
     thread: tuple[tuple[str, str], ...] = (),
 ) -> str:
-    """Assemble the verifier's context. Order: rules, ruler, claim, change."""
+    """Assemble the verifier's context. Order: rules, claim, change. The agent
+    verifier reads the ruler from the base/ checkout, so it is not fenced into
+    the prompt."""
     parts: list[str] = []
     if today:
         parts.append(f"Today's date (UTC): {today}")
@@ -265,19 +255,6 @@ def build_verify_prompt(
         "## The contract (the rules this repo set; from the default branch, "
         "not the PR)\n" + _fenced(contract_text[:MAX_CONTRACT_CHARS])
     )
-    if ruler_files:
-        parts.append(
-            "## Ruler source (frozen eval/tests the agent cannot modify; "
-            "read how the metric is ACTUALLY computed)"
-        )
-        total = 0
-        for path, content in ruler_files[:MAX_RULER_FILES]:
-            clipped = content[:MAX_RULER_FILE_CHARS]
-            if total + len(clipped) > MAX_RULER_CHARS:
-                parts.append(f"(ruler context cap reached before {_safe_path(path)})")
-                break
-            total += len(clipped)
-            parts.append(f"### {_safe_path(path)}\n{_fenced(clipped)}")
     # The claim is agent-authored (the most injection-prone input) and is
     # bounded like everything else; the report is capped generously — a
     # run report is a few thousand words, not tens of thousands.
@@ -336,7 +313,7 @@ def build_verify_agent_brief(
     branch so the rules arrive orchestrator-vouched."""
     return (
         f"{VERIFY_SYSTEM_PROMPT}\n\n{AGENT_VERIFY_INVESTIGATION}\n\n"
-        f"{build_verify_prompt(pr, contract_text, ruler_files=(), today=today, thread=thread)}"
+        f"{build_verify_prompt(pr, contract_text, today=today, thread=thread)}"
     )
 
 

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -49,7 +49,6 @@ def verify(
     completer: ScriptedCompleter,
     bot_login: str,
     contract_text: str,
-    ruler_files: tuple[tuple[str, str], ...] = (),
     today: str | None = None,
     thread: tuple[tuple[str, str], ...] = (),
 ) -> ReviewResult:
@@ -61,7 +60,7 @@ def verify(
         return ReviewResult(findings=[], notes="", skipped=skip)
     raw = completer.complete(
         VERIFY_SYSTEM_PROMPT,
-        build_verify_prompt(pr, contract_text, ruler_files, today, thread),
+        build_verify_prompt(pr, contract_text, today, thread),
         VERIFY_SCHEMA,
     )
     return verify_result_from_data(json.loads(raw))
@@ -83,19 +82,15 @@ def test_opt_out_and_empty_diff_still_skip() -> None:
     assert verify_skip_reason(make_pr(diff="  \n"), BOT) is not None
 
 
-def test_prompt_carries_contract_ruler_claim_and_change() -> None:
+def test_prompt_carries_contract_claim_and_change() -> None:
     prompt = build_verify_prompt(
         make_pr(),
         contract_text="benchmarks:\n  - name: tsp\n",
-        ruler_files=(("src/pilot/eval.py", "def evaluate(): ..."),),
         today="2026-08-09",
     )
     assert "## The contract" in prompt and "name: tsp" in prompt
-    assert "## Ruler source" in prompt and "def evaluate" in prompt
     assert "## The claim" in prompt and "Research report" in prompt
     assert "## The change" in prompt and "+x=1" in prompt
-    # the ruler section states the agent cannot modify it
-    assert "cannot modify" in prompt
 
 
 def test_verify_tags_findings_with_category_and_sanitizes() -> None:


### PR DESCRIPTION
## What

Two more pieces of completer-sunset residue, found while converging the sunset review:

- **Dead `ruler_files` path in `build_verify_prompt`.** It fenced ruler file contents into the verifier prompt. The agent verifier reads the ruler from the `base/` checkout instead, and its only production caller (`build_verify_agent_brief`) passed `ruler_files=()`. The deleted completer `verify()` was the sole caller that ever passed a non-empty value. So the parameter, the `if ruler_files:` branch, the `MAX_RULER_*` constants, and `_safe_path` (used only inside that branch) were all dead. Removed, and the one test that exercised the branch retargeted to contract/claim/change.
- **`roadmap.md` Phase 7 reconciliation.** Dropped the "#48 interim advisory override" clause — that override is the explicit-request feature removed in #81 — and renamed the retired `VERIFIER_API_KEY` to the current `ANTHROPIC_VERIFIER_KEY`.

## Why it's safe

No behavior change: production already passed `ruler_files=()`, so the removed branch never ran. The ruler still reaches the verifier — the agent reads it from `base/`, which the `AGENT_VERIFY_INVESTIGATION` brief already directs it to.

505 tests green; ruff check, ruff format --check, and mypy all clean.

Found by the convergence review of the completer sunset (#81) — the same sweep that produced #82.
