### PR TITLE
Steward onto the role-runner (collapse stage 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,14 +43,16 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
-- The author and follow-up responder sessions now run on the role-runner,
-  like the judges: `author_spec`/`followup_spec` (roles.py) are the
-  manifests, `climb_once`/`respond_once` dispatch through `run_role`, and
+- All five roles now run on the role-runner: `author_spec`/`followup_spec`/
+  `steward_spec` (roles.py) join the judges' specs as the manifests,
+  `climb_once`/`respond_once`/`live_steward` dispatch through `run_role`, and
   the CLIs build their harness from the spec (`build_editor_harness`, one
   builder for all editing roles), so the session budget and tool set have
   one source. The follow-up runs under the resuming role's key and scope
-  (author or steward, from the record and contract). Behavior unchanged;
-  steward dispatch is the remaining collapse.
+  (author or steward, from the record and contract); the steward's spec
+  carries its own territory (`contract.steward.allowed`). Behavior
+  unchanged. The session-dispatch half of the driver collapse is complete;
+  briefs/skills as app config is the remaining consolidation.
 - The verifier can now run as an agent session over TWO read-only checkouts:
   the PR head (the change under review) and the base branch (the trusted
   contract and ruler — all ruler reads are directed there, never at the PR).

--- a/docs/design/agent-substrate.md
+++ b/docs/design/agent-substrate.md
@@ -192,12 +192,11 @@ is the rare exception).
 
 ## The role-runner: one loop replaces five drivers
 
-Replaces the five per-role drivers — done for the judges (`review_cli` and
-`verifier_cli` are deleted), the author (`climb_once` runs `author_spec`
-through `run_role`), and the follow-up responder (`respond_once` runs
-`followup_spec`); `steward` dispatch still to collapse. Kernel code; it
-calls into the agentic realm at step 2, and everything trust-critical is
-deterministic.
+Replaces the five per-role drivers' session dispatch — all five roles now run
+through `run_role` with their RoleSpec (`review_cli` and `verifier_cli` are
+deleted; author, follow-up, and steward dispatch from their kernel modules).
+Kernel code; it calls into the agentic realm at step 2, and everything
+trust-critical is deterministic.
 
 1. **prep** — build the workspace (editable for author, read-only for judge);
    `brief.build(RoleSpec, task, memory)`; pick the backend adapter.

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -120,7 +120,7 @@ scope, key), and their spend counts against its budget.
 
 | Now | Fate |
 | --- | --- |
-| `climb`, `steward`, `followup` | Remaining copies of "prep → run a role → act on the result." Collapse into **one role-runner + a RoleSpec + a result-policy** each — done for the judges (`review_cli`/`verifier_cli` are deleted; reviewer and verifier run on the role-runner), the author (`climb_once` runs `author_spec` through `run_role`; the harness is built from the spec), and the follow-up responder (`respond_once` runs `followup_spec` under the resuming role's key and scope). Steward dispatch pending. The measure/gate/PR halves stay kernel; the brief/skills halves become app config. |
+| `climb`, `steward`, `followup` | Session dispatch collapsed: all five roles run through **one role-runner + a RoleSpec** (judges via their agent modules, `review_cli`/`verifier_cli` deleted; author via `climb_once`; follow-up via `respond_once` under the resuming role's key and scope; steward via `live_steward`) with the harness built from the spec (`build_editor_harness` for editing roles). What remains of these modules is each role's kernel half — measure/gate/PR/wake plumbing. The brief/skills halves becoming app config is the remaining consolidation. |
 | `review`, `verifier` (rendering, verdict/blocking machinery) | On the agent-session path; hold the shared vocabulary and rendering both judges use. |
 | `harness`, `brief` | The seam. Keep. Adapters live: claude, codex, hermes. |
 | `orchestrator`, `contract`, `github`, `compute`, `runstate`, `disk`, `limits`, `intake` | Kernel. Barely moves — the point. |

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -114,6 +114,39 @@ def verifier_spec(
     )
 
 
+def steward_spec(
+    *,
+    environment: Environment = "apptainer",
+    max_turns: int = 60,
+    walltime_s: int = 3600,
+    scope: tuple[str, ...] = (),
+) -> RoleSpec:
+    """The benchmark steward as an editing agent session.
+
+    Its territory is the contract's `steward.allowed` (env generators, eval
+    harness, tests), with the solver's scope forbidden in code — the role
+    separation that makes verifier-checked stewardship trustworthy. No
+    output_schema: the artifact is the env-work diff plus the report, and the
+    orchestrator runs the validation ruler. `scope=()` means "filled from the
+    contract by the kernel". Budget defaults mirror the steward CLI's.
+    """
+    return RoleSpec(
+        name="steward",
+        instructions=(
+            "Keep the benchmarks discriminating: restore headroom, harden "
+            "metrics, add evaluations — env work inside your steward "
+            "territory, never the solver's code. Propose; the orchestrator "
+            "validates and a human merges."
+        ),
+        key="steward",
+        tools=_AUTHOR_TOOLS,
+        execution=Execution(environment=environment, can_execute=True),
+        budget=SessionBudget(max_turns=max_turns, walltime_s=walltime_s),
+        skills=("kernel-primer", "plain-style", "ruler-hardening", "benchmark-design"),
+        scope=tuple(scope),
+    )
+
+
 def followup_spec(
     *,
     resuming: Literal["author", "steward"] = "author",

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from dataclasses import replace as dc_replace
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -32,6 +33,7 @@ from autoresearch.climb import (
     _best_effort,
     arm_self_deadline,
     arm_sigterm_containment,
+    build_editor_harness,
 )
 from autoresearch.contract import Contract, load_contract
 from autoresearch.github import FileTokenProvider, GitHubClient, Workspace
@@ -51,6 +53,9 @@ from autoresearch.progress import (
     load_leader,
     write_progress,
 )
+from autoresearch.role_runner import run_role
+from autoresearch.roles import steward_spec
+from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
     ABORTED,
     BUDGET_EXHAUSTED,
@@ -412,9 +417,15 @@ def live_steward(
     base_branch: str = "main",
     issue_number: int = 0,
     work_order: str = "",
+    spec: RoleSpec | None = None,
 ) -> LiveClimbOutcome:
     """Run one stewardship against the real target repo."""
     import os as _os
+
+    # a deployment bug is loud and immediate — same guard as climb_once
+    spec = spec or steward_spec()
+    if not spec.execution.can_execute:
+        raise ValueError("the steward is an editing role; the spec must allow execution")
 
     run_dir = run_root / "runs" / run_id
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -461,6 +472,10 @@ def live_steward(
         bench = next((b for b in contract.benchmarks if b.name == config.benchmark), None)
         if bench is None:
             raise ValueError(f"benchmark {config.benchmark!r} not in contract")
+        if not spec.scope:
+            # manifest truth: the spec run_role receives carries the steward's
+            # real territory; enforcement stays steward_out_of_scope below
+            spec = dc_replace(spec, scope=tuple(contract.steward.allowed))
 
         def changed_paths() -> list[str]:
             ws.git("add", "-A")
@@ -482,12 +497,16 @@ def live_steward(
                     f"(benchmark `{config.benchmark}`). A report will follow here.",
                 )
 
-        session = harness.run(
-            steward_brief(contract_text, contract, work_order, config.benchmark), workspace
+        role_result = run_role(
+            spec,
+            harness,
+            steward_brief(contract_text, contract, work_order, config.benchmark),
+            workspace,
         )
-        if session.is_error:
+        session = role_result.session
+        if not role_result.ok:
             raise SessionFailure(
-                session.error_detail or session.stop_reason,
+                role_result.error or session.error_detail or session.stop_reason,
                 budget_exhausted(session),
                 outage(session),
             )
@@ -731,7 +750,6 @@ def main() -> int:
     import time
     from datetime import UTC, datetime
 
-    from autoresearch.harness import ClaudeCodeHarness
     from autoresearch.orchestrator import SubprocessEvaluator
 
     arm_sigterm_containment()
@@ -781,19 +799,21 @@ def main() -> int:
     if armed:
         log.info("self-deadline armed: Terminated in %ds", armed)
 
+    # the manifest first, the harness from it (budget has one source: the args)
+    spec = steward_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
     try:
         outcome = live_steward(
             config=StewardConfig(target=args.target, benchmark=args.benchmark),
             run_root=args.run_root,
             run_id=run_id,
-            harness=ClaudeCodeHarness(
-                api_key=api_key,
+            harness=build_editor_harness(
+                api_key,
+                spec,
                 binary=args.claude_bin,
                 model=args.model,
-                max_turns=args.max_turns,
-                timeout_s=args.session_minutes * 60,
                 container_image=args.image,
             ),
+            spec=spec,
             evaluator=SubprocessEvaluator(container_image=args.image),
             github=GitHubClient(auth=bot_auth),
             bot_auth=bot_auth,

--- a/tests/test_role_runner.py
+++ b/tests/test_role_runner.py
@@ -121,3 +121,14 @@ def test_followup_spec_carries_the_resuming_roles_key() -> None:
     assert {"Write", "Edit", "Bash"} <= set(spec.tools)
     assert spec.output_schema is None  # the reply is prose; changes are re-measured
     assert followup_spec(resuming="steward").key == "steward"
+
+
+def test_steward_spec_is_an_executing_editor_in_its_own_territory() -> None:
+    from autoresearch.roles import steward_spec
+
+    spec = steward_spec()
+    assert spec.name == "steward" and spec.key == "steward"
+    assert spec.execution.can_execute is True
+    assert {"Write", "Edit", "Bash"} <= set(spec.tools)
+    assert spec.output_schema is None  # the artifact is the env-work diff + report
+    assert spec.scope == ()  # filled from contract.steward.allowed by the kernel

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -746,3 +746,5 @@ def test_read_only_spec_is_refused_before_any_work(tmp_path, steward_repo) -> No
             created="t",
             spec=reviewer_spec(),
         )
+    # "before any work" made checkable: no run dir, no record, nothing on disk
+    assert not (tmp_path / "state").exists()

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -725,3 +725,24 @@ def test_rebase_row_records_the_measurement_seed(tmp_path) -> None:
     raw = _json.loads((tmp_path / "results" / "leader.json").read_text())
     assert raw[bench.name]["run_seed"] == 987654321
     assert raw[bench.name]["best_run"] == "baseline-steward-tsp-s"
+
+
+def test_read_only_spec_is_refused_before_any_work(tmp_path, steward_repo) -> None:
+    # the steward edits env code; a judge spec here is a deployment bug — loud
+    # and immediate, before the record or any network work
+    from autoresearch.roles import reviewer_spec
+    from autoresearch.steward import StewardConfig, live_steward
+
+    with pytest.raises(ValueError, match="must allow execution"):
+        live_steward(
+            config=StewardConfig(target="org/pilot", benchmark="tsp"),
+            run_root=tmp_path / "state",
+            run_id="stw-badspec",
+            harness=None,  # type: ignore[arg-type]  # refused before any use
+            evaluator=None,  # type: ignore[arg-type]
+            github=None,  # type: ignore[arg-type]
+            bot_auth=None,  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="t",
+            spec=reviewer_spec(),
+        )


### PR DESCRIPTION
## What

Stage 3, the last of the driver collapse: the **steward moves onto the role-runner**, completing the pattern from #85 (author) and #86 (follow-up).

- `roles.py` gains `steward_spec`: the steward as an editing manifest in its own territory — key family `steward`, scope filled from `contract.steward.allowed` once the contract loads. No `output_schema`: the artifact is the env-work diff + report, and the orchestrator runs the validation ruler (unchanged).
- `live_steward` dispatches through `run_role` and raises `SessionFailure` off the runner's verdict, preferring its error detail. A read-only spec is refused loudly at the top of the function — before the record or any network work (the #86 review's cost lesson applied).
- The steward CLI builds its spec from args and its harness from the spec via the shared `build_editor_harness` — the last inline `ClaudeCodeHarness` construction outside the builder is gone.

## State of the collapse

**The session-dispatch half is complete: all five roles run through `run_role` with their RoleSpec** — judges (via their agent modules; `review_cli`/`verifier_cli` deleted in #81), author (`climb_once`), follow-up (`respond_once`, under the resuming role's key and scope), steward (`live_steward`). What remains of `climb`/`steward`/`followup` is each role's kernel half: measure/gate/PR/wake plumbing. The remaining consolidation is briefs/skills becoming app config, per consolidation.md.

Next after this merges: un-park the suite no-regression gate onto the finished shape.

## Behavior

Unchanged: same brief, same error taxonomy (`SessionFailure` budget/outage split intact). 512 tests green (2 added: spec shape + the loud read-only-spec refusal), full gate clean.
