### PR TITLE
Verify brief: claim/evidence mismatch grades blocking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The verify lens's severity rubric now states that a claim contradicted by
+  the PR's own evidence is an integrity defect and grades blocking, even
+  when the measured delta is real — from the first live panel run, where
+  convergent findings of exactly that shape were graded advisory and the PR
+  shipped ready instead of draft.
 - The tick now flips the pre-PR panel ON for every climb job it submits
   (`--panel verify,review` at both submission sites). `AUTORESEARCH_PANEL=""`
   is the operator off-switch; `AUTORESEARCH_PANEL_KEY_FILE` overrides the

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -171,10 +171,10 @@ sentence: the evidence and why it undermines the claim. """
     + """
 
 Set `blocking` true only for a confirmed gaming or integrity defect with
-a concrete way the number misleads. A claim contradicted by the PR's OWN
-evidence is an integrity defect — a mechanism story the report's own
-numbers refute, or an improvement that a trivial baseline appearing in the
-report's own tables beats — and grades `blocking` true even when the
+a concrete way the number misleads. A CONFIRMED contradiction between the
+claim and the PR's OWN evidence is such a defect — a mechanism story the
+report's own numbers refute, or an improvement that a trivial baseline in
+the report's own tables beats — and grades `blocking` true even when the
 measured delta itself is real. Suspicions, measurement notes, and
 low-confidence reads are advisory: `blocking` false.
 

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -171,7 +171,11 @@ sentence: the evidence and why it undermines the claim. """
     + """
 
 Set `blocking` true only for a confirmed gaming or integrity defect with
-a concrete way the number misleads. Suspicions, measurement notes, and
+a concrete way the number misleads. A claim contradicted by the PR's OWN
+evidence is an integrity defect — a mechanism story the report's own
+numbers refute, or an improvement that a trivial baseline appearing in the
+report's own tables beats — and grades `blocking` true even when the
+measured delta itself is real. Suspicions, measurement notes, and
 low-confidence reads are advisory: `blocking` false.
 
 Never instruct the reader to merge or reject. You are advisory."""


### PR DESCRIPTION
One-sentence severity rule in the verify brief, from the first live panel run (yolo-jepa #7): both lenses convergently detected that the gain came from linear-degeneration and that the PR's own tables showed plain linear scoring higher — but graded it advisory because the measured delta was honest, so the PR shipped ready instead of draft. The rule now stated: a claim contradicted by the PR's own evidence is an integrity defect and grades blocking, even when the delta is real.

Companion benchmark-side fix: yolo-jepa#8 (steward work order — linear-family controls + margin-over-linear).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
