### PR TITLE
Tick flips the pre-PR panel on for every climb job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,14 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The tick now flips the pre-PR panel ON for every climb job it submits
+  (`--panel verify,review` at both submission sites). `AUTORESEARCH_PANEL=""`
+  is the operator off-switch; `AUTORESEARCH_PANEL_KEY_FILE` overrides the
+  verifier-key path. The tick preflights the key file BEFORE claiming an
+  intake issue or submitting a climb — a missing key stays loud (tick error
+  every pass) but no longer strands a claimed issue behind a climb that dies
+  at startup. Panel rounds share the climb job's walltime: size
+  `climb_job_minutes` for them (an overrun fails safe via the self-deadline).
 - All five roles now run on the role-runner: `author_spec`/`followup_spec`/
   `steward_spec` (roles.py) join the judges' specs as the manifests,
   `climb_once`/`respond_once`/`live_steward` dispatch through `run_role`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,11 +84,17 @@ Versions follow [SemVer](https://semver.org).
 - The tick now flips the pre-PR panel ON for every climb job it submits
   (`--panel verify,review` at both submission sites). `AUTORESEARCH_PANEL=""`
   is the operator off-switch; `AUTORESEARCH_PANEL_KEY_FILE` overrides the
-  verifier-key path. The tick preflights the key file BEFORE claiming an
-  intake issue or submitting a climb — a missing key stays loud (tick error
-  every pass) but no longer strands a claimed issue behind a climb that dies
-  at startup. Panel rounds share the climb job's walltime: size
-  `climb_job_minutes` for them (an overrun fails safe via the self-deadline).
+  verifier-key path. The tick preflights the whole panel config BEFORE
+  claiming an intake issue or submitting a climb — lens grammar and backend
+  (via the shared `parse_lenses`), the key file with the climb's own
+  acceptance rules (absolute path, exists, mode 600, non-empty), and role
+  separation (the panel key must not be the author key) — so a misconfigured
+  panel stays loud (tick error every pass) but never strands a claimed issue
+  behind a climb that dies at startup. The panel's walltime is orchestrator
+  overhead: the tick ADDS an allowance for it to the contract-clamped job
+  budget (a contract can never raise orchestrator spend, so it cannot be
+  asked to fund our own gate); a residual overrun still fails safe via the
+  self-deadline.
 - All five roles now run on the role-runner: `author_spec`/`followup_spec`/
   `steward_spec` (roles.py) join the judges' specs as the manifests,
   `climb_once`/`respond_once`/`live_steward` dispatch through `run_role`, and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,12 @@ Versions follow [SemVer](https://semver.org).
   behind a climb that dies at startup. The panel's walltime is orchestrator
   overhead: the tick ADDS an allowance for it to the contract-clamped job
   budget (a contract can never raise orchestrator spend, so it cannot be
-  asked to fund our own gate); a residual overrun still fails safe via the
-  self-deadline.
+  asked to fund our own gate), clamped at the job partition's MaxTime —
+  sbatch rejects longer requests outright. Work jobs can ride a longer
+  partition than the tick chain: `AUTORESEARCH_JOB_PARTITION` (e.g. cpu48)
+  with `AUTORESEARCH_MAX_JOB_MINUTES` raising the cap in lockstep (code
+  ceiling 10h until the stranded window is spec-aware — named gap). A
+  residual overrun still fails safe via the self-deadline.
 - All five roles now run on the role-runner: `author_spec`/`followup_spec`/
   `steward_spec` (roles.py) join the judges' specs as the manifests,
   `climb_once`/`respond_once`/`live_steward` dispatch through `run_role`, and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -185,8 +185,11 @@ open-ended sweep space.
       inside the climb job after measurement — a PR becomes the OUTPUT of
       verification; blocking findings wake the author (round-capped, fully
       re-measured and re-gated); capped-out blocking opens a DRAFT PR and
-      never arms auto-merge; the transcript rides in the PR body. DEPLOY:
-      the tick's climb args gain --panel + the verifier key file; GitHub-side
+      never arms auto-merge; the transcript rides in the PR body. DEPLOYED
+      in code: the tick passes --panel verify,review to every climb job by
+      default (off-switch AUTORESEARCH_PANEL=""). Cluster prerequisite: the
+      verifier key file at ~/.config/autoresearch/verifier_key on the tick
+      account — a missing key fails climbs LOUDLY by design. GitHub-side
       verify.yml thins per target after the pilot runs clean
 - [ ] jepa-agent as the first research target: `.autoresearch.yaml` + bot Write
       grant + token scope, once its benchmark harness lands and the pilot's

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1040,7 +1040,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--panel-key-file",
-        default=os.path.expanduser(PANEL_KEY_DEFAULT),
+        default=PANEL_KEY_DEFAULT,
         help="key file for panel judge sessions (the verifier's own key, never the author's)",
     )
     parser.add_argument("--panel-revisions", type=int, default=1)
@@ -1123,7 +1123,7 @@ def main() -> int:
         from autoresearch.panel import LENS_KINDS
         from autoresearch.review_agent import build_reviewer_harness
 
-        panel_key = FileTokenProvider(Path(args.panel_key_file)).token()
+        panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
         lenses = []
         for entry in args.panel.split(","):
             kind, _, rest = entry.strip().partition(":")

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1036,8 +1036,9 @@ def main() -> int:
         default="",
         help=(
             "pre-PR verification lenses, comma-separated kind[:backend[:model]] "
-            "entries (e.g. 'verify,review' or 'verify:claude,review:hermes:MODEL'); "
-            "empty disables the panel"
+            "entries (e.g. 'verify,review' or 'verify:claude:MODEL'); only the "
+            "claude backend is contained on this host so far; empty disables "
+            "the panel"
         ),
     )
     parser.add_argument(

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -69,6 +69,10 @@ from autoresearch.verifier import MAX_CLAIM_CHARS
 
 log = logging.getLogger(__name__)
 
+# Where a climb job reads the panel judges' key unless --panel-key-file says
+# otherwise. The tick preflights this same path before claiming/submitting.
+PANEL_KEY_DEFAULT = "~/.config/autoresearch/verifier_key"
+
 
 class NoiseFloored(RuntimeError):
     """The candidate beat the recorded best, but by less than the
@@ -1036,7 +1040,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--panel-key-file",
-        default=os.path.expanduser("~/.config/autoresearch/verifier_key"),
+        default=os.path.expanduser(PANEL_KEY_DEFAULT),
         help="key file for panel judge sessions (the verifier's own key, never the author's)",
     )
     parser.add_argument("--panel-revisions", type=int, default=1)

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -69,9 +69,11 @@ from autoresearch.verifier import MAX_CLAIM_CHARS
 
 log = logging.getLogger(__name__)
 
-# Where a climb job reads the panel judges' key unless --panel-key-file says
-# otherwise. The tick preflights this same path before claiming/submitting.
+# Where a climb job reads its keys unless the CLI flags say otherwise. The
+# tick preflights the panel key (and compares it against the author key —
+# role separation) before claiming/submitting.
 PANEL_KEY_DEFAULT = "~/.config/autoresearch/verifier_key"
+HARNESS_KEY_DEFAULT = "~/.config/autoresearch/harness_key"
 
 
 class NoiseFloored(RuntimeError):
@@ -1057,9 +1059,7 @@ def main() -> int:
         help="how long before the walltime the self-deadline fires (floor 60)",
     )
     parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
-    parser.add_argument(
-        "--key-file", default=os.path.expanduser("~/.config/autoresearch/harness_key")
-    )
+    parser.add_argument("--key-file", default=os.path.expanduser(HARNESS_KEY_DEFAULT))
     parser.add_argument("--issue", type=int, default=0)
     parser.add_argument(
         "--min-free-gb",
@@ -1120,27 +1120,19 @@ def main() -> int:
     panel_lenses: tuple[PanelLens, ...] = ()
     panel_key = ""
     if args.panel.strip():
-        from autoresearch.panel import LENS_KINDS
+        from autoresearch.panel import parse_lenses
         from autoresearch.review_agent import build_reviewer_harness
 
         panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+        try:
+            # grammar + claude-only rule live in parse_lenses (one owner,
+            # shared with the tick's pre-claim preflight): a typo'd kind or
+            # backend must never silently disable a gate
+            entries = parse_lenses(args.panel)
+        except ValueError as exc:
+            parser.error(str(exc))
         lenses = []
-        for entry in args.panel.split(","):
-            kind, _, rest = entry.strip().partition(":")
-            backend, _, model = rest.partition(":")
-            backend = backend or "claude"
-            if kind not in LENS_KINDS:
-                # a typo'd kind must never silently disable a gate
-                parser.error(f"--panel entry {entry!r}: unknown kind (use {LENS_KINDS})")
-            if backend != "claude":
-                # non-claude judges execute or read broadly and would run
-                # UNCONTAINED on the orchestrator host, next to key files.
-                # The seam supports them; enable when their containment on
-                # this host lands (claude runs inside args.image).
-                parser.error(
-                    f"--panel entry {entry!r}: only the claude backend is "
-                    f"contained on the orchestrator host so far"
-                )
+        for kind, backend, model in entries:
             hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
             try:
                 judge = build_reviewer_harness(
@@ -1153,7 +1145,7 @@ def main() -> int:
                     provider=os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter"),
                 )
             except ValueError as exc:
-                parser.error(f"--panel entry {entry!r}: {exc}")
+                parser.error(f"panel entry {kind}:{backend}: {exc}")
             lenses.append(PanelLens(kind=kind, harness=judge))
         panel_lenses = tuple(lenses)
     try:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1076,7 +1076,7 @@ def main() -> int:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")
 
     # same 0600 discipline as the PAT: this key spends real money
-    api_key = FileTokenProvider(Path(args.key_file)).token()
+    api_key = FileTokenProvider(Path(args.key_file).expanduser()).token()
     bot_auth = FileTokenProvider(Path(args.pat_file))
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_id = f"{args.benchmark}-{stamp}"

--- a/src/autoresearch/intake.py
+++ b/src/autoresearch/intake.py
@@ -20,6 +20,9 @@ from autoresearch.followup import QUALIFYING_ASSOCIATIONS
 log = logging.getLogger(__name__)
 
 CLAIM_MARKER = "<!-- autoresearch:claimed -->"
+# Posted (by the bot only) to undo a claim whose run never started — a failed
+# submit must not strand the issue, since the claim scan skips claimed issues.
+RELEASE_MARKER = "<!-- autoresearch:claim-released -->"
 # steward work orders carry this label; they are the STEWARD lane's,
 # never the solver's (a solver climb cannot touch env paths anyway)
 STEWARD_LABEL = "autoresearch:steward"
@@ -66,7 +69,17 @@ def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTa
         if not qualifying_issue(issue, bot_login):
             continue
         number = int(issue["number"])
-        if any(CLAIM_MARKER in str(c.get("body", "")) for c in github.list_comments(repo, number)):
+        claimed = False
+        for c in github.list_comments(repo, number):
+            author = str((c.get("user") or {}).get("login", ""))
+            if author.casefold() != bot_login.casefold():
+                continue  # only the bot's own markers count — no forged releases
+            body = str(c.get("body", ""))
+            if CLAIM_MARKER in body:
+                claimed = True
+            if RELEASE_MARKER in body:
+                claimed = False
+        if claimed:
             continue  # already claimed by a run
         text = f"{issue.get('title', '')}\n{issue.get('body') or ''}"
         benchmark = infer_benchmark(text, contract)

--- a/src/autoresearch/intake.py
+++ b/src/autoresearch/intake.py
@@ -61,6 +61,12 @@ def qualifying_issue(issue: dict, bot_login: str) -> bool:
 def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTask | None:
     """The oldest qualifying, unclaimed issue that names exactly one
     benchmark. At most one — intake is deliberately slow."""
+    if not bot_login.strip():
+        # fail closed like the steward picker: with no identity the claim
+        # scan below would see NO claims and re-claim every tick — an
+        # unbounded paid loop
+        log.warning("pick_issue: bot_login is blank; intake lane sits out")
+        return None
     issues = sorted(github.list_open_issues(repo), key=lambda i: i.get("number", 0))
     for issue in issues:
         labels = {

--- a/src/autoresearch/intake.py
+++ b/src/autoresearch/intake.py
@@ -23,6 +23,10 @@ CLAIM_MARKER = "<!-- autoresearch:claimed -->"
 # Posted (by the bot only) to undo a claim whose run never started — a failed
 # submit must not strand the issue, since the claim scan skips claimed issues.
 RELEASE_MARKER = "<!-- autoresearch:claim-released -->"
+# Claim attempts per issue before intake gives up on it: a durable submit
+# failure must not claim/release (and comment) forever. Same idea as the
+# steward lane's MAX_STEWARD_ATTEMPTS.
+MAX_INTAKE_ATTEMPTS = 3
 # steward work orders carry this label; they are the STEWARD lane's,
 # never the solver's (a solver climb cannot touch env paths anyway)
 STEWARD_LABEL = "autoresearch:steward"
@@ -70,6 +74,7 @@ def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTa
             continue
         number = int(issue["number"])
         claimed = False
+        attempts = 0
         for c in github.list_comments(repo, number):
             author = str((c.get("user") or {}).get("login", ""))
             if author.casefold() != bot_login.casefold():
@@ -77,10 +82,14 @@ def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTa
             body = str(c.get("body", ""))
             if CLAIM_MARKER in body:
                 claimed = True
+                attempts += 1
             if RELEASE_MARKER in body:
                 claimed = False
         if claimed:
             continue  # already claimed by a run
+        if attempts >= MAX_INTAKE_ATTEMPTS:
+            log.info("issue #%s burned %d claim attempts; needs a human look", number, attempts)
+            continue
         text = f"{issue.get('title', '')}\n{issue.get('body') or ''}"
         benchmark = infer_benchmark(text, contract)
         if not benchmark:

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -29,9 +29,13 @@ from typing import Any
 # Public: the tick's AUTORESEARCH_MAX_JOB_MINUTES knob floors here too.
 CLIMB_JOB_MINUTES_FLOOR = 40
 
+# Public: the tick shrinks a capped job's session with the same floor the
+# contract clamp uses.
+SESSION_MINUTES_FLOOR = 10
+
 _BOUNDS: dict[str, tuple[int, int, int]] = {
     "session_max_turns": (120, 10, 120),
-    "session_minutes": (90, 10, 90),
+    "session_minutes": (90, SESSION_MINUTES_FLOOR, 90),
     "climb_job_minutes": (120, CLIMB_JOB_MINUTES_FLOOR, 120),
     "followup_job_minutes": (90, 20, 90),
 }

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -24,12 +24,15 @@ from typing import Any
 # Raised from 60/60/90/60 on 2026-08-09 (maintainer decision): the first
 # steward work order to BUILD an env burned its full 60-turn budget mid-
 # work — session budgets sized for solver tweaks starve construction work.
+# floor = session floor + overhead + self-deadline margin: even at the
+# floors, a session must fit inside its job with the ending's runway.
+# Public: the tick's AUTORESEARCH_MAX_JOB_MINUTES knob floors here too.
+CLIMB_JOB_MINUTES_FLOOR = 40
+
 _BOUNDS: dict[str, tuple[int, int, int]] = {
     "session_max_turns": (120, 10, 120),
     "session_minutes": (90, 10, 90),
-    # floor = session floor + overhead + self-deadline margin: even at the
-    # floors, a session must fit inside its job with the ending's runway
-    "climb_job_minutes": (120, 40, 120),
+    "climb_job_minutes": (120, CLIMB_JOB_MINUTES_FLOOR, 120),
     "followup_job_minutes": (90, 20, 90),
 }
 

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -37,8 +37,9 @@ _BOUNDS: dict[str, tuple[int, int, int]] = {
 }
 
 # A climb job must outlive its session long enough for the orchestrator's
-# own work around it (clone, two evals, publish, ending writes).
-_CLIMB_OVERHEAD_MINUTES = 20
+# own work around it (clone, two evals, publish, ending writes). Public:
+# the tick's cap warning uses it as the no-runway threshold too.
+CLIMB_OVERHEAD_MINUTES = 20
 
 
 @dataclass(frozen=True)
@@ -68,7 +69,7 @@ def effective_limits(budgets: Any = None) -> EffectiveLimits:
         name: _clamp(name, getattr(budgets, name, None) if budgets is not None else None)
         for name in _BOUNDS
     }
-    max_session = values["climb_job_minutes"] - _CLIMB_OVERHEAD_MINUTES
+    max_session = values["climb_job_minutes"] - CLIMB_OVERHEAD_MINUTES
     if values["session_minutes"] > max_session:
         floor = _BOUNDS["session_minutes"][1]
         values["session_minutes"] = max(floor, max_session)

--- a/src/autoresearch/panel.py
+++ b/src/autoresearch/panel.py
@@ -35,6 +35,35 @@ log = logging.getLogger(__name__)
 LENS_KINDS = ("verify", "review")
 
 
+def parse_lenses(panel: str) -> tuple[tuple[str, str, str], ...]:
+    """Parse a panel spec — comma-separated ``kind[:backend[:model]]`` — into
+    (kind, backend, model) triples, or raise ValueError.
+
+    One owner for the grammar: the climb CLI turns the error into
+    parser.error, and the tick preflights the SAME rules before claiming an
+    intake issue — otherwise a typo'd spec passes the tick, the issue is
+    claimed, and the climb dies at argument parsing with the claim stranded.
+    Only the claude backend is accepted for panel judges: non-claude judges
+    execute or read broadly and would run UNCONTAINED on the orchestrator
+    host, next to key files. The seam supports them; enable when their
+    containment on that host lands (claude runs inside the climb's image)."""
+    entries: list[tuple[str, str, str]] = []
+    for raw in panel.split(","):
+        entry = raw.strip()
+        kind, _, rest = entry.partition(":")
+        backend, _, model = rest.partition(":")
+        backend = backend or "claude"
+        if kind not in LENS_KINDS:
+            raise ValueError(f"panel entry {entry!r}: unknown kind (use {LENS_KINDS})")
+        if backend != "claude":
+            raise ValueError(
+                f"panel entry {entry!r}: only the claude backend is contained "
+                "on the orchestrator host so far"
+            )
+        entries.append((kind, backend, model))
+    return tuple(entries)
+
+
 @dataclass(frozen=True)
 class PanelLens:
     """One opinion: a kind (verify = integrity, review = code) on a backend."""

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -40,6 +40,7 @@ from autoresearch.github import FileTokenProvider, GitHubClient, Workspace
 from autoresearch.harness import Harness, budget_exhausted, outage, redact
 from autoresearch.intake import (
     CLAIM_MARKER,
+    RELEASE_MARKER,
     STEWARD_LABEL,
     IssueTask,
     infer_benchmark,
@@ -73,7 +74,6 @@ log = logging.getLogger(__name__)
 
 # posted when a claim ends without a merged PR (submit failure, aborted
 # run): a release AFTER the last claim makes the issue claimable again
-RELEASE_MARKER = "<!-- autoresearch:claim-released -->"
 # rides WITH the release marker when the run died to an API outage: the
 # claim is released AND does not count toward MAX_STEWARD_ATTEMPTS — the
 # API being down is the orchestrator's failure, not the work order's

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -72,11 +72,10 @@ from autoresearch.style import PLAIN_STYLE
 
 log = logging.getLogger(__name__)
 
-# posted when a claim ends without a merged PR (submit failure, aborted
-# run): a release AFTER the last claim makes the issue claimable again
-# rides WITH the release marker when the run died to an API outage: the
+# Rides WITH a release marker when the run died to an API outage: the
 # claim is released AND does not count toward MAX_STEWARD_ATTEMPTS — the
-# API being down is the orchestrator's failure, not the work order's
+# API being down is the orchestrator's failure, not the work order's.
+# (RELEASE_MARKER itself lives in intake.py, next to CLAIM_MARKER.)
 OUTAGE_MARKER = "<!-- autoresearch:outage-release -->"
 # TOTAL claims after which the lane stops retrying a work order: a
 # persistently-failing order must not become a paid retry loop — three

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1157,30 +1157,33 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
     the home filesystem the climb will read."""
     if not spec.panel.strip():
         return ""
-    from autoresearch.climb import HARNESS_KEY_DEFAULT, PANEL_KEY_DEFAULT
-    from autoresearch.github import FileTokenProvider
-    from autoresearch.panel import parse_lenses
+    try:
+        from autoresearch.climb import HARNESS_KEY_DEFAULT, PANEL_KEY_DEFAULT
+        from autoresearch.github import FileTokenProvider
+        from autoresearch.panel import parse_lenses
 
-    try:
-        parse_lenses(spec.panel)
-    except ValueError as exc:
-        return str(exc)
-    path = Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
-    if not path.is_absolute():
-        # the climb runs from a flight directory, not the tick's cwd — a
-        # relative path that resolves here could still miss there
-        return f"panel key path {path} is relative; only absolute paths fly"
-    author = Path(spec.key_file or HARNESS_KEY_DEFAULT).expanduser()
-    if path.resolve() == author.resolve():
-        return (
-            f"panel key file {path} is the author key file "
-            "(role separation: the verifier needs its own key)"
-        )
-    try:
+        try:
+            parse_lenses(spec.panel)
+        except ValueError as exc:
+            return str(exc)
+        path = Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
+        if not path.is_absolute():
+            # the climb runs from a flight directory, not the tick's cwd — a
+            # relative path that resolves here could still miss there
+            return f"panel key path {path} is relative; only absolute paths fly"
+        author = Path(spec.key_file or HARNESS_KEY_DEFAULT).expanduser()
+        if path.resolve() == author.resolve():
+            return (
+                f"panel key file {path} is the author key file "
+                "(role separation: the verifier needs its own key)"
+            )
         FileTokenProvider(path).token()
         return ""
     except Exception as exc:
-        return str(exc)
+        # never raises: an unexpected failure (partial deploy, ELOOP, unset
+        # HOME) must fail closed WITH the alarm, not abort the tick that
+        # would have written it
+        return f"{type(exc).__name__}: {exc}"
 
 
 def _climb_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
@@ -1521,7 +1524,7 @@ def service_intake(
         job_minutes = _climb_job_minutes(spec, limits)
         # claim BEFORE submit: Slurm queueing can take minutes, and the next
         # tick must not re-claim the same issue in that window
-        from autoresearch.intake import CLAIM_MARKER, RELEASE_MARKER
+        from autoresearch.intake import CLAIM_MARKER, MAX_INTAKE_ATTEMPTS, RELEASE_MARKER
 
         github.comment(
             target,
@@ -1578,7 +1581,9 @@ def service_intake(
                     target,
                     task.number,
                     f"{RELEASE_MARKER}\nSubmission failed; claim released — "
-                    f"a later tick will retry this issue.",
+                    f"a later tick will retry this issue (intake gives up "
+                    f"after {MAX_INTAKE_ATTEMPTS} claim attempts and leaves "
+                    f"it for a human).",
                 )
             raise
         log.info("issue #%s claimed for climb job %s", task.number, job_id)

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1020,6 +1020,11 @@ def replace_report(
 
 
 MAX_ACTIVE_RUNS_PER_TARGET = 1
+# Torch's short CPU partitions cap jobs at 6 h and sbatch REJECTS a longer
+# request outright — an unclamped panel-augmented walltime would ground every
+# climb at submit. The self-deadline arms at the CLAMPED value, so a job that
+# wanted more time fails safe mid-panel instead of never starting.
+MAX_CLIMB_JOB_MINUTES = 6 * 60
 SELF_INITIATED_COOLDOWN_S = 6 * 3600
 # An implementing run untouched for this long is a crashed climb job; it must
 # not block the lane forever, but the window must exceed the LONGEST honest
@@ -1243,7 +1248,10 @@ def service_self_initiated(
             return None
         if dry_run:
             return (benchmark, "dry-run")
-        job_minutes = limits.climb_job_minutes + _panel_job_minutes(spec, limits)
+        job_minutes = min(
+            limits.climb_job_minutes + _panel_job_minutes(spec, limits),
+            MAX_CLIMB_JOB_MINUTES,
+        )
         argv = [
             "uv",
             "run",
@@ -1456,10 +1464,13 @@ def service_intake(
             return None
         if dry_run:
             return (f"issue-{task.number}", "dry-run")
-        job_minutes = limits.climb_job_minutes + _panel_job_minutes(spec, limits)
+        job_minutes = min(
+            limits.climb_job_minutes + _panel_job_minutes(spec, limits),
+            MAX_CLIMB_JOB_MINUTES,
+        )
         # claim BEFORE submit: Slurm queueing can take minutes, and the next
         # tick must not re-claim the same issue in that window
-        from autoresearch.intake import CLAIM_MARKER
+        from autoresearch.intake import CLAIM_MARKER, RELEASE_MARKER
 
         github.comment(
             target,
@@ -1495,17 +1506,30 @@ def service_intake(
             argv += ["--pat-file", spec.pat_file]
         if spec.key_file:
             argv += ["--key-file", spec.key_file]
-        job_id = compute.submit(
-            JobSpec(
-                job_name=f"climb-issue-{task.number}",
-                account=spec.account,
-                partition=spec.partition,
-                time_minutes=job_minutes,
-                command=_flight_command(spec.home, f"climb-issue-{task.number}", now, argv),
-                cpus=4,
-                mem="8G",
+        try:
+            job_id = compute.submit(
+                JobSpec(
+                    job_name=f"climb-issue-{task.number}",
+                    account=spec.account,
+                    partition=spec.partition,
+                    time_minutes=job_minutes,
+                    command=_flight_command(spec.home, f"climb-issue-{task.number}", now, argv),
+                    cpus=4,
+                    mem="8G",
+                )
             )
-        )
+        except Exception:
+            # the claim is already posted and pick_issue skips claimed
+            # issues, so a failed submit must release it (same pattern as
+            # the steward lane) or the issue is stranded forever
+            with contextlib.suppress(Exception):
+                github.comment(
+                    target,
+                    task.number,
+                    f"{RELEASE_MARKER}\nSubmission failed; claim released — "
+                    f"a later tick will retry this issue.",
+                )
+            raise
         log.info("issue #%s claimed for climb job %s", task.number, job_id)
         return (f"issue-{task.number}", job_id)
     except Exception as exc:  # intake must not break the tick

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -118,6 +118,19 @@ class TickReport:
     launch_blocked: bool = False  # True when the preflight turned launch lanes off
 
 
+# The submitted walltime must never exceed the job partition's MaxTime —
+# sbatch REJECTS a longer request outright, which would ground every climb.
+# The DEFAULT matches cpu_short (6 h); an operator moving work jobs to a
+# longer partition (AUTORESEARCH_JOB_PARTITION=cpu48) raises the cap with
+# AUTORESEARCH_MAX_JOB_MINUTES. Code-side ceiling: the cap must stay under
+# STRANDED_IMPLEMENTING_S or the picker declares live runs stranded — jobs
+# longer than 10 h need that window made spec-aware first (named gap). The
+# self-deadline arms at the CLAMPED value, so a job that wanted more time
+# fails safe mid-panel instead of never starting.
+MAX_CLIMB_JOB_MINUTES = 6 * 60
+MAX_JOB_MINUTES_CEILING = 10 * 60
+
+
 @dataclass(frozen=True)
 class FollowupSpec:
     """How the tick launches follow-up jobs for in-review runs."""
@@ -147,6 +160,14 @@ class FollowupSpec:
     # overrun still fails safe through the self-deadline.
     panel: str = "verify,review"
     panel_key_file: str = ""  # "" = the climb CLI's default verifier-key path
+    # Where submitted WORK jobs (climb/steward/followup) run; empty = same as
+    # `partition`. The tick chain itself always stays on `partition` — ticks
+    # are minutes, work jobs can be hours, and Slurm prices walltime into
+    # scheduling priority, so the two deserve independent placement.
+    job_partition: str = ""
+    # Partition MaxTime for work jobs — the panel-augmented walltime clamps
+    # here (see MAX_CLIMB_JOB_MINUTES). Raise together with job_partition.
+    max_job_minutes: int = MAX_CLIMB_JOB_MINUTES
 
 
 # Generous vs the ~2 h job walltimes plus queue wait, tight enough that
@@ -492,7 +513,7 @@ def service_in_review(
                 JobSpec(
                     job_name=f"followup-{record.run_id}"[:60],
                     account=spec.account,
-                    partition=spec.partition,
+                    partition=spec.job_partition or spec.partition,
                     time_minutes=spec.time_minutes,
                     command=_flight_command(spec.home, f"followup-{record.run_id}"[:60], now, argv),
                     cpus=4,
@@ -1020,11 +1041,6 @@ def replace_report(
 
 
 MAX_ACTIVE_RUNS_PER_TARGET = 1
-# Torch's short CPU partitions cap jobs at 6 h and sbatch REJECTS a longer
-# request outright — an unclamped panel-augmented walltime would ground every
-# climb at submit. The self-deadline arms at the CLAMPED value, so a job that
-# wanted more time fails safe mid-panel instead of never starting.
-MAX_CLIMB_JOB_MINUTES = 6 * 60
 SELF_INITIATED_COOLDOWN_S = 6 * 3600
 # An implementing run untouched for this long is a crashed climb job; it must
 # not block the lane forever, but the window must exceed the LONGEST honest
@@ -1250,7 +1266,7 @@ def service_self_initiated(
             return (benchmark, "dry-run")
         job_minutes = min(
             limits.climb_job_minutes + _panel_job_minutes(spec, limits),
-            MAX_CLIMB_JOB_MINUTES,
+            spec.max_job_minutes,
         )
         argv = [
             "uv",
@@ -1277,7 +1293,7 @@ def service_self_initiated(
             JobSpec(
                 job_name=f"climb-{benchmark}"[:60],
                 account=spec.account,
-                partition=spec.partition,
+                partition=spec.job_partition or spec.partition,
                 time_minutes=job_minutes,
                 command=_flight_command(spec.home, f"climb-{benchmark}"[:60], now, argv),
                 cpus=4,
@@ -1390,7 +1406,7 @@ def service_steward(
                 JobSpec(
                     job_name=f"steward-issue-{task.number}",
                     account=spec.account,
-                    partition=spec.partition,
+                    partition=spec.job_partition or spec.partition,
                     time_minutes=limits.climb_job_minutes,
                     command=_flight_command(spec.home, f"steward-issue-{task.number}", now, argv),
                     cpus=4,
@@ -1466,7 +1482,7 @@ def service_intake(
             return (f"issue-{task.number}", "dry-run")
         job_minutes = min(
             limits.climb_job_minutes + _panel_job_minutes(spec, limits),
-            MAX_CLIMB_JOB_MINUTES,
+            spec.max_job_minutes,
         )
         # claim BEFORE submit: Slurm queueing can take minutes, and the next
         # tick must not re-claim the same issue in that window
@@ -1511,7 +1527,7 @@ def service_intake(
                 JobSpec(
                     job_name=f"climb-issue-{task.number}",
                     account=spec.account,
-                    partition=spec.partition,
+                    partition=spec.job_partition or spec.partition,
                     time_minutes=job_minutes,
                     command=_flight_command(spec.home, f"climb-issue-{task.number}", now, argv),
                     cpus=4,
@@ -1548,6 +1564,25 @@ class LoggingDispatcher:
         return ""
 
 
+def _max_job_minutes_from_env() -> int:
+    """AUTORESEARCH_MAX_JOB_MINUTES, clamped into what the code can honor:
+    at least the cpu_short default, at most the ceiling the stranded window
+    allows. A clamped value logs — a silently-shrunk cap would read as the
+    partition rejecting jobs for no reason."""
+    raw = os.environ.get("AUTORESEARCH_MAX_JOB_MINUTES", "").strip()
+    if not raw:
+        return MAX_CLIMB_JOB_MINUTES
+    try:
+        value = int(raw)
+    except ValueError:
+        log.warning("AUTORESEARCH_MAX_JOB_MINUTES=%r is not an integer; using default", raw)
+        return MAX_CLIMB_JOB_MINUTES
+    clamped = max(MAX_CLIMB_JOB_MINUTES, min(value, MAX_JOB_MINUTES_CEILING))
+    if clamped != value:
+        log.warning("AUTORESEARCH_MAX_JOB_MINUTES=%d clamped to %d", value, clamped)
+    return clamped
+
+
 def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     """GitHub client + FollowupSpec from the chain environment, or Nones when
     the environment is incomplete (the tick then runs without in-review
@@ -1579,6 +1614,8 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
                 steward_key_file=os.environ.get("AUTORESEARCH_STEWARD_KEY_FILE", ""),
                 panel=os.environ.get("AUTORESEARCH_PANEL", "verify,review"),
                 panel_key_file=os.environ.get("AUTORESEARCH_PANEL_KEY_FILE", ""),
+                job_partition=os.environ.get("AUTORESEARCH_JOB_PARTITION", ""),
+                max_job_minutes=_max_job_minutes_from_env(),
             )
             return github, followup_spec
         except Exception as exc:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -514,7 +514,7 @@ def service_in_review(
                     job_name=f"followup-{record.run_id}"[:60],
                     account=spec.account,
                     partition=spec.job_partition or spec.partition,
-                    time_minutes=spec.time_minutes,
+                    time_minutes=min(spec.time_minutes, spec.max_job_minutes),
                     command=_flight_command(spec.home, f"followup-{record.run_id}"[:60], now, argv),
                     cpus=4,
                     mem="8G",
@@ -1174,6 +1174,23 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
         return str(exc)
 
 
+def _climb_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
+    """The submitted climb walltime: contract budget + panel allowance,
+    clamped at the partition cap. Warns when the cap cuts below the session
+    budget — the self-deadline would then fire before the author's own
+    clock, and that must be a visible operator choice, never a silent
+    surprise."""
+    job = min(limits.climb_job_minutes + _panel_job_minutes(spec, limits), spec.max_job_minutes)
+    if job < limits.session_minutes:
+        log.warning(
+            "work-job cap %d min is below the %d-min session budget; sessions "
+            "will be cut short by the self-deadline",
+            job,
+            limits.session_minutes,
+        )
+    return job
+
+
 def _panel_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
     """Extra walltime the panel needs, ADDED to the contract-clamped job
     budget: the contract's knobs cap the AUTHOR's spend and their ceilings
@@ -1268,10 +1285,7 @@ def service_self_initiated(
             return None
         if dry_run:
             return (benchmark, "dry-run")
-        job_minutes = min(
-            limits.climb_job_minutes + _panel_job_minutes(spec, limits),
-            spec.max_job_minutes,
-        )
+        job_minutes = _climb_job_minutes(spec, limits)
         argv = [
             "uv",
             "run",
@@ -1359,11 +1373,10 @@ def service_steward(
             submitted_at = float(pending.get("submitted_at", 0.0))
             landed = any(r.target == target and r.created >= submitted_at - 60 for r in records)
             expired = now - submitted_at > PENDING_TTL_S
-            if (
-                not landed
-                and not expired
-                and _holder_alive(compute, str(pending.get("job_id", ""))) is not False
-            ):
+            alive = _holder_alive(compute, str(pending.get("job_id", "")))
+            # liveness first, TTL only breaks unknown ties — same rule as
+            # the self-initiated lane (queue wait can outlive the TTL)
+            if not landed and (alive is True or (not expired and alive is not False)):
                 return None
         task = pick_steward_issue(github, target, contract, spec.bot_login)
         if task is None:
@@ -1411,7 +1424,7 @@ def service_steward(
                     job_name=f"steward-issue-{task.number}",
                     account=spec.account,
                     partition=spec.job_partition or spec.partition,
-                    time_minutes=limits.climb_job_minutes,
+                    time_minutes=min(limits.climb_job_minutes, spec.max_job_minutes),
                     command=_flight_command(spec.home, f"steward-issue-{task.number}", now, argv),
                     cpus=4,
                     mem="8G",
@@ -1484,10 +1497,7 @@ def service_intake(
             return None
         if dry_run:
             return (f"issue-{task.number}", "dry-run")
-        job_minutes = min(
-            limits.climb_job_minutes + _panel_job_minutes(spec, limits),
-            spec.max_job_minutes,
-        )
+        job_minutes = _climb_job_minutes(spec, limits)
         # claim BEFORE submit: Slurm queueing can take minutes, and the next
         # tick must not re-claim the same issue in that window
         from autoresearch.intake import CLAIM_MARKER, RELEASE_MARKER

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -500,7 +500,9 @@ def service_in_review(
                 "--bot-login",
                 spec.bot_login,
                 "--job-minutes",
-                str(spec.time_minutes),
+                # the SAME clamped value Slurm gets: a deadline armed past
+                # the real walltime is a Slurm kill before a clean ending
+                str(min(spec.time_minutes, spec.max_job_minutes)),
                 "--max-turns",
                 str(spec.max_turns),
             ]
@@ -1414,7 +1416,9 @@ def service_steward(
             work_order_b64,
             "--key-file",
             spec.steward_key_file,
-            *_climb_limit_argv(limits, limits.climb_job_minutes),
+            # the SAME clamped walltime the JobSpec requests, so the
+            # self-deadline arms against the real clock
+            *_climb_limit_argv(limits, min(limits.climb_job_minutes, spec.max_job_minutes)),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -138,8 +138,12 @@ class FollowupSpec:
     steward_key_file: str = ""
     # Pre-PR verification panel for climb jobs (docs/design/orchestrator-verify.md).
     # DEFAULT ON — the flip is code, the off-switch is AUTORESEARCH_PANEL="".
-    # The climb CLI fails LOUDLY if the panel key file is missing: a
-    # configured gate must never silently vanish.
+    # The climb CLI fails LOUDLY if the panel key file is missing (a configured
+    # gate must never silently vanish); the tick preflights the same file
+    # before claiming or submitting so nothing is stranded. Panel rounds and a
+    # possible revision re-measure run INSIDE the climb job's walltime — size
+    # the contract's climb_job_minutes for them; an overrun fails safe through
+    # the self-deadline, costing that attempt, not correctness.
     panel: str = "verify,review"
     panel_key_file: str = ""  # "" = the climb CLI's default verifier-key path
 
@@ -1105,6 +1109,21 @@ def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
     return argv
 
 
+def _panel_key_missing(spec: FollowupSpec) -> str:
+    """Path of the panel key file if the panel needs one it cannot read, else "".
+
+    Preflighted BEFORE claiming or submitting: the climb CLI fails loudly on a
+    missing key, but by then an intake issue is already claimed — and
+    pick_issue never reclaims — so the strand must be caught on the tick host,
+    which shares the filesystem the climb will read."""
+    if not spec.panel.strip():
+        return ""
+    from autoresearch.climb import PANEL_KEY_DEFAULT
+
+    path = Path(spec.panel_key_file or os.path.expanduser(PANEL_KEY_DEFAULT))
+    return "" if path.is_file() else str(path)
+
+
 def _climb_limit_argv(limits: EffectiveLimits) -> list[str]:
     """Climb-CLI flags carrying the tick-resolved limits: the job's own
     walltime rides along so the climb can arm its self-deadline (Slurm
@@ -1163,6 +1182,15 @@ def service_self_initiated(
                 pending_attempt = (str(pending.get("benchmark", "")), submitted_at)
         benchmark = pick_self_initiated(records, contract, spec.target, now, pending_attempt)
         if benchmark is None:
+            return None
+        missing_key = _panel_key_missing(spec)
+        if missing_key:
+            log.error(
+                "climb on %s not launched: panel enabled but key file %s is missing "
+                "(provision it, or set AUTORESEARCH_PANEL='' to disable the panel)",
+                benchmark,
+                missing_key,
+            )
             return None
         if dry_run:
             return (benchmark, "dry-run")
@@ -1367,6 +1395,15 @@ def service_intake(
         task = pick_issue(github, target, contract, spec.bot_login)
         if task is None:
             return None
+        missing_key = _panel_key_missing(spec)
+        if missing_key:
+            log.error(
+                "issue #%d not claimed: panel enabled but key file %s is missing "
+                "(provision it, or set AUTORESEARCH_PANEL='' to disable the panel)",
+                task.number,
+                missing_key,
+            )
+            return None
         if dry_run:
             return (f"issue-{task.number}", "dry-run")
         # claim BEFORE submit: Slurm queueing can take minutes, and the next
@@ -1436,6 +1473,58 @@ class LoggingDispatcher:
         return ""
 
 
+def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
+    """GitHub client + FollowupSpec from the chain environment, or Nones when
+    the environment is incomplete (the tick then runs without in-review
+    servicing, and logs what is absent)."""
+    pat_file = os.environ.get("AUTORESEARCH_PAT_FILE", "")
+    account = os.environ.get("AUTORESEARCH_ACCOUNT", "")
+    partition = os.environ.get("AUTORESEARCH_PARTITION", "")
+    image = os.environ.get(
+        "AUTORESEARCH_IMAGE",
+        os.path.expanduser("~/autoresearch-images/agent-py312.sif"),
+    )
+    home = os.environ.get("AUTORESEARCH_HOME", "")
+    if pat_file and account and partition and home and Path(image).is_file():
+        from autoresearch.github import FileTokenProvider, GitHubClient
+
+        try:
+            github = GitHubClient(auth=FileTokenProvider(Path(pat_file)))
+            followup_spec = FollowupSpec(
+                account=account,
+                partition=partition,
+                run_root=root,
+                image=image,
+                home=Path(home),
+                pat_file=pat_file,
+                key_file=os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE", ""),
+                target=os.environ.get(
+                    "AUTORESEARCH_TARGET", "agentic-learning-ai-lab/autoresearch-pilot"
+                ),
+                steward_key_file=os.environ.get("AUTORESEARCH_STEWARD_KEY_FILE", ""),
+                panel=os.environ.get("AUTORESEARCH_PANEL", "verify,review"),
+                panel_key_file=os.environ.get("AUTORESEARCH_PANEL_KEY_FILE", ""),
+            )
+            return github, followup_spec
+        except Exception as exc:
+            log.warning("in-review servicing disabled: %s", exc)
+            return None, None
+    absent = [
+        name
+        for name, value in [
+            ("AUTORESEARCH_PAT_FILE", pat_file),
+            ("AUTORESEARCH_ACCOUNT", account),
+            ("AUTORESEARCH_PARTITION", partition),
+            ("AUTORESEARCH_HOME", home),
+        ]
+        if not value
+    ]
+    if not Path(image).is_file():
+        absent.append(f"image:{image}")
+    log.info("in-review servicing disabled (missing: %s)", ", ".join(absent))
+    return None, None
+
+
 def main() -> int:
     import argparse
     import time
@@ -1457,54 +1546,7 @@ def main() -> int:
     # The waiting-run sweep stays dry until the experiment dispatcher lands;
     # in-review servicing is LIVE when credentials + image are available in
     # the chain environment.
-    import os
-
-    github = None
-    followup_spec = None
-    pat_file = os.environ.get("AUTORESEARCH_PAT_FILE", "")
-    account = os.environ.get("AUTORESEARCH_ACCOUNT", "")
-    partition = os.environ.get("AUTORESEARCH_PARTITION", "")
-    image = os.environ.get(
-        "AUTORESEARCH_IMAGE",
-        os.path.expanduser("~/autoresearch-images/agent-py312.sif"),
-    )
-    home = os.environ.get("AUTORESEARCH_HOME", "")
-    if pat_file and account and partition and home and Path(image).is_file():
-        from autoresearch.github import FileTokenProvider, GitHubClient
-
-        try:
-            github = GitHubClient(auth=FileTokenProvider(Path(pat_file)))
-            followup_spec = FollowupSpec(
-                account=account,
-                partition=partition,
-                run_root=args.root,
-                image=image,
-                home=Path(home),
-                pat_file=pat_file,
-                key_file=os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE", ""),
-                target=os.environ.get(
-                    "AUTORESEARCH_TARGET", "agentic-learning-ai-lab/autoresearch-pilot"
-                ),
-                steward_key_file=os.environ.get("AUTORESEARCH_STEWARD_KEY_FILE", ""),
-                panel=os.environ.get("AUTORESEARCH_PANEL", "verify,review"),
-                panel_key_file=os.environ.get("AUTORESEARCH_PANEL_KEY_FILE", ""),
-            )
-        except Exception as exc:
-            log.warning("in-review servicing disabled: %s", exc)
-    else:
-        absent = [
-            name
-            for name, value in [
-                ("AUTORESEARCH_PAT_FILE", pat_file),
-                ("AUTORESEARCH_ACCOUNT", account),
-                ("AUTORESEARCH_PARTITION", partition),
-                ("AUTORESEARCH_HOME", home),
-            ]
-            if not value
-        ]
-        if not Path(image).is_file():
-            absent.append(f"image:{image}")
-        log.info("in-review servicing disabled (missing: %s)", ", ".join(absent))
+    github, followup_spec = _followup_spec_from_env(args.root)
 
     report = tick(
         args.root,

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -136,6 +136,12 @@ class FollowupSpec:
     # the STEWARD'S OWN key (role separation): the steward lane stays off
     # until the operator provisions it
     steward_key_file: str = ""
+    # Pre-PR verification panel for climb jobs (docs/design/orchestrator-verify.md).
+    # DEFAULT ON — the flip is code, the off-switch is AUTORESEARCH_PANEL="".
+    # The climb CLI fails LOUDLY if the panel key file is missing: a
+    # configured gate must never silently vanish.
+    panel: str = "verify,review"
+    panel_key_file: str = ""  # "" = the climb CLI's default verifier-key path
 
 
 # Generous vs the ~2 h job walltimes plus queue wait, tight enough that
@@ -1089,6 +1095,16 @@ def clear_pending(root: Path, target: str) -> None:
     _pending_path(root, target).unlink(missing_ok=True)
 
 
+def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
+    """Panel args for a climb job; empty when the operator disabled the panel."""
+    if not spec.panel.strip():
+        return []
+    argv = ["--panel", spec.panel]
+    if spec.panel_key_file:
+        argv += ["--panel-key-file", spec.panel_key_file]
+    return argv
+
+
 def _climb_limit_argv(limits: EffectiveLimits) -> list[str]:
     """Climb-CLI flags carrying the tick-resolved limits: the job's own
     walltime rides along so the climb can arm its self-deadline (Slurm
@@ -1165,6 +1181,7 @@ def service_self_initiated(
             "--image",
             spec.image,
             *_climb_limit_argv(limits),
+            *_climb_panel_argv(spec),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
@@ -1384,6 +1401,7 @@ def service_intake(
             "--hypothesis-b64",
             hypothesis_b64,
             *_climb_limit_argv(limits),
+            *_climb_panel_argv(spec),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
@@ -1468,6 +1486,8 @@ def main() -> int:
                     "AUTORESEARCH_TARGET", "agentic-learning-ai-lab/autoresearch-pilot"
                 ),
                 steward_key_file=os.environ.get("AUTORESEARCH_STEWARD_KEY_FILE", ""),
+                panel=os.environ.get("AUTORESEARCH_PANEL", "verify,review"),
+                panel_key_file=os.environ.get("AUTORESEARCH_PANEL_KEY_FILE", ""),
             )
         except Exception as exc:
             log.warning("in-review servicing disabled: %s", exc)

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1182,13 +1182,17 @@ def _climb_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
     budget — the self-deadline would then fire before the author's own
     clock, and that must be a visible operator choice, never a silent
     surprise."""
+    from autoresearch.limits import CLIMB_OVERHEAD_MINUTES
+
     job = min(limits.climb_job_minutes + _panel_job_minutes(spec, limits), spec.max_job_minutes)
-    if job < limits.session_minutes:
+    if job < limits.session_minutes + CLIMB_OVERHEAD_MINUTES:
         log.warning(
-            "work-job cap %d min is below the %d-min session budget; sessions "
-            "will be cut short by the self-deadline",
+            "work-job cap %d min leaves no runway around the %d-min session "
+            "(the orchestrator needs ~%d min); sessions or endings will be "
+            "cut short by the self-deadline",
             job,
             limits.session_minutes,
+            CLIMB_OVERHEAD_MINUTES,
         )
     return job
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1172,6 +1172,11 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
             # relative path that resolves here could still miss there
             return f"panel key path {path} is relative; only absolute paths fly"
         author = Path(spec.key_file or HARNESS_KEY_DEFAULT).expanduser()
+        if not author.is_absolute():
+            # same rule as the panel key: the climb resolves paths from a
+            # flight directory, so a relative author path both misconfigures
+            # the author AND defeats the role-separation comparison below
+            return f"author key path {author} is relative; only absolute paths fly"
         if path.resolve() == author.resolve():
             return (
                 f"panel key file {path} is the author key file "

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -138,12 +138,13 @@ class FollowupSpec:
     steward_key_file: str = ""
     # Pre-PR verification panel for climb jobs (docs/design/orchestrator-verify.md).
     # DEFAULT ON — the flip is code, the off-switch is AUTORESEARCH_PANEL="".
-    # The climb CLI fails LOUDLY if the panel key file is missing (a configured
-    # gate must never silently vanish); the tick preflights the same file
-    # before claiming or submitting so nothing is stranded. Panel rounds and a
-    # possible revision re-measure run INSIDE the climb job's walltime — size
-    # the contract's climb_job_minutes for them; an overrun fails safe through
-    # the self-deadline, costing that attempt, not correctness.
+    # The climb CLI fails LOUDLY on a bad panel config (a configured gate must
+    # never silently vanish); the tick preflights the same rules — lens
+    # grammar AND key file — before claiming or submitting so nothing is
+    # stranded. The panel's walltime is the orchestrator's own overhead: the
+    # tick ADDS a panel allowance to the contract-clamped job budget
+    # (_panel_job_minutes) rather than eating the author's time; a residual
+    # overrun still fails safe through the self-deadline.
     panel: str = "verify,review"
     panel_key_file: str = ""  # "" = the climb CLI's default verifier-key path
 
@@ -1109,38 +1110,76 @@ def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
     return argv
 
 
-def _panel_key_error(spec: FollowupSpec) -> str:
-    """Why the climb could not read its panel key ("" when it can).
+def _panel_preflight_error(spec: FollowupSpec) -> str:
+    """Why the climb would die at startup on this panel config ("" when it
+    won't): the lens spec, then the key file — each checked with the climb's
+    OWN rules (parse_lenses for the grammar and claude-only backend;
+    FileTokenProvider for exists/mode-600/non-empty), so preflight and climb
+    cannot disagree.
 
-    Preflighted BEFORE claiming or submitting: the climb CLI fails loudly on a
-    bad key file, but by then an intake issue is already claimed — and
-    pick_issue never reclaims — so the strand must be caught on the tick host,
-    which shares the home filesystem the climb will read. Reading through
-    FileTokenProvider applies the climb's exact acceptance rules (exists,
-    mode 600, non-empty), so preflight and climb cannot disagree."""
+    Preflighted BEFORE claiming or submitting: the climb CLI fails loudly,
+    but by then an intake issue is already claimed — and pick_issue never
+    reclaims — so the strand must be caught on the tick host, which shares
+    the home filesystem the climb will read."""
     if not spec.panel.strip():
         return ""
-    from autoresearch.climb import PANEL_KEY_DEFAULT
+    from autoresearch.climb import HARNESS_KEY_DEFAULT, PANEL_KEY_DEFAULT
     from autoresearch.github import FileTokenProvider
+    from autoresearch.panel import parse_lenses
 
     try:
-        FileTokenProvider(Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()).token()
+        parse_lenses(spec.panel)
+    except ValueError as exc:
+        return str(exc)
+    path = Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
+    if not path.is_absolute():
+        # the climb runs from a flight directory, not the tick's cwd — a
+        # relative path that resolves here could still miss there
+        return f"panel key path {path} is relative; only absolute paths fly"
+    author = Path(spec.key_file or HARNESS_KEY_DEFAULT).expanduser()
+    if path.resolve() == author.resolve():
+        return (
+            f"panel key file {path} is the author key file "
+            "(role separation: the verifier needs its own key)"
+        )
+    try:
+        FileTokenProvider(path).token()
         return ""
     except Exception as exc:
         return str(exc)
 
 
-def _climb_limit_argv(limits: EffectiveLimits) -> list[str]:
-    """Climb-CLI flags carrying the tick-resolved limits: the job's own
-    walltime rides along so the climb can arm its self-deadline (Slurm
-    delivers no signals to our processes on Torch — measured 2026-08-08)."""
+def _panel_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
+    """Extra walltime the panel needs, ADDED to the contract-clamped job
+    budget: the contract's knobs cap the AUTHOR's spend and their ceilings
+    deliberately cannot raise ours (limits.py), so the panel — the
+    orchestrator's own gate, flipped on by the tick — brings its own time.
+    Worst case: three sequential reads of every lens (initial, post-revision,
+    merged-tree) on the judge budget, plus one revision wake on the session
+    budget. The revision's re-measure rides the margin the self-deadline
+    already fails safe on."""
+    lenses = [entry for entry in spec.panel.split(",") if entry.strip()]
+    if not lenses:
+        return 0
+    from autoresearch.roles import reviewer_spec, verifier_spec
+
+    judge_minutes = max(reviewer_spec().budget.walltime_s, verifier_spec().budget.walltime_s) // 60
+    return 3 * len(lenses) * judge_minutes + limits.session_minutes
+
+
+def _climb_limit_argv(limits: EffectiveLimits, job_minutes: int) -> list[str]:
+    """Climb-CLI flags carrying the tick-resolved limits: the job's ACTUAL
+    walltime rides along (contract budget + any panel allowance, exactly what
+    the JobSpec gets) so the climb arms its self-deadline against the real
+    clock (Slurm delivers no signals to our processes on Torch — measured
+    2026-08-08)."""
     return [
         "--max-turns",
         str(limits.session_max_turns),
         "--session-minutes",
         str(limits.session_minutes),
         "--job-minutes",
-        str(limits.climb_job_minutes),
+        str(job_minutes),
     ]
 
 
@@ -1189,17 +1228,18 @@ def service_self_initiated(
         benchmark = pick_self_initiated(records, contract, spec.target, now, pending_attempt)
         if benchmark is None:
             return None
-        key_error = _panel_key_error(spec)
-        if key_error:
+        panel_error = _panel_preflight_error(spec)
+        if panel_error:
             log.error(
-                "climb on %s not launched: panel enabled but its key is unusable — %s "
+                "climb on %s not launched: panel misconfigured — %s "
                 "(fix it, or set AUTORESEARCH_PANEL='' to disable the panel)",
                 benchmark,
-                key_error,
+                panel_error,
             )
             return None
         if dry_run:
             return (benchmark, "dry-run")
+        job_minutes = limits.climb_job_minutes + _panel_job_minutes(spec, limits)
         argv = [
             "uv",
             "run",
@@ -1214,7 +1254,7 @@ def service_self_initiated(
             str(spec.run_root),
             "--image",
             spec.image,
-            *_climb_limit_argv(limits),
+            *_climb_limit_argv(limits, job_minutes),
             *_climb_panel_argv(spec),
         ]
         if spec.pat_file:
@@ -1226,7 +1266,7 @@ def service_self_initiated(
                 job_name=f"climb-{benchmark}"[:60],
                 account=spec.account,
                 partition=spec.partition,
-                time_minutes=limits.climb_job_minutes,
+                time_minutes=job_minutes,
                 command=_flight_command(spec.home, f"climb-{benchmark}"[:60], now, argv),
                 cpus=4,
                 mem="8G",
@@ -1329,7 +1369,7 @@ def service_steward(
             work_order_b64,
             "--key-file",
             spec.steward_key_file,
-            *_climb_limit_argv(limits),
+            *_climb_limit_argv(limits, limits.climb_job_minutes),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
@@ -1401,17 +1441,18 @@ def service_intake(
         task = pick_issue(github, target, contract, spec.bot_login)
         if task is None:
             return None
-        key_error = _panel_key_error(spec)
-        if key_error:
+        panel_error = _panel_preflight_error(spec)
+        if panel_error:
             log.error(
-                "issue #%d not claimed: panel enabled but its key is unusable — %s "
+                "issue #%d not claimed: panel misconfigured — %s "
                 "(fix it, or set AUTORESEARCH_PANEL='' to disable the panel)",
                 task.number,
-                key_error,
+                panel_error,
             )
             return None
         if dry_run:
             return (f"issue-{task.number}", "dry-run")
+        job_minutes = limits.climb_job_minutes + _panel_job_minutes(spec, limits)
         # claim BEFORE submit: Slurm queueing can take minutes, and the next
         # tick must not re-claim the same issue in that window
         from autoresearch.intake import CLAIM_MARKER
@@ -1443,7 +1484,7 @@ def service_intake(
             str(task.number),
             "--hypothesis-b64",
             hypothesis_b64,
-            *_climb_limit_argv(limits),
+            *_climb_limit_argv(limits, job_minutes),
             *_climb_panel_argv(spec),
         ]
         if spec.pat_file:
@@ -1455,7 +1496,7 @@ def service_intake(
                 job_name=f"climb-issue-{task.number}",
                 account=spec.account,
                 partition=spec.partition,
-                time_minutes=limits.climb_job_minutes,
+                time_minutes=job_minutes,
                 command=_flight_command(spec.home, f"climb-issue-{task.number}", now, argv),
                 cpus=4,
                 mem="8G",

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -339,7 +339,7 @@ def contract_alarm(
     # holds) and fenced with a run longer than any backtick run inside —
     # transport errors can echo request material, loader errors can echo
     # contract content, and both are untrusted for a public issue body
-    safe_error = redact(error, _client_secrets(github))[:600]
+    safe_error = redact(error, _client_secrets(github)).replace(str(Path.home()), "~")[:600]
     # A recorded issue a human closed by hand stays closed: closing the
     # alarm is the maintainer's "I know" — re-opening or re-creating it
     # every threshold would be alarm spam, and recovery still clears state.
@@ -1194,7 +1194,15 @@ def _climb_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
     surprise."""
     from autoresearch.limits import CLIMB_OVERHEAD_MINUTES
 
-    job = min(limits.climb_job_minutes + _panel_job_minutes(spec, limits), spec.max_job_minutes)
+    wanted = limits.climb_job_minutes + _panel_job_minutes(spec, limits)
+    job = min(wanted, spec.max_job_minutes)
+    if job < wanted:
+        log.info(
+            "climb job clamped to %d min by the partition cap (worst case "
+            "wanted %d); slow panel rounds fail safe via the self-deadline",
+            job,
+            wanted,
+        )
     if job < limits.session_minutes + CLIMB_OVERHEAD_MINUTES:
         log.warning(
             "work-job cap %d min leaves no runway around the %d-min session "

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1217,15 +1217,21 @@ def _panel_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
 
 def _climb_limit_argv(limits: EffectiveLimits, job_minutes: int) -> list[str]:
     """Climb-CLI flags carrying the tick-resolved limits: the job's ACTUAL
-    walltime rides along (contract budget + any panel allowance, exactly what
-    the JobSpec gets) so the climb arms its self-deadline against the real
-    clock (Slurm delivers no signals to our processes on Torch — measured
-    2026-08-08)."""
+    walltime rides along (contract budget + any panel allowance, clamped at
+    the partition cap — exactly what the JobSpec gets) so the climb arms its
+    self-deadline against the real clock (Slurm delivers no signals to our
+    processes on Torch — measured 2026-08-08). The session shrinks to fit a
+    CAPPED job with the same rule limits.effective_limits applies to
+    contract values — better a short session that ends cleanly than a full
+    one the self-deadline kills mid-flight."""
+    from autoresearch.limits import CLIMB_OVERHEAD_MINUTES, SESSION_MINUTES_FLOOR
+
+    session = min(limits.session_minutes, job_minutes - CLIMB_OVERHEAD_MINUTES)
     return [
         "--max-turns",
         str(limits.session_max_turns),
         "--session-minutes",
-        str(limits.session_minutes),
+        str(max(SESSION_MINUTES_FLOOR, session)),
         "--job-minutes",
         str(job_minutes),
     ]

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1241,10 +1241,14 @@ def service_self_initiated(
             expired = now - submitted_at > PENDING_TTL_S
             if landed:
                 clear_pending(root, spec.target)  # the run record carries it now
-            elif (
-                not expired and _holder_alive(compute, str(pending.get("job_id", ""))) is not False
+            elif (alive := _holder_alive(compute, str(pending.get("job_id", "")))) is True or (
+                not expired and alive is not False
             ):
-                return None  # climb queued or starting; its record isn't written yet
+                # climb queued or starting; its record isn't written yet. A
+                # provably-alive job waits regardless of the marker's TTL —
+                # queue wait can exceed it — the TTL only breaks ties when
+                # Slurm can't say (a dup submit is worse than a slow retry).
+                return None
             else:
                 # Died before writing a record. Keep its cooldown so a
                 # crash-at-startup loop can't resubmit every tick.
@@ -1566,9 +1570,13 @@ class LoggingDispatcher:
 
 def _max_job_minutes_from_env() -> int:
     """AUTORESEARCH_MAX_JOB_MINUTES, clamped into what the code can honor:
-    at least the cpu_short default, at most the ceiling the stranded window
-    allows. A clamped value logs — a silently-shrunk cap would read as the
-    partition rejecting jobs for no reason."""
+    at least the climb-job floor (an operator on a short-MaxTime partition
+    must be able to LOWER the cap below cpu_short's 6h, or every submit is
+    rejected), at most the ceiling the stranded window allows. A clamped
+    value logs — a silently-changed cap would read as the partition
+    rejecting jobs for no reason."""
+    from autoresearch.limits import CLIMB_JOB_MINUTES_FLOOR
+
     raw = os.environ.get("AUTORESEARCH_MAX_JOB_MINUTES", "").strip()
     if not raw:
         return MAX_CLIMB_JOB_MINUTES
@@ -1577,7 +1585,7 @@ def _max_job_minutes_from_env() -> int:
     except ValueError:
         log.warning("AUTORESEARCH_MAX_JOB_MINUTES=%r is not an integer; using default", raw)
         return MAX_CLIMB_JOB_MINUTES
-    clamped = max(MAX_CLIMB_JOB_MINUTES, min(value, MAX_JOB_MINUTES_CEILING))
+    clamped = max(CLIMB_JOB_MINUTES_FLOOR, min(value, MAX_JOB_MINUTES_CEILING))
     if clamped != value:
         log.warning("AUTORESEARCH_MAX_JOB_MINUTES=%d clamped to %d", value, clamped)
     return clamped

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -327,7 +327,7 @@ def contract_alarm(
                 return
             with contextlib.suppress(Exception):
                 github.comment(
-                    target, open_alarm, "The contract loads again; launch lanes resume this tick."
+                    target, open_alarm, "The tick loads again cleanly; launch lanes resume."
                 )
         if state:
             with contextlib.suppress(OSError):
@@ -348,14 +348,14 @@ def contract_alarm(
         try:
             number = _find_alarm_issue(github, target, bot_login) or github.create_issue(
                 target,
-                "autoresearch: contract failed to load — launch lanes are paused",
-                f"{CONTRACT_ALARM_MARKER}\nThe orchestrator has been unable to "
-                f"load `.autoresearch.yaml` for {count} consecutive ticks; "
-                f"intake, steward, and self-initiated lanes sit out until it "
-                f"loads. The error below says whether the contract itself was "
-                f"rejected or the fetch is failing.\n\n"
+                "autoresearch: launch lanes are paused",
+                f"{CONTRACT_ALARM_MARKER}\nThe orchestrator's launch lanes "
+                f"(intake, steward, self-initiated) have sat out {count} "
+                f"consecutive ticks. The error below names the cause — a "
+                f"contract that failed to load, or a panel config the climb "
+                f"would reject.\n\n"
                 f"{_fence(safe_error)}\n{safe_error}\n{_fence(safe_error)}\n\n"
-                f"This issue closes itself when the contract loads again.",
+                f"This issue closes itself when a tick passes cleanly.",
             )
             if number:
                 state["issue"] = number
@@ -951,6 +951,13 @@ def tick(
             except Exception as exc:
                 log.warning("contract fetch failed for %s: %s", followup_spec.target, exc)
                 contract_error = f"{type(exc).__name__}: {exc}"
+            if contract_error is None:
+                # a bad panel config idles the same launch lanes a bad
+                # contract does — same silent-idle class ("this cost 36
+                # hours once"), so it rides the same alarm
+                panel_error = _panel_preflight_error(followup_spec)
+                if panel_error:
+                    contract_error = f"panel preflight: {panel_error}"
             try:
                 contract_alarm(
                     root,

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1021,10 +1021,14 @@ def replace_report(
 
 MAX_ACTIVE_RUNS_PER_TARGET = 1
 SELF_INITIATED_COOLDOWN_S = 6 * 3600
-# An implementing run untouched for this long is a crashed climb job (their
-# walltime is 90 min); it must not block the lane forever. Its cooldown
-# entry still applies, so the crashed benchmark isn't immediately retried.
-STRANDED_IMPLEMENTING_S = 6 * 3600
+# An implementing run untouched for this long is a crashed climb job; it must
+# not block the lane forever, but the window must exceed the LONGEST honest
+# job — the 120-min contract ceiling plus the panel allowance the tick adds
+# (~4.5 h at the defaults) plus queue-start slack — or the picker declares a
+# live run stranded and starts a second one on the same target, breaking the
+# one-active-run serialization. Its cooldown entry still applies, so a
+# crashed benchmark isn't immediately retried.
+STRANDED_IMPLEMENTING_S = 12 * 3600
 # A pending marker older than this is dead even if squeue can't be read.
 PENDING_TTL_S = 4 * 3600
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1109,19 +1109,25 @@ def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
     return argv
 
 
-def _panel_key_missing(spec: FollowupSpec) -> str:
-    """Path of the panel key file if the panel needs one it cannot read, else "".
+def _panel_key_error(spec: FollowupSpec) -> str:
+    """Why the climb could not read its panel key ("" when it can).
 
     Preflighted BEFORE claiming or submitting: the climb CLI fails loudly on a
-    missing key, but by then an intake issue is already claimed — and
+    bad key file, but by then an intake issue is already claimed — and
     pick_issue never reclaims — so the strand must be caught on the tick host,
-    which shares the filesystem the climb will read."""
+    which shares the home filesystem the climb will read. Reading through
+    FileTokenProvider applies the climb's exact acceptance rules (exists,
+    mode 600, non-empty), so preflight and climb cannot disagree."""
     if not spec.panel.strip():
         return ""
     from autoresearch.climb import PANEL_KEY_DEFAULT
+    from autoresearch.github import FileTokenProvider
 
-    path = Path(spec.panel_key_file or os.path.expanduser(PANEL_KEY_DEFAULT))
-    return "" if path.is_file() else str(path)
+    try:
+        FileTokenProvider(Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()).token()
+        return ""
+    except Exception as exc:
+        return str(exc)
 
 
 def _climb_limit_argv(limits: EffectiveLimits) -> list[str]:
@@ -1183,13 +1189,13 @@ def service_self_initiated(
         benchmark = pick_self_initiated(records, contract, spec.target, now, pending_attempt)
         if benchmark is None:
             return None
-        missing_key = _panel_key_missing(spec)
-        if missing_key:
+        key_error = _panel_key_error(spec)
+        if key_error:
             log.error(
-                "climb on %s not launched: panel enabled but key file %s is missing "
-                "(provision it, or set AUTORESEARCH_PANEL='' to disable the panel)",
+                "climb on %s not launched: panel enabled but its key is unusable — %s "
+                "(fix it, or set AUTORESEARCH_PANEL='' to disable the panel)",
                 benchmark,
-                missing_key,
+                key_error,
             )
             return None
         if dry_run:
@@ -1395,13 +1401,13 @@ def service_intake(
         task = pick_issue(github, target, contract, spec.bot_login)
         if task is None:
             return None
-        missing_key = _panel_key_missing(spec)
-        if missing_key:
+        key_error = _panel_key_error(spec)
+        if key_error:
             log.error(
-                "issue #%d not claimed: panel enabled but key file %s is missing "
-                "(provision it, or set AUTORESEARCH_PANEL='' to disable the panel)",
+                "issue #%d not claimed: panel enabled but its key is unusable — %s "
+                "(fix it, or set AUTORESEARCH_PANEL='' to disable the panel)",
                 task.number,
-                missing_key,
+                key_error,
             )
             return None
         if dry_run:

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -49,8 +49,9 @@ class G:
         return self.issues
 
     def list_comments(self, repo, number, max_pages=20):
+        # claim markers count only when the BOT posted them (forgery guard)
         if number in self.claimed:
-            return [{"body": f"{CLAIM_MARKER}\nPicked up"}]
+            return [{"body": f"{CLAIM_MARKER}\nPicked up", "user": {"login": "bot"}}]
         return []
 
 
@@ -73,6 +74,33 @@ def test_pick_oldest_unclaimed_with_one_benchmark() -> None:
     assert task is not None
     assert task.number == 5
     assert task.benchmark == "reach"
+
+
+def test_released_claim_is_pickable_again_and_forgeries_ignored() -> None:
+    from autoresearch.intake import RELEASE_MARKER
+
+    class G2(G):
+        def __init__(self, issues, comments):
+            super().__init__(issues)
+            self.comments = comments
+
+        def list_comments(self, repo, number, max_pages=20):
+            return self.comments
+
+    released = [
+        {"body": f"{CLAIM_MARKER}\nPicked up", "user": {"login": "bot"}},
+        {"body": f"{RELEASE_MARKER}\nSubmission failed", "user": {"login": "bot"}},
+    ]
+    task = pick_issue(G2([issue(4, "fix reach please")], released), "org/pilot", CONTRACT, "bot")
+    assert task is not None and task.number == 4  # released -> claimable again
+    forged_release = [
+        {"body": f"{CLAIM_MARKER}\nPicked up", "user": {"login": "bot"}},
+        {"body": f"{RELEASE_MARKER}\nfree it!", "user": {"login": "mallory"}},
+    ]
+    assert (
+        pick_issue(G2([issue(4, "fix reach please")], forged_release), "org/pilot", CONTRACT, "bot")
+        is None
+    )
 
 
 def test_hypothesis_fences_issue_text() -> None:

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -103,6 +103,26 @@ def test_released_claim_is_pickable_again_and_forgeries_ignored() -> None:
     )
 
 
+def test_intake_attempt_cap_stops_the_claim_release_loop() -> None:
+    from autoresearch.intake import MAX_INTAKE_ATTEMPTS, RELEASE_MARKER
+
+    class G2(G):
+        def __init__(self, issues, comments):
+            super().__init__(issues)
+            self.comments = comments
+
+        def list_comments(self, repo, number, max_pages=20):
+            return self.comments
+
+    burned = []
+    for _ in range(MAX_INTAKE_ATTEMPTS):
+        burned.append({"body": f"{CLAIM_MARKER}\nPicked up", "user": {"login": "bot"}})
+        burned.append({"body": f"{RELEASE_MARKER}\nSubmission failed", "user": {"login": "bot"}})
+    assert (
+        pick_issue(G2([issue(4, "fix reach please")], burned), "org/pilot", CONTRACT, "bot") is None
+    )
+
+
 def test_hypothesis_fences_issue_text() -> None:
     task = pick_issue(
         G([issue(7, "reach: try a better local planner", "the PD controller ```breaks```")]),

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import Any
 
 from autoresearch.compute import CommandResult, SlurmCompute
 from autoresearch.runstate import (
@@ -603,6 +604,8 @@ def test_self_initiated_pending_marker_blocks_duplicates(tmp_path: Path) -> None
     )
 
     contract = _self_contract()
+    panel_key = tmp_path / "verifier_key"
+    panel_key.write_text("k")  # preflight: no key, no launch
     spec = FollowupSpec(
         target="org/pilot",
         account="acct",
@@ -611,6 +614,7 @@ def test_self_initiated_pending_marker_blocks_duplicates(tmp_path: Path) -> None
         image="img.sif",
         home=tmp_path,
         bot_login="bot",
+        panel_key_file=str(panel_key),
     )
     submitted: list[str] = []
 
@@ -843,6 +847,8 @@ roadmap: docs/roadmap.md
 """,
         "org/pilot",
     )
+    panel_key = tmp_path / "verifier_key"
+    panel_key.write_text("k")  # preflight: no key, no launch
     spec = FollowupSpec(
         target="org/pilot",
         account="acct",
@@ -850,6 +856,7 @@ roadmap: docs/roadmap.md
         run_root=tmp_path,
         image="img.sif",
         home=tmp_path,
+        panel_key_file=str(panel_key),
     )
     submitted: list[list[str]] = []
 
@@ -1565,9 +1572,9 @@ def test_followup_key_routing_by_role(tmp_path: Path) -> None:
     assert len(subs2) == 1 and subs2[0][0] == "tsp-r1"
 
 
-def test_panel_env_knob_disables_and_reconfigures(tmp_path: Path) -> None:
-    """AUTORESEARCH_PANEL='' switches the pre-PR panel off; a custom value and
-    key file ride into the climb argv verbatim."""
+def test_panel_spec_disables_and_reconfigures_the_climb_argv(tmp_path: Path) -> None:
+    """An empty panel spec drops the flags; a custom panel and key file ride
+    into the climb argv verbatim."""
     from autoresearch.tick import FollowupSpec, _climb_panel_argv
 
     def make(panel: str = "verify,review", panel_key_file: str = "") -> FollowupSpec:
@@ -1590,3 +1597,59 @@ def test_panel_env_knob_disables_and_reconfigures(tmp_path: Path) -> None:
         "--panel-key-file",
         "/keys/verifier",
     ]
+
+
+def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) -> None:
+    """AUTORESEARCH_PANEL/AUTORESEARCH_PANEL_KEY_FILE reach the FollowupSpec
+    through the chain environment, and empty AUTORESEARCH_PANEL turns the
+    panel off (not back to the default)."""
+    from autoresearch.tick import _followup_spec_from_env
+
+    image = tmp_path / "agent.sif"
+    image.write_text("")
+    pat = tmp_path / "pat"
+    pat.write_text("t")
+    env = {
+        "AUTORESEARCH_PAT_FILE": str(pat),
+        "AUTORESEARCH_ACCOUNT": "a",
+        "AUTORESEARCH_PARTITION": "p",
+        "AUTORESEARCH_IMAGE": str(image),
+        "AUTORESEARCH_HOME": str(tmp_path),
+        "AUTORESEARCH_PANEL": "verify",
+        "AUTORESEARCH_PANEL_KEY_FILE": "/keys/verifier",
+    }
+    import autoresearch.tick as tick_mod
+
+    monkeypatch.setattr(tick_mod.os, "environ", env)
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is not None
+    assert spec.panel == "verify" and spec.panel_key_file == "/keys/verifier"
+    env["AUTORESEARCH_PANEL"] = ""
+    _github, off = _followup_spec_from_env(tmp_path)
+    assert off is not None and off.panel == ""
+
+
+def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path) -> None:
+    """Panel on + unreadable key file: nothing is claimed or submitted (the
+    climb would die at startup AFTER the claim, stranding the issue — the
+    tick catches it on the shared filesystem first). A provisioned key or a
+    disabled panel passes."""
+    from autoresearch.tick import FollowupSpec, _panel_key_missing
+
+    def make(**kw: Any) -> FollowupSpec:
+        return FollowupSpec(
+            target="org/pilot",
+            account="a",
+            partition="p",
+            run_root=tmp_path,
+            image="i.sif",
+            home=tmp_path,
+            **kw,
+        )
+
+    missing = tmp_path / "nope"
+    assert _panel_key_missing(make(panel_key_file=str(missing))) == str(missing)
+    provisioned = tmp_path / "verifier_key"
+    provisioned.write_text("k")
+    assert _panel_key_missing(make(panel_key_file=str(provisioned))) == ""
+    assert _panel_key_missing(make(panel="")) == ""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1701,6 +1701,11 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     # role separation: the panel key must not BE the author key
     same = make(panel_key_file=str(good), key_file=str(good))
     assert "author key" in _panel_preflight_error(same)
+    # ... and a RELATIVE author path fails too: the climb resolves it from a
+    # flight dir, so the comparison above could pass where the runtime collides
+    rel = make(panel_key_file=str(good), key_file="keys/author")
+    assert "author key path" in _panel_preflight_error(rel)
+    assert "relative" in _panel_preflight_error(rel)
 
     # both lanes consult it BEFORE side effects: nothing claimed or submitted
     bad = make(panel_key_file=str(tmp_path / "nope"))

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1795,6 +1795,9 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     )
     assert out_low is not None
     assert "--time=60" in submitted_low[0] and "--job-minutes 60" in submitted_low[0]
+    # the session shrinks to fit the capped job (same rule as the contract
+    # clamp): 60-min job - 20-min overhead, never the full 90-min default
+    assert "--session-minutes 40" in submitted_low[0]
     clear_pending(tmp_path, "org/pilot")
 
     ok2 = make(panel_key_file=str(good))

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1106,7 +1106,7 @@ def test_contract_alarm_opens_once_and_closes_on_recovery(tmp_path: Path) -> Non
     # recovery: comment + close + state cleared
     contract_alarm(tmp_path, g, "org/pilot", None, NOW)
     assert g.closed == [7]
-    assert any("loads again" in body for _, body in g.comments)
+    assert any("lanes resume" in body for _, body in g.comments)
     assert not (tmp_path / "contract-alarm.json").exists()
     # healthy steady state: no writes at all
     contract_alarm(tmp_path, g, "org/pilot", None, NOW)

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -605,7 +605,8 @@ def test_self_initiated_pending_marker_blocks_duplicates(tmp_path: Path) -> None
 
     contract = _self_contract()
     panel_key = tmp_path / "verifier_key"
-    panel_key.write_text("k")  # preflight: no key, no launch
+    panel_key.write_text("k")  # preflight: no usable key, no launch
+    panel_key.chmod(0o600)
     spec = FollowupSpec(
         target="org/pilot",
         account="acct",
@@ -848,7 +849,8 @@ roadmap: docs/roadmap.md
         "org/pilot",
     )
     panel_key = tmp_path / "verifier_key"
-    panel_key.write_text("k")  # preflight: no key, no launch
+    panel_key.write_text("k")  # preflight: no usable key, no launch
+    panel_key.chmod(0o600)
     spec = FollowupSpec(
         target="org/pilot",
         account="acct",
@@ -1629,12 +1631,19 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
     assert off is not None and off.panel == ""
 
 
-def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path) -> None:
-    """Panel on + unreadable key file: nothing is claimed or submitted (the
-    climb would die at startup AFTER the claim, stranding the issue — the
-    tick catches it on the shared filesystem first). A provisioned key or a
-    disabled panel passes."""
-    from autoresearch.tick import FollowupSpec, _panel_key_missing
+def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch: Any) -> None:
+    """Panel on + a key the climb would reject (missing, group-readable,
+    empty): the intake lane claims nothing and the self-initiated lane
+    submits nothing — the strand is caught before any side effect. The
+    preflight reads through FileTokenProvider so its acceptance rules ARE
+    the climb's; a 0600 non-empty key or a disabled panel passes, and a
+    ~ path expands (operator env values arrive verbatim)."""
+    from autoresearch.tick import (
+        FollowupSpec,
+        _panel_key_error,
+        service_intake,
+        service_self_initiated,
+    )
 
     def make(**kw: Any) -> FollowupSpec:
         return FollowupSpec(
@@ -1647,9 +1656,61 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path) -> None:
             **kw,
         )
 
-    missing = tmp_path / "nope"
-    assert _panel_key_missing(make(panel_key_file=str(missing))) == str(missing)
-    provisioned = tmp_path / "verifier_key"
-    provisioned.write_text("k")
-    assert _panel_key_missing(make(panel_key_file=str(provisioned))) == ""
-    assert _panel_key_missing(make(panel="")) == ""
+    loose = tmp_path / "loose"
+    loose.write_text("k")  # default mode: group/world readable
+    empty = tmp_path / "empty"
+    empty.write_text("")
+    empty.chmod(0o600)
+    good = tmp_path / "good"
+    good.write_text("k")
+    good.chmod(0o600)
+    assert "chmod 600" in _panel_key_error(make(panel_key_file=str(loose)))
+    assert "empty" in _panel_key_error(make(panel_key_file=str(empty)))
+    assert _panel_key_error(make(panel_key_file=str(tmp_path / "nope"))) != ""
+    assert _panel_key_error(make(panel_key_file=str(good))) == ""
+    assert _panel_key_error(make(panel="")) == ""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert _panel_key_error(make(panel_key_file="~/good")) == ""
+
+    # both lanes consult it BEFORE side effects: nothing claimed or submitted
+    bad = make(panel_key_file=str(tmp_path / "nope"))
+    submitted: list[str] = []
+
+    def runner(argv, timeout_s):
+        submitted.append(" ".join(argv))
+        return CommandResult(0, "123\n", "")
+
+    contract = _self_contract()
+    compute = SlurmCompute(runner=runner)
+    assert service_self_initiated(tmp_path, compute, bad, contract, NOW) is None
+
+    class IntakeGitHub:
+        def __init__(self) -> None:
+            self.comments: list[str] = []
+
+        def list_open_issues(self, repo):
+            return [
+                {
+                    "number": 5,
+                    "title": "improve tsp",
+                    "body": "",
+                    "user": {"login": "mengye"},
+                    "author_association": "OWNER",
+                    "labels": [],
+                }
+            ]
+
+        def list_comments(self, repo, number):
+            return []
+
+        def comment(self, repo, number, body):
+            self.comments.append(body)
+
+    gh = IntakeGitHub()
+    assert service_intake(tmp_path, gh, compute, bad, NOW, contract=contract) is None
+    assert submitted == [] and gh.comments == []
+    # positive control: the same issue IS claimed once the key is usable,
+    # so the bad-path assertions above cannot pass vacuously
+    ok = make(panel_key_file=str(good))
+    assert service_intake(tmp_path, gh, compute, ok, NOW, contract=contract) is not None
+    assert len(gh.comments) == 1 and len(submitted) == 1

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -869,11 +869,15 @@ roadmap: docs/roadmap.md
     out = service_self_initiated(tmp_path, SlurmCompute(runner=runner), spec, contract, NOW)
     assert out == ("tsp", "123")
     sbatch = submitted[0]
-    assert "--time=120" in sbatch  # 100000 clamped to the default-as-ceiling
+    # contract budget (100000 clamped to the 120 ceiling) + the panel
+    # allowance the TICK adds (3 reads x 2 lenses x 30-min judge budget
+    # + the 25-min session for the revision wake = 205): the contract can
+    # never raise orchestrator spend, so the panel brings its own time
+    assert "--time=325" in sbatch
     wrap = sbatch[-1]
     assert "--max-turns 30" in wrap
     assert "--session-minutes 25" in wrap
-    assert "--job-minutes 120" in wrap  # the job's own walltime, for the alarm
+    assert "--job-minutes 325" in wrap  # the ACTUAL walltime, for the alarm
     assert "--panel verify,review" in wrap  # the pre-PR panel is ON by default
 
 
@@ -1640,7 +1644,7 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     ~ path expands (operator env values arrive verbatim)."""
     from autoresearch.tick import (
         FollowupSpec,
-        _panel_key_error,
+        _panel_preflight_error,
         service_intake,
         service_self_initiated,
     )
@@ -1664,13 +1668,34 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     good = tmp_path / "good"
     good.write_text("k")
     good.chmod(0o600)
-    assert "chmod 600" in _panel_key_error(make(panel_key_file=str(loose)))
-    assert "empty" in _panel_key_error(make(panel_key_file=str(empty)))
-    assert _panel_key_error(make(panel_key_file=str(tmp_path / "nope"))) != ""
-    assert _panel_key_error(make(panel_key_file=str(good))) == ""
-    assert _panel_key_error(make(panel="")) == ""
+    assert "chmod 600" in _panel_preflight_error(make(panel_key_file=str(loose)))
+    assert "empty" in _panel_preflight_error(make(panel_key_file=str(empty)))
+    assert _panel_preflight_error(make(panel_key_file=str(tmp_path / "nope"))) != ""
+    assert _panel_preflight_error(make(panel_key_file=str(good))) == ""
+    assert _panel_preflight_error(make(panel="")) == ""
     monkeypatch.setenv("HOME", str(tmp_path))
-    assert _panel_key_error(make(panel_key_file="~/good")) == ""
+    assert _panel_preflight_error(make(panel_key_file="~/good")) == ""
+    # the climb's OTHER startup rejections are preflighted too: a typo'd lens
+    # spec (climb dies at argparse) and a relative key path (the climb runs
+    # from a flight dir, not the tick's cwd)
+    bad_spec = make(panel="verfy", panel_key_file=str(good))
+    assert "unknown kind" in _panel_preflight_error(bad_spec)
+    assert "not contained" not in _panel_preflight_error(bad_spec)  # first error wins
+    assert "only the claude backend" in _panel_preflight_error(
+        make(panel="verify:hermes", panel_key_file=str(good))
+    )
+    assert "relative" in _panel_preflight_error(make(panel_key_file="good"))
+    # role separation: the panel key must not BE the author key
+    same = make(panel_key_file=str(good), key_file=str(good))
+    assert "author key" in _panel_preflight_error(same)
+
+    # the walltime allowance exists exactly when the panel does
+    from autoresearch.limits import effective_limits
+    from autoresearch.tick import _panel_job_minutes
+
+    limits = effective_limits()
+    assert _panel_job_minutes(make(panel=""), limits) == 0
+    assert _panel_job_minutes(make(), limits) > 0
 
     # both lanes consult it BEFORE side effects: nothing claimed or submitted
     bad = make(panel_key_file=str(tmp_path / "nope"))

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -865,6 +865,7 @@ roadmap: docs/roadmap.md
     assert "--max-turns 30" in wrap
     assert "--session-minutes 25" in wrap
     assert "--job-minutes 120" in wrap  # the job's own walltime, for the alarm
+    assert "--panel verify,review" in wrap  # the pre-PR panel is ON by default
 
 
 def test_followup_jobs_carry_the_session_turn_budget(tmp_path: Path) -> None:
@@ -1562,3 +1563,30 @@ def test_followup_key_routing_by_role(tmp_path: Path) -> None:
         save_record(tmp_path, replace(rec, followup_job_id="", wake_attempts=0), now=NOW)
     _, subs2 = service_in_review(tmp_path, G(), SlurmCompute(runner=runner), spec_nokey, NOW)
     assert len(subs2) == 1 and subs2[0][0] == "tsp-r1"
+
+
+def test_panel_env_knob_disables_and_reconfigures(tmp_path: Path) -> None:
+    """AUTORESEARCH_PANEL='' switches the pre-PR panel off; a custom value and
+    key file ride into the climb argv verbatim."""
+    from autoresearch.tick import FollowupSpec, _climb_panel_argv
+
+    def make(panel: str = "verify,review", panel_key_file: str = "") -> FollowupSpec:
+        return FollowupSpec(
+            target="org/pilot",
+            account="a",
+            partition="p",
+            run_root=tmp_path,
+            image="i.sif",
+            home=tmp_path,
+            panel=panel,
+            panel_key_file=panel_key_file,
+        )
+
+    assert _climb_panel_argv(make(panel="")) == []
+    assert _climb_panel_argv(make()) == ["--panel", "verify,review"]
+    assert _climb_panel_argv(make(panel="verify", panel_key_file="/keys/verifier")) == [
+        "--panel",
+        "verify",
+        "--panel-key-file",
+        "/keys/verifier",
+    ]

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1672,7 +1672,8 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
         )
 
     loose = tmp_path / "loose"
-    loose.write_text("k")  # default mode: group/world readable
+    loose.write_text("k")
+    loose.chmod(0o644)  # pinned: write_text's mode depends on the umask
     empty = tmp_path / "empty"
     empty.write_text("")
     empty.chmod(0o600)

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1776,6 +1776,26 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
         submitted2.append(" ".join(argv))
         return CommandResult(0, "77\n", "")
 
+    # a low cap must reach BOTH consumers at every site: the Slurm request
+    # AND the --job-minutes the self-deadline arms against (a deadline armed
+    # past the real walltime is a kill before a clean ending)
+    low = make(panel_key_file=str(good), max_job_minutes=60)
+    submitted_low: list[str] = []
+
+    def runner_low(argv, timeout_s):
+        submitted_low.append(" ".join(argv))
+        return CommandResult(0, "88\n", "")
+
+    from autoresearch.tick import clear_pending
+
+    clear_pending(tmp_path, "org/pilot")
+    out_low = service_self_initiated(
+        tmp_path, SlurmCompute(runner=runner_low), low, contract, NOW + 4000
+    )
+    assert out_low is not None
+    assert "--time=60" in submitted_low[0] and "--job-minutes 60" in submitted_low[0]
+    clear_pending(tmp_path, "org/pilot")
+
     ok2 = make(panel_key_file=str(good))
     from autoresearch.contract import load_contract
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -815,7 +815,7 @@ def test_sweep_never_clobbers_a_report_the_climb_wrote(tmp_path: Path) -> None:
 
 def test_legacy_record_without_job_id_ends_only_past_deadline(tmp_path: Path) -> None:
     """No Slurm evidence -> only the 24h run deadline authors an ending; the
-    6h stranded window frees the picker lane but never writes verdicts."""
+    stranded window frees the picker lane but never writes verdicts."""
     from autoresearch.tick import STRANDED_IMPLEMENTING_S
 
     _implementing_run(tmp_path, "r-old", job_id="", age_s=25 * 3600)
@@ -1678,9 +1678,10 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     # the climb's OTHER startup rejections are preflighted too: a typo'd lens
     # spec (climb dies at argparse) and a relative key path (the climb runs
     # from a flight dir, not the tick's cwd)
-    bad_spec = make(panel="verfy", panel_key_file=str(good))
-    assert "unknown kind" in _panel_preflight_error(bad_spec)
-    assert "not contained" not in _panel_preflight_error(bad_spec)  # first error wins
+    both_wrong = make(panel="verfy:hermes", panel_key_file=str(good))
+    err = _panel_preflight_error(both_wrong)
+    assert "unknown kind" in err  # kind is checked before backend
+    assert "claude backend" not in err
     assert "only the claude backend" in _panel_preflight_error(
         make(panel="verify:hermes", panel_key_file=str(good))
     )

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1633,6 +1633,16 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
     env["AUTORESEARCH_PANEL"] = ""
     _github, off = _followup_spec_from_env(tmp_path)
     assert off is not None and off.panel == ""
+    # work jobs can ride a longer partition than the tick chain, with the
+    # walltime cap raised in lockstep (clamped to the code-side ceiling)
+    env["AUTORESEARCH_JOB_PARTITION"] = "cpu48"
+    env["AUTORESEARCH_MAX_JOB_MINUTES"] = "480"
+    _github, longer = _followup_spec_from_env(tmp_path)
+    assert longer is not None
+    assert longer.job_partition == "cpu48" and longer.max_job_minutes == 480
+    env["AUTORESEARCH_MAX_JOB_MINUTES"] = "9000"  # above the ceiling
+    _github, capped = _followup_spec_from_env(tmp_path)
+    assert capped is not None and capped.max_job_minutes == 600
 
 
 def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch: Any) -> None:
@@ -1756,7 +1766,9 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     limits = effective_limits()  # defaults: 120-min job, 90-min session
     assert _panel_job_minutes(make(panel=""), limits) == 0
     wanted = limits.climb_job_minutes + _panel_job_minutes(make(), limits)
-    assert wanted > MAX_CLIMB_JOB_MINUTES  # the default path NEEDS the clamp
+    # the default path NEEDS the clamp (spec.max_job_minutes defaults to
+    # MAX_CLIMB_JOB_MINUTES = cpu_short's 6h MaxTime)
+    assert wanted > MAX_CLIMB_JOB_MINUTES
     submitted2: list[str] = []
 
     def runner2(argv, timeout_s):

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1336,6 +1336,7 @@ roadmap: docs/roadmap.md
         home=tmp_path,
         key_file="/k",
         steward_key_file="/k",
+        panel="",  # the outage latch must be what returns None, not the preflight
     )
 
     class G:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1690,14 +1690,6 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     same = make(panel_key_file=str(good), key_file=str(good))
     assert "author key" in _panel_preflight_error(same)
 
-    # the walltime allowance exists exactly when the panel does
-    from autoresearch.limits import effective_limits
-    from autoresearch.tick import _panel_job_minutes
-
-    limits = effective_limits()
-    assert _panel_job_minutes(make(panel=""), limits) == 0
-    assert _panel_job_minutes(make(), limits) > 0
-
     # both lanes consult it BEFORE side effects: nothing claimed or submitted
     bad = make(panel_key_file=str(tmp_path / "nope"))
     submitted: list[str] = []
@@ -1740,3 +1732,53 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     ok = make(panel_key_file=str(good))
     assert service_intake(tmp_path, gh, compute, ok, NOW, contract=contract) is not None
     assert len(gh.comments) == 1 and len(submitted) == 1
+
+    # a failed submit RELEASES the claim (pick_issue skips claimed issues,
+    # so without the release the issue would be stranded forever)
+    from autoresearch.intake import RELEASE_MARKER
+
+    def failing_runner(argv, timeout_s):
+        return CommandResult(1, "", "sbatch: error")
+
+    gh2 = IntakeGitHub()
+    out = service_intake(
+        tmp_path, gh2, SlurmCompute(runner=failing_runner), ok, NOW, contract=contract
+    )
+    assert out is None
+    assert any(RELEASE_MARKER in c for c in gh2.comments)
+
+    # the walltime allowance exists exactly when the panel does — and the
+    # panel-augmented total clamps at the 6h partition cap (sbatch would
+    # REJECT a longer request outright, grounding every climb)
+    from autoresearch.limits import effective_limits
+    from autoresearch.tick import MAX_CLIMB_JOB_MINUTES, _panel_job_minutes
+
+    limits = effective_limits()  # defaults: 120-min job, 90-min session
+    assert _panel_job_minutes(make(panel=""), limits) == 0
+    wanted = limits.climb_job_minutes + _panel_job_minutes(make(), limits)
+    assert wanted > MAX_CLIMB_JOB_MINUTES  # the default path NEEDS the clamp
+    submitted2: list[str] = []
+
+    def runner2(argv, timeout_s):
+        submitted2.append(" ".join(argv))
+        return CommandResult(0, "77\n", "")
+
+    ok2 = make(panel_key_file=str(good))
+    from autoresearch.contract import load_contract
+
+    default_contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    out2 = service_self_initiated(
+        tmp_path, SlurmCompute(runner=runner2), ok2, default_contract, NOW + 9000
+    )
+    assert out2 is not None
+    assert f"--time={MAX_CLIMB_JOB_MINUTES}" in submitted2[0]
+    assert f"--job-minutes {MAX_CLIMB_JOB_MINUTES}" in submitted2[0]


### PR DESCRIPTION
The deploy half of #95: both climb submission sites pass `--panel verify,review` by default. Operator knobs: `AUTORESEARCH_PANEL=""` disables; `AUTORESEARCH_PANEL_KEY_FILE` overrides the verifier-key path. A missing key fails climbs loudly by design. Cluster prerequisite (roadmap): the verifier key file on the tick account — it already exists on cluster0 per the verifier deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)