### PR TITLE
Suite no-regression gate: shared-path diffs must not regress sibling benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Suite no-regression gate: contracts may declare `scope.shared` (shared code
+  paths — encoder, world model, training loop). A solver diff touching one is
+  only credited after every sibling benchmark is re-measured on both sides
+  (paired seed); a sibling regressing beyond its own floor ends the run as
+  `suite-regression`, an honest negative. Env-specific diffs still measure
+  only their benchmark. The gate re-runs on the merged tree when the base
+  moved; the PR body carries the suite table. Follow-up pushes are not yet
+  suite-gated (named gap).
 - The reviewer can now run on three backends, selected by `REVIEW_BACKEND`
   (`claude` | `codex` | `hermes`) with per-backend keys
   (`ANTHROPIC_REVIEWER_KEY` | `OPENAI_REVIEWER_KEY` | `OPENROUTER_API_KEY`) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,10 +31,12 @@ Versions follow [SemVer](https://semver.org).
   paths — encoder, world model, training loop). A solver diff touching one is
   only credited after every sibling benchmark is re-measured on both sides
   (paired seed); a sibling regressing beyond its own floor ends the run as
-  `suite-regression`, an honest negative. Env-specific diffs still measure
-  only their benchmark. The gate re-runs on the merged tree when the base
-  moved; the PR body carries the suite table. Follow-up pushes are not yet
-  suite-gated (named gap).
+  `suite-regression`, an honest negative — including when the regression is
+  found on the merged tree after the base moved (never an abort). Env-specific
+  diffs still measure only their benchmark; the PR body carries the suite
+  table. A shared path outside the allowed scope is dead config and fails at
+  load. Benchmark names are now slug-shaped (they reach branch names and
+  ledger keys). Follow-up pushes are not yet suite-gated (named gap).
 - The reviewer can now run on three backends, selected by `REVIEW_BACKEND`
   (`claude` | `codex` | `hermes`) with per-backend keys
   (`ANTHROPIC_REVIEWER_KEY` | `OPENAI_REVIEWER_KEY` | `OPENROUTER_API_KEY`) and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -169,7 +169,14 @@ open-ended sweep space.
       credit if one regresses beyond its own floor — an honest negative,
       not an abort. Env-specific diffs stay cheap (one benchmark measured).
       Re-gated on the merged tree when the base moved. Follow-up pushes are
-      NOT yet suite-gated — named gap, wire with the follow-up re-measure
+      NOT yet suite-gated — named gap, wire with the follow-up re-measure.
+      Credit rule for the future generalist inversion (maintainer 2026-08-15):
+      shared-path CONTACT prices the suite pass but never grants suite-wide
+      credit — a config fork routing one benchmark to new code would launder
+      universality. Multi-row credit must be evidence-based (siblings improved
+      in the same pass, or mechanism verified shared); per-benchmark eval
+      configs belong in ruler territory so shared code cannot observe the
+      benchmark identity; input-sniffing forks stay a verifier lens item
 - [ ] jepa-agent as the first research target: `.autoresearch.yaml` + bot Write
       grant + token scope, once its benchmark harness lands and the pilot's
       PR-quality bar is met

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,6 +162,14 @@ open-ended sweep space.
       steward key + pilot contract `steward:` section + the four work-order
       issues (denoise v2 [PR #18 draft as spec], reach v3, probe v2,
       speedup noise floor)
+- [x] Suite no-regression gate (yolo-jepa lessons: both gamed climbs bought
+      their number by exploiting one benchmark's structure): the contract
+      declares `scope.shared` paths; a solver diff touching them has every
+      sibling benchmark re-measured on both sides (paired seed) and loses
+      credit if one regresses beyond its own floor — an honest negative,
+      not an abort. Env-specific diffs stay cheap (one benchmark measured).
+      Re-gated on the merged tree when the base moved. Follow-up pushes are
+      NOT yet suite-gated — named gap, wire with the follow-up re-measure
 - [ ] jepa-agent as the first research target: `.autoresearch.yaml` + bot Write
       grant + token scope, once its benchmark harness lands and the pilot's
       PR-quality bar is met

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -172,11 +172,14 @@ open-ended sweep space.
       NOT yet suite-gated — named gap, wire with the follow-up re-measure.
       Credit rule for the future generalist inversion (maintainer 2026-08-15):
       shared-path CONTACT prices the suite pass but never grants suite-wide
-      credit — a config fork routing one benchmark to new code would launder
-      universality. Multi-row credit must be evidence-based (siblings improved
-      in the same pass, or mechanism verified shared); per-benchmark eval
-      configs belong in ruler territory so shared code cannot observe the
-      benchmark identity; input-sniffing forks stay a verifier lens item
+      credit. A per-benchmark fork is legitimate STAGED research (mechanism
+      proven on the toy first, larger benchmarks later, possibly coupled with
+      other innovations) when claimed as such — the offense is a claim/evidence
+      mismatch, never the fork. Multi-row credit must be evidence-based
+      (siblings improved in the same pass, or mechanism verified shared);
+      claim-vs-mechanism consistency is the verifier lens item; per-benchmark
+      eval configs stay ruler territory so shared code cannot observe the
+      benchmark identity
 - [ ] jepa-agent as the first research target: `.autoresearch.yaml` + bot Write
       grant + token scope, once its benchmark harness lands and the pilot's
       PR-quality bar is met

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -33,11 +33,13 @@ from autoresearch.orchestrator import (
     ClimbConfig,
     Evaluator,
     SubprocessEvaluator,
+    SuiteMeasurement,
     benchmark_floor,
     clears_min_delta,
     climb_once,
     out_of_scope,
     pr_body,
+    suite_regressed,
 )
 from autoresearch.orchestrator import improved as orch_improved
 from autoresearch.progress import (
@@ -92,6 +94,9 @@ RULER = (
 
 _ENDINGS_BY_OUTCOME = {
     "no-improvement": NEGATIVE_RESULT,
+    # the improvement was real but bought by regressing a sibling benchmark —
+    # an honest negative with a named cause, not a malfunction
+    "suite-regression": NEGATIVE_RESULT,
     "session-error": ABORTED,
     "session-budget": BUDGET_EXHAUSTED,
     "session-outage": STUCK,  # infrastructure failure, nothing about the run
@@ -437,7 +442,44 @@ def live_climb(
                         f"{baseline} after merging the moved base (upstream "
                         f"absorbed or invalidated the improvement)"
                     )
-                result = dc_replace(result, baseline=baseline, candidate=candidate)
+                suite = result.suite
+                if suite:
+                    # the suite gate must hold on the tree that actually lands,
+                    # same as the claim itself — re-measure every sibling on
+                    # the fresh pair under the recorded suite seed
+                    rows = []
+                    for row in suite:
+                        sib = next(b for b in contract.benchmarks if b.name == row.name)
+                        env = (
+                            {sib.seed_env: str(result.suite_seed)}
+                            if sib.seed_env and result.suite_seed
+                            else None
+                        )
+                        sib_base = _measure_committed(
+                            ws, evaluator, run_dir, f"fresh-base-{sib.name}", fresh_base, sib, env
+                        )
+                        sib_cand = _measure_committed(
+                            ws, evaluator, run_dir, f"merged-{sib.name}", merged_sha, sib, env
+                        )
+                        regressed = suite_regressed(
+                            sib_base, sib_cand, sib.direction, sib.min_delta, sib.min_delta_rel
+                        )
+                        if regressed:
+                            raise WorkspaceDrift(
+                                f"suite regression after merging the moved base: "
+                                f"{sib.name} {sib_base} -> {sib_cand}"
+                            )
+                        rows.append(
+                            SuiteMeasurement(
+                                name=sib.name,
+                                baseline=sib_base,
+                                candidate=sib_cand,
+                                regressed=False,
+                                display_digits=sib.display_digits,
+                            )
+                        )
+                    suite = tuple(rows)
+                result = dc_replace(result, baseline=baseline, candidate=candidate, suite=suite)
 
             # Progress record (BENCHMARKS.md + results/leader.json), written
             # by the orchestrator from ITS measurements after the drift check

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -76,6 +76,12 @@ class WorkspaceDrift(RuntimeError):
     """The tree changed between measurement and commit."""
 
 
+class SuiteRegressed(RuntimeError):
+    """A sibling benchmark regressed beyond its floor on the landing tree —
+    the improvement was bought by breaking siblings. An honest negative
+    result wherever it is caught, never an abort."""
+
+
 def _title_pair(a: float, b: float) -> str:
     """Compact but never ambiguous: widen precision until the two numbers
     render differently (a title reading '10.00 -> 10.00' looks like no
@@ -487,24 +493,26 @@ def live_climb(
                     # same as the claim itself — re-measure every sibling on
                     # the fresh pair under the recorded suite seed
                     rows = []
-                    for row in suite:
+                    for i, row in enumerate(suite):
                         sib = next(b for b in contract.benchmarks if b.name == row.name)
                         env = (
                             {sib.seed_env: str(result.suite_seed)}
                             if sib.seed_env and result.suite_seed
                             else None
                         )
+                        # worktree labels use the sibling INDEX: the name is
+                        # contract text (untrusted) and must not shape a path
                         sib_base = _measure_committed(
-                            ws, evaluator, run_dir, f"fresh-base-{sib.name}", fresh_base, sib, env
+                            ws, evaluator, run_dir, f"fresh-base-sib{i}", fresh_base, sib, env
                         )
                         sib_cand = _measure_committed(
-                            ws, evaluator, run_dir, f"merged-{sib.name}", merged_sha, sib, env
+                            ws, evaluator, run_dir, f"merged-sib{i}", merged_sha, sib, env
                         )
                         regressed = suite_regressed(
                             sib_base, sib_cand, sib.direction, sib.min_delta, sib.min_delta_rel
                         )
                         if regressed:
-                            raise WorkspaceDrift(
+                            raise SuiteRegressed(
                                 f"suite regression after merging the moved base: "
                                 f"{sib.name} {sib_base} -> {sib_cand}"
                             )
@@ -641,6 +649,20 @@ def live_climb(
             outcome_name = "no-improvement"
             result = dc_replace(result, outcome="no-improvement", note=str(exc))
             log.info("noise-floored for %s: %s", run_id, exc)
+            final = RunRecord(
+                **{
+                    **record.__dict__,
+                    "state": ENDED,
+                    "ending": NEGATIVE_RESULT,
+                    "ending_note": redact(str(exc), secrets)[:480],
+                }
+            )
+        except SuiteRegressed as exc:
+            # the gate's verdict is the same wherever it fires: an honest
+            # negative, not an abort — the merged tree just answered later
+            outcome_name = "suite-regression"
+            result = dc_replace(result, outcome="suite-regression", note=str(exc))
+            log.info("suite-regressed for %s: %s", run_id, exc)
             final = RunRecord(
                 **{
                     **record.__dict__,

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -62,7 +62,9 @@ class _StrictModel(BaseModel):
 
 
 class Benchmark(_StrictModel):
-    name: str = Field(min_length=1)
+    # Slug shape only: the name reaches branch names, ledger keys, and log
+    # labels — contract text must not shape refs or paths beyond a slug.
+    name: str = Field(min_length=1, pattern=r"^[A-Za-z0-9_.-]{1,64}$")
     command: str = Field(min_length=1)
     metric: str = Field(min_length=1)
     direction: Literal["min", "max"]
@@ -265,12 +267,20 @@ def load_contract(text: str, target_repo: str) -> Contract:
                 raise ScopeError(f"allowed path {entry!r} overlaps forbidden {str(path)!r}")
     # Shared paths route the suite gate off changed paths, which are already
     # scope-checked — but a malformed entry would silently never match, so
-    # the same load-time rigor applies.
+    # the same load-time rigor applies. A shared path the agent can never
+    # touch (no overlap with any allowed path) is dead config that reads as
+    # protection: refused loudly, like any contract typo.
+    solver_allowed = [normalize_path(entry) for entry in contract.scope.allowed]
     for entry in contract.scope.shared:
         shared = normalize_path(entry)
         for path in forbidden:
             if _overlaps(shared, path):
                 raise ScopeError(f"shared path {entry!r} overlaps forbidden {str(path)!r}")
+        if not any(_overlaps(shared, a) for a in solver_allowed):
+            raise ScopeError(
+                f"shared path {entry!r} overlaps no allowed path — the suite "
+                f"gate could never trigger on it"
+            )
     if contract.steward is not None:
         # same rigor as the solver scope, plus the role-separation invariant:
         # steward and solver territories must not overlap AT LOAD TIME — a

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -135,6 +135,13 @@ class Budgets(_StrictModel):
 
 class Scope(_StrictModel):
     allowed: list[str] = Field(min_length=1)
+    # Shared code paths (encoder / world model / training loop — code every
+    # benchmark exercises, as opposed to env-specific solver code). A solver
+    # diff touching any of these is suite-gated: the orchestrator re-measures
+    # EVERY sibling benchmark on both sides and refuses credit if one
+    # regresses beyond its own floor. Env-specific diffs stay cheap — only
+    # their benchmark is measured.
+    shared: list[str] = Field(default_factory=list)
 
 
 # The orchestrator's ledger: no agent scope — solver OR steward — may
@@ -256,6 +263,14 @@ def load_contract(text: str, target_repo: str) -> Contract:
         for path in forbidden:
             if _overlaps(allowed, path):
                 raise ScopeError(f"allowed path {entry!r} overlaps forbidden {str(path)!r}")
+    # Shared paths route the suite gate off changed paths, which are already
+    # scope-checked — but a malformed entry would silently never match, so
+    # the same load-time rigor applies.
+    for entry in contract.scope.shared:
+        shared = normalize_path(entry)
+        for path in forbidden:
+            if _overlaps(shared, path):
+                raise ScopeError(f"shared path {entry!r} overlaps forbidden {str(path)!r}")
     if contract.steward is not None:
         # same rigor as the solver scope, plus the role-separation invariant:
         # steward and solver territories must not overlap AT LOAD TIME — a

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -440,12 +440,13 @@ def out_of_scope(paths: Sequence[str], contract: Contract) -> list[str]:
 def shared_touched(paths: Sequence[str], contract: Contract) -> list[str]:
     """Changed paths under `scope.shared` — the suite-gate trigger. Runs on
     paths that already passed `out_of_scope`, so unparseable entries are
-    simply not shared (they were rejected upstream)."""
-    shared = [normalize_path(entry) for entry in contract.scope.shared]
+    simply not shared (they were rejected upstream). Case-folded like the
+    forbidden/steward checks: a `Model/` spelling must not dodge the gate."""
+    shared = [_fold(normalize_path(entry)) for entry in contract.scope.shared]
     hits = []
     for path in paths:
         try:
-            candidate = normalize_path(path)
+            candidate = _fold(normalize_path(path))
         except Exception:
             continue
         if any(candidate == s or s in candidate.parents for s in shared):

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -341,11 +341,22 @@ class ClimbConfig:
 
 
 @dataclass(frozen=True)
+class SuiteMeasurement:
+    """One sibling benchmark's paired measurement from the suite gate."""
+
+    name: str
+    baseline: float
+    candidate: float
+    regressed: bool
+    display_digits: int | None = None
+
+
+@dataclass(frozen=True)
 class ClimbResult:
     """What one attempt produced — the raw material of the run report."""
 
     # improved | no-improvement | session-error | session-budget |
-    # session-outage | eval-error | scope-violation
+    # session-outage | eval-error | scope-violation | suite-regression
     outcome: str
     baseline: float | None = None
     candidate: float | None = None
@@ -358,6 +369,11 @@ class ClimbResult:
     # the seed both measurements ran under (0 = benchmark has no seed_env):
     # recorded in the ledger row so the number is re-derivable
     run_seed: int = 0
+    # sibling measurements when the suite gate ran (shared paths touched);
+    # empty when the diff was env-specific or no shared paths are declared
+    suite: tuple[SuiteMeasurement, ...] = ()
+    # the seed every seeded sibling's pair ran under (0 = gate did not run)
+    suite_seed: int = 0
 
     def report(self, config: ClimbConfig, redact_secrets: tuple[str, ...] = ()) -> str:
         lines = [
@@ -368,6 +384,9 @@ class ClimbResult:
             lines.append(f"Baseline: {self.baseline}")
         if self.candidate is not None:
             lines.append(f"Candidate: {self.candidate}")
+        for row in self.suite:
+            verdict = "REGRESSED" if row.regressed else "ok"
+            lines.append(f"Suite {row.name}: {row.baseline} -> {row.candidate} ({verdict})")
         if self.note:
             lines.append(f"Note: {self.note}")
         if self.session is not None:
@@ -412,6 +431,22 @@ def out_of_scope(paths: Sequence[str], contract: Contract) -> list[str]:
         if not any(candidate == a or a in candidate.parents for a in allowed):
             violations.append(path)
     return violations
+
+
+def shared_touched(paths: Sequence[str], contract: Contract) -> list[str]:
+    """Changed paths under `scope.shared` — the suite-gate trigger. Runs on
+    paths that already passed `out_of_scope`, so unparseable entries are
+    simply not shared (they were rejected upstream)."""
+    shared = [normalize_path(entry) for entry in contract.scope.shared]
+    hits = []
+    for path in paths:
+        try:
+            candidate = normalize_path(path)
+        except Exception:
+            continue
+        if any(candidate == s or s in candidate.parents for s in shared):
+            hits.append(path)
+    return hits
 
 
 def steward_out_of_scope(paths: Sequence[str], contract: Contract) -> list[str]:
@@ -495,6 +530,27 @@ def clears_min_delta(
     return delta > floor
 
 
+def suite_regressed(
+    baseline: float,
+    candidate: float,
+    direction: str,
+    min_delta: float | None = None,
+    min_delta_rel: float | None = None,
+) -> bool:
+    """Did a sibling benchmark move the WRONG way beyond its own floor?
+
+    Both sides are same-seed paired, so with no floor declared any wrong-way
+    move counts (paired noise is ~0 by construction); a declared floor gives
+    a stochastic eval its honest tolerance. Non-finite values fail closed —
+    an unmeasurable sibling must never read as "no regression"."""
+    if not (math.isfinite(baseline) and math.isfinite(candidate)):
+        return True
+    drop = baseline - candidate if direction == "max" else candidate - baseline
+    if drop <= 0:
+        return False
+    return drop > benchmark_floor(baseline, min_delta, min_delta_rel)
+
+
 def improved(baseline: float, candidate: float, direction: str, min_rel: float) -> bool:
     """Direction-aware, threshold-clearing improvement. Non-finite values
     never count (the evaluator rejects them; this is defense in depth)."""
@@ -512,6 +568,7 @@ def make_task(
 ) -> Task:
     bench = _benchmark(contract, benchmark_name)
     better = "up" if bench.direction == "max" else "down"
+    suite_gated = bool(contract.scope.shared) and len(contract.benchmarks) > 1
     return Task(
         hypothesis=hypothesis
         or (
@@ -524,6 +581,12 @@ def make_task(
         done_criteria=(
             f"`{bench.command}` runs clean and {bench.metric} moves {better} "
             f"versus {baseline}; repository tests pass"
+            + (
+                "; a change touching shared paths is suite-gated — no sibling "
+                "benchmark may regress beyond its floor"
+                if suite_gated
+                else ""
+            )
         ),
     )
 
@@ -621,23 +684,91 @@ def climb_once(
             outcome="eval-error", baseline=baseline, session=session, note=f"candidate: {exc}"
         )
 
-    if improved(baseline, candidate, bench.direction, config.min_relative_improvement):
+    if not improved(baseline, candidate, bench.direction, config.min_relative_improvement):
         return ClimbResult(
-            outcome="improved",
+            outcome="no-improvement",
             baseline=baseline,
             candidate=candidate,
             session=session,
-            branch=f"{config.branch_prefix}/{config.benchmark}",
-            measured_paths=measured,
+            note="a negative result reported clearly is a success",
             run_seed=run_seed,
         )
+
+    # Suite gate: a diff touching shared code must not buy its improvement
+    # by regressing a sibling benchmark (the recurring gamed-climb shape:
+    # a real lever that exploits one benchmark's structure). Runs only on
+    # an otherwise-credited claim — a negative result needs no gate.
+    suite: tuple[SuiteMeasurement, ...] = ()
+    suite_seed = 0
+    siblings = [b for b in contract.benchmarks if b.name != bench.name]
+    if siblings and shared_touched(measured, contract):
+        if baseline_workspace is None:
+            # fail closed: without a pristine pre-session tree the sibling
+            # baselines cannot be measured, and an ungated shared diff must
+            # never read as a clean pass
+            return ClimbResult(
+                outcome="eval-error",
+                baseline=baseline,
+                candidate=candidate,
+                session=session,
+                note="suite gate: no pristine baseline workspace to measure siblings",
+                run_seed=run_seed,
+            )
+        suite_seed = run_seed or draw_run_seed()
+        rows = []
+        for sib in siblings:
+            env = {sib.seed_env: str(suite_seed)} if sib.seed_env else None
+            try:
+                # paired like the climbed benchmark: same seed both sides
+                sib_base = evaluator.evaluate(
+                    baseline_workspace, sib.command, sib.metric, extra_env=env
+                )
+                sib_cand = evaluator.evaluate(workspace, sib.command, sib.metric, extra_env=env)
+            except EvalError as exc:
+                return ClimbResult(
+                    outcome="eval-error",
+                    baseline=baseline,
+                    candidate=candidate,
+                    session=session,
+                    note=f"suite {sib.name}: {exc}",
+                    run_seed=run_seed,
+                )
+            rows.append(
+                SuiteMeasurement(
+                    name=sib.name,
+                    baseline=sib_base,
+                    candidate=sib_cand,
+                    regressed=suite_regressed(
+                        sib_base, sib_cand, sib.direction, sib.min_delta, sib.min_delta_rel
+                    ),
+                    display_digits=sib.display_digits,
+                )
+            )
+        suite = tuple(rows)
+        regressed = [r for r in suite if r.regressed]
+        if regressed:
+            named = ", ".join(f"{r.name} {r.baseline} -> {r.candidate}" for r in regressed)
+            return ClimbResult(
+                outcome="suite-regression",
+                baseline=baseline,
+                candidate=candidate,
+                session=session,
+                note=f"shared-path diff regressed sibling benchmark(s): {named}",
+                run_seed=run_seed,
+                suite=suite,
+                suite_seed=suite_seed,
+            )
+
     return ClimbResult(
-        outcome="no-improvement",
+        outcome="improved",
         baseline=baseline,
         candidate=candidate,
         session=session,
-        note="a negative result reported clearly is a success",
+        branch=f"{config.branch_prefix}/{config.benchmark}",
+        measured_paths=measured,
         run_seed=run_seed,
+        suite=suite,
+        suite_seed=suite_seed,
     )
 
 
@@ -657,6 +788,20 @@ def pr_body(
 
     if result.outcome != "improved" or result.baseline is None or result.candidate is None:
         raise ValueError("pr_body requires an improved result with both measurements")
+    suite_lines: list[str] = []
+    if result.suite:
+        suite_lines = [
+            "",
+            "Shared code was touched, so every sibling benchmark was re-measured "
+            "on both sides (paired seed): none regressed beyond its floor.",
+            "",
+            "| suite benchmark | baseline | candidate |",
+            "| --- | --- | --- |",
+        ] + [
+            f"| {row.name} | {fmt_metric(row.baseline, row.display_digits)} "
+            f"| {fmt_metric(row.candidate, row.display_digits)} |"
+            for row in result.suite
+        ]
     body = "\n".join(
         [
             f"Automated improvement attempt on `{config.benchmark}` "
@@ -666,6 +811,7 @@ def pr_body(
             "| --- | --- |",
             f"| baseline ({config.benchmark}) | {fmt_metric(result.baseline, display_digits)} |",
             f"| candidate | {fmt_metric(result.candidate, display_digits)} |",
+            *suite_lines,
             "",
             "Both numbers were measured by the orchestrator re-running the "
             "contract's eval command — not taken from the session. CI "

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1200,3 +1200,46 @@ def test_self_deadline_raises_terminated_into_containment(monkeypatch) -> None:
     finally:
         signal.alarm(0)
         signal.signal(signal.SIGALRM, original)
+
+
+def test_moved_base_regates_the_suite_on_the_merged_tree(tmp_path, target_repo) -> None:
+    """The suite gate must hold on the tree that actually lands: the sibling
+    passed at session time, but the merged tree regresses it — re-measurement
+    vetoes the push, same as an absorbed improvement."""
+    _push_contract(
+        tmp_path,
+        target_repo,
+        CONTRACT.replace(
+            "scope: {allowed: [src/pilot/solvers/]}\n",
+            "  - name: sokoban\n"
+            "    command: uv run python -m pilot.eval --benchmark sokoban --json\n"
+            "    metric: solve_rate\n"
+            "    direction: max\n"
+            "scope: {allowed: [src/pilot/], shared: [src/pilot/model/]}\n",
+        ).replace(
+            "benchmarks:\n", "benchmarks:\n", 1
+        ),
+        "suite",
+    )
+    github = FakeGitHub()
+    outcome = live_climb(
+        config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        run_root=tmp_path / "state",
+        run_id="tsp-suite-race",
+        harness=RacingHarness(
+            edits={"src/pilot/model/encoder.py": "shared=1\n"},
+            target_repo=target_repo,
+            tmp_path=tmp_path,
+        ),
+        # session pair, sibling pair (passes: 0.8 flat), then post-merge:
+        # climbed pair still improves, but the merged tree's sibling drops
+        evaluator=QueueEvaluator(values=[13.876, 13.1, 0.8, 0.8, 13.9, 13.2, 0.8, 0.5]),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_000.0,
+        created="t",
+    )
+    assert outcome.outcome == "publish-error"
+    assert github.prs == []
+    note = load_record(tmp_path / "state", "tsp-suite-race").ending_note
+    assert "suite regression after merging" in note and "sokoban" in note

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1240,10 +1240,12 @@ def test_moved_base_regates_the_suite_on_the_merged_tree(tmp_path, target_repo) 
         now=1_000_000.0,
         created="t",
     )
-    assert outcome.outcome == "publish-error"
+    assert outcome.outcome == "suite-regression"
     assert github.prs == []
-    note = load_record(tmp_path / "state", "tsp-suite-race").ending_note
-    assert "suite regression after merging" in note and "sokoban" in note
+    record = load_record(tmp_path / "state", "tsp-suite-race")
+    assert record.ending == "negative-result"  # the gate's promise: never an abort
+    assert "suite regression after merging" in record.ending_note
+    assert "sokoban" in record.ending_note
 
 
 def test_author_harness_is_built_from_the_spec() -> None:

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -203,3 +203,23 @@ roadmap: docs/roadmap.md
         load_contract(base % "-0.1", "org/pilot")
     with pytest.raises(ValueError):
         load_contract(base % "13", "org/pilot")  # 13 meaning 13% is a typo, not 13x
+
+
+def test_scope_shared_parses_and_defaults_empty() -> None:
+    contract = load_contract(PILOT_CONTRACT, "org/pilot")
+    assert contract.scope.shared == []
+    with_shared = PILOT_CONTRACT.replace(
+        "  allowed: [src/pilot/solvers/]",
+        "  allowed: [src/pilot/]\n  shared: [src/pilot/model/]",
+    )
+    contract = load_contract(with_shared, "org/pilot")
+    assert contract.scope.shared == ["src/pilot/model/"]
+
+
+def test_scope_shared_overlapping_forbidden_is_refused() -> None:
+    bad = PILOT_CONTRACT.replace(
+        "  allowed: [src/pilot/solvers/]",
+        "  allowed: [src/pilot/solvers/]\n  shared: [.github/]",
+    )
+    with pytest.raises(ScopeError, match="shared path"):
+        load_contract(bad, "org/pilot")

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -223,3 +223,19 @@ def test_scope_shared_overlapping_forbidden_is_refused() -> None:
     )
     with pytest.raises(ScopeError, match="shared path"):
         load_contract(bad, "org/pilot")
+
+
+def test_shared_path_outside_allowed_is_dead_config_and_refused() -> None:
+    bad = PILOT_CONTRACT.replace(
+        "  allowed: [src/pilot/solvers/]",
+        "  allowed: [src/pilot/solvers/]\n  shared: [src/other/]",
+    )
+    with pytest.raises(ScopeError, match="overlaps no allowed path"):
+        load_contract(bad, "org/pilot")
+
+
+def test_benchmark_name_must_be_a_slug() -> None:
+    # names reach branch names and ledger keys; contract text must not shape refs
+    bad = PILOT_CONTRACT.replace("name: tsp", "name: ../tsp evil")
+    with pytest.raises(ValidationError):
+        load_contract(bad, "org/pilot")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -54,10 +54,12 @@ class FakeEvaluator:
     values: list[float] = field(default_factory=list)
     calls: list[tuple[str, str]] = field(default_factory=list)
     seen_env: list = field(default_factory=list)
+    seen_ws: list = field(default_factory=list)
 
     def evaluate(self, workspace: Path, command: str, metric: str, extra_env=None) -> float:
         self.calls.append((command, metric))
         self.seen_env.append(dict(extra_env) if extra_env else None)
+        self.seen_ws.append(workspace)
         value = self.values.pop(0)
         if isinstance(value, Exception):
             raise value
@@ -576,6 +578,11 @@ def test_shared_diff_measures_every_sibling_and_passes(tmp_path: Path) -> None:
     # 2 climbed evals + a paired pass per sibling
     assert len(evaluator.calls) == 4
     assert evaluator.calls[2] == evaluator.calls[3]  # sibling: same command both sides
+    # each pair measures pristine-vs-session, sibling exactly like the climbed
+    # metric: [baseline ws, session ws, sibling baseline ws, sibling session ws]
+    pristine = evaluator.seen_ws[0]
+    assert pristine.name == "pristine"
+    assert evaluator.seen_ws == [pristine, pristine.parent, pristine, pristine.parent]
     (row,) = result.suite
     assert row.name == "sokoban" and not row.regressed
     assert row.baseline == 0.8 and row.candidate == 0.8
@@ -691,3 +698,12 @@ def test_climb_once_refuses_a_read_only_spec(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="must allow execution"):
         run_climb(tmp_path, [13.876], spec=reviewer_spec())
+
+
+def test_shared_match_is_case_folded_like_the_other_path_checks(tmp_path: Path) -> None:
+    # a Model/ spelling must not dodge the gate (forbidden/steward checks fold too)
+    result, evaluator = run_shared_climb(
+        tmp_path, [13.876, 13.10, 0.8, 0.8], changed=["src/pilot/Model/encoder.py"]
+    )
+    assert result.outcome == "improved"
+    assert len(evaluator.calls) == 4  # the suite pass ran

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -528,3 +528,151 @@ def test_subprocess_evaluator_env_is_private_per_eval(tmp_path: Path) -> None:
     evaluator.evaluate(tmp_path, capture, "m")
     seen = (tmp_path / "seen.txt").read_text().split()
     assert len(seen) == 2 and seen[0] != seen[1]
+
+
+# ---- suite no-regression gate --------------------------------------------
+
+SHARED_CONTRACT = """
+benchmarks:
+  - name: tsp
+    command: uv run python -m pilot.eval --benchmark tsp --json
+    metric: mean_tour_length
+    direction: min
+  - name: sokoban
+    command: uv run python -m pilot.eval --benchmark sokoban --json
+    metric: solve_rate
+    direction: max
+budgets: {gpu_hours_per_run: 1, runs_per_week: 10}
+scope: {allowed: [src/pilot/], shared: [src/pilot/model/]}
+roadmap: docs/roadmap.md
+"""
+
+
+def run_shared_climb(tmp_path, values, changed, contract=SHARED_CONTRACT, **kw):
+    harness = FakeHarness(result=ok_session())
+    evaluator = FakeEvaluator(values=list(values))
+    baseline_ws = tmp_path / "pristine"
+    baseline_ws.mkdir(exist_ok=True)
+    result = climb_once(
+        CONFIG,
+        contract,
+        tmp_path,
+        harness,
+        evaluator,
+        ruler="mean tour length over the frozen pool",
+        changed_paths=lambda: changed,
+        created="2026-08-06T00:00:00Z",
+        baseline_workspace=kw.pop("baseline_workspace", baseline_ws),
+        **kw,
+    )
+    return result, evaluator
+
+
+def test_shared_diff_measures_every_sibling_and_passes(tmp_path: Path) -> None:
+    result, evaluator = run_shared_climb(
+        tmp_path, [13.876, 13.10, 0.8, 0.8], changed=["src/pilot/model/encoder.py"]
+    )
+    assert result.outcome == "improved"
+    # 2 climbed evals + a paired pass per sibling
+    assert len(evaluator.calls) == 4
+    assert evaluator.calls[2] == evaluator.calls[3]  # sibling: same command both sides
+    (row,) = result.suite
+    assert row.name == "sokoban" and not row.regressed
+    assert row.baseline == 0.8 and row.candidate == 0.8
+
+
+def test_shared_diff_regressing_a_sibling_loses_credit(tmp_path: Path) -> None:
+    result, _ = run_shared_climb(
+        tmp_path, [13.876, 13.10, 0.8, 0.5], changed=["src/pilot/model/encoder.py"]
+    )
+    assert result.outcome == "suite-regression"
+    assert "sokoban" in result.note and "0.8" in result.note
+    assert result.branch == ""  # no PR is opened from this outcome
+    (row,) = result.suite
+    assert row.regressed
+
+
+def test_env_specific_diff_skips_the_suite_pass(tmp_path: Path) -> None:
+    result, evaluator = run_shared_climb(
+        tmp_path, [13.876, 13.10], changed=["src/pilot/solvers/tsp.py"]
+    )
+    assert result.outcome == "improved"
+    assert len(evaluator.calls) == 2  # cheap path: only the climbed benchmark
+    assert result.suite == ()
+
+
+def test_sibling_floor_gives_a_stochastic_eval_its_tolerance(tmp_path: Path) -> None:
+    floored = SHARED_CONTRACT.replace(
+        "    direction: max\n", "    direction: max\n    min_delta: 0.05\n", 1
+    )
+    result, _ = run_shared_climb(
+        tmp_path, [13.876, 13.10, 0.8, 0.77], changed=["src/pilot/model/encoder.py"],
+        contract=floored,
+    )
+    assert result.outcome == "improved"  # a 0.03 drop sits inside sokoban's 0.05 floor
+    (row,) = result.suite
+    assert not row.regressed
+
+
+def test_shared_diff_without_pristine_baseline_fails_closed(tmp_path: Path) -> None:
+    result, _ = run_shared_climb(
+        tmp_path, [13.876, 13.10], changed=["src/pilot/model/encoder.py"],
+        baseline_workspace=None,
+    )
+    assert result.outcome == "eval-error"
+    assert "no pristine baseline workspace" in result.note
+
+
+def test_sibling_eval_failure_is_an_eval_error_naming_it(tmp_path: Path) -> None:
+    result, _ = run_shared_climb(
+        tmp_path, [13.876, 13.10, EvalError("harness crashed")],
+        changed=["src/pilot/model/encoder.py"],
+    )
+    assert result.outcome == "eval-error"
+    assert "suite sokoban" in result.note
+
+
+def test_seeded_sibling_pair_is_pinned_to_one_suite_seed(tmp_path: Path) -> None:
+    seeded = SHARED_CONTRACT.replace(
+        "    direction: max\n", "    direction: max\n    seed_env: PILOT_SOKOBAN_SEED\n", 1
+    )
+    result, evaluator = run_shared_climb(
+        tmp_path, [13.876, 13.10, 0.8, 0.8], changed=["src/pilot/model/encoder.py"],
+        contract=seeded,
+    )
+    assert result.outcome == "improved"
+    sib_envs = evaluator.seen_env[2:]
+    assert sib_envs[0] == sib_envs[1]  # paired: same seed both sides
+    assert sib_envs[0] and "PILOT_SOKOBAN_SEED" in sib_envs[0]
+    assert result.suite_seed > 0
+
+
+def test_suite_regressed_is_direction_aware_and_fails_closed() -> None:
+    from autoresearch.orchestrator import suite_regressed
+
+    assert suite_regressed(0.8, 0.5, "max")  # max: drop is a regression
+    assert not suite_regressed(0.8, 0.9, "max")
+    assert suite_regressed(10.0, 12.0, "min")  # min: rise is a regression
+    assert not suite_regressed(10.0, 9.0, "min")
+    assert not suite_regressed(0.8, 0.77, "max", min_delta=0.05)  # inside the floor
+    assert suite_regressed(0.8, 0.70, "max", min_delta=0.05)  # beyond it
+    assert suite_regressed(float("nan"), 0.8, "max")  # unmeasurable fails closed
+
+
+def test_pr_body_carries_the_suite_table(tmp_path: Path) -> None:
+    result, _ = run_shared_climb(
+        tmp_path, [13.876, 13.10, 0.8, 0.8], changed=["src/pilot/model/encoder.py"]
+    )
+    body = pr_body(result, CONFIG, redact_secrets=())
+    assert "| sokoban | 0.8 | 0.8 |" in body
+    assert "none regressed beyond its floor" in body
+
+
+def test_task_names_the_suite_gate_only_when_it_exists(tmp_path: Path) -> None:
+    from autoresearch.contract import load_contract
+    from autoresearch.orchestrator import make_task
+
+    gated = make_task(load_contract(SHARED_CONTRACT, "org/pilot"), "tsp", 13.876)
+    assert "suite-gated" in gated.done_criteria
+    ungated = make_task(load_contract(CONTRACT, "org/pilot"), "tsp", 13.876)
+    assert "suite-gated" not in ungated.done_criteria


### PR DESCRIPTION
## What

The suite no-regression gate, un-parked now that the driver collapse (#85–#87) is complete — the yolo-jepa climb lessons (#2, #5: real levers that exploit one benchmark's structure) turned into a mechanical gate.

- **Contract**: `scope.shared` declares shared code paths (encoder, world model, training loop). Same load-time rigor as `allowed` (forbidden-overlap checks).
- **Gate** (`climb_once`, kernel): a solver diff touching a shared path is only credited after **every sibling benchmark is re-measured on both sides** (pristine baseline workspace vs candidate, one paired suite seed). A sibling regressing beyond **its own floor** (`min_delta`/`min_delta_rel`; floor 0 when undeclared — paired seeds make that sane) ends the run as `suite-regression`, an honest negative with the regressing benchmark named. Env-specific diffs stay cheap: only their benchmark is measured.
- **Freshness**: when the base moved, the suite gate re-runs on the merged tree (same worktree machinery as the climbed metric) — the gate holds on the tree that actually lands.
- **Surfaces**: the PR body carries the suite table ("shared code was touched … none regressed beyond its floor"); the run report lists per-sibling rows; the author's task names the rule when the contract declares shared paths.
- Fail-closed: no pristine baseline workspace → no silent pass; a sibling eval error names the sibling.

## Named gaps (deliberate)

- Follow-up pushes are not yet suite-gated (roadmap line; wires into the follow-up re-measure next).
- The gate triggers on path contact, not diff semantics — a shared-path comment edit pays the suite pass. Cheap and safe beats clever.

## Tests

13 gate tests: trigger/skip paths, per-direction regression + floor tolerance, paired sibling seeds, fail-closed branches, PR table, task wording, contract validation, and a live climb test proving the merged-tree re-gate vetoes the push. 525 total green; full gate clean.

History note: built before the collapse, parked on this branch, main merged in (merge commit — the only conflicts were appended test blocks). The orchestrator-side gate survived unchanged; only the climb.py wiring was re-verified against the new shape.
