### PR TITLE
Stage B: resume-seam design + measure planner

### DIFF
--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -97,17 +97,26 @@ edits are done — and it is also the only non-idempotent part. So the seam is
 AFTER the session:
 
 1. Session runs, ends. Its output is the dirty workspace.
-2. The workspace is SNAPSHOTTED (`dispatch.snapshot_tree`, retained by ref):
-   `candidate_sha`. The base is `base_sha` (the clone's pre-session HEAD).
-   Both are committed shas the dispatcher can check out.
+2. The workspace is SNAPSHOTTED (`dispatch.snapshot_tree`, which retains the
+   commit behind a unique random ref so independent snapshots of the same
+   tree never share a lifecycle): `candidate_sha` + its `candidate_ref`. The
+   base is `base_sha` (the clone's pre-session HEAD — a real branch commit, so
+   it needs no ref and never leaks). Both shas are checkoutable by the
+   dispatcher.
 3. The MEASURE-AND-DECIDE phase — a pure function of `(base_sha,
    candidate_sha, contract, seed)` — dispatches its measures through the
    `DispatchedMeasurer` (baseline@base_sha + candidate@candidate_sha, one
    wake), and on `MeasurementPending` the run parks as `waiting`.
 4. The record persists exactly what a fresh process needs to re-enter step 3
-   without the session: `base_sha`, `candidate_sha`, `seed`, the benchmark,
-   and a `stage` marking "measures dispatched". Everything else (contract,
-   ruler) is re-fetched.
+   without the session: `base_sha`, `candidate_sha` + `candidate_ref`, `seed`,
+   the benchmark, and a `stage` marking "measures dispatched". The
+   `candidate_ref` is essential and cannot be reconstructed from
+   `candidate_sha` (it is random by design): it is what a terminal wake hands
+   `dispatch.drop_snapshot` to release the snapshot once the run finishes (PR
+   opened or abandoned) — omit it and every parked run leaks a ref and its
+   commit. The snapshot must OUTLIVE all park/wake cycles (each eval checks out
+   `candidate_sha`), so the drop is deferred to the terminal state, never a
+   mid-cycle wake. Everything else (contract, ruler) is re-fetched.
 
 On the wake, a fresh process loads the record, re-enters measure-and-decide:
 the `DispatchedMeasurer` reads both cached results, `improved()` /
@@ -124,8 +133,11 @@ Sub-parts, each its own PR through the panel:
   logic behind a re-enterable function over committed shas; pure, tested
   with a fake measurer.
 - **B.2b:** wire `live_climb` — session -> snapshot -> measure_and_decide;
-  on park write the `waiting` record (base_sha/candidate_sha/seed/stage +
-  `experiment_job_id` = the afterany set) and end. When a revision supersedes
+  on park write the `waiting` record (base_sha/candidate_sha/`candidate_ref`/
+  seed/stage + `experiment_job_id` = the afterany set) and end. A terminal
+  wake `drop_snapshot`s `candidate_ref` (the snapshot outlives every park/wake
+  cycle, so the drop is deferred to run end, never mid-cycle). When a revision
+  supersedes
   a candidate, the revision loop `scancel`s the superseded candidate's still-
   running eval jobs before dispatching the new ones — the measurer keys each
   measure by its full determinant (so the results never alias), but only the
@@ -250,7 +262,7 @@ single writer via lease):
 | `experiment_job_id` `wake_job_id` `followup_job_id` | Slurm handles for the dispatched work, its afterany wake, and review servicing |
 | `resume_session_id` | the harness session a wake reconstructs — the entire "pause" state for a session's mind |
 | `state` `deadline` `terminal_seen` `wake_attempts` | wake bookkeeping; a waiting record REQUIRES a deadline |
-| `stage` (phase 1) | a small object, not a label: the parked measure point PLUS the process-local state re-entry needs — the pre-eval tree fingerprints and measured paths the drift check compares (today they are locals; a resumed process without them would fail the drift check closed on every dispatch) and the expected result-file names |
+| `stage` (phase 1) | a small object, not a label: the parked measure point PLUS the process-local state re-entry needs — `base_sha`, `candidate_sha` and the candidate snapshot's `candidate_ref` (random, so it MUST be stored — a terminal wake hands it to `drop_snapshot` or the snapshot leaks), the drawn `seed`, the pre-eval tree fingerprints and measured paths the drift check compares (today they are locals; a resumed process without them would fail the drift check closed on every dispatch), and the expected result-file names |
 | `last_comment_id` `last_review_id` `last_review_comment_id` | three cursors because GitHub's three comment collections have independent id sequences |
 | `ending` `ending_note` `created` `updated` | terminal record |
 

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -88,6 +88,50 @@ is believed.
 
 ## Phase 1 — eval as a job (climb + steward)
 
+### The resume seam (stage B)
+
+`climb_once` today fuses three things: baseline (pre-session tree), the
+SESSION (edits the workspace), and candidate (dirty post-session workspace),
+then decides. The session is the one part that must NOT re-run on wake — its
+edits are done — and it is also the only non-idempotent part. So the seam is
+AFTER the session:
+
+1. Session runs, ends. Its output is the dirty workspace.
+2. The workspace is SNAPSHOTTED (`dispatch.snapshot_tree`, retained by ref):
+   `candidate_sha`. The base is `base_sha` (the clone's pre-session HEAD).
+   Both are committed shas the dispatcher can check out.
+3. The MEASURE-AND-DECIDE phase — a pure function of `(base_sha,
+   candidate_sha, contract, seed)` — dispatches its measures through the
+   `DispatchedMeasurer` (baseline@base_sha + candidate@candidate_sha, one
+   wake), and on `MeasurementPending` the run parks as `waiting`.
+4. The record persists exactly what a fresh process needs to re-enter step 3
+   without the session: `base_sha`, `candidate_sha`, `seed`, the benchmark,
+   and a `stage` marking "measures dispatched". Everything else (contract,
+   ruler) is re-fetched.
+
+On the wake, a fresh process loads the record, re-enters measure-and-decide:
+the `DispatchedMeasurer` reads both cached results, `improved()` /
+suite-gate / panel run (panel in-job, cheap), and the PR opens — or another
+measure (a panel-revision re-measure) dispatches and it parks again. N
+park/wake cycles, each cheap because prior measures are cached. The session
+never re-runs because step 1's completion is durable: the candidate snapshot
+IS the session's persisted output.
+
+Sub-parts, each its own PR through the panel:
+- **B.1 (merged):** `DispatchedMeasurer` — submit/park/resume over committed
+  measures, cluster-authoritative liveness.
+- **B.2a:** the resumable `measure_and_decide` — extract the post-session
+  logic behind a re-enterable function over committed shas; pure, tested
+  with a fake measurer.
+- **B.2b:** wire `live_climb` — session -> snapshot -> measure_and_decide;
+  on park write the `waiting` record (base_sha/candidate_sha/seed/stage +
+  `experiment_job_id` = the afterany set) and end.
+- **B.2c:** the wake-entry CLI + the production `WakeDispatcher` (fills the
+  tick's WOULD-WAKE stub with a real dependency wake job). The existing
+  wake-fail-safety layers (afterany primary, sweep backup, deadline floor)
+  carry it unchanged.
+
+
 The submitted eval job: the contract command, on a worktree of the measured
 sha — where "the measured sha" is created if it does not exist yet: the
 candidate measure happens on a dirty workspace before anything is committed,

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -125,7 +125,11 @@ Sub-parts, each its own PR through the panel:
   with a fake measurer.
 - **B.2b:** wire `live_climb` — session -> snapshot -> measure_and_decide;
   on park write the `waiting` record (base_sha/candidate_sha/seed/stage +
-  `experiment_job_id` = the afterany set) and end.
+  `experiment_job_id` = the afterany set) and end. When a revision supersedes
+  a candidate, the revision loop `scancel`s the superseded candidate's still-
+  running eval jobs before dispatching the new ones — the measurer keys each
+  measure by its full determinant (so the results never alias), but only the
+  loop that owns the revision knows a prior candidate is now dead weight.
 - **B.2c:** the wake-entry CLI + the production `WakeDispatcher` (fills the
   tick's WOULD-WAKE stub with a real dependency wake job). The existing
   wake-fail-safety layers (afterany primary, sweep backup, deadline floor)

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -179,6 +179,18 @@ class Contract(_StrictModel):
     suite: SuiteAggregate | None = None
     steward: StewardScope | None = None
 
+    @field_validator("benchmarks")
+    @classmethod
+    def _unique_names(cls, benchmarks: list[Benchmark]) -> list[Benchmark]:
+        # Benchmark names are IDENTITIES: they key branch names, ledger rows,
+        # and dispatched measure/job names. A duplicate silently collides all
+        # three (two measures share an eval dir; one result is lost).
+        names = [b.name for b in benchmarks]
+        dupes = sorted({n for n in names if names.count(n) > 1})
+        if dupes:
+            raise ValueError(f"duplicate benchmark name(s): {', '.join(dupes)}")
+        return benchmarks
+
 
 _HOST_PREFIX = re.compile(r"^(?:[a-z+]+://)?(?:[^@/]*@)?(?:www\.)?github\.com[:/]+")
 

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -17,6 +17,7 @@ phase flows straight through to the decision.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from dataclasses import dataclass
 from pathlib import Path
@@ -138,8 +139,11 @@ class DispatchedMeasurer:
     def _job_name(self, m: Measure) -> str:
         # deterministic + unique per (run, measure): the CLUSTER can then be
         # asked "is this measure's job live" by name, independent of any local
-        # marker that a crashed submitter may not have written
-        return f"eval-{self.run_tag}-{m.name}"[:60]
+        # marker. Slurm truncates long names, so a readable prefix is followed
+        # by a hash of the FULL measure name — two long names sharing a prefix
+        # get distinct jobs (a plain truncation would collide them).
+        h = hashlib.sha1(m.name.encode()).hexdigest()[:8]
+        return f"eval-{self.run_tag[:20]}-{m.name[:20]}-{h}"
 
     def _done(self, m: Measure) -> bool:
         return (self._ev(m) / "exit-code").exists()

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -142,42 +142,47 @@ class DispatchedMeasurer:
     run_tag: str = "run"  # disambiguates job names across runs on one account
 
     def _det(self, m: Measure) -> str:
-        # Everything a measure's RESULT depends on and that can vary between two
-        # measures in one run: its logical role, the code (tree_sha), and the
+        # Everything a measure's RESULT depends on and that can vary across a
+        # PARK/RESUME (when a fresh measurer reads this run_dir): the container
+        # image, the measure's logical role, the code (tree_sha), and the
         # contract facts it is evaluated under (command, metric, seeded env).
         # A cache key missing any of these would return a value computed under
-        # DIFFERENT inputs — e.g. a resume that re-fetches the contract after
-        # its command or metric changed, reading the stale pre-change result.
-        # (image / account / walltime are measurer-wide constants, already
-        # scoped by run_dir for storage and run_tag for job names.) NUL
-        # separators keep the parts unambiguous (`a`+`bc` != `ab`+`c`).
+        # DIFFERENT inputs — e.g. a resume that re-fetched the contract after
+        # its command changed, or ran under a rebuilt image, reading the stale
+        # pre-change result. (account / walltime don't change a result's value,
+        # only whether it completes.) NUL separators keep the parts unambiguous
+        # (`a`+`bc` != `ab`+`c`).
         env = "".join(f"\0{k}={v}" for k, v in sorted(m.env().items()))
-        return f"{m.name}\0{m.tree_sha}\0{m.command}\0{m.metric}{env}"
+        return f"{self.image}\0{m.name}\0{m.tree_sha}\0{m.command}\0{m.metric}{env}"
 
     def _slot(self, m: Measure) -> str:
-        # Storage identity = the full determinant. Readable role + FULL sha
-        # (no code aliasing, debuggable) + a hash of the remaining contract
-        # facts, so a re-measure that changes the sha OR the command/metric/
-        # seed for the same role lands in a fresh eval dir, never a stale read;
-        # a resume with identical inputs reuses it. `m.name` stays the
-        # caller-facing key (results["candidate"]) — only where the bits live
-        # is scoped. A dir has 255 chars to spare, so the sha is verbatim, not
-        # a prefix.
-        h = hashlib.sha1(self._det(m).encode()).hexdigest()[:8]
+        # Storage identity = the full determinant, with NOTHING truncated: the
+        # eval dir is the durable result cache, so any prefix could alias two
+        # distinct measurements into one stale read. Readable role + FULL sha
+        # (verbatim, debuggable) + the FULL sha1 hex of the whole determinant
+        # (the collision-free disambiguator for the contract facts the sha
+        # alone does not pin — command/metric/seed). A re-measure that changes
+        # the sha OR any contract input lands in a fresh dir; a resume with
+        # identical inputs reuses it. `m.name` stays the caller-facing key
+        # (results["candidate"]). A dir has 255 chars to spare (~91 used).
+        h = hashlib.sha1(self._det(m).encode()).hexdigest()
         return f"{m.name}-{m.tree_sha}-{h}"
 
     def _ev(self, m: Measure) -> Path:
         return self.run_dir / f"eval-{self._slot(m)}"
 
     def _job_name(self, m: Measure) -> str:
-        # deterministic + unique per (run, full determinant): the CLUSTER can
-        # then be asked "is this measure's job live" by name, independent of
-        # any local marker. run_tag disambiguates jobs across runs sharing one
-        # Slurm account; the hash covers the whole determinant, so no
-        # truncation of the readable prefixes (for a human reading squeue) can
-        # collide two distinct jobs, and two measures differing in ANY input
-        # get distinct jobs.
-        h = hashlib.sha1(f"{self.run_tag}\0{self._det(m)}".encode()).hexdigest()[:12]
+        # A LIVENESS HINT, not a durable key: the cluster is asked "is this
+        # measure's job live" by name. Slurm caps name length, so this hash is
+        # necessarily bounded (16 hex = 64 bits) rather than full-width like the
+        # slot. That bound is safe because a job-name collision cannot cause a
+        # stale RESULT — results are read from the collision-free slot; the
+        # worst case is one measure seeing another's job as "live" and parking
+        # instead of dispatching, which the deadline sweep then re-checks. The
+        # hash covers the whole determinant (+ run_tag, which disambiguates
+        # jobs across runs sharing one Slurm account); the readable prefixes
+        # are for a human reading squeue.
+        h = hashlib.sha1(f"{self.run_tag}\0{self._det(m)}".encode()).hexdigest()[:16]
         return f"eval-{self.run_tag[:10]}-{m.name[:12]}-{h}"
 
     def _done(self, m: Measure) -> bool:

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -136,12 +136,17 @@ class DispatchedMeasurer:
     run_tag: str = "run"  # disambiguates job names across runs on one account
 
     def _slot(self, m: Measure) -> str:
-        # Storage identity = (logical name, tree_sha). A re-measure at a NEW
-        # candidate sha (a panel revision) lands in a fresh eval dir and a
+        # Storage identity = (logical name, FULL tree_sha). A re-measure at a
+        # NEW candidate sha (a panel revision) lands in a fresh eval dir and a
         # fresh job, so it never reads the prior sha's cached result; a resume
         # at the SAME sha reuses it. `m.name` stays the caller-facing key
         # (results["candidate"]) — only where the bits live is sha-scoped.
-        return f"{m.name}-{m.tree_sha[:8]}"
+        # The full sha, not a prefix: a truncated prefix would alias two
+        # commits that share those chars into one cached result. A dir name has
+        # 255 chars to spare, so it carries the sha verbatim (debuggable); the
+        # job name folds it into a hash only because Slurm names are length-
+        # budgeted.
+        return f"{m.name}-{m.tree_sha}"
 
     def _ev(self, m: Measure) -> Path:
         return self.run_dir / f"eval-{self._slot(m)}"

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -84,7 +84,11 @@ class SiblingSpec:
     seed: int = 0
 
     def env(self) -> tuple[tuple[str, str], ...]:
-        return ((self.seed_env, str(self.seed)),) if self.seed_env else ()
+        # inject only a REAL drawn seed: 0 is the ledger's "no seed recorded"
+        # sentinel (draw_run_seed returns 1+), so a seeded sibling with an
+        # unset (0) seed injects no var rather than a literal "0" that would
+        # read as a real seed. Guards key off truthiness, per the convention.
+        return ((self.seed_env, str(self.seed)),) if self.seed_env and self.seed else ()
 
 
 def plan_measures(
@@ -107,7 +111,9 @@ def plan_measures(
     OWN seed_env and seed, exactly the 2N-paired comparison the in-job gate
     computes, now dispatched.
     """
-    env: tuple[tuple[str, str], ...] = ((seed_env, str(seed)),) if seed_env else ()
+    # inject only a REAL drawn seed (>= 1); seed 0 is the "no seed recorded"
+    # sentinel, never a value to run under (see SiblingSpec.env / draw_run_seed).
+    env: tuple[tuple[str, str], ...] = ((seed_env, str(seed)),) if seed_env and seed else ()
     plan = [
         Measure("baseline", base_sha, command, metric, env),
         Measure("candidate", candidate_sha, command, metric, env),
@@ -135,32 +141,43 @@ class DispatchedMeasurer:
     eval_minutes: int
     run_tag: str = "run"  # disambiguates job names across runs on one account
 
+    def _det(self, m: Measure) -> str:
+        # Everything a measure's RESULT depends on and that can vary between two
+        # measures in one run: its logical role, the code (tree_sha), and the
+        # contract facts it is evaluated under (command, metric, seeded env).
+        # A cache key missing any of these would return a value computed under
+        # DIFFERENT inputs — e.g. a resume that re-fetches the contract after
+        # its command or metric changed, reading the stale pre-change result.
+        # (image / account / walltime are measurer-wide constants, already
+        # scoped by run_dir for storage and run_tag for job names.) NUL
+        # separators keep the parts unambiguous (`a`+`bc` != `ab`+`c`).
+        env = "".join(f"\0{k}={v}" for k, v in sorted(m.env().items()))
+        return f"{m.name}\0{m.tree_sha}\0{m.command}\0{m.metric}{env}"
+
     def _slot(self, m: Measure) -> str:
-        # Storage identity = (logical name, FULL tree_sha). A re-measure at a
-        # NEW candidate sha (a panel revision) lands in a fresh eval dir and a
-        # fresh job, so it never reads the prior sha's cached result; a resume
-        # at the SAME sha reuses it. `m.name` stays the caller-facing key
-        # (results["candidate"]) — only where the bits live is sha-scoped.
-        # The full sha, not a prefix: a truncated prefix would alias two
-        # commits that share those chars into one cached result. A dir name has
-        # 255 chars to spare, so it carries the sha verbatim (debuggable); the
-        # job name folds it into a hash only because Slurm names are length-
-        # budgeted.
-        return f"{m.name}-{m.tree_sha}"
+        # Storage identity = the full determinant. Readable role + FULL sha
+        # (no code aliasing, debuggable) + a hash of the remaining contract
+        # facts, so a re-measure that changes the sha OR the command/metric/
+        # seed for the same role lands in a fresh eval dir, never a stale read;
+        # a resume with identical inputs reuses it. `m.name` stays the
+        # caller-facing key (results["candidate"]) — only where the bits live
+        # is scoped. A dir has 255 chars to spare, so the sha is verbatim, not
+        # a prefix.
+        h = hashlib.sha1(self._det(m).encode()).hexdigest()[:8]
+        return f"{m.name}-{m.tree_sha}-{h}"
 
     def _ev(self, m: Measure) -> Path:
         return self.run_dir / f"eval-{self._slot(m)}"
 
     def _job_name(self, m: Measure) -> str:
-        # deterministic + unique per (run, measure, sha): the CLUSTER can then
-        # be asked "is this measure's job live" by name, independent of any
-        # local marker. The hash covers the FULL (run_tag, name, tree_sha)
-        # identity — so no truncation of the readable prefixes (for a human
-        # reading squeue) can collide two distinct jobs, and the same name at
-        # two shas gets two distinct jobs. NUL separators keep the parts
-        # unambiguous (`a`+`bc` distinct from `ab`+`c`).
-        ident = f"{self.run_tag}\0{m.name}\0{m.tree_sha}"
-        h = hashlib.sha1(ident.encode()).hexdigest()[:12]
+        # deterministic + unique per (run, full determinant): the CLUSTER can
+        # then be asked "is this measure's job live" by name, independent of
+        # any local marker. run_tag disambiguates jobs across runs sharing one
+        # Slurm account; the hash covers the whole determinant, so no
+        # truncation of the readable prefixes (for a human reading squeue) can
+        # collide two distinct jobs, and two measures differing in ANY input
+        # get distinct jobs.
+        h = hashlib.sha1(f"{self.run_tag}\0{self._det(m)}".encode()).hexdigest()[:12]
         return f"eval-{self.run_tag[:10]}-{m.name[:12]}-{h}"
 
     def _done(self, m: Measure) -> bool:

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -69,10 +69,13 @@ class Measure:
 @dataclass(frozen=True)
 class SiblingSpec:
     """One suite sibling's resolved measurement facts. Each sibling carries
-    its OWN seed variable and drawn seed — a sibling that resamples reads a
-    DIFFERENT env var than the climbed benchmark, and its pairing seed is its
-    own (the in-job suite gate draws one seed per benchmark, not one global
-    seed)."""
+    its OWN seed variable — a sibling that resamples reads a DIFFERENT env var
+    than the climbed benchmark (`sib.seed_env`, not the benchmark's). The
+    in-job gate draws ONE `suite_seed` and hands that single value to every
+    sibling through its own var, so callers set every sibling's `seed` to that
+    one suite_seed; the pair (base and cand) always shares it (common random
+    numbers). The per-sibling `seed` field only exists so the var, not the
+    value, can differ."""
 
     name: str
     command: str
@@ -85,7 +88,6 @@ class SiblingSpec:
 
 
 def plan_measures(
-    benchmark: str,
     command: str,
     metric: str,
     base_sha: str,
@@ -133,18 +135,28 @@ class DispatchedMeasurer:
     eval_minutes: int
     run_tag: str = "run"  # disambiguates job names across runs on one account
 
+    def _slot(self, m: Measure) -> str:
+        # Storage identity = (logical name, tree_sha). A re-measure at a NEW
+        # candidate sha (a panel revision) lands in a fresh eval dir and a
+        # fresh job, so it never reads the prior sha's cached result; a resume
+        # at the SAME sha reuses it. `m.name` stays the caller-facing key
+        # (results["candidate"]) — only where the bits live is sha-scoped.
+        return f"{m.name}-{m.tree_sha[:8]}"
+
     def _ev(self, m: Measure) -> Path:
-        return self.run_dir / f"eval-{m.name}"
+        return self.run_dir / f"eval-{self._slot(m)}"
 
     def _job_name(self, m: Measure) -> str:
-        # deterministic + unique per (run, measure): the CLUSTER can then be
-        # asked "is this measure's job live" by name, independent of any local
-        # marker. The hash covers the FULL (run_tag, measure name) identity —
-        # so no truncation of either the run tag OR the name (both readable
-        # prefixes only, for a human reading squeue) can collide two distinct
-        # jobs. The NUL separator keeps `a`+`bc` distinct from `ab`+`c`.
-        h = hashlib.sha1(f"{self.run_tag}\0{m.name}".encode()).hexdigest()[:12]
-        return f"eval-{self.run_tag[:12]}-{m.name[:12]}-{h}"
+        # deterministic + unique per (run, measure, sha): the CLUSTER can then
+        # be asked "is this measure's job live" by name, independent of any
+        # local marker. The hash covers the FULL (run_tag, name, tree_sha)
+        # identity — so no truncation of the readable prefixes (for a human
+        # reading squeue) can collide two distinct jobs, and the same name at
+        # two shas gets two distinct jobs. NUL separators keep the parts
+        # unambiguous (`a`+`bc` distinct from `ab`+`c`).
+        ident = f"{self.run_tag}\0{m.name}\0{m.tree_sha}"
+        h = hashlib.sha1(ident.encode()).hexdigest()[:12]
+        return f"eval-{self.run_tag[:10]}-{m.name[:12]}-{h}"
 
     def _done(self, m: Measure) -> bool:
         return (self._ev(m) / "exit-code").exists()
@@ -156,7 +168,7 @@ class DispatchedMeasurer:
     def _dispatch(self, m: Measure) -> str:
         script = write_eval_job(
             self.run_dir,
-            m.name,
+            self._slot(m),
             repo_root=self.repo_root,
             snapshot_sha=m.tree_sha,
             command=m.command,
@@ -220,4 +232,4 @@ class DispatchedMeasurer:
             pending.append(self._dispatch(m))
         if pending or blind:
             raise MeasurementPending(tuple(pending))
-        return {m.name: read_eval_result(self.run_dir, m.name, m.metric) for m in measures}
+        return {m.name: read_eval_result(self.run_dir, self._slot(m), m.metric) for m in measures}

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -65,6 +65,39 @@ class Measure:
         return dict(self.extra_env)
 
 
+def plan_measures(
+    benchmark: str,
+    command: str,
+    metric: str,
+    base_sha: str,
+    candidate_sha: str,
+    seed_env: str = "",
+    seed: int = 0,
+    siblings: tuple[tuple[str, str, str], ...] = (),
+) -> list[Measure]:
+    """The measures a climb needs, as a pure function of its committed shas
+    and contract facts — the same inputs a wake process reconstructs from the
+    run record, so the plan is identical before and after a park.
+
+    Always: `baseline` @ base_sha and `candidate` @ candidate_sha, paired on
+    the same `seed` (common random numbers) when the benchmark resamples.
+    For a suite gate, each sibling `(name, command, metric)` contributes a
+    paired `sib-<name>-base` @ base_sha and `sib-<name>-cand` @ candidate_sha
+    — the same 2N-paired comparison the in-job gate computes, now dispatched.
+    """
+    env: tuple[tuple[str, str], ...] = ((seed_env, str(seed)),) if seed_env else ()
+    plan = [
+        Measure("baseline", base_sha, command, metric, env),
+        Measure("candidate", candidate_sha, command, metric, env),
+    ]
+    for name, sib_cmd, sib_metric in siblings:
+        # each sibling draws its OWN paired seed at plan time when it
+        # resamples; here the caller has already resolved commands/metrics
+        plan.append(Measure(f"sib-{name}-base", base_sha, sib_cmd, sib_metric, env))
+        plan.append(Measure(f"sib-{name}-cand", candidate_sha, sib_cmd, sib_metric, env))
+    return plan
+
+
 @dataclass
 class DispatchedMeasurer:
     """Submits and reads a climb's dispatched measures. Stateless beyond the

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -139,11 +139,12 @@ class DispatchedMeasurer:
     def _job_name(self, m: Measure) -> str:
         # deterministic + unique per (run, measure): the CLUSTER can then be
         # asked "is this measure's job live" by name, independent of any local
-        # marker. Slurm truncates long names, so a readable prefix is followed
-        # by a hash of the FULL measure name — two long names sharing a prefix
-        # get distinct jobs (a plain truncation would collide them).
-        h = hashlib.sha1(m.name.encode()).hexdigest()[:8]
-        return f"eval-{self.run_tag[:20]}-{m.name[:20]}-{h}"
+        # marker. The hash covers the FULL (run_tag, measure name) identity —
+        # so no truncation of either the run tag OR the name (both readable
+        # prefixes only, for a human reading squeue) can collide two distinct
+        # jobs. The NUL separator keeps `a`+`bc` distinct from `ab`+`c`.
+        h = hashlib.sha1(f"{self.run_tag}\0{m.name}".encode()).hexdigest()[:12]
+        return f"eval-{self.run_tag[:12]}-{m.name[:12]}-{h}"
 
     def _done(self, m: Measure) -> bool:
         return (self._ev(m) / "exit-code").exists()

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -65,6 +65,24 @@ class Measure:
         return dict(self.extra_env)
 
 
+@dataclass(frozen=True)
+class SiblingSpec:
+    """One suite sibling's resolved measurement facts. Each sibling carries
+    its OWN seed variable and drawn seed — a sibling that resamples reads a
+    DIFFERENT env var than the climbed benchmark, and its pairing seed is its
+    own (the in-job suite gate draws one seed per benchmark, not one global
+    seed)."""
+
+    name: str
+    command: str
+    metric: str
+    seed_env: str = ""
+    seed: int = 0
+
+    def env(self) -> tuple[tuple[str, str], ...]:
+        return ((self.seed_env, str(self.seed)),) if self.seed_env else ()
+
+
 def plan_measures(
     benchmark: str,
     command: str,
@@ -73,7 +91,7 @@ def plan_measures(
     candidate_sha: str,
     seed_env: str = "",
     seed: int = 0,
-    siblings: tuple[tuple[str, str, str], ...] = (),
+    siblings: tuple[SiblingSpec, ...] = (),
 ) -> list[Measure]:
     """The measures a climb needs, as a pure function of its committed shas
     and contract facts — the same inputs a wake process reconstructs from the
@@ -81,20 +99,21 @@ def plan_measures(
 
     Always: `baseline` @ base_sha and `candidate` @ candidate_sha, paired on
     the same `seed` (common random numbers) when the benchmark resamples.
-    For a suite gate, each sibling `(name, command, metric)` contributes a
-    paired `sib-<name>-base` @ base_sha and `sib-<name>-cand` @ candidate_sha
-    — the same 2N-paired comparison the in-job gate computes, now dispatched.
+    For a suite gate, each `SiblingSpec` contributes a paired `sib-<name>-base`
+    @ base_sha and `sib-<name>-cand` @ candidate_sha — each on the SIBLING's
+    OWN seed_env and seed, exactly the 2N-paired comparison the in-job gate
+    computes, now dispatched.
     """
     env: tuple[tuple[str, str], ...] = ((seed_env, str(seed)),) if seed_env else ()
     plan = [
         Measure("baseline", base_sha, command, metric, env),
         Measure("candidate", candidate_sha, command, metric, env),
     ]
-    for name, sib_cmd, sib_metric in siblings:
-        # each sibling draws its OWN paired seed at plan time when it
-        # resamples; here the caller has already resolved commands/metrics
-        plan.append(Measure(f"sib-{name}-base", base_sha, sib_cmd, sib_metric, env))
-        plan.append(Measure(f"sib-{name}-cand", candidate_sha, sib_cmd, sib_metric, env))
+    for sib in siblings:
+        plan.append(Measure(f"sib-{sib.name}-base", base_sha, sib.command, sib.metric, sib.env()))
+        plan.append(
+            Measure(f"sib-{sib.name}-cand", candidate_sha, sib.command, sib.metric, sib.env())
+        )
     return plan
 
 

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -118,6 +118,21 @@ def test_empty_benchmarks_refused() -> None:
         )
 
 
+def test_duplicate_benchmark_names_refused() -> None:
+    # two benchmarks sharing a name would collide their result dirs and
+    # dispatched job names — reject at load, not silently at measure time.
+    b = {"command": "run", "metric": "r2", "direction": "max"}
+    with pytest.raises(ValidationError, match="duplicate benchmark name"):
+        Contract.model_validate(
+            {
+                "benchmarks": [{"name": "tsp", **b}, {"name": "tsp", **b}],
+                "budgets": {"gpu_hours_per_run": 0, "runs_per_week": 1},
+                "scope": {"allowed": ["src/"]},
+                "roadmap": "README.md",
+            }
+        )
+
+
 def test_seed_env_accepts_env_var_names_only() -> None:
     """seed_env reaches a subprocess environment: strict shape."""
     from autoresearch.contract import load_contract

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -89,7 +89,7 @@ def test_live_job_reparks_on_real_id_never_resubmits(tmp_path):
     """A job squeue reports as running is parked on its real id — even if its
     local marker is MISSING (the crash-before-marker case)."""
     submitted: list = []
-    m = _measurer(tmp_path, submitted, live={"eval-r1-candidate-266ec841": "102"})
+    m = _measurer(tmp_path, submitted, live={"eval-r1-candidate-f882a1f6f00a": "102"})
     _land(tmp_path, "baseline", 0.50)
     # candidate has NO marker (submitter died in the gap) but IS live
     with pytest.raises(MeasurementPending) as exc:
@@ -205,3 +205,26 @@ def test_long_measure_names_get_distinct_job_names(tmp_path):
     b = Measure("sib-" + "x" * 60 + "-cand", "a" * 40, "c", "r2")
     ja, jb = m._job_name(a), m._job_name(b)
     assert ja != jb and len(ja) <= 60 and len(jb) <= 60
+
+
+def test_long_run_tags_get_distinct_job_names(tmp_path):
+    """Two run tags sharing their first chars must get distinct job names for
+    the same measure (the hash covers the full run_tag, not just a prefix)."""
+    from autoresearch.compute import CommandResult, SlurmCompute
+
+    def mk(tag):
+        return DispatchedMeasurer(
+            compute=SlurmCompute(runner=lambda a, t: CommandResult(0, "", "")),
+            run_dir=tmp_path,
+            repo_root=tmp_path,
+            image="/i",
+            account="a",
+            partition="p",
+            eval_minutes=60,
+            run_tag=tag,
+        )
+
+    meas = Measure("baseline", "a" * 40, "c", "r2")
+    n1 = mk("heldout_probe-20260818-aaa")._job_name(meas)
+    n2 = mk("heldout_probe-20260818-bbb")._job_name(meas)
+    assert n1 != n2 and len(n1) <= 60 and len(n2) <= 60

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 
 from autoresearch.compute import CommandResult, SlurmCompute
-from autoresearch.measure import DispatchedMeasurer, Measure, MeasurementPending
+from autoresearch.measure import DispatchedMeasurer, Measure, MeasurementPending, plan_measures
 from autoresearch.orchestrator import EvalError
 
 
@@ -132,3 +132,40 @@ def test_measure_carries_paired_seed():
 
 def test_empty_pending_afterany_is_blank():
     assert MeasurementPending(()).afterany() == ""
+
+
+def test_plan_baseline_and_candidate_paired_seed():
+    plan = plan_measures("hp", "cmd", "r2", "a" * 40, "b" * 40, seed_env="S", seed=7)
+    assert [m.name for m in plan] == ["baseline", "candidate"]
+    assert plan[0].tree_sha == "a" * 40 and plan[1].tree_sha == "b" * 40
+    assert plan[0].env() == {"S": "7"} and plan[1].env() == {"S": "7"}  # common random numbers
+
+
+def test_plan_no_seed_env_no_extra_env():
+    plan = plan_measures("hp", "cmd", "r2", "a" * 40, "b" * 40)
+    assert all(m.env() == {} for m in plan)
+
+
+def test_plan_suite_adds_paired_siblings():
+    plan = plan_measures(
+        "hp",
+        "cmd",
+        "r2",
+        "a" * 40,
+        "b" * 40,
+        siblings=(("tsp", "tspcmd", "len"), ("reach", "rcmd", "succ")),
+    )
+    names = [m.name for m in plan]
+    assert names == [
+        "baseline",
+        "candidate",
+        "sib-tsp-base",
+        "sib-tsp-cand",
+        "sib-reach-base",
+        "sib-reach-cand",
+    ]
+    # each sibling pair is base vs candidate on the same command
+    base = next(m for m in plan if m.name == "sib-tsp-base")
+    cand = next(m for m in plan if m.name == "sib-tsp-cand")
+    assert base.tree_sha == "a" * 40 and cand.tree_sha == "b" * 40
+    assert base.command == "tspcmd" and base.metric == "len"

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -89,7 +89,7 @@ def test_live_job_reparks_on_real_id_never_resubmits(tmp_path):
     """A job squeue reports as running is parked on its real id — even if its
     local marker is MISSING (the crash-before-marker case)."""
     submitted: list = []
-    m = _measurer(tmp_path, submitted, live={"eval-r1-candidate": "102"})
+    m = _measurer(tmp_path, submitted, live={"eval-r1-candidate-266ec841": "102"})
     _land(tmp_path, "baseline", 0.50)
     # candidate has NO marker (submitter died in the gap) but IS live
     with pytest.raises(MeasurementPending) as exc:
@@ -184,3 +184,24 @@ def test_plan_suite_siblings_use_their_own_seed_env():
     assert tsp_base.command == "tspcmd" and tsp_base.metric == "len"
     # a sibling with no seed gets no env, regardless of the climbed seed
     assert next(m for m in plan if m.name == "sib-reach-base").env() == {}
+
+
+def test_long_measure_names_get_distinct_job_names(tmp_path):
+    """Two long measure names sharing a 60-char prefix must get distinct
+    Slurm job names (a plain truncation would collide them into one job)."""
+    from autoresearch.compute import CommandResult, SlurmCompute
+
+    m = DispatchedMeasurer(
+        compute=SlurmCompute(runner=lambda a, t: CommandResult(0, "", "")),
+        run_dir=tmp_path,
+        repo_root=tmp_path,
+        image="/i",
+        account="a",
+        partition="p",
+        eval_minutes=60,
+        run_tag="r1",
+    )
+    a = Measure("sib-" + "x" * 60 + "-base", "a" * 40, "c", "r2")
+    b = Measure("sib-" + "x" * 60 + "-cand", "a" * 40, "c", "r2")
+    ja, jb = m._job_name(a), m._job_name(b)
+    assert ja != jb and len(ja) <= 60 and len(jb) <= 60

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -9,7 +9,13 @@ from pathlib import Path
 import pytest
 
 from autoresearch.compute import CommandResult, SlurmCompute
-from autoresearch.measure import DispatchedMeasurer, Measure, MeasurementPending, plan_measures
+from autoresearch.measure import (
+    DispatchedMeasurer,
+    Measure,
+    MeasurementPending,
+    SiblingSpec,
+    plan_measures,
+)
 from autoresearch.orchestrator import EvalError
 
 
@@ -146,14 +152,19 @@ def test_plan_no_seed_env_no_extra_env():
     assert all(m.env() == {} for m in plan)
 
 
-def test_plan_suite_adds_paired_siblings():
+def test_plan_suite_siblings_use_their_own_seed_env():
     plan = plan_measures(
         "hp",
         "cmd",
         "r2",
         "a" * 40,
         "b" * 40,
-        siblings=(("tsp", "tspcmd", "len"), ("reach", "rcmd", "succ")),
+        seed_env="HP_SEED",
+        seed=7,
+        siblings=(
+            SiblingSpec("tsp", "tspcmd", "len", seed_env="TSP_SEED", seed=42),
+            SiblingSpec("reach", "rcmd", "succ"),  # no seed
+        ),
     )
     names = [m.name for m in plan]
     assert names == [
@@ -164,8 +175,12 @@ def test_plan_suite_adds_paired_siblings():
         "sib-reach-base",
         "sib-reach-cand",
     ]
-    # each sibling pair is base vs candidate on the same command
-    base = next(m for m in plan if m.name == "sib-tsp-base")
-    cand = next(m for m in plan if m.name == "sib-tsp-cand")
-    assert base.tree_sha == "a" * 40 and cand.tree_sha == "b" * 40
-    assert base.command == "tspcmd" and base.metric == "len"
+    # the climbed benchmark's seed does NOT leak onto siblings
+    tsp_base = next(m for m in plan if m.name == "sib-tsp-base")
+    tsp_cand = next(m for m in plan if m.name == "sib-tsp-cand")
+    assert tsp_base.env() == {"TSP_SEED": "42"}  # its OWN var and seed
+    assert tsp_cand.env() == {"TSP_SEED": "42"}  # paired on the sibling's seed
+    assert "HP_SEED" not in tsp_base.env()
+    assert tsp_base.command == "tspcmd" and tsp_base.metric == "len"
+    # a sibling with no seed gets no env, regardless of the climbed seed
+    assert next(m for m in plan if m.name == "sib-reach-base").env() == {}

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -289,6 +289,9 @@ def test_changed_contract_for_same_name_and_sha_is_not_aliased(tmp_path):
     jobs = {m._job_name(x) for x in (base, new_cmd, new_metric, new_seed)}
     assert len(slots) == 4  # every determinant change gets its own storage
     assert len(jobs) == 4  # and its own cluster job
+    # the durable slot's disambiguator is the FULL sha1 hex (no truncated
+    # prefix that two distinct determinants could birthday-collide into)
+    assert len(m._slot(base).split("-")[-1]) == 40
     # a v1 result must not satisfy a v2-command read
     _land(m, base, 0.42)
     with pytest.raises(MeasurementPending):

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -48,10 +48,10 @@ def _measurer(
     )
 
 
-# storage is keyed by (logical name, tree_sha[:8]) — the on-disk slots for the
-# _measures() pair below:
-BASE = "baseline-" + "a" * 8
-CAND = "candidate-" + "b" * 8
+# storage is keyed by (logical name, full tree_sha) — the on-disk slots for
+# the _measures() pair below:
+BASE = "baseline-" + "a" * 40
+CAND = "candidate-" + "b" * 40
 
 
 def _land(tmp_path: Path, slot: str, value=None, code="0", job="101"):
@@ -247,6 +247,18 @@ def test_same_name_new_sha_gets_fresh_storage_and_job(tmp_path):
     assert m._ev(v1) != m._ev(v2)  # distinct on-disk slots
     assert m._job_name(v1) != m._job_name(v2)  # distinct cluster jobs
     # a landed v1 result is invisible to a v2 read (no stale inheritance)
-    _land(tmp_path, CAND, 0.42)  # eval-candidate-bbbbbbbb
+    _land(tmp_path, CAND, 0.42)  # eval-candidate-bbb...(40)
     with pytest.raises(MeasurementPending):
         m.results([v2])  # v2's slot has no result -> dispatched, not read
+
+
+def test_shared_sha_prefix_does_not_alias_storage(tmp_path):
+    """Two commits sharing an 8-char SHA prefix but differing later must NOT
+    share an eval dir — a truncated slot would let the second read the first's
+    cached result."""
+    m = _measurer(tmp_path, [])
+    p = "a" * 8
+    a = Measure("candidate", p + "b" * 32, "cmd", "r2")
+    b = Measure("candidate", p + "c" * 32, "cmd", "r2")
+    assert m._ev(a) != m._ev(b)
+    assert m._job_name(a) != m._job_name(b)

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -48,14 +48,10 @@ def _measurer(
     )
 
 
-# storage is keyed by (logical name, full tree_sha) — the on-disk slots for
-# the _measures() pair below:
-BASE = "baseline-" + "a" * 40
-CAND = "candidate-" + "b" * 40
-
-
-def _land(tmp_path: Path, slot: str, value=None, code="0", job="101"):
-    ev = tmp_path / f"eval-{slot}"
+def _land(m: DispatchedMeasurer, measure: Measure, value=None, code="0", job="101"):
+    # land a completed eval into the measure's own storage slot — derived from
+    # the measurer so the test never hardcodes the identity formula.
+    ev = m.run_dir / f"eval-{m._slot(measure)}"
     ev.mkdir(parents=True, exist_ok=True)
     (ev / "submitted").write_text(job)
     (ev / "exit-code").write_text(code)
@@ -63,8 +59,8 @@ def _land(tmp_path: Path, slot: str, value=None, code="0", job="101"):
         (ev / "stdout").write_text(json.dumps({"metric": "r2", "value": value}) + "\n")
 
 
-def _dispatched(tmp_path: Path, slot: str, job="101"):
-    ev = tmp_path / f"eval-{slot}"
+def _dispatched(m: DispatchedMeasurer, measure: Measure, job="101"):
+    ev = m.run_dir / f"eval-{m._slot(measure)}"
     ev.mkdir(parents=True, exist_ok=True)
     (ev / "submitted").write_text(job)
 
@@ -85,8 +81,9 @@ def test_first_pass_dispatches_all_and_parks(tmp_path):
 def test_resume_reads_completed_without_resubmitting(tmp_path):
     submitted: list = []
     m = _measurer(tmp_path, submitted)
-    _land(tmp_path, BASE, 0.50)
-    _land(tmp_path, CAND, 0.61)
+    base, cand = _measures()
+    _land(m, base, 0.50)
+    _land(m, cand, 0.61)
     assert m.results(_measures()) == {"baseline": 0.50, "candidate": 0.61}
     assert submitted == []
 
@@ -95,9 +92,10 @@ def test_live_job_reparks_on_real_id_never_resubmits(tmp_path):
     """A job squeue reports as running is parked on its real id — even if its
     local marker is MISSING (the crash-before-marker case)."""
     submitted: list = []
-    cand_job = _measurer(tmp_path, [])._job_name(_measures()[1])
+    base, cand = _measures()
+    cand_job = _measurer(tmp_path, [])._job_name(cand)
     m = _measurer(tmp_path, submitted, live={cand_job: "102"})
-    _land(tmp_path, BASE, 0.50)
+    _land(m, base, 0.50)
     # candidate has NO marker (submitter died in the gap) but IS live
     with pytest.raises(MeasurementPending) as exc:
         m.results(_measures())
@@ -110,8 +108,9 @@ def test_dispatched_but_vanished_fails_not_resubmits(tmp_path):
     producing a result (SIGKILL / GONE) -> EvalError, never resubmit."""
     submitted: list = []
     m = _measurer(tmp_path, submitted, live={})  # nothing live
-    _land(tmp_path, BASE, 0.50)
-    _dispatched(tmp_path, CAND, job="102")  # marker, not live, no result
+    base, cand = _measures()
+    _land(m, base, 0.50)
+    _dispatched(m, cand, job="102")  # marker, not live, no result
     with pytest.raises(EvalError, match="vanished"):
         m.results(_measures())
     assert submitted == []
@@ -119,8 +118,9 @@ def test_dispatched_but_vanished_fails_not_resubmits(tmp_path):
 
 def test_nonzero_exit_raises(tmp_path):
     m = _measurer(tmp_path, [])
-    _land(tmp_path, BASE, 0.50)
-    _land(tmp_path, CAND, code="97")
+    base, cand = _measures()
+    _land(m, base, 0.50)
+    _land(m, cand, code="97")
     with pytest.raises(EvalError, match="candidate"):
         m.results(_measures())
 
@@ -130,7 +130,8 @@ def test_squeue_blind_parks_without_dispatch(tmp_path):
     marker id if any), let the sweep deadline retry; never dispatch blind."""
     submitted: list = []
     m = _measurer(tmp_path, submitted, squeue_fails=True)
-    _dispatched(tmp_path, BASE, job="102")  # has a marker
+    base, _cand = _measures()
+    _dispatched(m, base, job="102")  # has a marker
     # candidate has no marker; blind -> park, empty dep -> sweep handles it
     with pytest.raises(MeasurementPending) as exc:
         m.results(_measures())
@@ -157,6 +158,15 @@ def test_plan_baseline_and_candidate_paired_seed():
 def test_plan_no_seed_env_no_extra_env():
     plan = plan_measures("cmd", "r2", "a" * 40, "b" * 40)
     assert all(m.env() == {} for m in plan)
+
+
+def test_plan_seed_zero_sentinel_is_not_injected():
+    # 0 is the "no seed recorded" sentinel — a seeded benchmark whose seed is
+    # unset (0) must inject NO seed var, not a literal "S=0" real seed.
+    plan = plan_measures("cmd", "r2", "a" * 40, "b" * 40, seed_env="S", seed=0)
+    assert all(m.env() == {} for m in plan)
+    sib = SiblingSpec("tsp", "tspcmd", "len", seed_env="TSP_SEED", seed=0)
+    assert sib.env() == ()
 
 
 def test_plan_suite_siblings_use_their_own_seed_env():
@@ -238,7 +248,7 @@ def test_long_run_tags_get_distinct_job_names(tmp_path):
 
 def test_same_name_new_sha_gets_fresh_storage_and_job(tmp_path):
     """A panel revision re-measures `candidate` at a NEW sha. Storage identity
-    is (name, tree_sha), so the new sha must NOT read the old sha's cached
+    includes the tree_sha, so the new sha must NOT read the old sha's cached
     eval dir and must NOT reuse its cluster job name — otherwise a revision
     would silently inherit the pre-revision result."""
     m = _measurer(tmp_path, [])
@@ -247,7 +257,7 @@ def test_same_name_new_sha_gets_fresh_storage_and_job(tmp_path):
     assert m._ev(v1) != m._ev(v2)  # distinct on-disk slots
     assert m._job_name(v1) != m._job_name(v2)  # distinct cluster jobs
     # a landed v1 result is invisible to a v2 read (no stale inheritance)
-    _land(tmp_path, CAND, 0.42)  # eval-candidate-bbb...(40)
+    _land(m, v1, 0.42)
     with pytest.raises(MeasurementPending):
         m.results([v2])  # v2's slot has no result -> dispatched, not read
 
@@ -262,3 +272,24 @@ def test_shared_sha_prefix_does_not_alias_storage(tmp_path):
     b = Measure("candidate", p + "c" * 32, "cmd", "r2")
     assert m._ev(a) != m._ev(b)
     assert m._job_name(a) != m._job_name(b)
+
+
+def test_changed_contract_for_same_name_and_sha_is_not_aliased(tmp_path):
+    """The cache key is the full measurement determinant, not just (name, sha):
+    the same role at the same commit but a DIFFERENT command / metric / seed
+    (e.g. a resume that re-fetched a changed contract) must land in a fresh
+    eval dir and job, never read the result computed under the old command."""
+    m = _measurer(tmp_path, [])
+    sha = "d" * 40
+    base = Measure("candidate", sha, "cmd --v1", "r2")
+    new_cmd = Measure("candidate", sha, "cmd --v2", "r2")
+    new_metric = Measure("candidate", sha, "cmd --v1", "auroc")
+    new_seed = Measure("candidate", sha, "cmd --v1", "r2", extra_env=(("S", "7"),))
+    slots = {m._slot(x) for x in (base, new_cmd, new_metric, new_seed)}
+    jobs = {m._job_name(x) for x in (base, new_cmd, new_metric, new_seed)}
+    assert len(slots) == 4  # every determinant change gets its own storage
+    assert len(jobs) == 4  # and its own cluster job
+    # a v1 result must not satisfy a v2-command read
+    _land(m, base, 0.42)
+    with pytest.raises(MeasurementPending):
+        m.results([new_cmd])

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -48,8 +48,14 @@ def _measurer(
     )
 
 
-def _land(tmp_path: Path, name: str, value=None, code="0", job="101"):
-    ev = tmp_path / f"eval-{name}"
+# storage is keyed by (logical name, tree_sha[:8]) — the on-disk slots for the
+# _measures() pair below:
+BASE = "baseline-" + "a" * 8
+CAND = "candidate-" + "b" * 8
+
+
+def _land(tmp_path: Path, slot: str, value=None, code="0", job="101"):
+    ev = tmp_path / f"eval-{slot}"
     ev.mkdir(parents=True, exist_ok=True)
     (ev / "submitted").write_text(job)
     (ev / "exit-code").write_text(code)
@@ -57,8 +63,8 @@ def _land(tmp_path: Path, name: str, value=None, code="0", job="101"):
         (ev / "stdout").write_text(json.dumps({"metric": "r2", "value": value}) + "\n")
 
 
-def _dispatched(tmp_path: Path, name: str, job="101"):
-    ev = tmp_path / f"eval-{name}"
+def _dispatched(tmp_path: Path, slot: str, job="101"):
+    ev = tmp_path / f"eval-{slot}"
     ev.mkdir(parents=True, exist_ok=True)
     (ev / "submitted").write_text(job)
 
@@ -79,8 +85,8 @@ def test_first_pass_dispatches_all_and_parks(tmp_path):
 def test_resume_reads_completed_without_resubmitting(tmp_path):
     submitted: list = []
     m = _measurer(tmp_path, submitted)
-    _land(tmp_path, "baseline", 0.50)
-    _land(tmp_path, "candidate", 0.61)
+    _land(tmp_path, BASE, 0.50)
+    _land(tmp_path, CAND, 0.61)
     assert m.results(_measures()) == {"baseline": 0.50, "candidate": 0.61}
     assert submitted == []
 
@@ -89,8 +95,9 @@ def test_live_job_reparks_on_real_id_never_resubmits(tmp_path):
     """A job squeue reports as running is parked on its real id — even if its
     local marker is MISSING (the crash-before-marker case)."""
     submitted: list = []
-    m = _measurer(tmp_path, submitted, live={"eval-r1-candidate-f882a1f6f00a": "102"})
-    _land(tmp_path, "baseline", 0.50)
+    cand_job = _measurer(tmp_path, [])._job_name(_measures()[1])
+    m = _measurer(tmp_path, submitted, live={cand_job: "102"})
+    _land(tmp_path, BASE, 0.50)
     # candidate has NO marker (submitter died in the gap) but IS live
     with pytest.raises(MeasurementPending) as exc:
         m.results(_measures())
@@ -103,8 +110,8 @@ def test_dispatched_but_vanished_fails_not_resubmits(tmp_path):
     producing a result (SIGKILL / GONE) -> EvalError, never resubmit."""
     submitted: list = []
     m = _measurer(tmp_path, submitted, live={})  # nothing live
-    _land(tmp_path, "baseline", 0.50)
-    _dispatched(tmp_path, "candidate", job="102")  # marker, not live, no result
+    _land(tmp_path, BASE, 0.50)
+    _dispatched(tmp_path, CAND, job="102")  # marker, not live, no result
     with pytest.raises(EvalError, match="vanished"):
         m.results(_measures())
     assert submitted == []
@@ -112,8 +119,8 @@ def test_dispatched_but_vanished_fails_not_resubmits(tmp_path):
 
 def test_nonzero_exit_raises(tmp_path):
     m = _measurer(tmp_path, [])
-    _land(tmp_path, "baseline", 0.50)
-    _land(tmp_path, "candidate", code="97")
+    _land(tmp_path, BASE, 0.50)
+    _land(tmp_path, CAND, code="97")
     with pytest.raises(EvalError, match="candidate"):
         m.results(_measures())
 
@@ -123,7 +130,7 @@ def test_squeue_blind_parks_without_dispatch(tmp_path):
     marker id if any), let the sweep deadline retry; never dispatch blind."""
     submitted: list = []
     m = _measurer(tmp_path, submitted, squeue_fails=True)
-    _dispatched(tmp_path, "baseline", job="102")  # has a marker
+    _dispatched(tmp_path, BASE, job="102")  # has a marker
     # candidate has no marker; blind -> park, empty dep -> sweep handles it
     with pytest.raises(MeasurementPending) as exc:
         m.results(_measures())
@@ -141,20 +148,19 @@ def test_empty_pending_afterany_is_blank():
 
 
 def test_plan_baseline_and_candidate_paired_seed():
-    plan = plan_measures("hp", "cmd", "r2", "a" * 40, "b" * 40, seed_env="S", seed=7)
+    plan = plan_measures("cmd", "r2", "a" * 40, "b" * 40, seed_env="S", seed=7)
     assert [m.name for m in plan] == ["baseline", "candidate"]
     assert plan[0].tree_sha == "a" * 40 and plan[1].tree_sha == "b" * 40
     assert plan[0].env() == {"S": "7"} and plan[1].env() == {"S": "7"}  # common random numbers
 
 
 def test_plan_no_seed_env_no_extra_env():
-    plan = plan_measures("hp", "cmd", "r2", "a" * 40, "b" * 40)
+    plan = plan_measures("cmd", "r2", "a" * 40, "b" * 40)
     assert all(m.env() == {} for m in plan)
 
 
 def test_plan_suite_siblings_use_their_own_seed_env():
     plan = plan_measures(
-        "hp",
         "cmd",
         "r2",
         "a" * 40,
@@ -228,3 +234,19 @@ def test_long_run_tags_get_distinct_job_names(tmp_path):
     n1 = mk("heldout_probe-20260818-aaa")._job_name(meas)
     n2 = mk("heldout_probe-20260818-bbb")._job_name(meas)
     assert n1 != n2 and len(n1) <= 60 and len(n2) <= 60
+
+
+def test_same_name_new_sha_gets_fresh_storage_and_job(tmp_path):
+    """A panel revision re-measures `candidate` at a NEW sha. Storage identity
+    is (name, tree_sha), so the new sha must NOT read the old sha's cached
+    eval dir and must NOT reuse its cluster job name — otherwise a revision
+    would silently inherit the pre-revision result."""
+    m = _measurer(tmp_path, [])
+    v1 = Measure("candidate", "b" * 40, "cmd", "r2")
+    v2 = Measure("candidate", "c" * 40, "cmd", "r2")  # revised candidate
+    assert m._ev(v1) != m._ev(v2)  # distinct on-disk slots
+    assert m._job_name(v1) != m._job_name(v2)  # distinct cluster jobs
+    # a landed v1 result is invisible to a v2 read (no stale inheritance)
+    _land(tmp_path, CAND, 0.42)  # eval-candidate-bbbbbbbb
+    with pytest.raises(MeasurementPending):
+        m.results([v2])  # v2's slot has no result -> dispatched, not read


### PR DESCRIPTION
The concrete stage-B plan (the resume seam is post-session: snapshot the dirty workspace, and measure-and-decide becomes a pure function of committed shas — re-enterable on wake, session never re-runs) written into docs/design/dispatcher.md, plus the first code unit: `plan_measures`, the pure function that builds a climb's Measure list (baseline + candidate paired on one seed; a suite gate's 2N paired siblings) from committed shas + contract facts.

Doc + one pure function; the live_climb split (B.2b) and wake CLI + WakeDispatcher (B.2c) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)