### PR TITLE
Select the dispatched measurer per benchmark (PR-A2: the switch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,10 @@ Versions follow [SemVer](https://semver.org).
   dispatched path the climb skips the local baseline worktree (the eval jobs
   check out each sha themselves) and `snapshot` registers no live map. An
   expensive benchmark now parks its baseline before the session (PARK 1) and
-  its candidate after (PARK 2). The wake path that resumes from these parks is
-  the next part.
+  its candidate after (PARK 2). If the WAITING record fails to persist, the
+  already-submitted eval jobs are cancelled rather than orphaned in the queue
+  (nothing would ever wake them). The wake path that resumes from these parks
+  is the next part.
 - The climb PARK mechanics — dispatcher phase 1, stage B part 2c(i). When a
   measurer parks (`MeasurementPending`), `climb_once` raises `ClimbParked` at
   whichever point hibernated: `baseline` (before the session even runs — the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Dispatched measurement is now SELECTED per benchmark — dispatcher phase 1,
+  stage B part 2c(ii), the switch that first makes a park fire. `live_climb`
+  reads the benchmark's `eval_minutes` once and, when it exceeds the in-job
+  runway (`should_dispatch`) and cluster coordinates are present, measures
+  through a `DispatchedMeasurer` (each eval its own Slurm job) instead of the
+  inline `LocalMeasurer`; otherwise nothing changes. The coordinates are a new
+  `DispatchSettings` group (compute + image + account + partition) the climb
+  CLI reads once from `--account`/`--partition`/`--image` (defaulting to the
+  `AUTORESEARCH_*` chain env the tick already sets on the climb job); absent
+  any of them, measurement stays inline regardless of the hint. On the
+  dispatched path the climb skips the local baseline worktree (the eval jobs
+  check out each sha themselves) and `snapshot` registers no live map. An
+  expensive benchmark now parks its baseline before the session (PARK 1) and
+  its candidate after (PARK 2). The wake path that resumes from these parks is
+  the next part.
 - The climb PARK mechanics — dispatcher phase 1, stage B part 2c(i). When a
   measurer parks (`MeasurementPending`), `climb_once` raises `ClimbParked` at
   whichever point hibernated: `baseline` (before the session even runs — the

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from typing import Any
 
 from autoresearch.contract import load_contract
-from autoresearch.dispatch import Snapshot, drop_snapshot, snapshot_tree
+from autoresearch.dispatch import Snapshot, drop_snapshot, should_dispatch, snapshot_tree
 from autoresearch.github import (
     FileTokenProvider,
     GitError,
@@ -31,11 +31,12 @@ from autoresearch.github import (
     Workspace,
 )
 from autoresearch.harness import ClaudeCodeHarness, Harness, redact
-from autoresearch.measure import LocalMeasurer
+from autoresearch.measure import DispatchSettings, LocalMeasurer
 from autoresearch.orchestrator import (
     ClimbConfig,
     ClimbParked,
     Evaluator,
+    Measurer,
     SubprocessEvaluator,
     SuiteMeasurement,
     benchmark_floor,
@@ -392,6 +393,7 @@ def live_climb(
     spec: RoleSpec | None = None,
     panel_lenses: tuple[PanelLens, ...] = (),
     panel_revisions: int = 1,
+    dispatch: DispatchSettings | None = None,
 ) -> LiveClimbOutcome:
     """Run one climb against the real target repo. With `panel_lenses`, the
     pre-PR verification panel gates the claim before any PR exists
@@ -477,12 +479,25 @@ def live_climb(
                     f"(benchmark `{config.benchmark}`). A report will follow here.",
                 )
 
+        # Expensive benchmarks measure as dispatched cluster jobs; cheap ones
+        # (and any run with no cluster coordinates) measure inline. The choice
+        # is the benchmark's eval-time hint against the in-job runway, decided
+        # ONCE here so the baseline setup, the measurer, and the park deadline
+        # all agree on it.
+        eval_minutes = next(
+            (b.eval_minutes for b in contract.benchmarks if b.name == config.benchmark), None
+        )
+        dispatched = dispatch is not None and should_dispatch(eval_minutes)
+
         # The baseline is measured in a throwaway worktree of the pre-session
         # commit — the session never sees the directory the baseline eval ran
         # in, so eval artifacts (even gitignored ones) cannot leak the run
-        # seed or the sampled pool into the solver's view.
+        # seed or the sampled pool into the solver's view. The dispatched
+        # backend checks out each sha in its own eval job, so it needs no such
+        # worktree.
         baseline_wt = run_dir / "measure-baseline"
-        ws.git("worktree", "add", "--detach", str(baseline_wt), "HEAD")
+        if not dispatched:
+            ws.git("worktree", "add", "--detach", str(baseline_wt), "HEAD")
         # the panel's base is the PRE-SESSION commit — the exact tree the
         # baseline was measured on — never origin/<base_branch>, which can
         # name a different branch than the clone's checkout (terra, #95 r3)
@@ -502,19 +517,33 @@ def live_climb(
             if panel_lenses
             else None
         )
-        # The measurer runs the eval inline in the caller's worktrees: the
-        # pristine pre-session tree (baseline_wt, a CLEAN checkout of base_sha,
-        # so cache-safe) for base_sha, and the session's LIVE workspace for
-        # every candidate snapshot (measured fresh — its content is not pinned
-        # by the sha). `snapshot` commits the workspace's current content to a
-        # candidate sha; we own the ref lifecycle and drop every snapshot once
-        # the climb ends (nothing parks yet — the dispatched path is a later PR).
-        measurer = LocalMeasurer(evaluator, clean={pre_session_sha: baseline_wt})
+        # DISPATCHED: each measure runs as its own eval job, checking out its
+        # tree sha fresh from this workspace's `refs/dispatch/*` — so the
+        # measurer needs only the repo, and a not-yet-done measure PARKS the
+        # climb. INLINE: the eval runs in the caller's worktrees — the pristine
+        # pre-session tree (baseline_wt, a CLEAN checkout, cache-safe) for
+        # base_sha and the session's LIVE workspace for every candidate
+        # snapshot (measured fresh — its content is not pinned by the sha) —
+        # and never parks. Either way `snapshot` commits the workspace's
+        # current content to a candidate sha and we own the ref lifecycle,
+        # keeping the one candidate ref a park needs and dropping the rest when
+        # the climb ends.
+        measurer: Measurer
+        if dispatched:
+            assert dispatch is not None and eval_minutes is not None  # should_dispatch(None) False
+            measurer = dispatch.measurer(
+                run_dir, repo_root=workspace, eval_minutes=eval_minutes, run_tag=run_id
+            )
+        else:
+            measurer = LocalMeasurer(evaluator, clean={pre_session_sha: baseline_wt})
         snapshots: list[Snapshot] = []
 
         def snapshot() -> str:
             snap = snapshot_tree(ws, pre_session_sha)
-            measurer.live[snap.commit] = workspace  # this candidate -> the live workspace
+            # inline only: register the live workspace for this candidate sha.
+            # dispatched jobs check the sha out fresh, so they need no map.
+            if isinstance(measurer, LocalMeasurer):
+                measurer.live[snap.commit] = workspace
             snapshots.append(snap)
             return snap.commit
 
@@ -549,9 +578,6 @@ def live_climb(
                 # keep exactly ONE snapshot for that sha (two can share a
                 # commit); record and keep that same ref, drop the rest.
                 kept_ref = next((s.ref for s in snapshots if s.commit == p.candidate_sha), "")
-            eval_minutes = next(
-                (b.eval_minutes for b in contract.benchmarks if b.name == config.benchmark), None
-            )
             import time
 
             # anchor the deadline to the PARK (when the evals were submitted),
@@ -567,7 +593,9 @@ def live_climb(
                 if parked and kept_ref and snap.ref == kept_ref:
                     continue
                 drop_snapshot(ws, snap)  # best-effort + self-logging; never raises
-            if not _best_effort(
+            # the baseline worktree exists only on the inline path (the
+            # dispatched backend never created one).
+            if not dispatched and not _best_effort(
                 "baseline worktree cleanup",
                 lambda: ws.git("worktree", "remove", "--force", str(baseline_wt)),
             ):
@@ -1140,6 +1168,12 @@ def main() -> int:
     parser.add_argument("--benchmark", required=True)
     parser.add_argument("--run-root", required=True, type=Path)
     parser.add_argument("--image", default="", help="apptainer image for session+eval")
+    # Cluster coordinates for DISPATCHED measurement (expensive benchmarks run
+    # each eval as its own Slurm job). Default from the chain env the tick
+    # already sets on the climb job; absent any of the three, measurement stays
+    # inline regardless of the benchmark's eval hint.
+    parser.add_argument("--account", default=os.environ.get("AUTORESEARCH_ACCOUNT", ""))
+    parser.add_argument("--partition", default=os.environ.get("AUTORESEARCH_PARTITION", ""))
     parser.add_argument(
         "--uncontained",
         action="store_true",
@@ -1268,6 +1302,20 @@ def main() -> int:
                 parser.error(f"panel entry {kind}:{backend}: {exc}")
             lenses.append(PanelLens(kind=kind, harness=judge))
         panel_lenses = tuple(lenses)
+
+    # Dispatched measurement needs the full cluster triple AND a real image
+    # file to bind against; missing any, the climb measures inline (the tick
+    # sets these on the climb job's env, a bare CLI run leaves them empty).
+    dispatch: DispatchSettings | None = None
+    if args.account and args.partition and args.image and Path(args.image).is_file():
+        from autoresearch.compute import SlurmCompute
+
+        dispatch = DispatchSettings(
+            compute=SlurmCompute(),
+            image=args.image,
+            account=args.account,
+            partition=args.partition,
+        )
     try:
         try:
             outcome = live_climb(
@@ -1284,6 +1332,7 @@ def main() -> int:
                 spec=spec,
                 panel_lenses=panel_lenses,
                 panel_revisions=args.panel_revisions,
+                dispatch=dispatch,
                 evaluator=SubprocessEvaluator(container_image=args.image),
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -23,7 +23,13 @@ from pathlib import Path
 from typing import Any
 
 from autoresearch.contract import load_contract
-from autoresearch.dispatch import Snapshot, drop_snapshot, should_dispatch, snapshot_tree
+from autoresearch.dispatch import (
+    Snapshot,
+    afterany_ids,
+    drop_snapshot,
+    should_dispatch,
+    snapshot_tree,
+)
 from autoresearch.github import (
     FileTokenProvider,
     GitError,
@@ -176,7 +182,7 @@ def _park_run(
     this and resumes) is a later PR."""
     from autoresearch.dispatch import effective_eval_minutes
 
-    job_ids = parked.afterany.split(":")[1:] if parked.afterany else []
+    job_ids = afterany_ids(parked.afterany)
     stage: dict[str, object] = {
         "phase": parked.phase,
         "base_sha": parked.base_sha,
@@ -583,7 +589,19 @@ def live_climb(
             # anchor the deadline to the PARK (when the evals were submitted),
             # not the run's start `now` — a session lasting hours would otherwise
             # eat the queue budget and let the sweep cancel a still-queued eval.
-            _park_run(run_root, record, p, kept_ref, eval_minutes, time.time())
+            try:
+                _park_run(run_root, record, p, kept_ref, eval_minutes, time.time())
+            except Exception:
+                # The WAITING record did not persist, so nothing will ever wake
+                # the eval jobs this park already submitted. Cancel them so they
+                # don't sit in the queue as orphans (best-effort, self-logging),
+                # then fall through to the error handler — `parked` stays None,
+                # so the finally still drops every snapshot. A park only happens
+                # on the dispatched path, so `dispatch` is set here.
+                assert dispatch is not None
+                for job_id in afterany_ids(p.afterany):
+                    dispatch.compute.cancel(job_id)
+                raise
             parked = p
             return LiveClimbOutcome(run_id=run_id, outcome="parked")
         finally:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -493,7 +493,17 @@ def live_climb(
         eval_minutes = next(
             (b.eval_minutes for b in contract.benchmarks if b.name == config.benchmark), None
         )
-        dispatched = dispatch is not None and should_dispatch(eval_minutes)
+        wants_dispatch = should_dispatch(eval_minutes)
+        dispatched = dispatch is not None and wants_dispatch
+        if wants_dispatch and dispatch is None:
+            # a benchmark asked to be dispatched but no cluster coordinates
+            # reached us — never silently: name it, then measure inline
+            log.warning(
+                "benchmark %s wants dispatched eval (eval_minutes=%s) but no cluster "
+                "coordinates (image/account/partition) are set; measuring inline",
+                config.benchmark,
+                eval_minutes,
+            )
 
         # The baseline is measured in a throwaway worktree of the pre-session
         # commit — the session never sees the directory the baseline eval ran
@@ -1185,11 +1195,16 @@ def main() -> int:
     parser.add_argument("--target", required=True)
     parser.add_argument("--benchmark", required=True)
     parser.add_argument("--run-root", required=True, type=Path)
-    parser.add_argument("--image", default="", help="apptainer image for session+eval")
-    # Cluster coordinates for DISPATCHED measurement (expensive benchmarks run
-    # each eval as its own Slurm job). Default from the chain env the tick
-    # already sets on the climb job; absent any of the three, measurement stays
-    # inline regardless of the benchmark's eval hint.
+    # All three default from the chain env the tick sets on the climb job, so
+    # a contained run with AUTORESEARCH_{IMAGE,ACCOUNT,PARTITION} set selects
+    # dispatched measurement without extra flags. The image also containers the
+    # session + inline eval; absent any of the three, measurement stays inline
+    # regardless of the benchmark's eval hint.
+    parser.add_argument(
+        "--image",
+        default=os.environ.get("AUTORESEARCH_IMAGE", ""),
+        help="apptainer image for session+eval",
+    )
     parser.add_argument("--account", default=os.environ.get("AUTORESEARCH_ACCOUNT", ""))
     parser.add_argument("--partition", default=os.environ.get("AUTORESEARCH_PARTITION", ""))
     parser.add_argument(

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -68,6 +68,12 @@ def should_dispatch(eval_minutes: int | None) -> bool:
     return effective_eval_minutes(eval_minutes) > IN_JOB_EVAL_MINUTES
 
 
+def afterany_ids(afterany: str) -> list[str]:
+    """The job ids inside an ``afterany:<id>:<id>...`` dependency string, or
+    ``[]`` when there are none (a blind park carries an empty dependency)."""
+    return afterany.split(":")[1:] if afterany else []
+
+
 @dataclass(frozen=True)
 class Snapshot:
     """A retained snapshot of a dirty workspace. `ref` keeps the commit

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -262,6 +262,39 @@ class DispatchedMeasurer:
         return {m.name: read_eval_result(self.run_dir, self._slot(m), m.metric) for m in measures}
 
 
+@dataclass(frozen=True)
+class DispatchSettings:
+    """The cluster coordinates a dispatched measurer needs, grouped so the
+    composition root (the climb CLI) reads them ONCE from its args/env and the
+    climb just carries them. The per-run pieces (run dir, snapshot repo, the
+    benchmark's eval hint, the run tag) are bound at build time by `measurer`,
+    so this stays a static description of WHERE to dispatch, not a live handle
+    to one run."""
+
+    compute: SlurmCompute
+    image: str
+    account: str
+    partition: str
+
+    def measurer(
+        self, run_dir: Path, repo_root: Path, eval_minutes: int, run_tag: str
+    ) -> DispatchedMeasurer:
+        """Bind these coordinates to one run's dispatched measurer. `repo_root`
+        is the workspace whose `refs/dispatch/*` snapshots the eval jobs check
+        out; `eval_minutes` is the benchmark's contract hint (clamped in the
+        job spec)."""
+        return DispatchedMeasurer(
+            compute=self.compute,
+            run_dir=run_dir,
+            repo_root=repo_root,
+            image=self.image,
+            account=self.account,
+            partition=self.partition,
+            eval_minutes=eval_minutes,
+            run_tag=run_tag,
+        )
+
+
 @dataclass
 class LocalMeasurer:
     """The inline `Measurer`: runs each measure in-process, for cheap

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -25,6 +25,12 @@ scope: {allowed: [src/pilot/solvers/]}
 roadmap: docs/roadmap.md
 """
 
+# Same contract with an eval hint past the in-job runway, so `should_dispatch`
+# selects the dispatched backend.
+CONTRACT_DISPATCH = CONTRACT.replace(
+    "    direction: min\n", "    direction: min\n    eval_minutes: 30\n"
+)
+
 
 def _session(sid: str = "s1") -> SessionResult:
     return SessionResult(
@@ -124,14 +130,13 @@ def _git(cwd: Path, *args: str) -> str:
     ).stdout
 
 
-@pytest.fixture
-def target_repo(tmp_path: Path, monkeypatch) -> Path:
+def _seed_target(tmp_path: Path, monkeypatch, contract: str) -> Path:
     """A bare 'github' repo seeded with a pilot-shaped tree; Workspace.clone
     is monkeypatched to clone from it instead of github.com."""
     seed = tmp_path / "seed"
     (seed / "src" / "pilot" / "solvers").mkdir(parents=True)
     (seed / "docs").mkdir()
-    (seed / ".autoresearch.yaml").write_text(CONTRACT)
+    (seed / ".autoresearch.yaml").write_text(contract)
     (seed / "docs" / "roadmap.md").write_text("# roadmap\n")
     (seed / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): ...\n")
     _git(seed, "init", "-q", "-b", "main")
@@ -150,6 +155,16 @@ def target_repo(tmp_path: Path, monkeypatch) -> Path:
 
     monkeypatch.setattr(climb_mod.Workspace, "clone", staticmethod(fake_clone))
     return bare
+
+
+@pytest.fixture
+def target_repo(tmp_path: Path, monkeypatch) -> Path:
+    return _seed_target(tmp_path, monkeypatch, CONTRACT)
+
+
+@pytest.fixture
+def target_repo_dispatch(tmp_path: Path, monkeypatch) -> Path:
+    return _seed_target(tmp_path, monkeypatch, CONTRACT_DISPATCH)
 
 
 @dataclass
@@ -219,7 +234,7 @@ class NoAuth:
         return "unused"
 
 
-def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1") -> tuple:
+def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None) -> tuple:
     github = FakeGitHub()
     outcome = live_climb(
         config=ClimbConfig(target="org/pilot", benchmark="tsp"),
@@ -232,8 +247,33 @@ def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1") -> tuple:
         now=1_000_000.0,
         created="2026-08-06T00:00:00Z",
         secrets=("sk-live-key",),
+        dispatch=dispatch,
     )
     return outcome, github
+
+
+def _fake_dispatch(image="/img.sif", account="acct", partition="cpu"):
+    """A DispatchSettings whose SlurmCompute never touches real Slurm: sbatch
+    returns a fresh numeric id, squeue reports no live job (so results()
+    dispatches then parks on the ids it just submitted)."""
+    from autoresearch.compute import CommandResult, SlurmCompute
+    from autoresearch.measure import DispatchSettings
+
+    ids = iter(range(1000, 1100))
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            return CommandResult(0, f"{next(ids)}\n", "")
+        if argv[0] == "squeue":
+            return CommandResult(0, "", "")  # nothing live -> dispatch
+        raise AssertionError(f"unexpected slurm call: {argv[0]}")
+
+    return DispatchSettings(
+        compute=SlurmCompute(runner=runner),
+        image=image,
+        account=account,
+        partition=partition,
+    )
 
 
 def test_improvement_produces_branch_commit_and_pr(tmp_path, target_repo) -> None:
@@ -1519,3 +1559,42 @@ def test_moved_base_gets_a_fresh_panel_read_and_blocking_drafts(tmp_path, target
     assert "merged-tree interaction looks gamed" in pr["body"]
     assert "Verification round 2" in pr["body"]  # numbering continued post-merge
     assert github.armed == []
+
+
+def test_expensive_benchmark_dispatches_baseline_and_parks(tmp_path, target_repo_dispatch) -> None:
+    # eval_minutes=30 is past the in-job runway, so the baseline measures as a
+    # dispatched job BEFORE the session — the climb parks (PARK 1) instead of
+    # running the harness.
+    outcome, github = run_live(
+        tmp_path,
+        target_repo_dispatch,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+        values=[],  # the inline evaluator is never called on the dispatched path
+        dispatch=_fake_dispatch(),
+    )
+    assert outcome.outcome == "parked"
+    assert github.prs == []  # session never ran; no PR
+    record = load_record(tmp_path / "state", "tsp-1")
+    assert record.state == "waiting"
+    # PARK 1 is the baseline (no candidate yet); the afterany carries the one
+    # submitted eval job the wake depends on.
+    assert record.stage["phase"] == "baseline"
+    assert record.stage["afterany"] == "afterany:1000"
+    assert record.experiment_job_id == "1000"  # single-job park: the sweep polls it
+    # the dispatched backend checks out each sha in its own job, so no local
+    # baseline worktree was ever created
+    assert not (tmp_path / "state" / "runs" / "tsp-1" / "measure-baseline").exists()
+
+
+def test_cheap_benchmark_ignores_dispatch_and_measures_inline(tmp_path, target_repo) -> None:
+    # dispatch settings are present, but the benchmark has no eval hint, so
+    # should_dispatch() is False and the climb measures inline as usual.
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+        values=[13.876, 13.1],
+        dispatch=_fake_dispatch(),
+    )
+    assert outcome.outcome == "improved"
+    assert github.prs[0]["head"] == "feat/auto/agent-01/tsp-1"

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1629,3 +1629,23 @@ def test_failed_park_write_cancels_orphaned_eval_jobs(
     )
     assert outcome.outcome == "climb-error"  # the failed park ends the run
     assert cancelled == ["1000"]  # the one dispatched baseline job was cancelled
+
+
+def test_expensive_benchmark_without_coords_falls_back_inline(
+    tmp_path, target_repo_dispatch, caplog
+) -> None:
+    # eval_minutes=30 wants dispatch, but no cluster coordinates reached us
+    # (dispatch=None) — measure inline rather than fail, and say so.
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        outcome, github = run_live(
+            tmp_path,
+            target_repo_dispatch,
+            edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+            values=[13.876, 13.1],
+            dispatch=None,
+        )
+    assert outcome.outcome == "improved"  # inline fallback measured it
+    assert github.prs[0]["head"] == "feat/auto/agent-01/tsp-1"
+    assert "wants dispatched eval" in caplog.text

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -252,10 +252,11 @@ def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None
     return outcome, github
 
 
-def _fake_dispatch(image="/img.sif", account="acct", partition="cpu"):
+def _fake_dispatch(image="/img.sif", account="acct", partition="cpu", cancelled=None):
     """A DispatchSettings whose SlurmCompute never touches real Slurm: sbatch
     returns a fresh numeric id, squeue reports no live job (so results()
-    dispatches then parks on the ids it just submitted)."""
+    dispatches then parks on the ids it just submitted). `cancelled`, if given,
+    records the job ids passed to scancel."""
     from autoresearch.compute import CommandResult, SlurmCompute
     from autoresearch.measure import DispatchSettings
 
@@ -266,6 +267,10 @@ def _fake_dispatch(image="/img.sif", account="acct", partition="cpu"):
             return CommandResult(0, f"{next(ids)}\n", "")
         if argv[0] == "squeue":
             return CommandResult(0, "", "")  # nothing live -> dispatch
+        if argv[0] == "scancel":
+            if cancelled is not None:
+                cancelled.append(argv[1])
+            return CommandResult(0, "", "")
         raise AssertionError(f"unexpected slurm call: {argv[0]}")
 
     return DispatchSettings(
@@ -1598,3 +1603,29 @@ def test_cheap_benchmark_ignores_dispatch_and_measures_inline(tmp_path, target_r
     )
     assert outcome.outcome == "improved"
     assert github.prs[0]["head"] == "feat/auto/agent-01/tsp-1"
+
+
+def test_failed_park_write_cancels_orphaned_eval_jobs(
+    tmp_path, target_repo_dispatch, monkeypatch
+) -> None:
+    # the baseline dispatched one job; if the WAITING record then fails to
+    # write, nothing will ever wake that job, so it must be cancelled rather
+    # than left orphaned in the queue.
+    from autoresearch import climb as climb_mod
+
+    cancelled: list[str] = []
+    dispatch = _fake_dispatch(cancelled=cancelled)
+
+    def boom(*args, **kwargs):
+        raise OSError("state dir full")
+
+    monkeypatch.setattr(climb_mod, "_park_run", boom)
+    outcome, _ = run_live(
+        tmp_path,
+        target_repo_dispatch,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+        values=[],
+        dispatch=dispatch,
+    )
+    assert outcome.outcome == "climb-error"  # the failed park ends the run
+    assert cancelled == ["1000"]  # the one dispatched baseline job was cancelled


### PR DESCRIPTION
Dispatcher phase 1, stage B part 2c(ii). Wires `should_dispatch` into `live_climb` — **the switch that first makes a park actually fire**. Until now nothing parked, because the only backend on the live path (`LocalMeasurer`) never raises `MeasurementPending`.

## What

- Read the benchmark's `eval_minutes` **once**, up front. When it exceeds the in-job runway (`should_dispatch`) **and** cluster coordinates are present, measure through a `DispatchedMeasurer` (each eval its own Slurm job); otherwise the inline `LocalMeasurer`, unchanged.
- New `DispatchSettings` group (compute + image + account + partition), read once by the climb CLI from `--account`/`--partition`/`--image`, defaulting to the `AUTORESEARCH_*` chain env the tick already sets on the climb job. **Absent any of them, measurement stays inline** regardless of the hint — so local runs and the whole existing suite are untouched.
- Dispatched path skips the local baseline worktree (the eval jobs check out each sha themselves) and registers no `live` map in `snapshot()`. The ref lifecycle and the one-candidate-ref keep from #106 are unchanged.
- An expensive benchmark now parks its baseline before the session (PARK 1) and its candidate after (PARK 2).

## Tests

- `eval_minutes=30` benchmark dispatches its baseline and parks — single-job park records its id, `stage.phase == "baseline"`, no baseline worktree.
- A hint-less benchmark **with** dispatch settings present stays inline (proves the `should_dispatch` gate).

Full gate green (ruff/format/mypy), 646 tests pass.

## Not in this PR

The wake half (`WakeDispatcher`, PR-B) that resumes from these parks, and the park-time robustness now newly reachable — orphaned eval jobs on a failed park-write, and multi-job park job-ids reachable to a cancel/reap path — are the next parts. Filed against the follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
