### PR TITLE
Author session onto the role-runner (collapse stage 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Versions follow [SemVer](https://semver.org).
   wakes scanning bot PRs, advisory rounds never fed a wake. Verifier rounds
   still do.
 
+### Changed
+
+- The author session now runs on the role-runner, like the judges:
+  `author_spec` (roles.py) is the manifest, `climb_once` dispatches through
+  `run_role`, and the climb CLI builds its harness from the spec
+  (`build_author_harness`), so the session budget has one source. Behavior
+  unchanged; steward and follow-up dispatch are the remaining collapses.
+
 ### Added
 
 - The reviewer can now run on three backends, selected by `REVIEW_BACKEND`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,14 +25,6 @@ Versions follow [SemVer](https://semver.org).
   wakes scanning bot PRs, advisory rounds never fed a wake. Verifier rounds
   still do.
 
-### Changed
-
-- The author session now runs on the role-runner, like the judges:
-  `author_spec` (roles.py) is the manifest, `climb_once` dispatches through
-  `run_role`, and the climb CLI builds its harness from the spec
-  (`build_author_harness`), so the session budget has one source. Behavior
-  unchanged; steward and follow-up dispatch are the remaining collapses.
-
 ### Added
 
 - The reviewer can now run on three backends, selected by `REVIEW_BACKEND`
@@ -51,6 +43,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The author session now runs on the role-runner, like the judges:
+  `author_spec` (roles.py) is the manifest, `climb_once` dispatches through
+  `run_role`, and the climb CLI builds its harness from the spec
+  (`build_author_harness`), so the session budget and tool set have one
+  source. Behavior unchanged; steward and follow-up dispatch are the
+  remaining collapses.
 - The verifier can now run as an agent session over TWO read-only checkouts:
   the PR head (the change under review) and the base branch (the trusted
   contract and ruler — all ruler reads are directed there, never at the PR).

--- a/docs/design/agent-substrate.md
+++ b/docs/design/agent-substrate.md
@@ -193,9 +193,10 @@ is the rare exception).
 ## The role-runner: one loop replaces five drivers
 
 Replaces the five per-role drivers — done for the judges (`review_cli` and
-`verifier_cli` are deleted); `climb`, `steward`, `followup` still to collapse.
-Kernel code; it calls into the agentic realm at step 2, and everything
-trust-critical is deterministic.
+`verifier_cli` are deleted) and the author's session dispatch (`climb_once`
+runs `author_spec` through `run_role`); `steward` and `followup` dispatch
+still to collapse. Kernel code; it calls into the agentic realm at step 2,
+and everything trust-critical is deterministic.
 
 1. **prep** — build the workspace (editable for author, read-only for judge);
    `brief.build(RoleSpec, task, memory)`; pick the backend adapter.

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -120,7 +120,7 @@ scope, key), and their spend counts against its budget.
 
 | Now | Fate |
 | --- | --- |
-| `climb`, `steward`, `followup` | Remaining copies of "prep → run a role → act on the result." Collapse into **one role-runner + a RoleSpec + a result-policy** each — done for the judges (`review_cli`/`verifier_cli` are deleted; reviewer and verifier run on the role-runner). The measure/gate/PR halves stay kernel; the brief/skills halves become app config. |
+| `climb`, `steward`, `followup` | Remaining copies of "prep → run a role → act on the result." Collapse into **one role-runner + a RoleSpec + a result-policy** each — done for the judges (`review_cli`/`verifier_cli` are deleted; reviewer and verifier run on the role-runner) and for the author's session dispatch (`climb_once` runs `author_spec` through `run_role`; the harness is built from the spec). Steward and follow-up dispatch pending. The measure/gate/PR halves stay kernel; the brief/skills halves become app config. |
 | `review`, `verifier` (rendering, verdict/blocking machinery) | On the agent-session path; hold the shared vocabulary and rendering both judges use. |
 | `harness`, `brief` | The seam. Keep. Adapters live: claude, codex, hermes. |
 | `orchestrator`, `contract`, `github`, `compute`, `runstate`, `disk`, `limits`, `intake` | Kernel. Barely moves — the point. |

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -47,6 +47,8 @@ from autoresearch.progress import (
     update_leader,
     write_progress,
 )
+from autoresearch.roles import author_spec
+from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
     ABORTED,
     BUDGET_EXHAUSTED,
@@ -158,6 +160,33 @@ def _measure_committed(
             _best_effort("worktree prune", lambda: ws.git("worktree", "prune"))
 
 
+def build_author_harness(
+    api_key: str,
+    spec: RoleSpec | None = None,
+    *,
+    binary: str | None = None,
+    model: str | None = None,
+    container_image: str = "",
+) -> ClaudeCodeHarness:
+    """Construct the author's harness from its RoleSpec — the same deployment
+    wiring the judges use (`spec.budget` drives turns and walltime, so
+    manifest and harness cannot disagree). Claude only: the author runs
+    contained (apptainer) with the full editing tool set, and KEEPS
+    instruction-file discovery — the target repo's CLAUDE.md is legitimate
+    guidance for an editing role, unlike a judge's untrusted checkout."""
+    spec = spec or author_spec()
+    if not spec.execution.can_execute:
+        raise ValueError("build_author_harness is for editing roles")
+    return ClaudeCodeHarness(
+        api_key=api_key,
+        binary=binary or "claude",
+        model=model or "claude-opus-5",
+        max_turns=spec.budget.max_turns,
+        timeout_s=spec.budget.walltime_s,
+        container_image=container_image,
+    )
+
+
 def live_climb(
     config: ClimbConfig,
     run_root: Path,
@@ -172,6 +201,7 @@ def live_climb(
     base_branch: str = "main",
     issue_number: int = 0,
     task_hypothesis: str = "",
+    spec: RoleSpec | None = None,
 ) -> LiveClimbOutcome:
     """Run one climb against the real target repo."""
     run_dir = run_root / "runs" / run_id
@@ -272,6 +302,7 @@ def live_climb(
                 created=created,
                 task_hypothesis=task_hypothesis,
                 baseline_workspace=baseline_wt,
+                spec=spec,
             )
         finally:
             if not _best_effort(
@@ -817,20 +848,22 @@ def main() -> int:
     if armed:
         log.info("self-deadline armed: Terminated in %ds", armed)
 
+    # the manifest first, the harness from it: budget has one source (the args)
+    spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
     try:
         try:
             outcome = live_climb(
                 config=ClimbConfig(target=args.target, benchmark=args.benchmark),
                 run_root=args.run_root,
                 run_id=run_id,
-                harness=ClaudeCodeHarness(
-                    api_key=api_key,
+                harness=build_author_harness(
+                    api_key,
+                    spec,
                     binary=args.claude_bin,
                     model=args.model,
-                    max_turns=args.max_turns,
-                    timeout_s=args.session_minutes * 60,
                     container_image=args.image,
                 ),
+                spec=spec,
                 evaluator=SubprocessEvaluator(container_image=args.image),
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -183,6 +183,9 @@ def build_author_harness(
         model=model or "claude-opus-5",
         max_turns=spec.budget.max_turns,
         timeout_s=spec.budget.walltime_s,
+        # the manifest drives the tool set, same as the budget (all author
+        # tools are native Claude tools; no MCP tools to filter out)
+        allowed_tools=spec.tools,
         container_image=container_image,
     )
 

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -599,9 +599,12 @@ def climb_once(
     )
     role_result = run_role(spec, harness, render(brief), workspace)
     session = role_result.session
-    if session.is_error:
-        # our caps running out is a budget ending, not a malfunction; the
-        # API refusing us is an outage — neither is the run's own failure
+    if not role_result.ok:
+        # the role-runner's verdict, not just the raw session flag (for a
+        # schema-less role they coincide today, but any failure the runner
+        # learns to report must not slip through as a clean run).
+        # Our caps running out is a budget ending, not a malfunction; the
+        # API refusing us is an outage — neither is the run's own failure.
         if outage(session):
             kind = "session-outage"
         elif budget_exhausted(session):
@@ -612,7 +615,7 @@ def climb_once(
             outcome=kind,
             baseline=baseline,
             session=session,
-            note=session.error_detail or session.stop_reason,
+            note=role_result.error or session.error_detail or session.stop_reason,
         )
 
     # Scope BEFORE measurement: an out-of-scope tree is never evaluated,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -20,6 +20,7 @@ import math
 import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from dataclasses import replace as dc_replace
 from pathlib import Path
 from secrets import randbits
 from typing import Protocol
@@ -33,6 +34,9 @@ from autoresearch.contract import (
     path_is_forbidden,
 )
 from autoresearch.harness import Harness, SessionResult, budget_exhausted, outage, redact
+from autoresearch.role_runner import run_role
+from autoresearch.roles import author_spec
+from autoresearch.rolespec import RoleSpec
 
 log = logging.getLogger(__name__)
 
@@ -541,6 +545,7 @@ def climb_once(
     created: str = "",
     task_hypothesis: str = "",
     baseline_workspace: Path | None = None,
+    spec: RoleSpec | None = None,
 ) -> ClimbResult:
     """One implement→evaluate→verify cycle in an existing clean workspace.
 
@@ -549,9 +554,20 @@ def climb_once(
     `changed_paths` reports every path the session touched (the caller wires
     it to `git add -A` + staged paths); scope is enforced on it BEFORE the
     candidate eval runs.
+
+    The session runs as the author role on the role-runner (`spec` defaults
+    to `author_spec`; the caller that built the harness passes its spec so
+    manifest and harness agree). Scope enforcement stays HERE, on the
+    contract — the spec's scope is the manifest copy, filled from the same
+    contract.
     """
     contract = load_contract(contract_text, config.target)
     bench = _benchmark(contract, config.benchmark)
+    spec = spec or author_spec()
+    if not spec.execution.can_execute:
+        raise ValueError("climb_once runs an editing role; the spec must allow execution")
+    if not spec.scope:
+        spec = dc_replace(spec, scope=tuple(contract.scope.allowed))
 
     # Baseline from the PRE-session tree — never from a stored number
     # (architecture: "baseline re-run at the merge-base, not a trusted
@@ -581,7 +597,8 @@ def climb_once(
         ),
         created=created,
     )
-    session = harness.run(render(brief), workspace)
+    role_result = run_role(spec, harness, render(brief), workspace)
+    session = role_result.session
     if session.is_error:
         # our caps running out is a budget ending, not a malfunction; the
         # API refusing us is an outage — neither is the run's own failure

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -16,6 +16,49 @@ from autoresearch.verifier import VERIFY_SCHEMA, verify_result_from_data
 # retriever. No Write/Edit/Bash — a judge never executes untrusted PR code.
 _JUDGE_TOOLS = ("Read", "Grep", "Glob", "pr-context-read", "retriever")
 
+# The full editing set: the author implements, runs tests, and self-validates
+# inside its container. Execution is the role's job, not a leak.
+_AUTHOR_TOOLS = ("Read", "Grep", "Glob", "Write", "Edit", "Bash")
+
+
+def author_spec(
+    *,
+    environment: Environment = "apptainer",
+    max_turns: int = 60,
+    walltime_s: int = 3600,
+    scope: tuple[str, ...] = (),
+) -> RoleSpec:
+    """The climbing author as an editing agent session.
+
+    No output_schema: the artifact is the workspace diff plus the free-text
+    research report, judged by measurement (the kernel re-runs the eval), not
+    by parsing. `scope` is the contract's allowed paths; an empty tuple means
+    "filled from the contract by the kernel" (climb_once), which owns scope
+    enforcement either way. Budget defaults mirror the climb CLI's.
+    """
+    return RoleSpec(
+        name="author",
+        instructions=(
+            "Improve the configured benchmark: one concrete hypothesis, "
+            "implemented inside the contract's allowed paths, self-validated "
+            "by running the eval. Write a research report — hypothesis, what "
+            "moved, negatives, one next step."
+        ),
+        key="author",
+        tools=_AUTHOR_TOOLS,
+        execution=Execution(environment=environment, can_execute=True),
+        budget=SessionBudget(max_turns=max_turns, walltime_s=walltime_s),
+        skills=(
+            "kernel-primer",
+            "plain-style",
+            "hypothesis-discipline",
+            "honest-method",
+            "experiment-lifecycle",
+            "research-report",
+        ),
+        scope=tuple(scope),
+    )
+
 
 def reviewer_spec(
     *, environment: Environment = "gh-runner", max_turns: int = 40, walltime_s: int = 1800

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1200,3 +1200,18 @@ def test_self_deadline_raises_terminated_into_containment(monkeypatch) -> None:
     finally:
         signal.alarm(0)
         signal.signal(signal.SIGALRM, original)
+
+
+def test_author_harness_is_built_from_the_spec() -> None:
+    """The spec is the single source for the session budget: manifest and
+    harness cannot disagree (the judges' build_reviewer_harness pattern)."""
+    from autoresearch.climb import build_author_harness
+    from autoresearch.roles import author_spec, reviewer_spec
+
+    spec = author_spec(max_turns=7, walltime_s=120)
+    harness = build_author_harness("sk-key", spec, container_image="img.sif")
+    assert harness.max_turns == 7
+    assert harness.timeout_s == 120
+    assert harness.container_image == "img.sif"
+    with pytest.raises(ValueError, match="editing roles"):
+        build_author_harness("sk-key", reviewer_spec())

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -528,3 +528,11 @@ def test_subprocess_evaluator_env_is_private_per_eval(tmp_path: Path) -> None:
     evaluator.evaluate(tmp_path, capture, "m")
     seen = (tmp_path / "seen.txt").read_text().split()
     assert len(seen) == 2 and seen[0] != seen[1]
+
+
+def test_climb_once_refuses_a_read_only_spec(tmp_path: Path) -> None:
+    # the author is an editing role; a judge spec here is a deployment bug
+    from autoresearch.roles import reviewer_spec
+
+    with pytest.raises(ValueError, match="must allow execution"):
+        run_climb(tmp_path, [13.876], spec=reviewer_spec())

--- a/tests/test_role_runner.py
+++ b/tests/test_role_runner.py
@@ -1,5 +1,5 @@
-"""Role-runner: structured-output validation, the repair loop, and the reviewer
-RoleSpec. The harness is faked; no session is actually run."""
+"""Role-runner: structured-output validation, the repair loop, and the role
+specs. The harness is faked; no session is actually run."""
 
 from __future__ import annotations
 
@@ -10,8 +10,7 @@ from pathlib import Path
 from autoresearch.harness import SessionResult
 from autoresearch.review import FINDINGS_SCHEMA
 from autoresearch.role_runner import run_role
-from autoresearch.roles import reviewer_spec
-from autoresearch.rolespec import Execution, RoleSpec, SessionBudget
+from autoresearch.roles import author_spec, reviewer_spec
 
 _WORKSPACE = Path("/tmp/does-not-matter")
 _FINDINGS = json.dumps({"findings": [], "notes": "looks fine"})
@@ -46,22 +45,20 @@ class _SeqHarness:
         return self.results.pop(0)
 
 
-def _author_spec() -> RoleSpec:
-    return RoleSpec(
-        name="author",
-        instructions="improve",
-        key="author",
-        tools=("Read", "Edit", "Bash"),
-        execution=Execution(environment="apptainer", can_execute=True),
-        budget=SessionBudget(max_turns=10, walltime_s=60),
-    )
-
-
 def test_reviewer_spec_is_read_only_and_uses_findings_schema() -> None:
     spec = reviewer_spec()
     assert spec.execution.can_execute is False
     assert spec.scope is None
     assert spec.output_schema is FINDINGS_SCHEMA
+
+
+def test_author_spec_is_an_executing_editor_with_no_schema() -> None:
+    spec = author_spec()
+    assert spec.execution.can_execute is True
+    assert {"Write", "Edit", "Bash"} <= set(spec.tools)
+    assert spec.output_schema is None  # the artifact is the diff + report
+    assert spec.scope == ()  # filled from the contract by the kernel
+    assert author_spec(scope=("src/x/",)).scope == ("src/x/",)
 
 
 def test_happy_path_returns_validated_data() -> None:
@@ -110,6 +107,6 @@ def test_session_error_propagates() -> None:
 
 
 def test_editing_role_needs_no_schema() -> None:
-    result = run_role(_author_spec(), _SeqHarness([_session("done")]), "brief", _WORKSPACE)
+    result = run_role(author_spec(), _SeqHarness([_session("done")]), "brief", _WORKSPACE)
     assert result.ok is True
     assert result.data is None


### PR DESCRIPTION
## What

Stage 1 of the remaining driver collapse (consolidation.md): the **author session moves onto the role-runner**, the same shape the judges already have — a RoleSpec manifest + `run_role` dispatch + harness built from the spec.

- `roles.py` gains `author_spec`: the editing manifest — full tool set (`Write`/`Edit`/`Bash`), `can_execute`, apptainer, **no `output_schema`** (the artifact is the workspace diff + free-text report, judged by measurement, not parsing). `scope=()` means "filled from the contract by the kernel".
- `climb_once` dispatches through `run_role(spec, …)` instead of calling `harness.run` raw, refuses a read-only spec, and fills the spec's scope from the contract. **Scope enforcement is unchanged** — `out_of_scope` on the contract, before the candidate eval, as before.
- `climb.build_author_harness` mirrors `build_reviewer_harness`: `spec.budget` drives turns/walltime, so manifest and harness cannot disagree. Claude-only, and it keeps instruction-file discovery — the target repo's CLAUDE.md is legitimate guidance for an *editing* role, unlike a judge's untrusted checkout (`--bare` stays judge-only). The climb CLI builds the spec from its args and the harness from the spec.
- `test_role_runner`'s local `_author_spec` test double is replaced by the real one (no two copies).

## Behavior

Unchanged: same brief, same session call, same error taxonomy. All 505 pre-existing tests pass untouched; 3 added (spec shape, read-only-spec guard, spec→harness budget mapping).

## Staging

Agreed staging, one PR per stage: **(1) author — this PR**, (2) follow-up responder dispatch, (3) steward dispatch. The parked suite no-regression gate lands after the collapse.
