### PR TITLE
Add LocalMeasurer: the inline Measurer backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `LocalMeasurer` (`measure` module) — dispatcher phase 1, stage B part 2b(i):
+  the inline `Measurer` backend, for cheap benchmarks and local runs where a
+  dispatched job would cost more than the eval. It measures the worktrees the
+  caller already has (`base_sha` -> pre-session tree, `candidate_sha` -> the
+  session workspace), so it adds no checkout and no new trust surface — the
+  same evaluator on the same worktrees the synchronous climb always used — and
+  never parks. Caches per measure identity so a tree measured twice (baseline
+  for the brief, then in the gate) runs once. The second backend behind the
+  `Measurer` seam `measure_and_decide` already targets; wiring the seam into
+  `climb_once` (with `should_dispatch` picking inline vs dispatched) is next.
+
 - `measure_and_decide` (`orchestrator` module) — dispatcher phase 1, stage B
   part 2a: the post-session decision extracted as a PURE function of committed
   shas and a `Measurer` seam (scope, then baseline/candidate paired measure,

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -272,24 +272,29 @@ class LocalMeasurer:
     same worktrees the synchronous climb always did. It never parks (no
     `MeasurementPending`), so `measure_and_decide` flows straight through.
 
-    CALLER CONTRACT: `trees[sha]` must be a worktree holding EXACTLY that
-    committed sha's content. Unlike `DispatchedMeasurer`, which checks the sha
-    out itself, this backend TRUSTS the map — the guarantee that measured
-    content matches the committed sha is the caller's to keep (climb_once maps
-    candidate_sha to the workspace it just snapshotted). The map is fixed for a
-    measurer's life; because a sha is content-addressed, the cache keys on the
-    sha (not the worktree path) — remapping a sha to different content mid-life
-    would violate the contract, not merely stale the cache.
+    CALLER CONTRACT: `trees[sha]` is the worktree the sha was snapshotted FROM,
+    so it holds sha's TRACKED content. This backend measures that live worktree
+    directly (no checkout) — exactly as the synchronous climb always did. That
+    is a WEAKER guarantee than the dispatched backend's fresh checkout: the
+    candidate's worktree is the session's workspace, which (like before) can
+    also carry UNTRACKED files — eval artifacts, caches — that the committed sha
+    does not. A benchmark whose result depends only on tracked code measures
+    identically either way; one that reads untracked artifacts can differ, and
+    there the dispatched clean checkout is the trustworthy one. Choose this
+    backend for cheap, self-contained evals; dispatch the rest. It TRUSTS the
+    map — it does not verify the worktree against the sha.
 
     Caches by the measure's full identity (name, tree, command, metric, env),
     so a tree measured twice in one climb — the baseline once for the brief and
-    again in the gate — is evaluated once. The cache is per-instance in memory,
+    again in the gate — is evaluated once. The key is the sha, not the worktree
+    path: a sha is content-addressed over tracked files, which is exact for the
+    tracked-only evals this backend is for. The cache is per-instance in memory,
     which is all the inline path needs: it runs to completion in one process
     and never resumes across a death (that is the dispatched path's job)."""
 
     evaluator: Evaluator
-    # tree_sha -> an existing worktree holding EXACTLY that committed content
-    # (caller-guaranteed; see the class docstring's CALLER CONTRACT).
+    # tree_sha -> the worktree the sha was snapshotted from (holds sha's tracked
+    # content; see the class docstring's CALLER CONTRACT for the untracked caveat).
     trees: dict[str, Path]
     _cache: dict[tuple[str, str, str, str, tuple[tuple[str, str], ...]], float] = field(
         default_factory=dict

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -272,6 +272,15 @@ class LocalMeasurer:
     same worktrees the synchronous climb always did. It never parks (no
     `MeasurementPending`), so `measure_and_decide` flows straight through.
 
+    CALLER CONTRACT: `trees[sha]` must be a worktree holding EXACTLY that
+    committed sha's content. Unlike `DispatchedMeasurer`, which checks the sha
+    out itself, this backend TRUSTS the map — the guarantee that measured
+    content matches the committed sha is the caller's to keep (climb_once maps
+    candidate_sha to the workspace it just snapshotted). The map is fixed for a
+    measurer's life; because a sha is content-addressed, the cache keys on the
+    sha (not the worktree path) — remapping a sha to different content mid-life
+    would violate the contract, not merely stale the cache.
+
     Caches by the measure's full identity (name, tree, command, metric, env),
     so a tree measured twice in one climb — the baseline once for the brief and
     again in the gate — is evaluated once. The cache is per-instance in memory,
@@ -279,7 +288,8 @@ class LocalMeasurer:
     and never resumes across a death (that is the dispatched path's job)."""
 
     evaluator: Evaluator
-    # tree_sha -> an existing worktree holding exactly that committed content.
+    # tree_sha -> an existing worktree holding EXACTLY that committed content
+    # (caller-guaranteed; see the class docstring's CALLER CONTRACT).
     trees: dict[str, Path]
     _cache: dict[tuple[str, str, str, str, tuple[tuple[str, str], ...]], float] = field(
         default_factory=dict

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from autoresearch.compute import JobSpec, SlurmCompute
@@ -28,7 +28,7 @@ from autoresearch.dispatch import (
     read_eval_result,
     write_eval_job,
 )
-from autoresearch.orchestrator import EvalError
+from autoresearch.orchestrator import EvalError, Evaluator
 
 log = logging.getLogger(__name__)
 
@@ -260,3 +260,44 @@ class DispatchedMeasurer:
         if pending or blind:
             raise MeasurementPending(tuple(pending))
         return {m.name: read_eval_result(self.run_dir, self._slot(m), m.metric) for m in measures}
+
+
+@dataclass
+class LocalMeasurer:
+    """The inline `Measurer`: runs each measure in-process, for cheap
+    benchmarks and local runs where dispatching a job would cost more than the
+    eval. It measures the worktrees the CALLER already has — `base_sha` -> the
+    pre-session tree, `candidate_sha` -> the session's workspace — so it adds
+    no checkout and no new trust surface: it runs the same evaluator on the
+    same worktrees the synchronous climb always did. It never parks (no
+    `MeasurementPending`), so `measure_and_decide` flows straight through.
+
+    Caches by the measure's full identity (name, tree, command, metric, env),
+    so a tree measured twice in one climb — the baseline once for the brief and
+    again in the gate — is evaluated once. The cache is per-instance in memory,
+    which is all the inline path needs: it runs to completion in one process
+    and never resumes across a death (that is the dispatched path's job)."""
+
+    evaluator: Evaluator
+    # tree_sha -> an existing worktree holding exactly that committed content.
+    trees: dict[str, Path]
+    _cache: dict[tuple[str, str, str, str, tuple[tuple[str, str], ...]], float] = field(
+        default_factory=dict
+    )
+
+    def results(self, measures: list[Measure]) -> dict[str, float]:
+        out: dict[str, float] = {}
+        for m in measures:
+            env = tuple(sorted(m.env().items()))
+            key = (m.name, m.tree_sha, m.command, m.metric, env)
+            if key not in self._cache:
+                worktree = self.trees.get(m.tree_sha)
+                if worktree is None:
+                    raise EvalError(
+                        f"local measurer has no worktree for {m.name} @ {m.tree_sha[:12]}"
+                    )
+                self._cache[key] = self.evaluator.evaluate(
+                    worktree, m.command, m.metric, extra_env=dict(env) or None
+                )
+            out[m.name] = self._cache[key]
+        return out

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -623,9 +623,10 @@ class Measurer(Protocol):
     keyed by its name, or — for a dispatched backend — raises
     `MeasurementPending` after submitting the not-yet-done jobs, for the caller
     to park on. Two backends behind this one seam: `LocalMeasurer` (inline
-    checkout + eval, for cheap benchmarks and local runs) and
-    `measure.DispatchedMeasurer` (cluster jobs, for expensive evals); the seam
-    is what lets `measure_and_decide` be re-enterable without knowing which."""
+    eval in the caller's existing worktrees, for cheap benchmarks and local
+    runs) and `measure.DispatchedMeasurer` (cluster jobs on a fresh checkout of
+    each committed sha, for expensive evals); the seam is what lets
+    `measure_and_decide` be re-enterable without knowing which."""
 
     def results(self, measures: list[Measure]) -> dict[str, float]: ...
 

--- a/tests/test_local_measurer.py
+++ b/tests/test_local_measurer.py
@@ -54,6 +54,20 @@ def test_caches_repeated_identity(tmp_path):
     assert len(ev.calls) == 2  # each measured once, not four times
 
 
+def test_cache_key_is_the_full_identity_not_just_name_and_tree(tmp_path):
+    # a weaker key (name+tree only) would collide these into one stale value.
+    base, _ = _trees(tmp_path)
+    ev = FakeEvaluator({(base, "cmd1"): 0.1, (base, "cmd2"): 0.2})
+    m = LocalMeasurer(ev, {BASE: base})
+    # same name + tree, DIFFERENT command -> distinct results, not a cache hit
+    assert m.results([Measure("x", BASE, "cmd1", "r2")])["x"] == 0.1
+    assert m.results([Measure("x", BASE, "cmd2", "r2")])["x"] == 0.2
+    # same name + tree + command, DIFFERENT env (seed) -> a fresh eval each
+    m.results([Measure("x", BASE, "cmd1", "r2", extra_env=(("S", "1"),))])
+    m.results([Measure("x", BASE, "cmd1", "r2", extra_env=(("S", "2"),))])
+    assert len(ev.calls) == 4  # 4 distinct identities -> 4 evals, none collided
+
+
 def test_missing_worktree_is_eval_error(tmp_path):
     m = LocalMeasurer(FakeEvaluator({}), {})  # no trees registered
     with pytest.raises(EvalError, match="no worktree"):

--- a/tests/test_local_measurer.py
+++ b/tests/test_local_measurer.py
@@ -1,0 +1,102 @@
+"""LocalMeasurer: the inline Measurer backend. It measures the caller's
+existing worktrees (no checkout), caches per identity, and never parks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from autoresearch.measure import LocalMeasurer, Measure, SiblingSpec, plan_measures
+from autoresearch.orchestrator import EvalError
+
+BASE = "a" * 40
+CAND = "b" * 40
+
+
+class FakeEvaluator:
+    """Returns a value keyed by (workspace, command); records every call."""
+
+    def __init__(self, values: dict[tuple[Path, str], float]):
+        self.values = values
+        self.calls: list[tuple[Path, str, str, dict | None]] = []
+
+    def evaluate(self, workspace, command, metric, extra_env=None):
+        self.calls.append((workspace, command, metric, extra_env))
+        return self.values[(workspace, command)]
+
+
+def _trees(tmp_path: Path) -> tuple[Path, Path]:
+    base, cand = tmp_path / "base", tmp_path / "cand"
+    base.mkdir()
+    cand.mkdir()
+    return base, cand
+
+
+def test_measures_each_tree_with_the_climb_command(tmp_path):
+    base, cand = _trees(tmp_path)
+    ev = FakeEvaluator({(base, "cmd"): 0.50, (cand, "cmd"): 0.61})
+    m = LocalMeasurer(ev, {BASE: base, CAND: cand})
+    out = m.results(plan_measures("cmd", "r2", BASE, CAND))
+    assert out == {"baseline": 0.50, "candidate": 0.61}
+    # baseline ran in the base tree, candidate in the candidate tree
+    assert (base, "cmd", "r2") == ev.calls[0][:3]
+    assert (cand, "cmd", "r2") == ev.calls[1][:3]
+
+
+def test_caches_repeated_identity(tmp_path):
+    base, cand = _trees(tmp_path)
+    ev = FakeEvaluator({(base, "cmd"): 0.50, (cand, "cmd"): 0.61})
+    m = LocalMeasurer(ev, {BASE: base, CAND: cand})
+    plan = plan_measures("cmd", "r2", BASE, CAND)
+    m.results(plan)
+    m.results(plan)  # same identities -> served from cache
+    assert len(ev.calls) == 2  # each measured once, not four times
+
+
+def test_missing_worktree_is_eval_error(tmp_path):
+    m = LocalMeasurer(FakeEvaluator({}), {})  # no trees registered
+    with pytest.raises(EvalError, match="no worktree"):
+        m.results([Measure("baseline", BASE, "cmd", "r2")])
+
+
+def test_passes_the_paired_seed_to_both_sides(tmp_path):
+    base, cand = _trees(tmp_path)
+    ev = FakeEvaluator({(base, "cmd"): 0.50, (cand, "cmd"): 0.61})
+    m = LocalMeasurer(ev, {BASE: base, CAND: cand})
+    m.results(plan_measures("cmd", "r2", BASE, CAND, seed_env="S", seed=7))
+    assert [c[3] for c in ev.calls] == [{"S": "7"}, {"S": "7"}]  # common random numbers
+
+
+def test_no_seed_passes_none_not_empty_dict(tmp_path):
+    base, cand = _trees(tmp_path)
+    ev = FakeEvaluator({(base, "cmd"): 0.50, (cand, "cmd"): 0.61})
+    m = LocalMeasurer(ev, {BASE: base, CAND: cand})
+    m.results(plan_measures("cmd", "r2", BASE, CAND))
+    assert all(c[3] is None for c in ev.calls)  # matches the evaluator's default
+
+
+def test_siblings_run_their_own_command_on_the_right_trees(tmp_path):
+    base, cand = _trees(tmp_path)
+    ev = FakeEvaluator(
+        {(base, "cmd"): 0.50, (cand, "cmd"): 0.61, (base, "sibcmd"): 0.8, (cand, "sibcmd"): 0.79}
+    )
+    m = LocalMeasurer(ev, {BASE: base, CAND: cand})
+    plan = plan_measures(
+        "cmd",
+        "r2",
+        BASE,
+        CAND,
+        siblings=(SiblingSpec("tsp", "sibcmd", "len", seed_env="T", seed=9),),
+    )
+    out = m.results(plan)
+    assert out == {
+        "baseline": 0.50,
+        "candidate": 0.61,
+        "sib-tsp-base": 0.8,
+        "sib-tsp-cand": 0.79,
+    }
+    # the sibling pair ran sibcmd on base and cand, each carrying the suite seed
+    sib_calls = [c for c in ev.calls if c[1] == "sibcmd"]
+    assert {c[0] for c in sib_calls} == {base, cand}
+    assert all(c[3] == {"T": "9"} for c in sib_calls)


### PR DESCRIPTION
## What

Dispatcher phase 1, **stage B part 2b(i)**: `LocalMeasurer` — the inline `Measurer` backend, the second backend behind the seam `measure_and_decide` (PR #103) already targets.

It's for cheap benchmarks and local runs, where dispatching a Slurm job would cost more than the eval itself. `should_dispatch(eval_minutes)` will pick between this and the merged `DispatchedMeasurer`.

## The key design choice — no checkout, no new trust surface

Rather than re-checking-out committed shas inline (which would reopen the entire git-filter security surface stage A spent seven rounds hardening), `LocalMeasurer` measures **the worktrees the caller already has**:

- `base_sha` → the pre-session tree
- `candidate_sha` → the session's workspace

Those are exactly the worktrees today's synchronous climb already evaluates, so this adds **no checkout and no new trust surface** — it's the same evaluator on the same trees, just behind the `Measurer` interface. (The dispatched backend keeps measuring the committed snapshot on a remote node; that's its property.)

## Behavior

- **Never parks** — no `MeasurementPending`, so `measure_and_decide` flows straight through to the decision.
- **Caches per measure identity** (name, tree, command, metric, env), so a tree measured twice in one climb — baseline once for the brief, then again in the gate — is evaluated once. In-memory is all the inline path needs: it runs to completion in one process and never resumes across a death (that's the dispatched path's job).
- Missing worktree for a requested sha → `EvalError` (a safety net; the caller always registers `base_sha`/`candidate_sha`).

## Test

`tests/test_local_measurer.py` — a fake evaluator (no git needed): routes each measure to the right tree with the right command/metric, caches repeated identities (2 calls, not 4), passes the paired seed to both sides, passes `None` (not `{}`) when unseeded, and runs siblings' own commands on the right trees. Full suite 629 green, ruff + mypy clean.

## Not in this PR

Wiring `climb_once`/`live_climb` onto the seam — building the `{sha: worktree}` map, snapshotting the candidate, and `should_dispatch` picking inline vs dispatched — is the next part (2b-ii).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
