### PR TITLE
Enable the terra second opinion on our own PRs (dogfood)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -18,3 +18,18 @@ jobs:
       bot_login: agentic-learning-bot
     secrets:
       anthropic_reviewer_key: ${{ secrets.ANTHROPIC_REVIEWER_KEY }}
+
+  # Independent second opinion (terra via hermes/OpenRouter) through the
+  # least-token split — its round carries a Lens label and its own reviewer
+  # attribution in the stamp. Independence is the point: no coordination
+  # with the primary round.
+  second-opinion:
+    if: github.event.action != 'labeled' || github.event.label.name == 'autoresearch:review'
+
+    uses: agentic-learning-ai-lab/autoresearch/.github/workflows/advisory-second-opinion.yml@main
+    with:
+      bot_login: agentic-learning-bot
+      model: openai/gpt-5.6-terra
+      lens_label: second opinion — terra
+    secrets:
+      openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -29,6 +29,7 @@ jobs:
     uses: agentic-learning-ai-lab/autoresearch/.github/workflows/advisory-second-opinion.yml@main
     with:
       bot_login: agentic-learning-bot
+      backend: hermes  # explicit: the model id below is an OpenRouter id
       model: openai/gpt-5.6-terra
       lens_label: second opinion — terra
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- autoresearch's own PRs now get a terra second opinion (openai/gpt-5.6-terra
+  via hermes/OpenRouter) next to the Claude round — the first live user of the
+  least-token split. Takes effect for PRs opened after this merges
+  (`pull_request_target` runs the base branch's workflow).
 - Second-opinion reviews from non-Claude backends on the auto path, via the
   least-token split (`advisory-second-opinion.yml`): a read-only session job
   runs the backend (hermes/terra via OpenRouter, or codex) and emits raw

--- a/src/autoresearch/review_post_cli.py
+++ b/src/autoresearch/review_post_cli.py
@@ -76,7 +76,13 @@ def post_from_file(
             # sanitize: the detail crossed the job boundary and lands in a
             # comment — collapse newlines, neutralize markdown, cap length
             detail = sanitize(str(envelope.get("detail", "")), 300)
-            post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
+            # name WHOSE round failed: with two standing reviewers, an
+            # unattributed stub is ambiguous exactly when a key dies
+            who = " ".join(lens_label.split())[:MAX_LENS_LABEL] or str(
+                envelope.get("reviewed_by", "")
+            )
+            role = f"advisory review ({who})" if who else "advisory review"
+            post_skip_stub(client, repo, number, role, RuntimeError(detail))
             return "skip-stub"
         data = envelope.get("data")
         review = result_from_data(data if isinstance(data, dict) else {})

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -523,3 +523,21 @@ def test_stamp_attribution_is_sanitized(tmp_path: Path) -> None:
     assert post_from_file(client, "org/repo", 7, "autoresearch-bot", path) is not None  # type: ignore[arg-type]
     body, _inline = client.reviews[0]
     assert "reviewer `evil # heading`" in body  # collapsed + backtick-stripped
+
+
+def test_skip_stub_names_its_lens(tmp_path: Path) -> None:
+    # with two standing reviewers, a could-not-run stub must say WHOSE round
+    from autoresearch.review_post_cli import post_from_file
+
+    client = _Client()
+    path = _findings_envelope(tmp_path, kind="skip-stub", detail="key dead")
+    post_from_file(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        "autoresearch-bot",
+        path,
+        lens_label="second opinion — terra",
+    )
+    (comment,) = client.comments
+    assert "advisory review (second opinion — terra)" in comment


### PR DESCRIPTION
First live caller of the least-token split (#91): `review.yml` gains a `second-opinion` job — `openai/gpt-5.6-terra` via hermes/OpenRouter, Lens label `second opinion — terra`, `OPENROUTER_API_KEY` already present on this repo. Independent of the primary Claude round by design.

Notes:
- `pull_request_target` runs the BASE branch's workflow, so terra activates for PRs opened after this merges — this PR itself gets only the Claude round (whose stamp now demonstrates the new reviewer attribution).
- A dead/expired key will announce itself as a could-not-run stub per triggering PR (maintainer requirement — never silent).
- Migration pathway on record: after the split runs clean live, a consolidation PR folds claude into the split topology (one reusable, backend as input) and deletes `advisory-second-opinion.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)