### PR TITLE
hermes openai-direct: provider-aware key wiring

### DIFF
--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -41,7 +41,9 @@ on:
         description: >-
           Model for the session. Empty uses the backend default
           (claude-opus-5 for claude; the backend's own default otherwise).
-          For hermes pass an OpenRouter id.
+          For hermes pass an OpenRouter id — except with
+          hermes_provider: openai, which REQUIRES the provider-native id
+          (gpt-5.6-terra, no openai/ prefix).
         type: string
         required: false
         default: ''

--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -89,10 +89,13 @@ on:
         description: Anthropic key for the claude backend.
         required: false
       openrouter_api_key:
-        description: OpenRouter key for the hermes backend.
+        description: OpenRouter key for the hermes backend (default provider).
         required: false
       openai_reviewer_key:
-        description: OpenAI key for the codex backend.
+        description: >-
+          OpenAI key, shared by the codex backend and hermes with
+          hermes_provider: openai — one org key, two backends; only the
+          selected session's tree ever sees it.
         required: false
       checkout_ssh_key:
         description: >-

--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -45,6 +45,15 @@ on:
         type: string
         required: false
         default: ''
+      hermes_provider:
+        description: >-
+          Credential provider for the hermes backend: openrouter (default) or
+          openai — openai-direct uses OPENAI_REVIEWER_KEY, avoids the
+          OpenRouter platform fee, and takes provider-NATIVE model ids
+          (gpt-5.6-terra, no openai/ prefix).
+        type: string
+        required: false
+        default: openrouter
       opinion_label:
         description: >-
           Label shown on the posted round (who this opinion is). Leave empty
@@ -184,7 +193,7 @@ jobs:
           REVIEW_CODEX_LEGACY_LANDLOCK: ${{ inputs.backend == 'codex' && '1' || '' }}
           # hermes reads its pinned clone from here; provider seeds ~/.hermes.
           REVIEW_HERMES_REPO: ${{ github.workspace }}/hermes-agent
-          REVIEW_HERMES_PROVIDER: openrouter
+          REVIEW_HERMES_PROVIDER: ${{ inputs.hermes_provider }}
           # read-only job token: PR metadata/diff fetch only
           GITHUB_TOKEN: ${{ github.token }}
           PR_REPO: ${{ github.repository }}

--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -247,7 +247,12 @@ jobs:
           cache-dependency-glob: .autoresearch/uv.lock
       - name: Download findings
         id: findings
-        continue-on-error: true  # no artifact = clean skip upstream
+        # NO continue-on-error: every session outcome uploads an envelope
+        # (findings / skip-stub / skip-clean), so a missing artifact means
+        # the session died before emitting — fail this job visibly (the
+        # caller's PR stays green; the job is continue-on-error at job
+        # level). Observed live 2026-08-15: errored terra sessions posted
+        # nothing and read as quiet clean days.
         uses: actions/download-artifact@v4
         with:
           name: review-findings-${{ inputs.opinion_id || inputs.backend }}-${{ env.PR_NUMBER }}

--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -209,6 +209,20 @@ jobs:
           REVIEW_CHECKOUT: ${{ github.workspace }}/pr-head
           REVIEW_EMIT_FILE: ${{ runner.temp }}/findings.json
         run: uv run python -m autoresearch.review_agent_cli
+      - name: Backstop envelope
+        # Runs only when the CLI exited 0 (default step semantics): a
+        # reviewer_ref pinned BEFORE envelope-on-every-outcome writes nothing
+        # on a clean skip, which would hard-fail the post job's required
+        # download on every bot PR. A crashed session exits nonzero, skips
+        # this step, and still fails loudly downstream.
+        working-directory: .autoresearch
+        env:
+          PR_REPO: ${{ github.repository }}
+          EMIT_FILE: ${{ runner.temp }}/findings.json
+        run: |
+          if [ ! -f "$EMIT_FILE" ]; then
+            uv run python -c "import json, os, pathlib; pathlib.Path(os.environ['EMIT_FILE']).write_text(json.dumps({'repo': os.environ['PR_REPO'], 'number': int(os.environ['PR_NUMBER']), 'kind': 'skip-clean', 'detail': 'session wrote no envelope (reviewer_ref predates envelope emission)'}))"
+          fi
       - name: Upload findings
         # not `success()`: a session step that died AFTER emitting must still
         # deliver its findings (or its skip-stub) to the posting job

--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -185,9 +185,12 @@ jobs:
           # ONLY the chosen backend's key enters the session process tree: a
           # shell/file-reading backend must not be able to lift a sibling
           # backend's key via /proc (terra's blocking finding, #94 round 1)
+          # ... and for hermes the key follows the PROVIDER: an openai-direct
+          # session gets only the OpenAI key, an openrouter session only the
+          # OpenRouter key.
           ANTHROPIC_REVIEWER_KEY: ${{ inputs.backend == 'claude' && secrets.anthropic_reviewer_key || '' }}
-          OPENROUTER_API_KEY: ${{ inputs.backend == 'hermes' && secrets.openrouter_api_key || '' }}
-          OPENAI_REVIEWER_KEY: ${{ inputs.backend == 'codex' && secrets.openai_reviewer_key || '' }}
+          OPENROUTER_API_KEY: ${{ inputs.backend == 'hermes' && inputs.hermes_provider != 'openai' && secrets.openrouter_api_key || '' }}
+          OPENAI_REVIEWER_KEY: ${{ (inputs.backend == 'codex' || (inputs.backend == 'hermes' && inputs.hermes_provider == 'openai')) && secrets.openai_reviewer_key || '' }}
           # codex's default bwrap can't init on GitHub-hosted; opt into
           # Landlock (read-only, no egress). Harmless for other backends.
           REVIEW_CODEX_LEGACY_LANDLOCK: ${{ inputs.backend == 'codex' && '1' || '' }}

--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -214,14 +214,18 @@ jobs:
         # reviewer_ref pinned BEFORE envelope-on-every-outcome writes nothing
         # on a clean skip, which would hard-fail the post job's required
         # download on every bot PR. A crashed session exits nonzero, skips
-        # this step, and still fails loudly downstream.
+        # this step, and still fails loudly downstream. The backstop is a
+        # skip-STUB, not skip-clean: the poster's own skip re-check silences
+        # it on bot/opt-out PRs (the pinned-ref clean-skip case), while a
+        # session that went silent on a human PR posts a visible
+        # could-not-run round instead of being relabeled a quiet day.
         working-directory: .autoresearch
         env:
           PR_REPO: ${{ github.repository }}
           EMIT_FILE: ${{ runner.temp }}/findings.json
         run: |
           if [ ! -f "$EMIT_FILE" ]; then
-            uv run python -c "import json, os, pathlib; pathlib.Path(os.environ['EMIT_FILE']).write_text(json.dumps({'repo': os.environ['PR_REPO'], 'number': int(os.environ['PR_NUMBER']), 'kind': 'skip-clean', 'detail': 'session wrote no envelope (reviewer_ref predates envelope emission)'}))"
+            uv run python -c "import json, os, pathlib; pathlib.Path(os.environ['EMIT_FILE']).write_text(json.dumps({'repo': os.environ['PR_REPO'], 'number': int(os.environ['PR_NUMBER']), 'kind': 'skip-stub', 'detail': 'session wrote no envelope (reviewer_ref predates envelope emission, or the session went silent)'}))"
           fi
       - name: Upload findings
         # not `success()`: a session step that died AFTER emitting must still

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -24,11 +24,16 @@ on:
       model:
         description: >-
           Model for the session. Empty -> the backend default (claude-opus-5,
-          codex configured, hermes default). For hermes pass an OpenRouter id,
-          e.g. deepseek/deepseek-chat.
+          codex configured, hermes default). For hermes pass the PROVIDER'S
+          native id (openrouter: deepseek/deepseek-chat; openai: gpt-5.6-terra).
         type: string
         required: false
         default: ''
+      hermes_provider:
+        description: hermes credential provider (openrouter | openai)
+        type: choice
+        options: [openrouter, openai]
+        default: openrouter
 
 permissions:
   contents: read
@@ -97,7 +102,7 @@ jobs:
           REVIEW_CODEX_LEGACY_LANDLOCK: ${{ inputs.backend == 'codex' && '1' || '' }}
           # hermes reads its pinned clone from here; provider seeds ~/.hermes.
           REVIEW_HERMES_REPO: ${{ github.workspace }}/hermes-agent
-          REVIEW_HERMES_PROVIDER: openrouter
+          REVIEW_HERMES_PROVIDER: ${{ inputs.hermes_provider }}
           GITHUB_TOKEN: ${{ github.token }}
           PR_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number }}

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -94,9 +94,11 @@ jobs:
         env:
           REVIEW_BACKEND: ${{ inputs.backend }}
           REVIEW_MODEL: ${{ inputs.model }}
-          ANTHROPIC_REVIEWER_KEY: ${{ secrets.ANTHROPIC_REVIEWER_KEY }}
-          OPENAI_REVIEWER_KEY: ${{ secrets.OPENAI_REVIEWER_KEY }}
-          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          # one key per session tree, same rule as the reusable: a
+          # file-reading backend must not be able to lift a sibling's key
+          ANTHROPIC_REVIEWER_KEY: ${{ inputs.backend == 'claude' && secrets.ANTHROPIC_REVIEWER_KEY || '' }}
+          OPENROUTER_API_KEY: ${{ inputs.backend == 'hermes' && inputs.hermes_provider != 'openai' && secrets.OPENROUTER_API_KEY || '' }}
+          OPENAI_REVIEWER_KEY: ${{ (inputs.backend == 'codex' || (inputs.backend == 'hermes' && inputs.hermes_provider == 'openai')) && secrets.OPENAI_REVIEWER_KEY || '' }}
           # codex's default bwrap can't init on GitHub-hosted; opt into Landlock
           # (read-only, no egress). Harmless for the other backends.
           REVIEW_CODEX_LEGACY_LANDLOCK: ${{ inputs.backend == 'codex' && '1' || '' }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -29,7 +29,10 @@ jobs:
     with:
       bot_login: agentic-learning-bot
       backend: hermes
-      model: openai/gpt-5.6-terra
+      # openai-direct: same token rate, no OpenRouter platform fee (the org's
+      # OpenAI account is tax-exempt); model id is provider-native
+      hermes_provider: openai
+      model: gpt-5.6-terra
       opinion_label: second opinion — terra
     secrets:
-      openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
+      openai_reviewer_key: ${{ secrets.OPENAI_REVIEWER_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -19,7 +19,7 @@ jobs:
     secrets:
       anthropic_reviewer_key: ${{ secrets.ANTHROPIC_REVIEWER_KEY }}
 
-  # Independent second opinion (terra via hermes/OpenRouter) — same reusable,
+  # Independent second opinion (terra via hermes, openai-direct) — same reusable,
   # different backend and opinion label. Independence is the point: no coordination with
   # the primary round.
   second-opinion:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,13 @@ Versions follow [SemVer](https://semver.org).
   job with a different backend/model. Session cost and turns are logged at
   emit/post time. On private repos the session job carries a read-scoped
   token only; it becomes tokenless at the public flip.
+- The hermes backend can run directly against the OpenAI API: the new
+  `hermes_provider` workflow input (`openrouter` default | `openai`) seeds
+  hermes's canonical `openai-api` provider and switches the key source to
+  `openai_reviewer_key` — same token rate, no OpenRouter platform fee, and
+  provider-native model ids (`gpt-5.6-terra`, no `openai/` prefix). Key
+  injection stays one-key-per-session-tree across the provider split, and a
+  typo'd provider posts a PR-visible skip stub like a typo'd backend.
 - Every judge round now names its reviewer in the round stamp —
   ``reviewer `backend/model`​`` (e.g. `claude/claude-opus-5`, `hermes/<terra
   id>`) — on advisory rounds, second opinions (via the envelope), and

--- a/docs/install.md
+++ b/docs/install.md
@@ -65,6 +65,12 @@ same reusable, different backend. Each opinion posts its own labeled round:
       openrouter_api_key: ${{ secrets.OPENROUTER_API_KEY }}
 ```
 
+To run the same hermes opinion **directly against the OpenAI API** (no
+OpenRouter platform fee), add `hermes_provider: openai` under `with:`, pass
+`openai_reviewer_key: ${{ secrets.OPENAI_REVIEWER_KEY }}` in `secrets:`
+instead of the OpenRouter key, and use the provider-NATIVE model id
+(`model: gpt-5.6-terra` — no `openai/` prefix).
+
 For `backend: codex` instead: pass `openai_reviewer_key: ${{ secrets.OPENAI_REVIEWER_KEY }}`
 in `secrets:`, and set `model` to a Codex model id (or omit it for the codex
 default) — an OpenRouter id will not work there.

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -881,7 +881,7 @@ class HermesHarness:
     # upstream split of the `file` toolset into read/write.
     approvals_deny: tuple[str, ...] = ()
     model: str = ""  # OpenRouter format (provider/model); empty -> hermes default
-    base_url: str = ""  # empty -> OpenRouter; any OpenAI-compatible endpoint works
+    base_url: str = ""  # empty -> the seeded provider's own endpoint
     max_turns: int = DEFAULT_MAX_TURNS
     timeout_s: int = DEFAULT_TIMEOUT_S
     enabled_toolsets: tuple[str, ...] = ("file",)

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -754,9 +754,10 @@ def _hermes_command(
 
     The BRIEF is never in argv — it is written to a file and `query` is only a
     short pointer instruction. The API key is never in argv either: hermes
-    reads OPENROUTER_API_KEY from the environment when --api_key is absent,
-    regardless of base_url. --save_sample makes hermes write a JSON trajectory
-    to its cwd, which is the machine-readable result channel."""
+    reads it from the env var its SEEDED PROVIDER's registry names (the
+    harness exports it under key_env; openrouter reads OPENROUTER_API_KEY,
+    openai-api reads OPENAI_API_KEY). --save_sample makes hermes write a JSON
+    trajectory to its cwd, which is the machine-readable result channel."""
     argv = [
         "uv",
         "run",

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -98,27 +98,27 @@ def build_reviewer_harness(
     if backend == "hermes":
         if hermes_repo is None:
             raise ValueError("hermes reviewer backend needs hermes_repo (the pinned clone)")
-        # openai-direct is NOT a hermes registry provider: hermes's headless
-        # client takes any OpenAI-compatible base_url and reads its key from
-        # the OPENROUTER_API_KEY env slot regardless of endpoint (verified
-        # against the pinned source, v2026.8.13). So "openai" here means:
-        # point base_url at api.openai.com, export the ORG'S OPENAI KEY into
-        # hermes's key slot, and use the provider-NATIVE model id
-        # (gpt-5.6-terra, no openai/ prefix). Same token rate, no OpenRouter
-        # platform fee, and the org's tax exemption applies.
-        endpoints = {"openrouter": "", "openai": "https://api.openai.com/v1"}
-        if (provider or "openrouter") not in endpoints:
+        # "openai" maps to hermes's canonical openai-api provider (api-key
+        # auth against api.openai.com, key read from OPENAI_API_KEY; plain
+        # "openai" is a provider GROUP in hermes, not an id). openai-direct
+        # skips the OpenRouter platform fee at the same token rate, and the
+        # org's tax exemption applies. Model ids are provider-native:
+        # openai/gpt-5.6-terra on openrouter, gpt-5.6-terra on openai-api.
+        hermes_providers = {
+            "openrouter": ("openrouter", "OPENROUTER_API_KEY"),
+            "openai": ("openai-api", "OPENAI_API_KEY"),
+        }
+        if (provider or "openrouter") not in hermes_providers:
             raise ValueError(f"unknown hermes provider: {provider!r}")
+        seed, key_env = hermes_providers[provider or "openrouter"]
         # Defaults already encode the judge shape: file toolset only, terminal
         # and every other executing/egress toolset disabled. Read-only rests on
         # that config plus the ephemeral runner (see the docstring above).
         return HermesHarness(
             api_key=api_key,
+            key_env=key_env,
             repo_dir=hermes_repo,
-            # the config seed hermes accepts; the endpoint override does the
-            # actual routing
-            provider="openrouter",
-            base_url=endpoints[provider or "openrouter"],
+            provider=seed,
             model=model or "",
             max_turns=spec.budget.max_turns,
             timeout_s=spec.budget.walltime_s,

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -10,6 +10,7 @@ the same rubric (via `build_agent_brief`), the same result policy
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 from datetime import UTC, datetime
@@ -339,4 +340,17 @@ def run_agent_review(
         return round_label
     except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
         log.warning("agent review did not complete: %s: %s", type(exc).__name__, exc)
+        if emit_path is not None:
+            # the invariant holds here too: the workflow backstop would cover
+            # a missing file, but with a generic detail — the real failure is
+            # the one worth reading on the PR
+            with contextlib.suppress(Exception):
+                _emit(
+                    emit_path,
+                    repo,
+                    number,
+                    kind="skip-stub",
+                    detail=f"{type(exc).__name__}: {exc}",
+                    reviewed_by=backend_id(harness),
+                )
         return None

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -98,24 +98,27 @@ def build_reviewer_harness(
     if backend == "hermes":
         if hermes_repo is None:
             raise ValueError("hermes reviewer backend needs hermes_repo (the pinned clone)")
-        # hermes resolves credentials from provider-specific env vars: the
-        # harness must export the key under the name the CHOSEN provider
-        # reads. openai-direct avoids the OpenRouter platform fee (and the
-        # org's tax exemption applies) at the same token rate.
-        key_envs = {"openrouter": "OPENROUTER_API_KEY", "openai": "OPENAI_API_KEY"}
-        key_env = key_envs.get(provider or "openrouter")
-        if key_env is None:
+        # openai-direct is NOT a hermes registry provider: hermes's headless
+        # client takes any OpenAI-compatible base_url and reads its key from
+        # the OPENROUTER_API_KEY env slot regardless of endpoint (verified
+        # against the pinned source, v2026.8.13). So "openai" here means:
+        # point base_url at api.openai.com, export the ORG'S OPENAI KEY into
+        # hermes's key slot, and use the provider-NATIVE model id
+        # (gpt-5.6-terra, no openai/ prefix). Same token rate, no OpenRouter
+        # platform fee, and the org's tax exemption applies.
+        endpoints = {"openrouter": "", "openai": "https://api.openai.com/v1"}
+        if (provider or "openrouter") not in endpoints:
             raise ValueError(f"unknown hermes provider: {provider!r}")
         # Defaults already encode the judge shape: file toolset only, terminal
         # and every other executing/egress toolset disabled. Read-only rests on
         # that config plus the ephemeral runner (see the docstring above).
         return HermesHarness(
             api_key=api_key,
-            key_env=key_env,
             repo_dir=hermes_repo,
-            provider=provider,
-            # model id is PROVIDER-NATIVE: openai/gpt-5.6-terra on openrouter,
-            # gpt-5.6-terra on openai-direct; empty -> hermes default
+            # the config seed hermes accepts; the endpoint override does the
+            # actual routing
+            provider="openrouter",
+            base_url=endpoints[provider or "openrouter"],
             model=model or "",
             max_turns=spec.budget.max_turns,
             timeout_s=spec.budget.walltime_s,

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -98,14 +98,25 @@ def build_reviewer_harness(
     if backend == "hermes":
         if hermes_repo is None:
             raise ValueError("hermes reviewer backend needs hermes_repo (the pinned clone)")
+        # hermes resolves credentials from provider-specific env vars: the
+        # harness must export the key under the name the CHOSEN provider
+        # reads. openai-direct avoids the OpenRouter platform fee (and the
+        # org's tax exemption applies) at the same token rate.
+        key_envs = {"openrouter": "OPENROUTER_API_KEY", "openai": "OPENAI_API_KEY"}
+        key_env = key_envs.get(provider or "openrouter")
+        if key_env is None:
+            raise ValueError(f"unknown hermes provider: {provider!r}")
         # Defaults already encode the judge shape: file toolset only, terminal
         # and every other executing/egress toolset disabled. Read-only rests on
         # that config plus the ephemeral runner (see the docstring above).
         return HermesHarness(
             api_key=api_key,
+            key_env=key_env,
             repo_dir=hermes_repo,
             provider=provider,
-            model=model or "",  # OpenRouter provider/model; empty -> hermes default
+            # model id is PROVIDER-NATIVE: openai/gpt-5.6-terra on openrouter,
+            # gpt-5.6-terra on openai-direct; empty -> hermes default
+            model=model or "",
             max_turns=spec.budget.max_turns,
             timeout_s=spec.budget.walltime_s,
         )

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -237,11 +237,14 @@ def run_agent_review(
     produce a verdict. Advisory: never raises the expected failures, so it can
     never turn a target repo's CI red.
 
-    With `emit_path`, nothing is posted: the raw findings (or a skip-stub
-    marker) are written there for a separate posting step — the least-token
+    With `emit_path`, nothing is posted: the raw findings (or a skip
+    envelope) are written there for a separate posting step — the least-token
     split (docs/design/reviewer-infra.md). The session job runs with read-only
     permissions; the posting job holds the write token but runs no session.
-    A clean skip (bot PR, opt-out, empty diff) writes nothing.
+    EVERY outcome writes an envelope — findings, a PR-visible skip-stub
+    (missing key, errored session), or skip-clean (bot PR, opt-out; posts
+    nothing) — so the posting job can treat a missing artifact as a broken
+    session, loudly.
     """
     spec = spec or reviewer_spec()
     today = today or datetime.now(UTC).date().isoformat()
@@ -250,6 +253,11 @@ def run_agent_review(
         skip = skip_reason(pr, bot_login)
         if skip is not None:
             log.info("skipping agent review of %s#%s: %s", repo, number, skip)
+            if emit_path is not None:
+                # even a clean skip leaves an envelope: the posting job can
+                # then REQUIRE an artifact, so "no artifact" always means a
+                # broken session, never an ambiguous quiet day
+                _emit(emit_path, repo, number, kind="skip-clean", detail=skip)
             return None
 
         role_result = run_role(spec, harness, build_agent_brief(pr, today), workspace)
@@ -260,20 +268,24 @@ def run_agent_review(
             # on the thread; other failures are logged, advisory-silent.
             detail = role_result.error or role_result.session.stop_reason
             log.warning("agent review produced no verdict on %s#%s: %s", repo, number, detail)
-            if outage(role_result.session) or budget_exhausted(role_result.session):
-                # `detail` is already api-key-redacted by the harness (it owns
-                # its own secret), so no secrets are passed here.
-                if emit_path is not None:
-                    _emit(
-                        emit_path,
-                        repo,
-                        number,
-                        kind="skip-stub",
-                        detail=detail,
-                        reviewed_by=backend_id(harness),
-                    )
-                else:
-                    post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
+            # `detail` is already api-key-redacted by the harness (it owns
+            # its own secret), so no secrets are passed here.
+            if emit_path is not None:
+                # EVERY errored session surfaces on the PR in the split
+                # topology: this job's log is not the record — the stub the
+                # post job publishes is. Observed live 2026-08-15: terra's
+                # structured-output failures posted nothing and two rounds
+                # read as quiet clean days.
+                _emit(
+                    emit_path,
+                    repo,
+                    number,
+                    kind="skip-stub",
+                    detail=detail,
+                    reviewed_by=backend_id(harness),
+                )
+            elif outage(role_result.session) or budget_exhausted(role_result.session):
+                post_skip_stub(client, repo, number, "advisory review", RuntimeError(detail))
             return None
 
         if emit_path is not None:

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -109,6 +109,21 @@ def main() -> int:
             return 0
         hermes_repo = Path(hermes_repo_env).resolve()
         provider = hermes_provider
+        if provider == "openai" and not os.environ.get("REVIEW_MODEL", "").strip():
+            # empty model falls back to hermes's default id, which is
+            # OpenRouter-shaped and cannot be served by api.openai.com
+            detail = "hermes+openai requires a provider-native REVIEW_MODEL"
+            log.warning("%s; skipping review", detail)
+            if emit_env:
+                _emit(
+                    Path(emit_env).resolve(),
+                    repo,
+                    number,
+                    kind="skip-stub",
+                    detail=detail,
+                    reviewed_by=backend,
+                )
+            return 0
     # The workflow checks out the PR head read-only into REVIEW_CHECKOUT; the
     # agent reads it but never executes it (read-only tool set). Fail closed:
     # defaulting to cwd would silently review the wrong tree (the reviewer's

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -43,10 +43,13 @@ def main() -> int:
     # key by REVIEW_BACKEND (claude | codex | hermes), per the Harness seam.
     backend = os.environ.get("REVIEW_BACKEND", "claude").strip().lower()
     emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
+    # hermes's key SOURCE follows its provider: openai-direct uses the same
+    # org-registered OpenAI key as codex (no OpenRouter platform fee)
+    hermes_provider = os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter").strip().lower()
     key_var = {
         "claude": "ANTHROPIC_REVIEWER_KEY",
         "codex": "OPENAI_REVIEWER_KEY",
-        "hermes": "OPENROUTER_API_KEY",
+        "hermes": "OPENAI_REVIEWER_KEY" if hermes_provider == "openai" else "OPENROUTER_API_KEY",
     }.get(backend)
     if key_var is None:
         log.warning("unknown REVIEW_BACKEND %r; skipping review", backend)
@@ -97,7 +100,7 @@ def main() -> int:
             log.warning("REVIEW_HERMES_REPO is unset; skipping (hermes needs its pinned clone)")
             return 0
         hermes_repo = Path(hermes_repo_env).resolve()
-        provider = os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter").strip()
+        provider = hermes_provider
     # The workflow checks out the PR head read-only into REVIEW_CHECKOUT; the
     # agent reads it but never executes it (read-only tool set). Fail closed:
     # defaulting to cwd would silently review the wrong tree (the reviewer's

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -44,24 +44,34 @@ def main() -> int:
     backend = os.environ.get("REVIEW_BACKEND", "claude").strip().lower()
     emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
     # hermes's key SOURCE follows its provider: openai-direct uses the same
-    # org-registered OpenAI key as codex (no OpenRouter platform fee)
-    hermes_provider = os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter").strip().lower()
+    # org-registered OpenAI key as codex (no OpenRouter platform fee).
+    # Explicitly-empty input means the default, same as an omitted one.
+    hermes_provider = (
+        os.environ.get("REVIEW_HERMES_PROVIDER", "").strip().lower() or "openrouter"
+    )
     key_var = {
         "claude": "ANTHROPIC_REVIEWER_KEY",
         "codex": "OPENAI_REVIEWER_KEY",
-        "hermes": "OPENAI_REVIEWER_KEY" if hermes_provider == "openai" else "OPENROUTER_API_KEY",
+        "hermes": {"openrouter": "OPENROUTER_API_KEY", "openai": "OPENAI_REVIEWER_KEY"}.get(
+            hermes_provider
+        ),
     }.get(backend)
     if key_var is None:
-        log.warning("unknown REVIEW_BACKEND %r; skipping review", backend)
+        # a typo in a caller's free-form backend/provider input must be a
+        # PR-visible stub, not a silent log line or a traceback
+        what = (
+            f"unknown REVIEW_HERMES_PROVIDER {hermes_provider!r}"
+            if backend == "hermes"
+            else f"unknown REVIEW_BACKEND {backend!r}"
+        )
+        log.warning("%s; skipping review", what)
         if emit_env:
-            # a typo in a caller's backend input must be a PR-visible stub,
-            # not a silent log line
             _emit(
                 Path(emit_env).resolve(),
                 repo,
                 number,
                 kind="skip-stub",
-                detail=f"unknown REVIEW_BACKEND {backend!r}",
+                detail=what,
                 reviewed_by=backend,
             )
         return 0

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -23,6 +23,22 @@ from autoresearch.review_agent import (
 log = logging.getLogger(__name__)
 
 
+def _skip_stub(emit_env: str, repo: str, number: int, detail: str, reviewed_by: str) -> None:
+    """A fail-closed skip still leaves an envelope when emitting: the post job
+    REQUIRES an artifact, and a standing reviewer that cannot run must say so
+    on the PR rather than fail into silence."""
+    log.warning("%s; skipping review", detail)
+    if emit_env:
+        _emit(
+            Path(emit_env).resolve(),
+            repo,
+            number,
+            kind="skip-stub",
+            detail=detail,
+            reviewed_by=reviewed_by,
+        )
+
+
 def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(message)s")
     # Fail closed on a missing/invalid PR reference too, so a misconfigured
@@ -33,11 +49,12 @@ def main() -> int:
         log.warning("PR_REPO/PR_NUMBER unset or invalid; skipping")
         return 0
     number = int(number_raw)
+    emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
     # Fail closed: without the bot login we cannot honor "never review
     # bot-authored PRs", so we do not review at all.
     bot_login = os.environ.get("REVIEW_BOT_LOGIN", "").strip()
     if not bot_login:
-        log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot identify bot-authored PRs)")
+        _skip_stub(emit_env, repo, number, "REVIEW_BOT_LOGIN is unset", "")
         return 0
     # Backend is a deployment choice, not baked in: pick the harness and its
     # key by REVIEW_BACKEND (claude | codex | hermes), per the Harness seam.
@@ -46,7 +63,6 @@ def main() -> int:
     # workflow's key-injection expressions can never disagree about a value:
     # a padded input misses both layers and lands in the unknown-value stub.
     backend = os.environ.get("REVIEW_BACKEND", "claude").lower() or "claude"
-    emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
     # a model id is never compared against workflow expressions, so trimming
     # is safe here — and the same trimmed value must reach gate and harness
     review_model = os.environ.get("REVIEW_MODEL", "").strip()
@@ -112,10 +128,28 @@ def main() -> int:
     if backend == "hermes":
         hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
         if not hermes_repo_env:
-            log.warning("REVIEW_HERMES_REPO is unset; skipping (hermes needs its pinned clone)")
+            _skip_stub(
+                emit_env,
+                repo,
+                number,
+                "REVIEW_HERMES_REPO is unset (hermes needs its pinned clone)",
+                backend,
+            )
             return 0
         hermes_repo = Path(hermes_repo_env).resolve()
         provider = hermes_provider
+        if provider == "openrouter" and review_model and "/" not in review_model:
+            # the mirror mistake: OpenRouter ids are provider/model-shaped, so
+            # a native id would burn a session on an unresolvable model
+            _skip_stub(
+                emit_env,
+                repo,
+                number,
+                "hermes+openrouter requires an OpenRouter-shaped REVIEW_MODEL "
+                "(openai/gpt-5.6-terra, with the provider prefix)",
+                backend,
+            )
+            return 0
         if provider == "openai" and (not review_model or "/" in review_model):
             # an empty model falls back to hermes's default id and a slash
             # marks an OpenRouter-shaped one — api.openai.com serves neither,
@@ -141,7 +175,13 @@ def main() -> int:
     # own repo) if the checkout step were misconfigured.
     checkout = os.environ.get("REVIEW_CHECKOUT", "").strip()
     if not checkout:
-        log.warning("REVIEW_CHECKOUT is unset; skipping (won't review the wrong tree)")
+        _skip_stub(
+            emit_env,
+            repo,
+            number,
+            "REVIEW_CHECKOUT is unset (won't review the wrong tree)",
+            backend,
+        )
         return 0
     workspace = Path(checkout).resolve()
     # The checkout is untrusted: rename instruction files (CLAUDE.md, .claude/
@@ -149,7 +189,13 @@ def main() -> int:
     # failure means an instruction file is still live — fail closed.
     renamed, failed = sanitize_checkout(workspace)
     if failed:
-        log.warning("checkout could not be fully sanitized (%d left); skipping", failed)
+        _skip_stub(
+            emit_env,
+            repo,
+            number,
+            f"checkout could not be fully sanitized ({failed} instruction files left)",
+            backend,
+        )
         return 0
     if renamed:
         log.info("sanitized %d instruction file(s) in the checkout", renamed)

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -41,12 +41,16 @@ def main() -> int:
         return 0
     # Backend is a deployment choice, not baked in: pick the harness and its
     # key by REVIEW_BACKEND (claude | codex | hermes), per the Harness seam.
-    backend = os.environ.get("REVIEW_BACKEND", "claude").strip().lower()
+    # Free-form caller inputs are compared with EXACTLY GitHub's expression
+    # semantics — case-insensitive, never trimmed — so this CLI and the
+    # workflow's key-injection expressions can never disagree about a value:
+    # a padded input misses both layers and lands in the unknown-value stub.
+    backend = os.environ.get("REVIEW_BACKEND", "claude").lower() or "claude"
     emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
     # hermes's key SOURCE follows its provider: openai-direct uses the same
     # org-registered OpenAI key as codex (no OpenRouter platform fee).
     # Explicitly-empty input means the default, same as an omitted one.
-    hermes_provider = os.environ.get("REVIEW_HERMES_PROVIDER", "").strip().lower() or "openrouter"
+    hermes_provider = os.environ.get("REVIEW_HERMES_PROVIDER", "").lower() or "openrouter"
     key_var = {
         "claude": "ANTHROPIC_REVIEWER_KEY",
         "codex": "OPENAI_REVIEWER_KEY",
@@ -109,10 +113,15 @@ def main() -> int:
             return 0
         hermes_repo = Path(hermes_repo_env).resolve()
         provider = hermes_provider
-        if provider == "openai" and not os.environ.get("REVIEW_MODEL", "").strip():
-            # empty model falls back to hermes's default id, which is
-            # OpenRouter-shaped and cannot be served by api.openai.com
-            detail = "hermes+openai requires a provider-native REVIEW_MODEL"
+        review_model = os.environ.get("REVIEW_MODEL", "").strip()
+        if provider == "openai" and (not review_model or "/" in review_model):
+            # an empty model falls back to hermes's default id and a slash
+            # marks an OpenRouter-shaped one — api.openai.com serves neither,
+            # so the session would burn its budget on an unservable id
+            detail = (
+                "hermes+openai requires a provider-native REVIEW_MODEL "
+                "(gpt-5.6-terra, no openai/ prefix)"
+            )
             log.warning("%s; skipping review", detail)
             if emit_env:
                 _emit(

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -47,6 +47,9 @@ def main() -> int:
     # a padded input misses both layers and lands in the unknown-value stub.
     backend = os.environ.get("REVIEW_BACKEND", "claude").lower() or "claude"
     emit_env = os.environ.get("REVIEW_EMIT_FILE", "").strip()
+    # a model id is never compared against workflow expressions, so trimming
+    # is safe here — and the same trimmed value must reach gate and harness
+    review_model = os.environ.get("REVIEW_MODEL", "").strip()
     # hermes's key SOURCE follows its provider: openai-direct uses the same
     # org-registered OpenAI key as codex (no OpenRouter platform fee).
     # Explicitly-empty input means the default, same as an omitted one.
@@ -113,7 +116,6 @@ def main() -> int:
             return 0
         hermes_repo = Path(hermes_repo_env).resolve()
         provider = hermes_provider
-        review_model = os.environ.get("REVIEW_MODEL", "").strip()
         if provider == "openai" and (not review_model or "/" in review_model):
             # an empty model falls back to hermes's default id and a slash
             # marks an OpenRouter-shaped one — api.openai.com serves neither,
@@ -157,7 +159,7 @@ def main() -> int:
         api_key,
         backend=backend,
         binary=os.environ.get("REVIEW_BINARY") or None,  # else the backend default on PATH
-        model=os.environ.get("REVIEW_MODEL") or None,
+        model=review_model or None,
         hermes_repo=hermes_repo,
         provider=provider,
         sandbox_extra=sandbox_extra,

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -62,7 +62,10 @@ def main() -> int:
     # semantics — case-insensitive, never trimmed — so this CLI and the
     # workflow's key-injection expressions can never disagree about a value:
     # a padded input misses both layers and lands in the unknown-value stub.
-    backend = os.environ.get("REVIEW_BACKEND", "claude").lower() or "claude"
+    # explicit-empty mirrors the workflow too: '' matches no key-injection
+    # expression there, so here it must land in the unknown-backend stub
+    # rather than silently meaning claude
+    backend = os.environ.get("REVIEW_BACKEND", "claude").lower()
     # a model id is never compared against workflow expressions, so trimming
     # is safe here — and the same trimmed value must reach gate and harness
     review_model = os.environ.get("REVIEW_MODEL", "").strip()

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -46,9 +46,7 @@ def main() -> int:
     # hermes's key SOURCE follows its provider: openai-direct uses the same
     # org-registered OpenAI key as codex (no OpenRouter platform fee).
     # Explicitly-empty input means the default, same as an omitted one.
-    hermes_provider = (
-        os.environ.get("REVIEW_HERMES_PROVIDER", "").strip().lower() or "openrouter"
-    )
+    hermes_provider = os.environ.get("REVIEW_HERMES_PROVIDER", "").strip().lower() or "openrouter"
     key_var = {
         "claude": "ANTHROPIC_REVIEWER_KEY",
         "codex": "OPENAI_REVIEWER_KEY",

--- a/src/autoresearch/review_post_cli.py
+++ b/src/autoresearch/review_post_cli.py
@@ -59,6 +59,11 @@ def post_from_file(
         log.warning("findings envelope names a different PR; refused")
         return None
     kind = envelope.get("kind")
+    if kind == "skip-clean":
+        # a clean skip (bot PR, opt-out) posts nothing by design; the
+        # envelope exists so a MISSING artifact always means a broken session
+        log.info("session skipped cleanly (%s); nothing to post", envelope.get("detail", ""))
+        return None
     if kind not in ("skip-stub", "findings"):
         log.warning("unknown envelope kind %r; nothing posted", kind)
         return None

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -551,10 +551,12 @@ def test_hermes_openai_direct_exports_the_openai_key_env(tmp_path: Path) -> None
 
     h = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="openai")
     assert isinstance(h, HermesHarness)
-    assert h.key_env == "OPENAI_API_KEY" and h.provider == "openai"
+    assert h.base_url == "https://api.openai.com/v1"
+    assert h.provider == "openrouter"  # the config seed hermes accepts
+    assert h.key_env == "OPENROUTER_API_KEY"  # hermes's key slot, endpoint-independent
     default = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="")
     assert isinstance(default, HermesHarness)
-    assert default.key_env == "OPENROUTER_API_KEY"
+    assert default.base_url == ""
     import pytest
 
     with pytest.raises(ValueError, match="unknown hermes provider"):

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -541,3 +541,21 @@ def test_skip_stub_names_its_opinion(tmp_path: Path) -> None:
     )
     (comment,) = client.comments
     assert "advisory review (second opinion — terra)" in comment
+
+
+def test_hermes_openai_direct_exports_the_openai_key_env(tmp_path: Path) -> None:
+    # openai-direct: same token rate, no OpenRouter platform fee; hermes reads
+    # the key from the env var its provider registry names
+    from autoresearch.harness import HermesHarness
+    from autoresearch.review_agent import build_reviewer_harness
+
+    h = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="openai")
+    assert isinstance(h, HermesHarness)
+    assert h.key_env == "OPENAI_API_KEY" and h.provider == "openai"
+    default = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="")
+    assert isinstance(default, HermesHarness)
+    assert default.key_env == "OPENROUTER_API_KEY"
+    import pytest
+
+    with pytest.raises(ValueError, match="unknown hermes provider"):
+        build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="mystery")

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -551,12 +551,12 @@ def test_hermes_openai_direct_exports_the_openai_key_env(tmp_path: Path) -> None
 
     h = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="openai")
     assert isinstance(h, HermesHarness)
-    assert h.base_url == "https://api.openai.com/v1"
-    assert h.provider == "openrouter"  # the config seed hermes accepts
-    assert h.key_env == "OPENROUTER_API_KEY"  # hermes's key slot, endpoint-independent
+    assert h.provider == "openai-api"  # hermes's canonical id; "openai" is a group
+    assert h.key_env == "OPENAI_API_KEY"
     default = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="")
     assert isinstance(default, HermesHarness)
-    assert default.base_url == ""
+    assert default.provider == "openrouter"
+    assert default.key_env == "OPENROUTER_API_KEY"
     import pytest
 
     with pytest.raises(ValueError, match="unknown hermes provider"):

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -380,7 +380,9 @@ def test_emit_mode_outage_writes_skip_stub_marker(tmp_path: Path) -> None:
     assert "rate_limit_error" in envelope["detail"]
 
 
-def test_emit_mode_clean_skip_writes_no_file(tmp_path: Path) -> None:
+def test_emit_mode_clean_skip_writes_a_skip_clean_envelope(tmp_path: Path) -> None:
+    # even a clean skip leaves an envelope, so the post job can REQUIRE the
+    # artifact and a missing one always means a broken session
     client, harness = _Client(author="autoresearch-bot"), _Harness(_FINDINGS)
     out = tmp_path / "findings.json"
     label = run_agent_review(
@@ -393,7 +395,43 @@ def test_emit_mode_clean_skip_writes_no_file(tmp_path: Path) -> None:
         emit_path=out,
     )
     assert label is None
-    assert not out.exists()  # no artifact -> the post job no-ops
+    envelope = json.loads(out.read_text())
+    assert envelope["kind"] == "skip-clean"
+
+
+def test_emit_mode_errored_session_writes_a_stub(tmp_path: Path) -> None:
+    # NOT an outage/budget failure — e.g. invalid structured output. In the
+    # split topology this must still surface on the PR (observed live
+    # 2026-08-15: terra structured-output failures read as quiet clean days).
+    client = _Client()
+    harness = _Harness("", is_error=True, detail="invalid structured output: missing keys")
+    out = tmp_path / "findings.json"
+    label = run_agent_review(
+        client,  # type: ignore[arg-type]
+        "org/repo",
+        7,
+        harness,
+        _WORKSPACE,
+        bot_login="autoresearch-bot",
+        emit_path=out,
+    )
+    assert label is None
+    envelope = json.loads(out.read_text())
+    assert envelope["kind"] == "skip-stub"
+    assert "invalid structured output" in envelope["detail"]
+
+
+def test_post_from_file_skip_clean_posts_nothing(tmp_path: Path) -> None:
+    from autoresearch.review_post_cli import post_from_file
+
+    path = tmp_path / "findings.json"
+    path.write_text(
+        json.dumps({"repo": "org/repo", "number": 7, "kind": "skip-clean", "detail": "bot PR"})
+    )
+    client = _Client()
+    out = post_from_file(client, "org/repo", 7, "autoresearch-bot", path)  # type: ignore[arg-type]
+    assert out is None
+    assert client.reviews == [] and client.comments == []
 
 
 def _findings_envelope(tmp_path: Path, **overrides: Any) -> Path:

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -160,3 +160,46 @@ def test_hermes_openai_provider_reads_the_openai_key(monkeypatch: Any, tmp_path:
     assert cli.main() == 0
     assert calls["build_key"] == "sk-openai-test"
     assert calls["build_kwargs"]["provider"] == "openai"
+
+
+def test_unknown_hermes_provider_in_emit_mode_writes_a_stub(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    # the provider input is free-form like the backend input: a typo must be
+    # a PR-visible stub, never a traceback
+    import json
+
+    env = _base_env()
+    env.update(
+        {
+            "REVIEW_BACKEND": "hermes",
+            "REVIEW_HERMES_PROVIDER": "opnai",
+            "REVIEW_EMIT_FILE": str(tmp_path / "findings.json"),
+        }
+    )
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert "args" not in calls
+    envelope = json.loads((tmp_path / "findings.json").read_text())
+    assert envelope["kind"] == "skip-stub"
+    assert "unknown REVIEW_HERMES_PROVIDER" in envelope["detail"]
+
+
+def test_explicitly_empty_hermes_provider_means_the_default(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    # workflow env is always SET; empty must behave exactly like omitted
+    env = _base_env()
+    del env["ANTHROPIC_REVIEWER_KEY"]
+    env.update(
+        {
+            "REVIEW_BACKEND": "hermes",
+            "REVIEW_HERMES_PROVIDER": "",
+            "REVIEW_HERMES_REPO": str(tmp_path),
+            "OPENROUTER_API_KEY": "sk-or-test",
+        }
+    )
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert calls["build_key"] == "sk-or-test"
+    assert calls["build_kwargs"]["provider"] == "openrouter"

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -215,6 +215,51 @@ def test_hermes_openai_without_model_writes_a_stub(monkeypatch: Any, tmp_path: P
     assert "args" not in calls
 
 
+def test_fail_closed_skips_emit_stubs(monkeypatch: Any, tmp_path: Path) -> None:
+    # every fail-closed path leaves an envelope in emit mode: the post job
+    # requires the artifact, so a silent return would fail it for the wrong
+    # reason (and a misconfigured standing reviewer must be PR-visible)
+    import json
+
+    for missing, fragment in [
+        ("REVIEW_BOT_LOGIN", "REVIEW_BOT_LOGIN is unset"),
+        ("REVIEW_CHECKOUT", "REVIEW_CHECKOUT is unset"),
+    ]:
+        env = _base_env()
+        del env[missing]
+        env["REVIEW_EMIT_FILE"] = str(tmp_path / f"{missing}.json")
+        calls = _patch(monkeypatch, env)
+        assert cli.main() == 0
+        assert "args" not in calls
+        envelope = json.loads((tmp_path / f"{missing}.json").read_text())
+        assert envelope["kind"] == "skip-stub"
+        assert fragment in envelope["detail"]
+
+
+def test_openrouter_native_shaped_model_writes_a_stub(monkeypatch: Any, tmp_path: Path) -> None:
+    # the mirror of the openai-direct gate: OpenRouter cannot resolve a
+    # provider-native id, so the session would burn its budget for nothing
+    import json
+
+    env = _base_env()
+    del env["ANTHROPIC_REVIEWER_KEY"]
+    env.update(
+        {
+            "REVIEW_BACKEND": "hermes",
+            "REVIEW_HERMES_REPO": str(tmp_path),
+            "OPENROUTER_API_KEY": "sk-or-test",
+            "REVIEW_MODEL": "gpt-5.6-terra",  # missing the openai/ prefix
+            "REVIEW_EMIT_FILE": str(tmp_path / "findings.json"),
+        }
+    )
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert "args" not in calls
+    envelope = json.loads((tmp_path / "findings.json").read_text())
+    assert envelope["kind"] == "skip-stub"
+    assert "OpenRouter-shaped" in envelope["detail"]
+
+
 def test_padded_provider_matches_github_expression_semantics(
     monkeypatch: Any, tmp_path: Path
 ) -> None:

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -208,6 +208,35 @@ def test_hermes_openai_without_model_writes_a_stub(monkeypatch: Any, tmp_path: P
     envelope = json.loads((tmp_path / "findings.json").read_text())
     assert envelope["kind"] == "skip-stub"
     assert "provider-native REVIEW_MODEL" in envelope["detail"]
+    # an OpenRouter-shaped id is just as unservable as an empty one
+    env["REVIEW_MODEL"] = "openai/gpt-5.6-terra"
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert "args" not in calls
+
+
+def test_padded_provider_matches_github_expression_semantics(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    # the workflow's key-injection expressions compare untrimmed input; the
+    # CLI must apply the same rule so the two layers cannot disagree — a
+    # padded value lands in the unknown-provider stub, never a wrong-key skip
+    import json
+
+    env = _base_env()
+    env.update(
+        {
+            "REVIEW_BACKEND": "hermes",
+            "REVIEW_HERMES_PROVIDER": " openai ",
+            "REVIEW_EMIT_FILE": str(tmp_path / "findings.json"),
+        }
+    )
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert "args" not in calls
+    envelope = json.loads((tmp_path / "findings.json").read_text())
+    assert envelope["kind"] == "skip-stub"
+    assert "unknown REVIEW_HERMES_PROVIDER" in envelope["detail"]
 
 
 def test_explicitly_empty_hermes_provider_means_the_default(

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -143,3 +143,20 @@ def test_unknown_backend_in_emit_mode_writes_a_stub(monkeypatch: Any, tmp_path: 
     envelope = json.loads((tmp_path / "findings.json").read_text())
     assert envelope["kind"] == "skip-stub"
     assert "unknown REVIEW_BACKEND" in envelope["detail"]
+
+
+def test_hermes_openai_provider_reads_the_openai_key(monkeypatch: Any, tmp_path: Path) -> None:
+    env = _base_env()
+    del env["ANTHROPIC_REVIEWER_KEY"]
+    env.update(
+        {
+            "REVIEW_BACKEND": "hermes",
+            "REVIEW_HERMES_PROVIDER": "openai",
+            "REVIEW_HERMES_REPO": str(tmp_path),
+            "OPENAI_REVIEWER_KEY": "sk-openai-test",
+        }
+    )
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert calls["build_key"] == "sk-openai-test"
+    assert calls["build_kwargs"]["provider"] == "openai"

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -154,6 +154,7 @@ def test_hermes_openai_provider_reads_the_openai_key(monkeypatch: Any, tmp_path:
             "REVIEW_HERMES_PROVIDER": "openai",
             "REVIEW_HERMES_REPO": str(tmp_path),
             "OPENAI_REVIEWER_KEY": "sk-openai-test",
+            "REVIEW_MODEL": "gpt-5.6-terra",  # openai-direct requires a native id
         }
     )
     calls = _patch(monkeypatch, env)
@@ -183,6 +184,30 @@ def test_unknown_hermes_provider_in_emit_mode_writes_a_stub(
     envelope = json.loads((tmp_path / "findings.json").read_text())
     assert envelope["kind"] == "skip-stub"
     assert "unknown REVIEW_HERMES_PROVIDER" in envelope["detail"]
+
+
+def test_hermes_openai_without_model_writes_a_stub(monkeypatch: Any, tmp_path: Path) -> None:
+    # hermes's default model id is OpenRouter-shaped; api.openai.com cannot
+    # serve it, so an unset model must be a PR-visible stub, not a dead session
+    import json
+
+    env = _base_env()
+    del env["ANTHROPIC_REVIEWER_KEY"]
+    env.update(
+        {
+            "REVIEW_BACKEND": "hermes",
+            "REVIEW_HERMES_PROVIDER": "openai",
+            "REVIEW_HERMES_REPO": str(tmp_path),
+            "OPENAI_REVIEWER_KEY": "sk-openai-test",
+            "REVIEW_EMIT_FILE": str(tmp_path / "findings.json"),
+        }
+    )
+    calls = _patch(monkeypatch, env)
+    assert cli.main() == 0
+    assert "args" not in calls
+    envelope = json.loads((tmp_path / "findings.json").read_text())
+    assert envelope["kind"] == "skip-stub"
+    assert "provider-native REVIEW_MODEL" in envelope["detail"]
 
 
 def test_explicitly_empty_hermes_provider_means_the_default(


### PR DESCRIPTION
OpenRouter adds a ~5.5% platform fee + tax; the org's OpenAI registration is tax-exempt at the same token rate. The adapter already had the seams (`key_env`, `provider`, `base_url`) — this makes the wiring provider-aware instead of OpenRouter-hardcoded: builder maps provider→key_env, the CLI picks the key source (`hermes`+`openai` reads `OPENAI_REVIEWER_KEY`, already on every repo), and the reusable + bench gain a `hermes_provider` input. Model ids are provider-native (`gpt-5.6-terra` direct, no `openai/` prefix).

Plan: bench one terra-via-openai round (workflow_dispatch on this branch), then flip the standing terra callers (autoresearch review.yml + the parked jepa-agent/egolearn PRs) in the enablement pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)