### PR TITLE
Add the climb park mechanics (ClimbParked + WAITING stage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- The climb PARK mechanics — dispatcher phase 1, stage B part 2c(i). When a
+  measurer parks (`MeasurementPending`), `climb_once` raises `ClimbParked` at
+  whichever point hibernated: `baseline` (before the session even runs — the
+  wake will rerun it) or `candidate` (after it — the wake decides). `live_climb`
+  catches it and writes a `WAITING` record carrying the re-entry `stage` (a new
+  `RunRecord` field: committed shas, drawn seeds, the candidate snapshot ref,
+  and the afterany set), keeps the candidate snapshot alive so the wake can read
+  it (dropping every other), and ends — never an error. Selecting the dispatched
+  backend for expensive evals (so parks actually fire) and the wake path that
+  resumes from the record are the next parts.
+
 ### Changed
 
 - `climb_once` now measures through the `Measurer` seam — dispatcher phase 1,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -164,20 +164,19 @@ def _park_run(
     run_id: str,
     record: RunRecord,
     parked: ClimbParked,
-    snapshots: list[Snapshot],
+    candidate_ref: str,
     eval_minutes: int | None,
     now: float,
 ) -> None:
     """Persist a dispatched climb's re-entry point as a WAITING record: the
     committed shas, drawn seeds, candidate snapshot ref, and afterany set a
-    fresh process reconstructs the measure-and-decide phase from. The wake path
-    (which reads this and resumes) is a later PR."""
+    fresh process reconstructs the measure-and-decide phase from. The caller
+    passes the EXACT `candidate_ref` it will keep alive (never re-derive it from
+    the commit — two snapshots can share a commit). The wake path (which reads
+    this and resumes) is a later PR."""
     from autoresearch.dispatch import effective_eval_minutes
 
     job_ids = parked.afterany.split(":")[1:] if parked.afterany else []
-    candidate_ref = ""
-    if parked.phase == "candidate":
-        candidate_ref = next((s.ref for s in snapshots if s.commit == parked.candidate_sha), "")
     stage: dict[str, object] = {
         "phase": parked.phase,
         "base_sha": parked.base_sha,
@@ -517,6 +516,7 @@ def live_climb(
             return snap.commit
 
         parked: ClimbParked | None = None
+        kept_ref = ""  # the ONE candidate snapshot ref that must outlive a park
         try:
             result = climb_once(
                 config,
@@ -542,17 +542,21 @@ def live_climb(
             # AFTER a successful write: if _park_run raises, it stays None so the
             # finally drops every snapshot (no leak) and the outer handler ends
             # the run as an error rather than a half-written hibernation.
+            if p.phase == "candidate":
+                # keep exactly ONE snapshot for that sha (two can share a
+                # commit); record and keep that same ref, drop the rest.
+                kept_ref = next((s.ref for s in snapshots if s.commit == p.candidate_sha), "")
             eval_minutes = next(
                 (b.eval_minutes for b in contract.benchmarks if b.name == config.benchmark), None
             )
-            _park_run(run_root, run_id, record, p, snapshots, eval_minutes, now)
+            _park_run(run_root, run_id, record, p, kept_ref, eval_minutes, now)
             parked = p
             return LiveClimbOutcome(run_id=run_id, outcome="parked")
         finally:
             for snap in snapshots:
-                # a candidate park must OUTLIVE the wake — keep that one snapshot;
-                # drop every other (intermediate / baseline-park) snapshot now.
-                if parked and parked.phase == "candidate" and snap.commit == parked.candidate_sha:
+                # a candidate park must OUTLIVE the wake — keep the ONE recorded
+                # snapshot (matched by ref, not commit); drop every other one.
+                if parked and kept_ref and snap.ref == kept_ref:
                     continue
                 drop_snapshot(ws, snap)  # best-effort + self-logging; never raises
             if not _best_effort(

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -193,10 +193,9 @@ def _park_run(
     # rides the DEADLINE floor instead (which sits past every eval's walltime).
     # The precise "all jobs done" fast wake is the afterany wake job (a later PR).
     experiment_job_id = job_ids[0] if len(job_ids) == 1 else ""
-    # The deadline is a FLOOR anchored to the run's start (`now`); its generous
-    # queue/grace slack absorbs the session's own duration, and the sweep
-    # re-bases it from `terminal_seen`. The wake dispatcher sets the precise
-    # park-time deadline later.
+    # The deadline is a FLOOR: park time (`now` here is the park moment, passed
+    # by the caller) + the eval walltime + a generous queue/grace slack, so a
+    # healthy queued-then-running eval never trips the sweep's cancel-on-pending.
     deadline = now + (effective_eval_minutes(eval_minutes) + PARK_QUEUE_SLACK_MIN) * 60
     waiting = RunRecord(
         **{
@@ -206,9 +205,12 @@ def _park_run(
             "resume_session_id": parked.session.session_id if parked.session else "",
             "deadline": deadline,
             "stage": stage,
-            # a fresh hibernation: the NEW experiment has not been seen terminal
-            # and carries no wake job yet (wake_attempts is KEPT — it is the
-            # stuck-detector across the whole run, not per park).
+            # a fresh hibernation from IMPLEMENTING: the run just LEFT waiting to
+            # do work (the session, a measure), so wake_attempts — "wakes since
+            # the run last left waiting" — resets; a productive park/wake cycle
+            # must not creep toward the stuck cap. The NEW experiment has not
+            # been seen terminal and carries no wake job yet.
+            "wake_attempts": 0,
             "terminal_seen": 0.0,
             "wake_job_id": "",
         }
@@ -549,7 +551,12 @@ def live_climb(
             eval_minutes = next(
                 (b.eval_minutes for b in contract.benchmarks if b.name == config.benchmark), None
             )
-            _park_run(run_root, run_id, record, p, kept_ref, eval_minutes, now)
+            import time
+
+            # anchor the deadline to the PARK (when the evals were submitted),
+            # not the run's start `now` — a session lasting hours would otherwise
+            # eat the queue budget and let the sweep cancel a still-queued eval.
+            _park_run(run_root, run_id, record, p, kept_ref, eval_minutes, time.time())
             parked = p
             return LiveClimbOutcome(run_id=run_id, outcome="parked")
         finally:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -34,6 +34,7 @@ from autoresearch.harness import ClaudeCodeHarness, Harness, redact
 from autoresearch.measure import LocalMeasurer
 from autoresearch.orchestrator import (
     ClimbConfig,
+    ClimbParked,
     Evaluator,
     SubprocessEvaluator,
     SuiteMeasurement,
@@ -63,6 +64,7 @@ from autoresearch.runstate import (
     IN_REVIEW,
     NEGATIVE_RESULT,
     STUCK,
+    WAITING,
     RunRecord,
     save_record,
     stamp_outage,
@@ -148,6 +150,47 @@ def _best_effort(what: str, fn: Callable[[], object], secrets: tuple[str, ...] =
     except Exception as exc:
         log.warning("%s failed: %s", what, redact(f"{type(exc).__name__}: {exc}", secrets))
         return False
+
+
+def _park_run(
+    run_root: Path,
+    run_id: str,
+    record: RunRecord,
+    parked: ClimbParked,
+    snapshots: list[Snapshot],
+    now: float,
+) -> None:
+    """Persist a dispatched climb's re-entry point as a WAITING record: the
+    committed shas, drawn seeds, candidate snapshot ref, and afterany set a
+    fresh process reconstructs the measure-and-decide phase from. The wake path
+    (which reads this and resumes) is a later PR."""
+    job_ids = parked.afterany.split(":")[1:] if parked.afterany else []
+    candidate_ref = ""
+    if parked.phase == "candidate":
+        candidate_ref = next((s.ref for s in snapshots if s.commit == parked.candidate_sha), "")
+    stage: dict[str, object] = {
+        "phase": parked.phase,
+        "base_sha": parked.base_sha,
+        "candidate_sha": parked.candidate_sha,
+        "candidate_ref": candidate_ref,
+        "seed": parked.seed,
+        "suite_seed": parked.suite_seed,
+        "afterany": parked.afterany,
+    }
+    waiting = RunRecord(
+        **{
+            **record.__dict__,
+            "state": WAITING,
+            "experiment_job_id": job_ids[0] if job_ids else "",
+            "resume_session_id": parked.session.session_id if parked.session else "",
+            # a nominal deadline floor now; the real walltime-based one lands
+            # with the wake dispatcher (deadline > 0 is required for a waiting
+            # run carrying an experiment job).
+            "deadline": now + 24 * 3600,
+            "stage": stage,
+        }
+    )
+    save_record(run_root, waiting, now)
 
 
 def _measure_committed(
@@ -449,6 +492,7 @@ def live_climb(
             snapshots.append(snap)
             return snap.commit
 
+        parked: ClimbParked | None = None
         try:
             result = climb_once(
                 config,
@@ -466,8 +510,20 @@ def live_climb(
                 panel_runner=panel_runner,
                 panel_revisions=panel_revisions,
             )
+        except ClimbParked as p:
+            # The climb dispatched its measures and hibernated. Persist the
+            # re-entry stage as a WAITING record (not an error), keep the
+            # candidate snapshot alive for the wake, and end. The wake re-enters
+            # from the record (the wake path is a later PR).
+            parked = p
+            _park_run(run_root, run_id, record, p, snapshots, now)
+            return LiveClimbOutcome(run_id=run_id, outcome="parked")
         finally:
             for snap in snapshots:
+                # a candidate park must OUTLIVE the wake — keep that one snapshot;
+                # drop every other (intermediate / baseline-park) snapshot now.
+                if parked and parked.phase == "candidate" and snap.commit == parked.candidate_sha:
+                    continue
                 drop_snapshot(ws, snap)  # best-effort + self-logging; never raises
             if not _best_effort(
                 "baseline worktree cleanup",

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -161,7 +161,6 @@ PARK_QUEUE_SLACK_MIN = 12 * 60
 
 def _park_run(
     run_root: Path,
-    run_id: str,
     record: RunRecord,
     parked: ClimbParked,
     candidate_ref: str,
@@ -205,11 +204,13 @@ def _park_run(
             "resume_session_id": parked.session.session_id if parked.session else "",
             "deadline": deadline,
             "stage": stage,
-            # a fresh hibernation from IMPLEMENTING: the run just LEFT waiting to
-            # do work (the session, a measure), so wake_attempts — "wakes since
-            # the run last left waiting" — resets; a productive park/wake cycle
-            # must not creep toward the stuck cap. The NEW experiment has not
-            # been seen terminal and carries no wake job yet.
+            # Reset only valid because THIS is the IMPLEMENTING->park entry: the
+            # run just LEFT waiting to do work (a session, a measure), so
+            # wake_attempts — "wakes since the run last left waiting" — is stale;
+            # a productive park/wake cycle must not creep toward the stuck cap.
+            # The wake path (a later PR) must NOT route a no-progress blind
+            # re-park (results still pending) back through here — resetting on
+            # that would defeat the stuck cap; a blind re-park keeps the counter.
             "wake_attempts": 0,
             "terminal_seen": 0.0,
             "wake_job_id": "",
@@ -556,7 +557,7 @@ def live_climb(
             # anchor the deadline to the PARK (when the evals were submitted),
             # not the run's start `now` — a session lasting hours would otherwise
             # eat the queue budget and let the sweep cancel a still-queued eval.
-            _park_run(run_root, run_id, record, p, kept_ref, eval_minutes, time.time())
+            _park_run(run_root, record, p, kept_ref, eval_minutes, time.time())
             parked = p
             return LiveClimbOutcome(run_id=run_id, outcome="parked")
         finally:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -187,12 +187,23 @@ def _park_run(
         "suite_seed": parked.suite_seed,
         "afterany": parked.afterany,
     }
+    # The sweep polls ONE experiment_job_id and wakes on its terminal+grace. That
+    # is right for a single-job park (baseline, or a candidate with no siblings):
+    # poll it. But a MULTI-job park (candidate + siblings) must not wake when the
+    # FIRST job finishes while the rest run — so it records no single job and
+    # rides the DEADLINE floor instead (which sits past every eval's walltime).
+    # The precise "all jobs done" fast wake is the afterany wake job (a later PR).
+    experiment_job_id = job_ids[0] if len(job_ids) == 1 else ""
+    # The deadline is a FLOOR anchored to the run's start (`now`); its generous
+    # queue/grace slack absorbs the session's own duration, and the sweep
+    # re-bases it from `terminal_seen`. The wake dispatcher sets the precise
+    # park-time deadline later.
     deadline = now + (effective_eval_minutes(eval_minutes) + PARK_QUEUE_SLACK_MIN) * 60
     waiting = RunRecord(
         **{
             **record.__dict__,
             "state": WAITING,
-            "experiment_job_id": job_ids[0] if job_ids else "",
+            "experiment_job_id": experiment_job_id,
             "resume_session_id": parked.session.session_id if parked.session else "",
             "deadline": deadline,
             "stage": stage,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -152,18 +152,28 @@ def _best_effort(what: str, fn: Callable[[], object], secrets: tuple[str, ...] =
         return False
 
 
+# A parked run's deadline is the FLOOR beneath the afterany wake: submit +
+# eval walltime + a generous queue/grace allowance. It must exceed the time a
+# healthy eval can legitimately sit queued-then-running, or `tick._sweep_one`
+# would cancel a still-queued job as "unschedulable".
+PARK_QUEUE_SLACK_MIN = 12 * 60
+
+
 def _park_run(
     run_root: Path,
     run_id: str,
     record: RunRecord,
     parked: ClimbParked,
     snapshots: list[Snapshot],
+    eval_minutes: int | None,
     now: float,
 ) -> None:
     """Persist a dispatched climb's re-entry point as a WAITING record: the
     committed shas, drawn seeds, candidate snapshot ref, and afterany set a
     fresh process reconstructs the measure-and-decide phase from. The wake path
     (which reads this and resumes) is a later PR."""
+    from autoresearch.dispatch import effective_eval_minutes
+
     job_ids = parked.afterany.split(":")[1:] if parked.afterany else []
     candidate_ref = ""
     if parked.phase == "candidate":
@@ -177,17 +187,20 @@ def _park_run(
         "suite_seed": parked.suite_seed,
         "afterany": parked.afterany,
     }
+    deadline = now + (effective_eval_minutes(eval_minutes) + PARK_QUEUE_SLACK_MIN) * 60
     waiting = RunRecord(
         **{
             **record.__dict__,
             "state": WAITING,
             "experiment_job_id": job_ids[0] if job_ids else "",
             "resume_session_id": parked.session.session_id if parked.session else "",
-            # a nominal deadline floor now; the real walltime-based one lands
-            # with the wake dispatcher (deadline > 0 is required for a waiting
-            # run carrying an experiment job).
-            "deadline": now + 24 * 3600,
+            "deadline": deadline,
             "stage": stage,
+            # a fresh hibernation: the NEW experiment has not been seen terminal
+            # and carries no wake job yet (wake_attempts is KEPT — it is the
+            # stuck-detector across the whole run, not per park).
+            "terminal_seen": 0.0,
+            "wake_job_id": "",
         }
     )
     save_record(run_root, waiting, now)
@@ -518,7 +531,10 @@ def live_climb(
             # AFTER a successful write: if _park_run raises, it stays None so the
             # finally drops every snapshot (no leak) and the outer handler ends
             # the run as an error rather than a half-written hibernation.
-            _park_run(run_root, run_id, record, p, snapshots, now)
+            eval_minutes = next(
+                (b.eval_minutes for b in contract.benchmarks if b.name == config.benchmark), None
+            )
+            _park_run(run_root, run_id, record, p, snapshots, eval_minutes, now)
             parked = p
             return LiveClimbOutcome(run_id=run_id, outcome="parked")
         finally:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -514,9 +514,12 @@ def live_climb(
             # The climb dispatched its measures and hibernated. Persist the
             # re-entry stage as a WAITING record (not an error), keep the
             # candidate snapshot alive for the wake, and end. The wake re-enters
-            # from the record (the wake path is a later PR).
-            parked = p
+            # from the record (the wake path is a later PR). `parked` is set only
+            # AFTER a successful write: if _park_run raises, it stays None so the
+            # finally drops every snapshot (no leak) and the outer handler ends
+            # the run as an error rather than a half-written hibernation.
             _park_run(run_root, run_id, record, p, snapshots, now)
+            parked = p
             return LiveClimbOutcome(run_id=run_id, outcome="parked")
         finally:
             for snap in snapshots:

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -90,8 +90,10 @@ class ClimbParked(Exception):
     """A dispatched climb submitted its measures and must hibernate until they
     finish. `climb_once` raises it (a park is an exceptional exit); the caller,
     which owns the run record and git, persists the fields below as the WAITING
-    stage, submits `afterany` as the wake dependency, and ends the process —
-    keeping the candidate snapshot alive so the wake can read it. `phase` is
+    stage — `afterany` among them, the dependency the wake PR will submit its
+    afterany wake job against (this PR only records it; `wake_job_id` stays
+    empty until then) — and ends the run's turn, keeping the candidate snapshot
+    alive so the wake can read it. `phase` is
     WHICH park: `baseline` (before the session — the wake reruns the session)
     or `candidate` (after it — the wake decides). The caller fills in the
     candidate snapshot ref (which it holds) when writing the stage."""

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -86,6 +86,37 @@ class EvalError(RuntimeError):
     """The benchmark command failed or produced no readable metric."""
 
 
+class ClimbParked(Exception):
+    """A dispatched climb submitted its measures and must hibernate until they
+    finish. `climb_once` raises it (a park is an exceptional exit); the caller,
+    which owns the run record and git, persists the fields below as the WAITING
+    stage, submits `afterany` as the wake dependency, and ends the process —
+    keeping the candidate snapshot alive so the wake can read it. `phase` is
+    WHICH park: `baseline` (before the session — the wake reruns the session)
+    or `candidate` (after it — the wake decides). The caller fills in the
+    candidate snapshot ref (which it holds) when writing the stage."""
+
+    def __init__(
+        self,
+        *,
+        phase: str,
+        afterany: str,
+        base_sha: str,
+        seed: int,
+        suite_seed: int,
+        candidate_sha: str = "",
+        session: SessionResult | None = None,
+    ):
+        self.phase = phase
+        self.afterany = afterany
+        self.base_sha = base_sha
+        self.seed = seed
+        self.suite_seed = suite_seed
+        self.candidate_sha = candidate_sha
+        self.session = session
+        super().__init__(f"climb parked at {phase} on {afterany or '(no dep)'}")
+
+
 class Evaluator(Protocol):
     """Runs a benchmark command in a workspace, returns the metric value."""
 
@@ -858,7 +889,7 @@ def climb_once(
 
     # deferred like measure_and_decide's import (measure -> dispatch ->
     # orchestrator for the eval primitives).
-    from autoresearch.measure import plan_measures
+    from autoresearch.measure import MeasurementPending, plan_measures
 
     run_seed = draw_run_seed() if bench.seed_env else 0
     siblings = [b for b in contract.benchmarks if b.name != bench.name]
@@ -886,6 +917,16 @@ def climb_once(
     except EvalError as exc:
         # the measurer already names the failing measure ("baseline: ...").
         return ClimbResult(outcome="eval-error", note=str(exc))
+    except MeasurementPending as pending:
+        # PARK 1 (dispatched baseline, before the session): the wake reads the
+        # baseline, then runs the session and re-enters. No candidate yet.
+        raise ClimbParked(
+            phase="baseline",
+            afterany=pending.afterany(),
+            base_sha=base_sha,
+            seed=run_seed,
+            suite_seed=suite_seed,
+        ) from None
 
     task = make_task(contract, config.benchmark, baseline, hypothesis=task_hypothesis)
     brief = build_brief(
@@ -964,17 +1005,32 @@ def climb_once(
                 panel_transcript="\n\n".join(panel_sections),
                 panel_rounds=panel_reads,
             )
-        outcome = measure_and_decide(
-            contract,
-            bench,
-            base_sha=base_sha,
-            candidate_sha=candidate_sha,
-            seed=run_seed,
-            suite_seed=suite_seed,
-            measured_paths=measured,
-            measurer=measurer,
-            min_relative_improvement=config.min_relative_improvement,
-        )
+        try:
+            outcome = measure_and_decide(
+                contract,
+                bench,
+                base_sha=base_sha,
+                candidate_sha=candidate_sha,
+                seed=run_seed,
+                suite_seed=suite_seed,
+                measured_paths=measured,
+                measurer=measurer,
+                min_relative_improvement=config.min_relative_improvement,
+            )
+        except MeasurementPending as pending:
+            # PARK 2 (dispatched candidate/suite, after the session): the wake
+            # reads the cached results and decides. Carries the candidate sha
+            # and the session so the caller persists the snapshot ref (drop at
+            # the terminal state) and the resume session id.
+            raise ClimbParked(
+                phase="candidate",
+                afterany=pending.afterany(),
+                base_sha=base_sha,
+                seed=run_seed,
+                suite_seed=suite_seed,
+                candidate_sha=candidate_sha,
+                session=session,
+            ) from None
         if isinstance(outcome, ClimbResult):
             # a terminal measurement outcome (scope-violation / eval-error /
             # no-improvement / suite-regression): add the session + panel

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -18,7 +18,7 @@ import contextlib
 import json
 import logging
 import os
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -140,6 +140,12 @@ class RunRecord:
     wake_attempts: int = 0
     deadline: float = 0.0  # unix; submit+walltime+slack, re-based on start
     terminal_seen: float = 0.0  # when the sweep first saw the experiment terminal
+    # A WAITING climb's re-entry point: the committed shas, drawn seeds, and the
+    # candidate snapshot ref a fresh process reconstructs the measure-and-decide
+    # phase from. `phase` says WHICH park (baseline, before the session; or
+    # candidate, after it). A JSON dict — small, forward-compatible — not the
+    # session state (that is `resume_session_id`).
+    stage: dict[str, object] = field(default_factory=dict)
     ending: str = ""  # one of ENDINGS once state == ENDED
     ending_note: str = ""
     created: float = 0.0

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -824,7 +824,13 @@ def _sweep_one(
             return
 
         if not record.experiment_job_id:
-            return  # not yet submitted; not the sweep's business
+            # No job id to poll. A BLIND PARK (the measurer could not read Slurm,
+            # so `MeasurementPending` carried no ids) still hibernated with a
+            # deadline — the deadline floor is its ONLY wake, so fire on it. A
+            # genuinely mid-write record has no deadline and is left alone.
+            if record.deadline > 0 and now > record.deadline:
+                wake(record, "blind park past deadline", "deadline")
+            return
 
         try:
             state = compute.status(record.experiment_job_id)

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -56,7 +56,9 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
 
     r = load_record(tmp_path, "tsp-1")
     assert r.state == "waiting"
-    assert r.experiment_job_id == "101"  # first of the afterany set
+    # a MULTI-job park records no single experiment job — the sweep must not
+    # wake when job 101 finishes while 102 runs; it rides the deadline floor.
+    assert r.experiment_job_id == ""
     # deadline is walltime-aware (eval walltime + queue slack), not a flat 24h,
     # so the sweep never cancels a still-queued job of a legitimately slow eval
     assert r.deadline == 1000.0 + (90 + 12 * 60) * 60
@@ -67,6 +69,19 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
     assert r.stage["candidate_ref"] == "refs/dispatch/tok"  # for drop at the terminal
     assert r.stage["seed"] == 7 and r.stage["suite_seed"] == 9
     assert r.stage["afterany"] == "afterany:101:102"
+
+
+def test_park_run_single_job_records_it_for_the_sweep(tmp_path) -> None:
+    # one eval job (a baseline park, or a candidate with no siblings): the sweep
+    # CAN poll it directly for a terminal+grace wake.
+    record = RunRecord(
+        run_id="tsp-3", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
+    )
+    parked = ClimbParked(
+        phase="baseline", afterany="afterany:77", base_sha="b" * 40, seed=0, suite_seed=0
+    )
+    _park_run(tmp_path, "tsp-3", record, parked, [], eval_minutes=90, now=1000.0)
+    assert load_record(tmp_path, "tsp-3").experiment_job_id == "77"
 
 
 def test_park_run_baseline_phase_has_no_candidate_or_session(tmp_path) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -52,7 +52,7 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
         candidate_sha="c" * 40,
         session=_session("s1"),
     )
-    _park_run(tmp_path, "tsp-1", record, parked, [snap], eval_minutes=90, now=1000.0)
+    _park_run(tmp_path, "tsp-1", record, parked, snap.ref, eval_minutes=90, now=1000.0)
 
     r = load_record(tmp_path, "tsp-1")
     assert r.state == "waiting"
@@ -80,7 +80,7 @@ def test_park_run_single_job_records_it_for_the_sweep(tmp_path) -> None:
     parked = ClimbParked(
         phase="baseline", afterany="afterany:77", base_sha="b" * 40, seed=0, suite_seed=0
     )
-    _park_run(tmp_path, "tsp-3", record, parked, [], eval_minutes=90, now=1000.0)
+    _park_run(tmp_path, "tsp-3", record, parked, "", eval_minutes=90, now=1000.0)
     assert load_record(tmp_path, "tsp-3").experiment_job_id == "77"
 
 
@@ -91,7 +91,7 @@ def test_park_run_baseline_phase_has_no_candidate_or_session(tmp_path) -> None:
     parked = ClimbParked(
         phase="baseline", afterany="afterany:55", base_sha="b" * 40, seed=0, suite_seed=0
     )
-    _park_run(tmp_path, "tsp-2", record, parked, [], eval_minutes=90, now=1000.0)
+    _park_run(tmp_path, "tsp-2", record, parked, "", eval_minutes=90, now=1000.0)
 
     r = load_record(tmp_path, "tsp-2")
     assert r.state == "waiting" and r.resume_session_id == ""  # session not run yet

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -8,10 +8,11 @@ from pathlib import Path
 
 import pytest
 
-from autoresearch.climb import live_climb
+from autoresearch.climb import _park_run, live_climb
+from autoresearch.dispatch import Snapshot
 from autoresearch.harness import SessionResult
-from autoresearch.orchestrator import ClimbConfig
-from autoresearch.runstate import load_record
+from autoresearch.orchestrator import ClimbConfig, ClimbParked
+from autoresearch.runstate import RunRecord, load_record
 
 CONTRACT = """\
 benchmarks:
@@ -23,6 +24,61 @@ budgets: {gpu_hours_per_run: 1, runs_per_week: 10}
 scope: {allowed: [src/pilot/solvers/]}
 roadmap: docs/roadmap.md
 """
+
+
+def _session(sid: str = "s1") -> SessionResult:
+    return SessionResult(
+        stop_reason="end_turn",
+        is_error=False,
+        cost_usd=1.0,
+        num_turns=5,
+        session_id=sid,
+        final_text="report",
+        transcript_path="",
+    )
+
+
+def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> None:
+    record = RunRecord(
+        run_id="tsp-1", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
+    )
+    snap = Snapshot(commit="c" * 40, tree="d" * 40, ref="refs/dispatch/tok")
+    parked = ClimbParked(
+        phase="candidate",
+        afterany="afterany:101:102",
+        base_sha="b" * 40,
+        seed=7,
+        suite_seed=9,
+        candidate_sha="c" * 40,
+        session=_session("s1"),
+    )
+    _park_run(tmp_path, "tsp-1", record, parked, [snap], now=1000.0)
+
+    r = load_record(tmp_path, "tsp-1")
+    assert r.state == "waiting"
+    assert r.experiment_job_id == "101"  # first of the afterany set
+    assert r.deadline > 1000.0  # the waiting-record invariant (has a deadline)
+    assert r.resume_session_id == "s1"  # the candidate park resumes the session
+    assert r.stage["phase"] == "candidate"
+    assert r.stage["base_sha"] == "b" * 40 and r.stage["candidate_sha"] == "c" * 40
+    assert r.stage["candidate_ref"] == "refs/dispatch/tok"  # for drop at the terminal
+    assert r.stage["seed"] == 7 and r.stage["suite_seed"] == 9
+    assert r.stage["afterany"] == "afterany:101:102"
+
+
+def test_park_run_baseline_phase_has_no_candidate_or_session(tmp_path) -> None:
+    record = RunRecord(
+        run_id="tsp-2", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
+    )
+    parked = ClimbParked(
+        phase="baseline", afterany="afterany:55", base_sha="b" * 40, seed=0, suite_seed=0
+    )
+    _park_run(tmp_path, "tsp-2", record, parked, [], now=1000.0)
+
+    r = load_record(tmp_path, "tsp-2")
+    assert r.state == "waiting" and r.resume_session_id == ""  # session not run yet
+    assert r.stage["phase"] == "baseline"
+    assert r.stage["candidate_sha"] == "" and r.stage["candidate_ref"] == ""
 
 
 def _git(cwd: Path, *args: str) -> str:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -52,12 +52,15 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
         candidate_sha="c" * 40,
         session=_session("s1"),
     )
-    _park_run(tmp_path, "tsp-1", record, parked, [snap], now=1000.0)
+    _park_run(tmp_path, "tsp-1", record, parked, [snap], eval_minutes=90, now=1000.0)
 
     r = load_record(tmp_path, "tsp-1")
     assert r.state == "waiting"
     assert r.experiment_job_id == "101"  # first of the afterany set
-    assert r.deadline > 1000.0  # the waiting-record invariant (has a deadline)
+    # deadline is walltime-aware (eval walltime + queue slack), not a flat 24h,
+    # so the sweep never cancels a still-queued job of a legitimately slow eval
+    assert r.deadline == 1000.0 + (90 + 12 * 60) * 60
+    assert r.terminal_seen == 0.0  # the NEW experiment has not been seen terminal
     assert r.resume_session_id == "s1"  # the candidate park resumes the session
     assert r.stage["phase"] == "candidate"
     assert r.stage["base_sha"] == "b" * 40 and r.stage["candidate_sha"] == "c" * 40
@@ -73,7 +76,7 @@ def test_park_run_baseline_phase_has_no_candidate_or_session(tmp_path) -> None:
     parked = ClimbParked(
         phase="baseline", afterany="afterany:55", base_sha="b" * 40, seed=0, suite_seed=0
     )
-    _park_run(tmp_path, "tsp-2", record, parked, [], now=1000.0)
+    _park_run(tmp_path, "tsp-2", record, parked, [], eval_minutes=90, now=1000.0)
 
     r = load_record(tmp_path, "tsp-2")
     assert r.state == "waiting" and r.resume_session_id == ""  # session not run yet

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -52,7 +52,7 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
         candidate_sha="c" * 40,
         session=_session("s1"),
     )
-    _park_run(tmp_path, "tsp-1", record, parked, snap.ref, eval_minutes=90, now=1000.0)
+    _park_run(tmp_path, record, parked, snap.ref, eval_minutes=90, now=1000.0)
 
     r = load_record(tmp_path, "tsp-1")
     assert r.state == "waiting"
@@ -80,7 +80,7 @@ def test_park_run_single_job_records_it_for_the_sweep(tmp_path) -> None:
     parked = ClimbParked(
         phase="baseline", afterany="afterany:77", base_sha="b" * 40, seed=0, suite_seed=0
     )
-    _park_run(tmp_path, "tsp-3", record, parked, "", eval_minutes=90, now=1000.0)
+    _park_run(tmp_path, record, parked, "", eval_minutes=90, now=1000.0)
     assert load_record(tmp_path, "tsp-3").experiment_job_id == "77"
 
 
@@ -99,7 +99,7 @@ def test_park_resets_wake_attempts_a_productive_park_left_waiting(tmp_path) -> N
     parked = ClimbParked(
         phase="baseline", afterany="afterany:9", base_sha="b" * 40, seed=0, suite_seed=0
     )
-    _park_run(tmp_path, "tsp-4", record, parked, "", eval_minutes=90, now=1000.0)
+    _park_run(tmp_path, record, parked, "", eval_minutes=90, now=1000.0)
     assert load_record(tmp_path, "tsp-4").wake_attempts == 0
 
 
@@ -110,7 +110,7 @@ def test_park_run_baseline_phase_has_no_candidate_or_session(tmp_path) -> None:
     parked = ClimbParked(
         phase="baseline", afterany="afterany:55", base_sha="b" * 40, seed=0, suite_seed=0
     )
-    _park_run(tmp_path, "tsp-2", record, parked, "", eval_minutes=90, now=1000.0)
+    _park_run(tmp_path, record, parked, "", eval_minutes=90, now=1000.0)
 
     r = load_record(tmp_path, "tsp-2")
     assert r.state == "waiting" and r.resume_session_id == ""  # session not run yet

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -84,6 +84,25 @@ def test_park_run_single_job_records_it_for_the_sweep(tmp_path) -> None:
     assert load_record(tmp_path, "tsp-3").experiment_job_id == "77"
 
 
+def test_park_resets_wake_attempts_a_productive_park_left_waiting(tmp_path) -> None:
+    # the run reached IMPLEMENTING (left waiting, did work) before this park, so
+    # "wakes since it last left waiting" resets — a productive park/wake cycle
+    # must not creep toward the stuck cap.
+    record = RunRecord(
+        run_id="tsp-4",
+        target="org/pilot",
+        task_title="t",
+        state="implementing",
+        benchmark="tsp",
+        wake_attempts=2,
+    )
+    parked = ClimbParked(
+        phase="baseline", afterany="afterany:9", base_sha="b" * 40, seed=0, suite_seed=0
+    )
+    _park_run(tmp_path, "tsp-4", record, parked, "", eval_minutes=90, now=1000.0)
+    assert load_record(tmp_path, "tsp-4").wake_attempts == 0
+
+
 def test_park_run_baseline_phase_has_no_candidate_or_session(tmp_path) -> None:
     record = RunRecord(
         run_id="tsp-2", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -204,6 +204,83 @@ def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
     assert not clears_min_delta(float("nan"), 11.9, "min", 0.5)
 
 
+class ParkingMeasurer:
+    """A Measurer that PARKS (raises MeasurementPending) on a chosen call —
+    stands in for the dispatched backend without a cluster."""
+
+    def __init__(self, park_on_call: int, values: dict[str, float] | None = None):
+        self.park_on = park_on_call
+        self.values = values or {}
+        self.calls = 0
+
+    def results(self, measures):
+        from autoresearch.measure import MeasurementPending
+
+        self.calls += 1
+        if self.calls == self.park_on:
+            raise MeasurementPending(("101", "102"))
+        return {m.name: self.values[m.name] for m in measures}
+
+
+def _bare_snapshot():
+    n = {"i": 0}
+
+    def snapshot() -> str:
+        n["i"] += 1
+        return f"cand{n['i']}"
+
+    return snapshot
+
+
+def test_baseline_measure_parks_before_the_session(tmp_path: Path) -> None:
+    # PARK 1: a dispatched baseline hibernates before the session even runs.
+    from autoresearch.orchestrator import ClimbParked
+
+    harness = FakeHarness(result=ok_session())
+    m = ParkingMeasurer(park_on_call=1)  # baseline is the first measure
+    with pytest.raises(ClimbParked) as exc:
+        climb_once(
+            CONFIG,
+            CONTRACT,
+            tmp_path,
+            harness,
+            m,
+            "base",
+            _bare_snapshot(),
+            ruler="r",
+            changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+            created="t",
+        )
+    assert exc.value.phase == "baseline" and exc.value.base_sha == "base"
+    assert exc.value.afterany == "afterany:101:102"
+    assert harness.calls == []  # the session never started
+
+
+def test_candidate_measure_parks_after_the_session(tmp_path: Path) -> None:
+    # PARK 2: baseline read, session ran, candidate dispatched -> hibernate.
+    from autoresearch.orchestrator import ClimbParked
+
+    harness = FakeHarness(result=ok_session())
+    m = ParkingMeasurer(park_on_call=2, values={"baseline": 13.876})
+    with pytest.raises(ClimbParked) as exc:
+        climb_once(
+            CONFIG,
+            CONTRACT,
+            tmp_path,
+            harness,
+            m,
+            "base",
+            _bare_snapshot(),
+            ruler="r",
+            changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+            created="t",
+        )
+    assert exc.value.phase == "candidate"
+    assert exc.value.candidate_sha == "cand1"
+    assert exc.value.session is not None  # the session ran before this park
+    assert harness.calls  # the session did start
+
+
 def test_session_error_short_circuits_before_second_eval(tmp_path: Path) -> None:
     bad = SessionResult(
         stop_reason="spawn-error",

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -99,7 +99,7 @@ def test_blind_park_with_no_job_id_wakes_on_its_deadline(tmp_path: Path) -> None
     # a park the measurer could not attach a job id to (Slurm was blind) still
     # hibernated with a deadline — the deadline floor is its ONLY wake.
     waiting_run(tmp_path, experiment_job_id="", deadline=NOW - 1)
-    report, dispatcher = run_tick(tmp_path, FakeSlurm(states={}))
+    _, dispatcher = run_tick(tmp_path, FakeSlurm(states={}))
     assert dispatcher.dispatched == [("r1", "blind park past deadline")]
 
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -95,6 +95,20 @@ def test_terminal_experiment_past_grace_gets_backup_wake(tmp_path: Path) -> None
     assert load_record(tmp_path, "r1").wake_attempts == 1
 
 
+def test_blind_park_with_no_job_id_wakes_on_its_deadline(tmp_path: Path) -> None:
+    # a park the measurer could not attach a job id to (Slurm was blind) still
+    # hibernated with a deadline — the deadline floor is its ONLY wake.
+    waiting_run(tmp_path, experiment_job_id="", deadline=NOW - 1)
+    report, dispatcher = run_tick(tmp_path, FakeSlurm(states={}))
+    assert dispatcher.dispatched == [("r1", "blind park past deadline")]
+
+
+def test_blind_park_before_its_deadline_is_left_alone(tmp_path: Path) -> None:
+    waiting_run(tmp_path, experiment_job_id="", deadline=NOW + 10_000)
+    _, dispatcher = run_tick(tmp_path, FakeSlurm(states={}))
+    assert dispatcher.dispatched == []
+
+
 def test_terminal_within_grace_leaves_it_to_the_afterany_job(tmp_path: Path) -> None:
     waiting_run(tmp_path, terminal_seen=NOW - 10)  # first seen moments ago
     report, dispatcher = run_tick(tmp_path, FakeSlurm(states={"100": "COMPLETED"}))


### PR DESCRIPTION
## What

Dispatcher phase 1, **stage B part 2c(i)**: the climb PARK mechanics. When a measurer parks (raises `MeasurementPending`), the climb must hibernate until its eval jobs finish instead of blocking a reasoning session for the full eval.

## The two park points

`climb_once` catches `MeasurementPending` at both places a dispatched measure can hibernate, and raises `ClimbParked` with the re-entry facts:

- **`baseline`** — the dispatched baseline, *before the session runs*. The wake will read the baseline, then run the session.
- **`candidate`** — the dispatched candidate/suite, *after the session*. The wake reads the cached results and decides. Carries the `candidate_sha` and the session (for `resume_session_id`).

## The park write

`live_climb` catches `ClimbParked` and writes a `WAITING` record via `_park_run`:

- A new `RunRecord.stage` field (a small JSON dict) holds the re-entry point: `phase`, `base_sha`, `candidate_sha`, `candidate_ref`, `seed`, `suite_seed`, `afterany`.
- The **candidate snapshot is kept** (it must outlive the wake so the eval jobs and the wake can read it); every *other* snapshot is dropped.
- A park is **not an error** — it never reaches the climb-error path; the run ends cleanly as `waiting`.

## Not yet live (by design)

`LocalMeasurer` never parks, so this path fires only once `should_dispatch` selects the dispatched backend for expensive evals — **the next PR** — and the wake that reads the record and resumes is the PR after that. This PR builds and unit-tests the mechanics, the same way `DispatchedMeasurer` was landed before it was wired.

## Test

- `climb_once` raises `ClimbParked` at each point: `baseline` before the session starts (harness never called), `candidate` after (session present, `candidate_sha` set), with the right `afterany`.
- `_park_run` writes a `WAITING` record with the full re-entry stage (seeds, candidate ref, afterany) and satisfies the waiting-record deadline invariant.

Full suite **640 green**, ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
