### PR TITLE
Reconcile design docs and roadmap with the sunset and verifier deploy

### DIFF
--- a/docs/design/agent-substrate.md
+++ b/docs/design/agent-substrate.md
@@ -168,9 +168,8 @@ reviewer on a GH runner is where we first prove an alternate backend (Codex) —
 a judge that never executes is the safe place to swap; the author runs in
 apptainer on Torch. Hermes's Singularity backend maps onto apptainer directly.
 
-**One seam.** The old one-shot `Completer` becomes a degenerate RoleSpec — no
-tools, no edit, `output_schema` set — a one-turn session on the same adapter.
-Cheap fast-pass, no second seam.
+**One seam.** The one-shot `Completer` is deleted outright — every role,
+judges included, is an agent session on the same adapter. No second seam.
 
 ## RoleSpec: the app manifest
 
@@ -193,9 +192,10 @@ is the rare exception).
 
 ## The role-runner: one loop replaces five drivers
 
-Replaces `climb`, `steward`, `followup`, `review_cli`, `verifier_cli`. Kernel
-code; it calls into the agentic realm at step 2, and everything trust-critical is
-deterministic.
+Replaces the five per-role drivers — done for the judges (`review_cli` and
+`verifier_cli` are deleted); `climb`, `steward`, `followup` still to collapse.
+Kernel code; it calls into the agentic realm at step 2, and everything
+trust-critical is deterministic.
 
 1. **prep** — build the workspace (editable for author, read-only for judge);
    `brief.build(RoleSpec, task, memory)`; pick the backend adapter.

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -120,9 +120,9 @@ scope, key), and their spend counts against its budget.
 
 | Now | Fate |
 | --- | --- |
-| `climb`, `steward`, `followup`, `review_cli`, `verifier_cli` | Five copies of "prep → run a role → act on the result." Collapse into **one role-runner + a RoleSpec + a result-policy** each. The measure/gate/PR halves stay kernel; the brief/skills halves become app config. |
-| `review`, `verifier` (rendering, verdict/blocking machinery) | Move onto the agent-session path; shared finding-rendering becomes a skill. |
-| `harness`, `llm`, `brief` | The seam. Keep. Add adapters. |
+| `climb`, `steward`, `followup` | Remaining copies of "prep → run a role → act on the result." Collapse into **one role-runner + a RoleSpec + a result-policy** each — done for the judges (`review_cli`/`verifier_cli` are deleted; reviewer and verifier run on the role-runner). The measure/gate/PR halves stay kernel; the brief/skills halves become app config. |
+| `review`, `verifier` (rendering, verdict/blocking machinery) | On the agent-session path; hold the shared vocabulary and rendering both judges use. |
+| `harness`, `brief` | The seam. Keep. Adapters live: claude, codex, hermes. |
 | `orchestrator`, `contract`, `github`, `compute`, `runstate`, `disk`, `limits`, `intake` | Kernel. Barely moves — the point. |
 | `tick` | Kernel, but bloated from the same accretion. Its own diet, later. |
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -149,8 +149,8 @@ open-ended sweep space.
 - [x] Verification agent (scaling.md Part 2d): verifier on the review
       chassis — bot-PRs only, gaming prompt, contract fenced in and ruler read
       from the base checkout, own capped key, silence-is-not-endorsement
-      header; label routes by author. Deployed on the yolo-jepa pilot
-      (`verify.yml` caller + repo-level `ANTHROPIC_VERIFIER_KEY`); each new
+      header; label routes by author. Deployed on yolo-jepa (first target:
+      `verify.yml` caller + repo-level `ANTHROPIC_VERIFIER_KEY`); each new
       target onboards by copying the caller and setting the key
 - [x] Benchmark steward CODE (maintainer direction 2026-08-08/09: the
       steward agent does env work, not hand edits): separate identity

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -146,12 +146,12 @@ open-ended sweep space.
 
 ## Phase 7 — Research targets & scale-out
 
-- [x] Verification agent CODE (scaling.md Part 2d): verifier on the review
-      chassis — bot-PRs only, gaming prompt with contract + ruler source in
-      context, own capped key, silence-is-not-endorsement header; label
-      routes by author. DEPLOY still pending: pilot caller workflow +
-      `ANTHROPIC_VERIFIER_KEY` org secret (maintainer) — required before any
-      statistically-verifiable target onboards
+- [x] Verification agent (scaling.md Part 2d): verifier on the review
+      chassis — bot-PRs only, gaming prompt, contract fenced in and ruler read
+      from the base checkout, own capped key, silence-is-not-endorsement
+      header; label routes by author. Deployed on the yolo-jepa pilot
+      (`verify.yml` caller + repo-level `ANTHROPIC_VERIFIER_KEY`); each new
+      target onboards by copying the caller and setting the key
 - [x] Benchmark steward CODE (maintainer direction 2026-08-08/09: the
       steward agent does env work, not hand edits): separate identity
       (`steward-01`, own key), territory = the contract's `steward.allowed`


### PR DESCRIPTION
## What

The docs reconciliation pass deferred from the sunset PRs (#81–#83), fact-checked against the org before writing:

- **roadmap Phase 7 — the verifier is deployed.** yolo-jepa runs the `verify.yml` caller with a repo-level `ANTHROPIC_VERIFIER_KEY` (set Aug 13), and it posted a real verdict on yolo-jepa PR #6 today. "DEPLOY still pending" replaced with the per-target onboarding step (copy the caller, set the key). Also fixed "ruler source in context" — the agent verifier reads the ruler from the base checkout.
- **consolidation.md kernel/app table** — states which part of the collapse happened: `review_cli`/`verifier_cli` deleted (judges run on the role-runner); `climb`/`steward`/`followup` remain. `llm` dropped from the seam row; adapters (claude/codex/hermes) are live.
- **agent-substrate.md** — the `Completer` was deleted outright rather than kept as a degenerate RoleSpec; the role-runner section says which drivers are collapsed vs pending.

Left as-is after checking: the steward's "DEPLOY pending" (no steward key, no caller anywhere — still true), and line 80's Torch deploy-shim note (unrelated).

Docs only. Full gate green (505 tests, ruff check + format, mypy).
