### PR TITLE
Least-token split: terra/open-model second opinions on the auto path

### DIFF
--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -9,9 +9,10 @@
 # TOOL SET (no Write/Edit/Bash). The other backends can't be trusted next to the
 # step's GITHUB_TOKEN here: codex reads by executing shell, and hermes's `file`
 # tool reads arbitrary paths — either can open /proc/<pid>/environ and lift the
-# token. Running them safely needs the tokenless split (findings -> artifact, a
-# separate step posts), which does not exist yet. Until then they run only from
-# the manual bench (review-agent.yml), where a human opts in with that caveat.
+# token. They run on the auto path via the LEAST-TOKEN SPLIT instead:
+# advisory-second-opinion.yml (read-only session job emits findings; a separate
+# posting job holds the write token with no session next to it). The manual
+# bench (review-agent.yml) remains for one-off experiments.
 name: advisory-review-agent
 
 on:

--- a/.github/workflows/advisory-second-opinion.yml
+++ b/.github/workflows/advisory-second-opinion.yml
@@ -39,6 +39,14 @@ on:
         type: string
         required: false
         default: second opinion
+      lens_id:
+        description: >-
+          Slug distinguishing this opinion's artifact and concurrency group
+          when a caller runs the SAME backend twice (two models). Defaults to
+          the backend name.
+        type: string
+        required: false
+        default: ''
       reviewer_repo:
         description: Repo holding the reviewer (change this if you forked).
         type: string
@@ -68,7 +76,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: advisory-second-opinion-${{ github.event.pull_request.number }}
+  group: advisory-second-opinion-${{ inputs.lens_id || inputs.backend }}-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
 jobs:
@@ -143,9 +151,12 @@ jobs:
           REVIEW_EMIT_FILE: ${{ runner.temp }}/findings.json
         run: uv run python -m autoresearch.review_agent_cli
       - name: Upload findings
+        # not `success()`: a session step that died AFTER emitting must still
+        # deliver its findings (or its skip-stub) to the posting job
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: second-opinion-findings-${{ env.PR_NUMBER }}
+          name: second-opinion-findings-${{ inputs.lens_id || inputs.backend }}-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}/findings.json
           if-no-files-found: ignore
           retention-days: 3
@@ -180,7 +191,7 @@ jobs:
         continue-on-error: true  # no artifact = clean skip upstream
         uses: actions/download-artifact@v4
         with:
-          name: second-opinion-findings-${{ env.PR_NUMBER }}
+          name: second-opinion-findings-${{ inputs.lens_id || inputs.backend }}-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}
       - name: Post the findings
         if: steps.findings.outcome == 'success'

--- a/.github/workflows/advisory-second-opinion.yml
+++ b/.github/workflows/advisory-second-opinion.yml
@@ -13,6 +13,12 @@
 #     posts through the normal advisory path.
 # Same constraints as the primary reviewer: never reviews bot PRs, never
 # approves, never fails the caller's CI, same-repo PRs only.
+#
+# Two behaviors by design: the "Round N" counter is SHARED with the primary
+# reviewer (concurrent rounds may number non-monotonically — the number is
+# cosmetic, the Lens label says who); and a missing/expired backend key posts
+# a fresh could-not-run stub per triggering PR until fixed — the noise IS the
+# warning (maintainer requirement: key failures must never be silent).
 name: advisory-second-opinion
 
 on:

--- a/.github/workflows/advisory-second-opinion.yml
+++ b/.github/workflows/advisory-second-opinion.yml
@@ -1,0 +1,195 @@
+# Reusable SECOND-OPINION reviewer: a non-Claude backend (hermes/terra, codex)
+# complementing the Claude advisory round, via the LEAST-TOKEN SPLIT.
+#
+# Why two jobs: these backends can read arbitrary paths or execute shell, so
+# they must never run next to a write-capable GITHUB_TOKEN (/proc reach —
+# docs/design/reviewer-infra.md). Split:
+#   session job — READ-ONLY permissions. The only secrets present are the
+#     session's own model key and a token whose theft buys read access to a
+#     repo the session is already reading, expiring with the job. Emits raw
+#     findings as an artifact; posts nothing.
+#   post job — holds pull-requests:write, runs NO model session. Re-validates
+#     the envelope (right PR, skip rules re-checked, sanitizing render) and
+#     posts through the normal advisory path.
+# Same constraints as the primary reviewer: never reviews bot PRs, never
+# approves, never fails the caller's CI, same-repo PRs only.
+name: advisory-second-opinion
+
+on:
+  workflow_call:
+    inputs:
+      bot_login:
+        description: Login of your bot account — its PRs are never reviewed. Required.
+        type: string
+        required: true
+      backend:
+        description: Second-opinion backend (hermes | codex).
+        type: string
+        required: false
+        default: hermes
+      model:
+        description: >-
+          Model for the session. For hermes pass an OpenRouter id (e.g. the
+          terra or deepseek id); empty uses the backend default.
+        type: string
+        required: false
+        default: ''
+      lens_label:
+        description: Short label shown on the posted round (who this opinion is).
+        type: string
+        required: false
+        default: second opinion
+      reviewer_repo:
+        description: Repo holding the reviewer (change this if you forked).
+        type: string
+        required: false
+        default: agentic-learning-ai-lab/autoresearch
+      reviewer_ref:
+        description: Ref of the reviewer to run. Pin to a tag or SHA in production.
+        type: string
+        required: false
+        default: main
+    secrets:
+      openrouter_api_key:
+        description: OpenRouter key for the hermes backend.
+        required: false
+      openai_reviewer_key:
+        description: OpenAI key for the codex backend.
+        required: false
+      checkout_ssh_key:
+        description: >-
+          Read-only deploy key for the reviewer repo, needed while it is
+          private; omit once public.
+        required: false
+
+# The caller grants this much; each job below narrows it further.
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: advisory-second-opinion-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  session:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 70
+    # Fork PRs must not reach any secret (pull_request_target context).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    # READ-ONLY: the session runs here, so the job token must not be worth
+    # stealing. pull-requests:read lets the CLI fetch the PR metadata/diff.
+    permissions:
+      contents: read
+      pull-requests: read
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      BACKEND: ${{ inputs.backend }}
+    steps:
+      - name: Check out the reviewer
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.reviewer_repo }}
+          ref: ${{ inputs.reviewer_ref }}
+          ssh-key: ${{ secrets.checkout_ssh_key }}
+          path: .autoresearch
+          persist-credentials: false
+      - name: Check out the PR head (read-only; never executed)
+        uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ env.PR_NUMBER }}/head
+          path: pr-head
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: .autoresearch/uv.lock
+      # Pinned artifacts, same discipline as the manual bench.
+      - name: Install the ${{ inputs.backend }} backend
+        env:
+          HERMES_REF: v2026.8.13
+        run: |
+          set -euo pipefail
+          case "$BACKEND" in
+            codex)
+              npm install -g @openai/codex@0.130.0
+              ;;
+            hermes)
+              git clone --depth 1 --branch "$HERMES_REF" \
+                https://github.com/NousResearch/hermes-agent \
+                "$GITHUB_WORKSPACE/hermes-agent"
+              ;;
+            *)
+              echo "unsupported second-opinion backend: $BACKEND" >&2
+              exit 0  # advisory: never red the caller's CI
+              ;;
+          esac
+      - name: Run the session (emit only — nothing posted from this job)
+        working-directory: .autoresearch
+        env:
+          REVIEW_BACKEND: ${{ inputs.backend }}
+          REVIEW_MODEL: ${{ inputs.model }}
+          OPENROUTER_API_KEY: ${{ secrets.openrouter_api_key }}
+          OPENAI_REVIEWER_KEY: ${{ secrets.openai_reviewer_key }}
+          REVIEW_CODEX_LEGACY_LANDLOCK: ${{ inputs.backend == 'codex' && '1' || '' }}
+          REVIEW_HERMES_REPO: ${{ github.workspace }}/hermes-agent
+          REVIEW_HERMES_PROVIDER: openrouter
+          # read-only job token: PR metadata/diff fetch only
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_REPO: ${{ github.repository }}
+          REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
+          REVIEW_CHECKOUT: ${{ github.workspace }}/pr-head
+          REVIEW_EMIT_FILE: ${{ runner.temp }}/findings.json
+        run: uv run python -m autoresearch.review_agent_cli
+      - name: Upload findings
+        uses: actions/upload-artifact@v4
+        with:
+          name: second-opinion-findings-${{ env.PR_NUMBER }}
+          path: ${{ runner.temp }}/findings.json
+          if-no-files-found: ignore
+          retention-days: 3
+
+  post:
+    runs-on: ubuntu-latest
+    needs: session
+    if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
+    continue-on-error: true
+    timeout-minutes: 15
+    # The write half: no model session runs in this job.
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Check out the reviewer
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.reviewer_repo }}
+          ref: ${{ inputs.reviewer_ref }}
+          ssh-key: ${{ secrets.checkout_ssh_key }}
+          path: .autoresearch
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: .autoresearch/uv.lock
+      - name: Download findings
+        id: findings
+        continue-on-error: true  # no artifact = clean skip upstream
+        uses: actions/download-artifact@v4
+        with:
+          name: second-opinion-findings-${{ env.PR_NUMBER }}
+          path: ${{ runner.temp }}
+      - name: Post the findings
+        if: steps.findings.outcome == 'success'
+        working-directory: .autoresearch
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ env.PR_NUMBER }}
+          REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
+          REVIEW_EMIT_FILE: ${{ runner.temp }}/findings.json
+          REVIEW_LENS_LABEL: ${{ inputs.lens_label }}
+        run: uv run python -m autoresearch.review_post_cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Versions follow [SemVer](https://semver.org).
   calling the new reusable next to the Claude one. On private repos the
   session job carries a read-scoped token only; it becomes tokenless at the
   public flip.
+- Every judge round now names its reviewer in the round stamp —
+  ``reviewer `backend/model`​`` (e.g. `claude/claude-opus-5`, `hermes/<terra
+  id>`) — on advisory rounds, second opinions (via the envelope), and
+  verifier rounds alike, so multi-reviewer threads read unambiguously.
 - Suite no-regression gate: contracts may declare `scope.shared` (shared code
   paths — encoder, world model, training loop). A solver diff touching one is
   only credited after every sibling benchmark is re-measured on both sides

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Second-opinion reviews from non-Claude backends on the auto path, via the
+  least-token split (`advisory-second-opinion.yml`): a read-only session job
+  runs the backend (hermes/terra via OpenRouter, or codex) and emits raw
+  findings as an artifact; a separate posting job — no session — re-validates
+  the envelope (right PR, bot-skip re-checked, sanitizing render) and posts
+  through the normal advisory path with a `Lens:` label. Targets opt in by
+  calling the new reusable next to the Claude one. On private repos the
+  session job carries a read-scoped token only; it becomes tokenless at the
+  public flip.
 - Suite no-regression gate: contracts may declare `scope.shared` (shared code
   paths — encoder, world model, training loop). A solver diff touching one is
   only credited after every sibling benchmark is re-measured on both sides

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -158,7 +158,9 @@ merge. The STRONGER containment is now built as the **least-token split**
 (`advisory-second-opinion.yml`): the session job holds read-only permissions
 (on a private repo the checkout still needs `contents: read`, so token theft
 buys read access to a repo the session is already reading, expiring with the
-job), and the posting job holds the write token with no session next to it.
+job; the read-only deploy key for the private reviewer repo is present for
+the same reason and in the same blast-radius class), and the posting job
+holds the write token with no session next to it.
 The residual read-scoped token drops to zero at the public flip.
 
 What is safe today, precisely. The agent workflows run only on same-repo PRs

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -154,9 +154,12 @@ it) plus the read-only tool set — and, on the auto path, only Claude, whose
 leaked spend-capped key is capped spend until rotation, not open-ended
 credential loss; a prompt-injected agent's text reaches a repo comment through
 the posting path, so the worst case is a wrong comment (read by a human), not a
-merge. The STRONGER containment — the tokenless split workflow (a sandboxed
-agent step with no write token → findings artifact → a separate minimal posting
-step) — is the fork-PR-phase work, NOT yet built.
+merge. The STRONGER containment is now built as the **least-token split**
+(`advisory-second-opinion.yml`): the session job holds read-only permissions
+(on a private repo the checkout still needs `contents: read`, so token theft
+buys read access to a repo the session is already reading, expiring with the
+job), and the posting job holds the write token with no session next to it.
+The residual read-scoped token drops to zero at the public flip.
 
 What is safe today, precisely. The agent workflows run only on same-repo PRs
 (the reviewer via `pull_request_target`'s same-repo gate; the verifier only on
@@ -172,8 +175,9 @@ model.
 ## What's next
 
 The harness runs read-only agent sessions over the PR-head checkout — that part
-is done. Still to build: the `retrieve` tool contract and the broker, added
-without changing the harness. The meta-benchmark scores whether a change catches
+is done, and the least-token split now carries non-Claude second opinions on
+the auto path. Still to build: the `retrieve` tool contract and the broker,
+added without changing the harness. The meta-benchmark scores whether a change catches
 more seeded gaming per dollar before it ships.
 
 ## Open decisions
@@ -247,14 +251,16 @@ namespace / `hidepid`), which the GitHub-hosted runners do not give us. Env
 scrub, read-only tool sets, and no-egress sandboxes each close a different hole
 but NONE closes the `/proc` read while the token sits in a parent process.
 
-Consequence for deployment: the **auto path is claude-only**, and that is now
-proven sound — Claude is write-safe, exec-safe, AND `/proc`-safe (probe above).
-codex and hermes reach `/proc` (shell / file read), so they run only from the
-manual bench (informed `/proc` caveat) or the cluster. The tokenless split is
-the prerequisite before THOSE path-opening backends are trusted next to a live
-token on the auto path; Claude does not need it for this vector. The split is
-still the same infrastructure the fork-PR public phase needs (untrusted code
-next to a token), so it lands there regardless.
+Consequence for deployment: the **single-job auto path is claude-only**, and
+that is proven sound — Claude is write-safe, exec-safe, AND `/proc`-safe
+(probe above). codex and hermes reach `/proc` (shell / file read), so they
+never run next to a write token: on the auto path they run through the
+least-token split (`advisory-second-opinion.yml` — read-only session job
+emits findings, a separate posting job writes), and the manual bench remains
+for one-off experiments. On private repos the split's session job still
+carries a read-scoped token (worst case: reading a repo the session already
+reads); at the public flip the checkout needs no token and the session job
+becomes truly tokenless — the same infrastructure the fork-PR phase needs.
 
 Re-test on version bumps: whether Claude's `Read` opens `/proc`, a hermes
 read-only toolset, a codex sandbox that hides `/proc`, or a runner that grants

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -135,6 +135,22 @@ OUTAGE_PATTERNS = (
 )
 
 
+def backend_id(harness: object) -> str:
+    """`backend/model` attribution for a round stamp — which reviewer wrote
+    this. Empty for unknown harness types (test fakes): the stamp then omits
+    the reviewer clause rather than naming something misleading."""
+    names = {
+        "ClaudeCodeHarness": "claude",
+        "CodexHarness": "codex",
+        "HermesHarness": "hermes",
+    }
+    backend = names.get(type(harness).__name__, "")
+    if not backend:
+        return ""
+    model = str(getattr(harness, "model", "") or "").strip()
+    return f"{backend}/{model}" if model else backend
+
+
 def outage(result: SessionResult) -> bool:
     """True when the session failed because the API refused us — dead
     credits, spend cap, bad key, throttling — not because of anything in

--- a/src/autoresearch/posting.py
+++ b/src/autoresearch/posting.py
@@ -29,7 +29,13 @@ EXPECTED_FAILURES = (
 
 
 def post_round(
-    client: GitHubClient, repo: str, number: int, marker: str, body: str, pr_data: dict
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    marker: str,
+    body: str,
+    pr_data: dict,
+    reviewed_by: str = "",
 ) -> str:
     """Post one NEW comment per round — numbered, stamped with the reviewed
     head — so every round notifies and stays visible (edits do neither).
@@ -38,13 +44,18 @@ def post_round(
     synchronize-triggered spam; runs are now only PR-open or an explicit
     label request, so volume is human-bounded.
     """
-    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
+    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data, reviewed_by)
     client.comment(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1))
     return round_label
 
 
 def _round_stamp(
-    client: GitHubClient, repo: str, number: int, marker: str, pr_data: dict
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    marker: str,
+    pr_data: dict,
+    reviewed_by: str = "",
 ) -> tuple[str, str]:
     """(stamp line, round label): prior rounds are counted across BOTH
     issue comments and review bodies, so switching a role between posting
@@ -68,7 +79,11 @@ def _round_stamp(
     except EXPECTED_FAILURES as exc:
         log.warning("could not count prior rounds: %s", exc)
         round_label = "**New round** (prior count unavailable)"
-    return f"{round_label} — reviewed head `{head_sha or 'unknown'}`.\n\n", round_label
+    # attribution is render-side data (it can cross a job boundary in the
+    # least-token split): strip backticks/newlines, cap, never trust
+    by = " ".join(str(reviewed_by).split()).replace("`", "")[:60]
+    by_clause = f" — reviewer `{by}`" if by else ""
+    return f"{round_label} — reviewed head `{head_sha or 'unknown'}`{by_clause}.\n\n", round_label
 
 
 def post_round_review(
@@ -80,6 +95,7 @@ def post_round_review(
     inline: list[dict],
     pr_data: dict,
     fallback_body: str,
+    reviewed_by: str = "",
 ) -> str:
     """The Reviews-API sibling of post_round: body summary plus anchored
     inline comments, event COMMENT always (the client hard-codes it). A
@@ -87,7 +103,7 @@ def post_round_review(
     fallback_body — the FULL single-comment rendering, because the review
     body alone may say no more than "findings are attached" while the
     findings live in the rejected inline payload."""
-    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data)
+    stamp, round_label = _round_stamp(client, repo, number, marker, pr_data, reviewed_by)
     try:
         client.create_pr_review(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1), inline)
     except EXPECTED_FAILURES as exc:

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -10,9 +10,11 @@ the same rubric (via `build_agent_brief`), the same result policy
 
 from __future__ import annotations
 
+import json
 import logging
 from datetime import UTC, datetime
 from pathlib import Path
+from typing import Any
 
 from autoresearch.github import GitHubClient
 from autoresearch.harness import (
@@ -174,6 +176,23 @@ def _pull_request(client: GitHubClient, repo: str, number: int) -> tuple[PullReq
     return pr, pr_data
 
 
+def _emit(
+    path: Path,
+    repo: str,
+    number: int,
+    *,
+    kind: str,
+    data: dict[str, Any] | None = None,
+    detail: str = "",
+) -> None:
+    """Write the posting step's input. repo/number ride along so the poster
+    can refuse an envelope that does not match its own PR reference."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"repo": repo, "number": number, "kind": kind, "data": data, "detail": detail})
+    )
+
+
 def run_agent_review(
     client: GitHubClient,
     repo: str,
@@ -184,12 +203,19 @@ def run_agent_review(
     bot_login: str,
     spec: RoleSpec | None = None,
     today: str | None = None,
+    emit_path: Path | None = None,
 ) -> str | None:
     """Review PR #`number` as an agent session over `workspace` (a read-only
     PR-head checkout the caller prepared). Post the findings inline via the
     Reviews API. Returns the round label, or None when it skipped or could not
     produce a verdict. Advisory: never raises the expected failures, so it can
     never turn a target repo's CI red.
+
+    With `emit_path`, nothing is posted: the raw findings (or a skip-stub
+    marker) are written there for a separate posting step — the least-token
+    split (docs/design/reviewer-infra.md). The session job runs with read-only
+    permissions; the posting job holds the write token but runs no session.
+    A clean skip (bot PR, opt-out, empty diff) writes nothing.
     """
     spec = spec or reviewer_spec()
     today = today or datetime.now(UTC).date().isoformat()
@@ -211,8 +237,19 @@ def run_agent_review(
             if outage(role_result.session) or budget_exhausted(role_result.session):
                 # `detail` is already api-key-redacted by the harness (it owns
                 # its own secret), so no secrets are passed here.
-                post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
+                if emit_path is not None:
+                    _emit(emit_path, repo, number, kind="skip-stub", detail=detail)
+                else:
+                    post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
             return None
+
+        if emit_path is not None:
+            # raw data, not rendered text: the posting step re-validates and
+            # sanitizes at the render boundary, so the artifact crossing the
+            # job boundary carries no pre-trusted markup
+            _emit(emit_path, repo, number, kind="findings", data=role_result.data)
+            log.info("emitted findings for %s#%s to %s", repo, number, emit_path)
+            return "emitted"
 
         rendered = format_review(review, pr.diff)
         full = format_comment(review)

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -22,6 +22,7 @@ from autoresearch.harness import (
     CodexHarness,
     Harness,
     HermesHarness,
+    backend_id,
     budget_exhausted,
     outage,
 )
@@ -184,12 +185,23 @@ def _emit(
     kind: str,
     data: dict[str, Any] | None = None,
     detail: str = "",
+    reviewed_by: str = "",
 ) -> None:
     """Write the posting step's input. repo/number ride along so the poster
-    can refuse an envelope that does not match its own PR reference."""
+    can refuse an envelope that does not match its own PR reference;
+    reviewed_by (backend/model) rides along for the round stamp."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
-        json.dumps({"repo": repo, "number": number, "kind": kind, "data": data, "detail": detail})
+        json.dumps(
+            {
+                "repo": repo,
+                "number": number,
+                "kind": kind,
+                "data": data,
+                "detail": detail,
+                "reviewed_by": reviewed_by,
+            }
+        )
     )
 
 
@@ -238,7 +250,14 @@ def run_agent_review(
                 # `detail` is already api-key-redacted by the harness (it owns
                 # its own secret), so no secrets are passed here.
                 if emit_path is not None:
-                    _emit(emit_path, repo, number, kind="skip-stub", detail=detail)
+                    _emit(
+                        emit_path,
+                        repo,
+                        number,
+                        kind="skip-stub",
+                        detail=detail,
+                        reviewed_by=backend_id(harness),
+                    )
                 else:
                     post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
             return None
@@ -247,7 +266,14 @@ def run_agent_review(
             # raw data, not rendered text: the posting step re-validates and
             # sanitizes at the render boundary, so the artifact crossing the
             # job boundary carries no pre-trusted markup
-            _emit(emit_path, repo, number, kind="findings", data=role_result.data)
+            _emit(
+                emit_path,
+                repo,
+                number,
+                kind="findings",
+                data=role_result.data,
+                reviewed_by=backend_id(harness),
+            )
             log.info("emitted findings for %s#%s to %s", repo, number, emit_path)
             return "emitted"
 
@@ -258,7 +284,15 @@ def run_agent_review(
             return None
         body, inline = rendered
         round_label = post_round_review(
-            client, repo, number, MARKER, body, inline, pr_data, fallback_body=full
+            client,
+            repo,
+            number,
+            MARKER,
+            body,
+            inline,
+            pr_data,
+            fallback_body=full,
+            reviewed_by=backend_id(harness),
         )
         log.info("posted agent review (%s) on %s#%s", round_label, repo, number)
         return round_label

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -13,7 +13,12 @@ import sys
 from pathlib import Path
 
 from autoresearch.github import EnvTokenProvider, GitHubClient
-from autoresearch.review_agent import build_reviewer_harness, run_agent_review, sanitize_checkout
+from autoresearch.review_agent import (
+    _emit,
+    build_reviewer_harness,
+    run_agent_review,
+    sanitize_checkout,
+)
 
 log = logging.getLogger(__name__)
 
@@ -45,9 +50,21 @@ def main() -> int:
     if key_var is None:
         log.warning("unknown REVIEW_BACKEND %r; skipping review", backend)
         return 0
+    emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
     api_key = os.environ.get(key_var, "").strip()
     if not api_key:
         log.warning("%s is unset or empty; skipping review", key_var)
+        if emit_env:
+            # a standing second-opinion service must not die silently when
+            # its key is missing or rotates out (keys expire): the stub the
+            # post job publishes is the PR-visible warning
+            _emit(
+                Path(emit_env).resolve(),
+                repo,
+                number,
+                kind="skip-stub",
+                detail=f"{key_var} is unset or empty",
+            )
         return 0
     # Backend-specific deployment config, resolved from env so the workflow
     # (which knows the host) supplies it, never the pure builder:
@@ -102,7 +119,6 @@ def main() -> int:
     # separate posting job (review_post_cli) holds the write token with no
     # session next to it. This is what makes non-Claude backends safe on the
     # auto path (docs/design/reviewer-infra.md).
-    emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
     run_agent_review(
         client,
         repo,

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -97,6 +97,12 @@ def main() -> int:
         provider=provider,
         sandbox_extra=sandbox_extra,
     )
+    # Least-token split: with REVIEW_EMIT_FILE set, findings are written there
+    # instead of posted — this job then needs only READ permissions, and a
+    # separate posting job (review_post_cli) holds the write token with no
+    # session next to it. This is what makes non-Claude backends safe on the
+    # auto path (docs/design/reviewer-infra.md).
+    emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
     run_agent_review(
         client,
         repo,
@@ -104,6 +110,7 @@ def main() -> int:
         harness,
         workspace,
         bot_login=bot_login,
+        emit_path=Path(emit_env).resolve() if emit_env else None,
     )
     return 0
 

--- a/src/autoresearch/review_post_cli.py
+++ b/src/autoresearch/review_post_cli.py
@@ -93,7 +93,15 @@ def post_from_file(
             body = body.replace(MARKER, f"{MARKER}\n**Lens:** {label}", 1)
             full = full.replace(MARKER, f"{MARKER}\n**Lens:** {label}", 1)
         round_label = post_round_review(
-            client, repo, number, MARKER, body, inline, pr_data, fallback_body=full
+            client,
+            repo,
+            number,
+            MARKER,
+            body,
+            inline,
+            pr_data,
+            fallback_body=full,
+            reviewed_by=str(envelope.get("reviewed_by", "")),
         )
         log.info("posted second-opinion review (%s) on %s#%s", round_label, repo, number)
         return round_label

--- a/src/autoresearch/review_post_cli.py
+++ b/src/autoresearch/review_post_cli.py
@@ -19,7 +19,14 @@ from pathlib import Path
 
 from autoresearch.github import EnvTokenProvider, GitHubClient
 from autoresearch.posting import EXPECTED_FAILURES, post_round_review, post_skip_stub
-from autoresearch.review import MARKER, format_comment, format_review, result_from_data, skip_reason
+from autoresearch.review import (
+    MARKER,
+    format_comment,
+    format_review,
+    result_from_data,
+    sanitize,
+    skip_reason,
+)
 from autoresearch.review_agent import _pull_request
 
 log = logging.getLogger(__name__)
@@ -52,22 +59,25 @@ def post_from_file(
         log.warning("findings envelope names a different PR; refused")
         return None
     kind = envelope.get("kind")
+    if kind not in ("skip-stub", "findings"):
+        log.warning("unknown envelope kind %r; nothing posted", kind)
+        return None
     try:
-        if kind == "skip-stub":
-            detail = str(envelope.get("detail", ""))[:300]
-            post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
-            return "skip-stub"
-        if kind != "findings":
-            log.warning("unknown envelope kind %r; nothing posted", kind)
-            return None
+        # The write authority re-checks the skip rules for EVERY kind: the
+        # session job decided them once, but this side of the artifact
+        # boundary is the one that must never post on a bot PR — a forged
+        # stub envelope is still a post.
         pr, pr_data = _pull_request(client, repo, number)
-        # The write authority re-checks the skip rules: the session job
-        # decided them once, but this side of the artifact boundary is the
-        # one that must never post on a bot PR.
         skip = skip_reason(pr, bot_login)
         if skip is not None:
             log.info("skipping post on %s#%s: %s", repo, number, skip)
             return None
+        if kind == "skip-stub":
+            # sanitize: the detail crossed the job boundary and lands in a
+            # comment — collapse newlines, neutralize markdown, cap length
+            detail = sanitize(str(envelope.get("detail", "")), 300)
+            post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
+            return "skip-stub"
         data = envelope.get("data")
         review = result_from_data(data if isinstance(data, dict) else {})
         rendered = format_review(review, pr.diff)
@@ -77,9 +87,11 @@ def post_from_file(
             return None
         body, inline = rendered
         if lens_label:
+            # AFTER the marker, never before it: round counting and the
+            # quote-reply defense both match marker-FIRST bodies
             label = " ".join(lens_label.split())[:MAX_LENS_LABEL]
-            body = f"**Lens:** {label}\n\n{body}"
-            full = f"**Lens:** {label}\n\n{full}"
+            body = body.replace(MARKER, f"{MARKER}\n**Lens:** {label}", 1)
+            full = full.replace(MARKER, f"{MARKER}\n**Lens:** {label}", 1)
         round_label = post_round_review(
             client, repo, number, MARKER, body, inline, pr_data, fallback_body=full
         )

--- a/src/autoresearch/review_post_cli.py
+++ b/src/autoresearch/review_post_cli.py
@@ -1,0 +1,125 @@
+"""Posting half of the least-token split.
+
+Reads the findings file the session job emitted (`REVIEW_EMIT_FILE`),
+re-validates it, and posts through the normal advisory path. This job holds
+the write token; no model session runs next to it. The artifact crosses a
+job boundary, so nothing in it is trusted: the envelope must name this PR,
+the skip rules are re-checked, and every string passes the same sanitizing
+render as the single-job path. Exits 0 on every failure — advisory means
+advisory.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from autoresearch.github import EnvTokenProvider, GitHubClient
+from autoresearch.posting import EXPECTED_FAILURES, post_round_review, post_skip_stub
+from autoresearch.review import MARKER, format_comment, format_review, result_from_data, skip_reason
+from autoresearch.review_agent import _pull_request
+
+log = logging.getLogger(__name__)
+
+# A lens label rides into the round body so a human can tell the second
+# opinion from the primary reviewer at a glance. Caller-configured, but
+# rendered into a comment: length-capped and newline-stripped.
+MAX_LENS_LABEL = 80
+
+
+def post_from_file(
+    client: GitHubClient,
+    repo: str,
+    number: int,
+    bot_login: str,
+    path: Path,
+    lens_label: str = "",
+) -> str | None:
+    """Post the emitted findings (or skip stub). Returns the round label, or
+    None when there was nothing to post or the envelope was refused."""
+    try:
+        envelope = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("findings file unreadable (%s); nothing posted", exc)
+        return None
+    if not isinstance(envelope, dict):
+        log.warning("findings file is not an object; nothing posted")
+        return None
+    if envelope.get("repo") != repo or envelope.get("number") != number:
+        log.warning("findings envelope names a different PR; refused")
+        return None
+    kind = envelope.get("kind")
+    try:
+        if kind == "skip-stub":
+            detail = str(envelope.get("detail", ""))[:300]
+            post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
+            return "skip-stub"
+        if kind != "findings":
+            log.warning("unknown envelope kind %r; nothing posted", kind)
+            return None
+        pr, pr_data = _pull_request(client, repo, number)
+        # The write authority re-checks the skip rules: the session job
+        # decided them once, but this side of the artifact boundary is the
+        # one that must never post on a bot PR.
+        skip = skip_reason(pr, bot_login)
+        if skip is not None:
+            log.info("skipping post on %s#%s: %s", repo, number, skip)
+            return None
+        data = envelope.get("data")
+        review = result_from_data(data if isinstance(data, dict) else {})
+        rendered = format_review(review, pr.diff)
+        full = format_comment(review)
+        if rendered is None or full is None:
+            log.info("nothing to post")
+            return None
+        body, inline = rendered
+        if lens_label:
+            label = " ".join(lens_label.split())[:MAX_LENS_LABEL]
+            body = f"**Lens:** {label}\n\n{body}"
+            full = f"**Lens:** {label}\n\n{full}"
+        round_label = post_round_review(
+            client, repo, number, MARKER, body, inline, pr_data, fallback_body=full
+        )
+        log.info("posted second-opinion review (%s) on %s#%s", round_label, repo, number)
+        return round_label
+    except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
+        log.warning("posting did not complete: %s: %s", type(exc).__name__, exc)
+        return None
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    repo = os.environ.get("PR_REPO", "").strip()
+    number_raw = os.environ.get("PR_NUMBER", "").strip()
+    if not repo or not number_raw.isdigit():
+        log.warning("PR_REPO/PR_NUMBER unset or invalid; skipping")
+        return 0
+    bot_login = os.environ.get("REVIEW_BOT_LOGIN", "").strip()
+    if not bot_login:
+        log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot re-check the bot skip)")
+        return 0
+    emit_file = os.environ.get("REVIEW_EMIT_FILE", "").strip()
+    if not emit_file:
+        log.warning("REVIEW_EMIT_FILE is unset; skipping")
+        return 0
+    path = Path(emit_file).resolve()
+    if not path.is_file():
+        log.info("no findings file at %s (clean skip upstream); nothing to post", path)
+        return 0
+    client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
+    post_from_file(
+        client,
+        repo,
+        int(number_raw),
+        bot_login,
+        path,
+        lens_label=os.environ.get("REVIEW_LENS_LABEL", "").strip(),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/autoresearch/verify_agent.py
+++ b/src/autoresearch/verify_agent.py
@@ -17,7 +17,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from autoresearch.github import GitHubClient
-from autoresearch.harness import Harness, budget_exhausted, outage
+from autoresearch.harness import Harness, backend_id, budget_exhausted, outage
 from autoresearch.posting import EXPECTED_FAILURES, post_round, post_skip_stub
 from autoresearch.review_agent import _pull_request
 from autoresearch.role_runner import run_role
@@ -101,7 +101,9 @@ def run_agent_verify(
         if body is None:
             log.info("nothing to post")
             return None
-        round_label = post_round(client, repo, number, VERIFY_MARKER, body, pr_data)
+        round_label = post_round(
+            client, repo, number, VERIFY_MARKER, body, pr_data, reviewed_by=backend_id(harness)
+        )
         log.info("posted verification (%s) on %s#%s", round_label, repo, number)
         return round_label
     except EXPECTED_FAILURES as exc:  # advisory role: never fail the target's CI

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -425,7 +425,12 @@ def test_post_from_file_posts_with_lens_label(tmp_path: Path) -> None:
     )
     assert label is not None
     body, inline = client.reviews[0]
-    assert body.startswith("**Lens:** second opinion — terra via hermes")
+    # marker stays FIRST (round counting + quote-reply defense); lens after it
+    from autoresearch.review import MARKER
+
+    assert body.lstrip().startswith(MARKER)  # marker first, then the round stamp
+    assert "**Lens:** second opinion — terra via hermes" in body
+    assert body.index(MARKER) < body.index("**Lens:**")
     assert any(c.get("path") == "models/encoder.py" for c in inline)
 
 
@@ -468,3 +473,22 @@ def test_post_from_file_publishes_the_skip_stub(tmp_path: Path) -> None:
     assert label == "skip-stub"
     assert client.reviews == []
     assert len(client.comments) == 1 and "could not run" in client.comments[0]
+
+
+def test_post_from_file_stub_is_skip_checked_and_sanitized(tmp_path: Path) -> None:
+    # a forged stub envelope is still a post: bot-skip re-checked, and the
+    # detail is sanitized (no fresh lines, no live markdown) before rendering
+    from autoresearch.review_post_cli import post_from_file
+
+    bot_client = _Client(author="autoresearch-bot")
+    path = _findings_envelope(tmp_path, kind="skip-stub", detail="x")
+    assert post_from_file(bot_client, "org/repo", 7, "autoresearch-bot", path) is None  # type: ignore[arg-type]
+    assert bot_client.comments == []
+
+    client = _Client()
+    evil = "boom\n# fake heading\n<script>alert(1)</script>"
+    path = _findings_envelope(tmp_path, kind="skip-stub", detail=evil)
+    assert post_from_file(client, "org/repo", 7, "autoresearch-bot", path) == "skip-stub"  # type: ignore[arg-type]
+    (comment,) = client.comments
+    assert "\n# fake heading" not in comment  # newline collapsed: no top-level markdown
+    assert "<script>" not in comment

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -335,3 +335,136 @@ def test_sanitize_checkout_renames_nested_instruction_files(tmp_path: Path) -> N
     assert (tmp_path / "models" / "CLAUDE.md.pr-data").exists()
     assert (tmp_path / ".claude.pr-data" / "settings.json").exists()
     assert (tmp_path / "models" / "encoder.py").exists()  # code untouched
+
+
+# ---- least-token split: emit mode + the posting half ----------------------
+
+
+def test_emit_mode_writes_findings_and_posts_nothing(tmp_path: Path) -> None:
+    client, harness = _Client(), _Harness(_FINDINGS)
+    out = tmp_path / "findings.json"
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+        emit_path=out,
+    )
+    assert label == "emitted"
+    assert client.reviews == [] and client.comments == []  # nothing posted here
+    envelope = json.loads(out.read_text())
+    assert envelope["repo"] == "org/repo" and envelope["number"] == 7
+    assert envelope["kind"] == "findings"
+    assert envelope["data"]["findings"][0]["file"] == "models/encoder.py"
+
+
+def test_emit_mode_outage_writes_skip_stub_marker(tmp_path: Path) -> None:
+    client = _Client()
+    harness = _Harness("", is_error=True, detail="rate_limit_error: slow down")
+    out = tmp_path / "findings.json"
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+        emit_path=out,
+    )
+    assert label is None
+    assert client.comments == []  # the stub is the POST job's to publish
+    envelope = json.loads(out.read_text())
+    assert envelope["kind"] == "skip-stub"
+    assert "rate_limit_error" in envelope["detail"]
+
+
+def test_emit_mode_clean_skip_writes_no_file(tmp_path: Path) -> None:
+    client, harness = _Client(author="autoresearch-bot"), _Harness(_FINDINGS)
+    out = tmp_path / "findings.json"
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+        emit_path=out,
+    )
+    assert label is None
+    assert not out.exists()  # no artifact -> the post job no-ops
+
+
+def _findings_envelope(tmp_path: Path, **overrides: Any) -> Path:
+    envelope = {
+        "repo": "org/repo",
+        "number": 7,
+        "kind": "findings",
+        "data": json.loads(_FINDINGS),
+        "detail": "",
+        **overrides,
+    }
+    path = tmp_path / "findings.json"
+    path.write_text(json.dumps(envelope))
+    return path
+
+
+def test_post_from_file_posts_with_lens_label(tmp_path: Path) -> None:
+    from autoresearch.review_post_cli import post_from_file
+
+    client = _Client()
+    path = _findings_envelope(tmp_path)
+    label = post_from_file(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        "autoresearch-bot",
+        path,
+        lens_label="second opinion — terra via hermes",
+    )
+    assert label is not None
+    body, inline = client.reviews[0]
+    assert body.startswith("**Lens:** second opinion — terra via hermes")
+    assert any(c.get("path") == "models/encoder.py" for c in inline)
+
+
+def test_post_from_file_refuses_wrong_pr_envelope(tmp_path: Path) -> None:
+    from autoresearch.review_post_cli import post_from_file
+
+    client = _Client()
+    path = _findings_envelope(tmp_path, number=99)
+    assert post_from_file(client, "org/repo", 7, "autoresearch-bot", path) is None  # type: ignore[arg-type]
+    assert client.reviews == [] and client.comments == []
+
+
+def test_post_from_file_tolerates_malformed_json(tmp_path: Path) -> None:
+    from autoresearch.review_post_cli import post_from_file
+
+    client = _Client()
+    path = tmp_path / "findings.json"
+    path.write_text("{not json")
+    assert post_from_file(client, "org/repo", 7, "autoresearch-bot", path) is None  # type: ignore[arg-type]
+    assert client.reviews == [] and client.comments == []
+
+
+def test_post_from_file_rechecks_the_bot_skip(tmp_path: Path) -> None:
+    # the write authority re-decides: a forged/buggy envelope must not make
+    # the poster comment on a bot PR
+    from autoresearch.review_post_cli import post_from_file
+
+    client = _Client(author="autoresearch-bot")
+    path = _findings_envelope(tmp_path)
+    assert post_from_file(client, "org/repo", 7, "autoresearch-bot", path) is None  # type: ignore[arg-type]
+    assert client.reviews == [] and client.comments == []
+
+
+def test_post_from_file_publishes_the_skip_stub(tmp_path: Path) -> None:
+    from autoresearch.review_post_cli import post_from_file
+
+    client = _Client()
+    path = _findings_envelope(tmp_path, kind="skip-stub", detail="rate_limit_error: slow down")
+    label = post_from_file(client, "org/repo", 7, "autoresearch-bot", path)  # type: ignore[arg-type]
+    assert label == "skip-stub"
+    assert client.reviews == []
+    assert len(client.comments) == 1 and "could not run" in client.comments[0]

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -492,3 +492,34 @@ def test_post_from_file_stub_is_skip_checked_and_sanitized(tmp_path: Path) -> No
     (comment,) = client.comments
     assert "\n# fake heading" not in comment  # newline collapsed: no top-level markdown
     assert "<script>" not in comment
+
+
+def test_backend_id_names_backend_and_model(tmp_path: Path) -> None:
+    from autoresearch.harness import ClaudeCodeHarness, HermesHarness, backend_id
+
+    assert backend_id(ClaudeCodeHarness(api_key="k")) == "claude/claude-opus-5"
+    hermes = HermesHarness(api_key="k", repo_dir=tmp_path, model="moonshot/kimi-k3")
+    assert backend_id(hermes) == "hermes/moonshot/kimi-k3"
+    assert backend_id(_Harness("x")) == ""  # unknown types: stamp omits the clause
+
+
+def test_emit_envelope_carries_reviewed_by_and_stamp_shows_it(tmp_path: Path) -> None:
+    from autoresearch.review_post_cli import post_from_file
+
+    path = _findings_envelope(tmp_path, reviewed_by="hermes/terra-test")
+    client = _Client()
+    assert post_from_file(client, "org/repo", 7, "autoresearch-bot", path) is not None  # type: ignore[arg-type]
+    body, _inline = client.reviews[0]
+    assert "reviewer `hermes/terra-test`" in body
+
+
+def test_stamp_attribution_is_sanitized(tmp_path: Path) -> None:
+    # reviewed_by crosses the artifact boundary: backticks/newlines must not
+    # escape the stamp's inline-code span
+    from autoresearch.review_post_cli import post_from_file
+
+    path = _findings_envelope(tmp_path, reviewed_by="evil`\n# heading")
+    client = _Client()
+    assert post_from_file(client, "org/repo", 7, "autoresearch-bot", path) is not None  # type: ignore[arg-type]
+    body, _inline = client.reviews[0]
+    assert "reviewer `evil # heading`" in body  # collapsed + backtick-stripped

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -112,3 +112,19 @@ def test_missing_checkout_fails_closed(monkeypatch: Any) -> None:
     calls = _patch(monkeypatch, env)
     assert cli.main() == 0
     assert calls == {}
+
+
+def test_missing_key_in_emit_mode_writes_a_stub(monkeypatch: Any, tmp_path: Path) -> None:
+    # a standing second opinion must not die silently when its key is
+    # missing/expired: the emitted stub becomes the PR-visible warning
+    import json
+
+    env = _base_env()
+    del env["ANTHROPIC_REVIEWER_KEY"]
+    env["REVIEW_EMIT_FILE"] = str(tmp_path / "findings.json")
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert "args" not in calls  # no session ran
+    envelope = json.loads((tmp_path / "findings.json").read_text())
+    assert envelope["kind"] == "skip-stub"
+    assert "ANTHROPIC_REVIEWER_KEY" in envelope["detail"]


### PR DESCRIPTION
Builds the split that lets a terra (or other open-model) judge complement the Claude reviewer on the auto path — the maintainer ask, unblocked by removing token adjacency rather than trusting the backend.

**Session job** (read-only permissions): runs hermes/codex over the PR-head checkout, emits RAW findings to an artifact, posts nothing. On a private repo its checkout still needs a read token — theft buys read access the session already has, expiring with the job; at the public flip the job becomes truly tokenless.
**Posting job** (write token, NO session): re-validates the envelope (right PR), re-checks the bot-skip rules (the write authority re-decides), renders through the same sanitizing path, posts with a `Lens:` label so the second opinion is distinguishable at a glance.

Pieces: `run_agent_review(emit_path=…)` emit mode; `review_post_cli` (posting half); `advisory-second-opinion.yml` reusable (two jobs, per-job permissions, pinned backend installs from the manual bench); reviewer-infra.md updated (single-job auto path stays claude-only; the split is how other backends reach auto; the durable no-token-in-process-tree invariant now has its implementation).

8 new tests (emit modes + posting half incl. wrong-PR refusal and bot-skip re-check); 536 green; full gate clean.

Enablement is a separate config PR per target (add the second `uses:` block + OPENROUTER key); proposal: dogfood on autoresearch first with terra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)