### PR TITLE
Wake side of a dispatched park: resume_climb (PR-B slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `resume_climb` (`orchestrator` module) — dispatcher phase 1, stage B part 2c,
+  slice 1: the WAKE side of a dispatched candidate park, as a re-enterable
+  function. It re-runs the post-session decision (`measure_and_decide`) over the
+  committed shas the record persisted, WITHOUT re-running the session — the
+  session's edits are already in `candidate_sha` and its write-up is now saved
+  on the park (a new `report` field in the WAITING `stage`) so the wake can
+  build the PR body and panel claim from it. The measurer reads the cached eval
+  results and it returns the decision, or a measure is not done yet (the suite
+  pairs after an improving candidate — "another round of experiments") and it
+  re-parks by raising `ClimbParked`, same shape as the first pass. This is the
+  seam the depth axis (docs/design/research-loop.md) grows from: slice 1 wakes
+  the grader with the panel off; waking the AGENT with the result lands next.
+  The wake-entry CLI + `WakeDispatcher` (delivery) are the following slices.
+
 - Dispatched measurement is now SELECTED per benchmark — dispatcher phase 1,
   stage B part 2c(ii), the switch that first makes a park fire. `live_climb`
   reads the benchmark's `eval_minutes` once and, when it exceeds the in-job

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,16 @@ Versions follow [SemVer](https://semver.org).
   agent-driven too"): a stale PR is a re-wake, not an orchestrator auto-merge.
   `WakeDispatcher` (the delivery that fires this on the eval jobs finishing) is
   the slice after.
+- The wake delivery — dispatcher phase 1, stage B part 2c, slices 2a+2b: a
+  `--resume RUN_ID` mode on the climb CLI (no session/api-key/panel — it rebuilds
+  the dispatched measurer and calls `resume_run`), and `JobWakeDispatcher`, the
+  production `WakeDispatcher` that submits a short CPU wake job running that CLI,
+  depending on the run's eval jobs (`afterany`) so it fires when they finish (or
+  immediately if already done). Still INERT: `tick.main` runs the sweep
+  `dry_run=True` with the `LoggingDispatcher`, so no wake is delivered yet.
+  Wiring `JobWakeDispatcher` in + flipping the dry-run stub + submitting the
+  afterany wake job at park (the deliberate ACTIVATION that unpauses yolo) is
+  the final slice.
 
 - Dispatched measurement is now SELECTED per benchmark — dispatcher phase 1,
   stage B part 2c(ii), the switch that first makes a park fire. `live_climb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- We credit **beating your own baseline**, not only beating the recorded best
+  (docs/design/research-loop.md, "two kinds of win"). The first-pass climb no
+  longer hard-fails a candidate that improves over `base_sha` by the gate's
+  threshold but does not beat the ledger's recorded best — that clean composable
+  win now opens a PR (a human, later a planner, judges). The `NoiseFloored`
+  ending and the recorded-best/stale-clone abort are removed; the gate
+  (`measure_and_decide`) still requires candidate to beat `base_sha` on paired
+  seeds, and the ledger's `best` still only advances on a genuine improvement
+  (SOTA stays tracked, just not required). The dispatched wake matches: when the
+  ledger does not move, it pushes the sealed candidate with no leaderboard commit
+  on top (this also fixes an empty-commit abort the reviewer caught).
+
 ### Fixed
 
 - Wake-path hardening from the self-review + advisory review of the dispatched

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,11 +42,15 @@ Versions follow [SemVer](https://semver.org).
   the dispatched measurer and calls `resume_run`), and `JobWakeDispatcher`, the
   production `WakeDispatcher` that submits a short CPU wake job running that CLI,
   depending on the run's eval jobs (`afterany`) so it fires when they finish (or
-  immediately if already done). Still INERT: `tick.main` runs the sweep
-  `dry_run=True` with the `LoggingDispatcher`, so no wake is delivered yet.
-  Wiring `JobWakeDispatcher` in + flipping the dry-run stub + submitting the
-  afterany wake job at park (the deliberate ACTIVATION that unpauses yolo) is
-  the final slice.
+  immediately if already done). `tick.main` now selects the wake delivery behind
+  an EXPLICIT on-switch (`_wake_dispatcher_from_env`, slice 2c): with
+  `AUTORESEARCH_DISPATCH_WAKE` set AND the chain env complete, the waiting-run
+  sweep runs LIVE with `JobWakeDispatcher`; otherwise it stays dry with the
+  `LoggingDispatcher` — dispatched climbing lands DARK, and a half-configured
+  environment fails safe to dry. With the switch on, the sweep delivers wakes: a
+  single-job park wakes on its eval's terminal, a multi-job park on the deadline
+  floor. The faster afterany wake submitted AT PARK (a wake the instant the eval
+  jobs finish, not on the next sweep) is the remaining responsiveness follow-up.
 
 - Dispatched measurement is now SELECTED per benchmark — dispatcher phase 1,
   stage B part 2c(ii), the switch that first makes a park fire. `live_climb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,11 +29,14 @@ Versions follow [SemVer](https://semver.org).
   machinery — a RE-PARK (a measure the wake just dispatched isn't done — the
   suite pairs an improving candidate fans out) re-persists the WAITING stage on
   the new afterany keeping the same snapshot; a NEGATIVE terminal drops the
-  snapshot and ends the record. The improved outcome commits `candidate_sha`
-  (the sealed snapshot) to a branch and opens the PR — the sha-not-live-tree
-  path — and is the next slice; it is unreachable here (dispatch is not yet
-  activated on any target). `WakeDispatcher` (the delivery that fires this on
-  the eval jobs finishing) is the slice after.
+  snapshot and ends the record; an IMPROVED terminal branches the sealed
+  `candidate_sha` (never the live tree — the scope-checked diff carries only
+  in-scope changes), folds the leaderboard update on top, pushes, opens the PR,
+  and ends the run in-review. The mechanical moved-base merge the first pass
+  does is deliberately NOT here (docs/design/research-loop.md, "the finish is
+  agent-driven too"): a stale PR is a re-wake, not an orchestrator auto-merge.
+  `WakeDispatcher` (the delivery that fires this on the eval jobs finishing) is
+  the slice after.
 
 - Dispatched measurement is now SELECTED per benchmark — dispatcher phase 1,
   stage B part 2c(ii), the switch that first makes a park fire. `live_climb`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- A dispatched climb now has ONE park, not two. The pre-session baseline
+  measurement is dropped: `climb_once` no longer measures `base_sha` before the
+  session (and never raises a `phase="baseline"` park). The baseline is measured
+  by the GATE (`measure_and_decide`, `base_sha` vs `candidate_sha`) after the
+  session, and the brief's reference number comes from the ledger's last-known
+  best (`brief_baseline`, `None` on a benchmark's first run) — so the agent
+  still sees "improve from ~X" without a dispatched pre-pass. This removes the
+  baseline-wake path entirely (a dispatched climb only ever candidate-parks),
+  and matches what `dispatcher.md`'s resume seam already specified (the seam is
+  after the session). Tradeoff: a broken eval command now costs a session before
+  it surfaces in the gate, instead of failing fast pre-session. `resume_run`
+  guards that every park it wakes is a candidate park.
+
 ### Added
 
 - `resume_climb` (`orchestrator` module) — dispatcher phase 1, stage B part 2c,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Wake-path hardening from the self-review + advisory review of the dispatched
+  wake (all pre-activation, the path is still dark):
+  - the improved wake now FORCE-checks-out the sealed candidate sha (at wake the
+    workspace is the session's dirty tree) and commits ONLY the ledger files on
+    top of it — never `git add -A`, which would sweep in untracked cruft the
+    session/eval left, unmeasured and unscoped;
+  - a no-progress re-park (a blind re-park with an empty afterany, or the same
+    jobs still pending) KEEPS `wake_attempts` instead of resetting it, so the
+    stuck cap still bites a run that wakes without advancing; a productive
+    re-park (a new job set) still resets;
+  - the wake never arms auto-merge — it runs no verification panel yet
+    (panel-on-wake is a later slice), so every dispatched improvement waits for
+    a human;
+  - the IN_REVIEW record is saved BEFORE the snapshot is dropped, so a failed
+    save leaves the run recoverable rather than an ABORTED record over a live
+    PR; a publish failure drops the snapshot (ENDED runs are never swept, so
+    keeping it only leaked the ref);
+  - terminal records clear the WAITING-only fields (`stage`, `deadline`,
+    `wake_attempts`, …) so a woken run does not carry a shrunk follow-up retry
+    budget into `in-review`;
+  - `measured_paths` is re-derived NUL-delimited (`-z`), so a path with a space
+    cannot slip past the scope check.
+
 ### Changed
 
 - A dispatched climb now has ONE park, not two. The pre-session baseline

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ Versions follow [SemVer](https://semver.org).
   seam the depth axis (docs/design/research-loop.md) grows from: slice 1 wakes
   the grader with the panel off; waking the AGENT with the result lands next.
   The wake-entry CLI + `WakeDispatcher` (delivery) are the following slices.
+- `resume_run` (`climb` module) — dispatcher phase 1, stage B part 2c, slice
+  1b: the wake-entry that rebuilds a parked climb's context from its record and
+  drives `resume_climb`. It re-derives `measured_paths` from the COMMITTED
+  `base..candidate` diff (the sealed candidate, never a live tree that may have
+  drifted since the park), and handles the two exits that reuse existing
+  machinery — a RE-PARK (a measure the wake just dispatched isn't done — the
+  suite pairs an improving candidate fans out) re-persists the WAITING stage on
+  the new afterany keeping the same snapshot; a NEGATIVE terminal drops the
+  snapshot and ends the record. The improved outcome commits `candidate_sha`
+  (the sealed snapshot) to a branch and opens the PR — the sha-not-live-tree
+  path — and is the next slice; it is unreachable here (dispatch is not yet
+  activated on any target). `WakeDispatcher` (the delivery that fires this on
+  the eval jobs finishing) is the slice after.
 
 - Dispatched measurement is now SELECTED per benchmark — dispatcher phase 1,
   stage B part 2c(ii), the switch that first makes a park fire. `live_climb`

--- a/docs/design/research-loop.md
+++ b/docs/design/research-loop.md
@@ -160,3 +160,42 @@ composes-with, might-replace — scored on performance *and* simplicity *and*
 optionality, never a single number. Composition itself becomes a search: "is
 `A+E` a cleaner path to near-SOTA?" and "can `E` replace `B+C+D`?" are
 experiments the portfolio generates.
+
+## Who picks the comparison — the agent frames, the gate keeps it honest
+
+The `A+E` win only makes sense against the *right* comparison, and choosing it
+is where the current design falls short of the vision.
+
+**Where the gate is today.** The gate measures `base_sha` (the full current
+`main`, e.g. `A+B+C+D`) against the candidate, head-to-head. So a candidate that
+is `A+E` — `E` swapped in for `B+C+D` — must beat the *whole* stack: `E` alone
+has to match everything `B+C+D` contributed. That bar rejects exactly the wins
+we want to credit: `A+E` landing *near* SOTA with fewer parts, or `E` as a
+viable *substitute*, both lose on the single number even though they are real
+contributions. Head-to-head-vs-`main` only ever credits SOTA.
+
+**Where it needs to go.** The fix is not "always compare to `A`" — letting an
+agent pick a weak baseline is the gaming door we must not open. It is to split
+the two roles cleanly:
+
+- **The agent frames the comparison.** It constructs the configs its story needs
+  — `A`, `A+E`, `A+B+C+D`, `A+E`-minus-`B+C+D` — runs those ablations itself (the
+  depth axis, via an eval tool), and makes a *specific* claim: "`A+E` is within
+  noise of `A+B+C+D` with three fewer components," or "`E` replaces `B+C+D`:
+  `A+E ≥ A+B+C+D`."
+- **The gate keeps it honest.** It re-runs *exactly the comparison the agent
+  declared* on the fixed benchmark. The agent chooses the framing; it can never
+  fake the numbers. This is the same un-gameable measurement that made the whole
+  system trustworthy, pointed at a claim instead of a fixed head-to-head.
+- **Transparency, not prohibition, stops weak-baseline gaming.** Every portfolio
+  entry is legible about the baseline it was measured against, so "measured vs
+  `A`, not the SOTA stack" is *visible* — and the well-rounded judge (and the
+  human) weighs whether the framing is honest and the win is real. A weak
+  baseline is allowed but exposed, not hidden.
+
+**The concrete gap.** Today `candidate_sha = base_sha + the agent's edits`, and
+there is no notion of measuring config `X` vs config `Y` beyond base-vs-candidate
+— and `A` is not even a commit that exists when `main` is `A+B+C+D`. Closing
+this is the agent-runs-experiments / declared-claim work: the same depth-axis
+substrate, letting the agent build and compare the configs its claim needs while
+the gate verifies the one it declared.

--- a/docs/design/research-loop.md
+++ b/docs/design/research-loop.md
@@ -84,3 +84,79 @@ to decide) comes first — it is needed regardless of the depth dial, it de-risk
 the exact pause/resume plumbing the depth loop reuses, and it unpauses the outer
 loop. Building it agent-first (resume with evidence, the panel revision as the
 first instance) means turning up depth later is a **knob, not a rewrite**.
+
+## The finish is agent-driven too
+
+Turning a credited improvement into a PR is not the orchestrator's job to
+mechanize. The first-pass finish today does the rigid thing — merge the base
+branch as it stands *now*, re-measure, and hard-fail if the candidate no longer
+beats the freshly-merged base. That is fragile (a concurrent merge can kill a
+real improvement) and it miscasts the orchestrator as the judge of research.
+
+The finish belongs to the agent, on the same wake machinery:
+
+- **Show a benefit; don't stack on top.** Like a research paper, a change
+  demonstrates its method beats *its baseline* — it does not have to be rebased
+  onto the newest `main` to be valid. Keep the paired baseline/candidate claim;
+  do not force "re-beat whatever `main` became."
+- **Complications go back to the agent.** A moved base, a conflict, a suite
+  that no longer looks clean — the wake hands these to the agent, which pulls
+  the latest, merges, does more research/coding if it needs to, and opens the PR
+  only when there is no conflict *and* the experiments still show the benefit.
+  Same "wake the agent with new information" as every other depth step.
+- **Staleness is re-waking, not merging.** A PR that goes stale later wakes the
+  agent again (perhaps a human pings it) to pull the latest and edit the PR —
+  never an orchestrator auto-merge.
+- **Humans merge, for now.** The human merges at their discretion. Eventually a
+  planner agent may hold some merge authority — a deliberate, later exception to
+  the README's "humans hold merge authority," decided explicitly rather than
+  drifted into.
+
+So the improved-wake is not a mechanical commit-and-push; it is the first place
+the depth axis touches the outside world. Build it as an agent-wake, not as
+orchestrator plumbing.
+
+## Two kinds of win
+
+A contribution does not have to be state-of-the-art to be real. We credit two
+kinds, and want **both**:
+
+1. **SOTA** — the best absolute number on the benchmark. Inherently
+   competitive: it is about being on top, so it does care about the current
+   best.
+2. **A composable win** — beat your own baseline with a clean, orthogonal story
+   that plugs into other methods on the leaderboard and still delivers. Not
+   necessarily the single best number, but a genuine building block: "+2% that
+   composes with anything."
+
+This is what "show a benefit, like a research paper" means concretely — a paper
+can be a new SOTA *or* a composable technique, and both are valid.
+
+Two consequences:
+
+- **The gate credits beating your baseline (type 2 by default); SOTA is a
+  separate, tracked-but-not-required axis.** We do not collapse everything into
+  "must beat the freshest `main`" — that only ever credits type 1 and throws
+  away real composable wins. It is also exactly the fragile moved-base hard-fail
+  we are dropping.
+- **The leaderboard is a portfolio, not a single champion.** It carries the
+  SOTA entry *and* the composable contributions, each legible about which
+  baseline/method it is measured relative to, so composability is visible. Two
+  orthogonal +2% wins are two entries — and combining them is itself a third
+  experiment worth running.
+
+The agent's finish declares which kind of win it is claiming, and the PR tells
+that story; the human (or, later, a planner) judges.
+
+**Composability with SOTA is a bonus, not a bar — and simplicity is its own
+win.** A composable block need not stack onto the full SOTA. If SOTA is
+`A+B+C+D` and we find `E`, then `A+E` landing *near* SOTA is a **cleaner** result
+than `A+B+C+D+E` — fewer moving parts for the same place, and parsimony is a
+real research value, not just the number. And even when `E` adds nothing on top
+of the full stack (`A+B+C+D+E ≈ A+B+C+D` within noise), `E` is worth keeping as
+a **future choice** if it could *substitute* for part of the stack (`E` in place
+of `B+C+D`). So the portfolio holds building blocks and their relationships —
+composes-with, might-replace — scored on performance *and* simplicity *and*
+optionality, never a single number. Composition itself becomes a search: "is
+`A+E` a cleaner path to near-SOTA?" and "can `E` replace `B+C+D`?" are
+experiments the portfolio generates.

--- a/docs/design/research-loop.md
+++ b/docs/design/research-loop.md
@@ -1,0 +1,86 @@
+# The research loop: breadth, depth, and one substrate
+
+**Status: north-star (2026-08-20), not a spec.** Captures how we want the
+research workflow to *feel* so the concrete builds don't quietly harden into a
+restrictive one-shot pipeline. It gates nothing; it exists to keep us honest.
+Pairs with `dispatcher.md` (the fire-and-wake substrate), `agent-substrate.md`
+(experiment submission as an `act` syscall), and `scaling.md` (the outer loop,
+seats, coordinated runs).
+
+## The picture in one paragraph
+
+Automated research is a **search that spends compute on two axes** over one
+pause-and-resume substrate. **Breadth** is the outer loop: many attempts, run
+independently over time. **Depth** is within an attempt: an agent tries
+something, sees the result, reasons on it, forms or kills a hypothesis, and
+tries again. Neither axis is the workflow; the workflow is *how much we spend on
+each*, and the substrate underneath — fire off a job, end the session, wake when
+it finishes — is the same whether the thing waking up is the grader or the
+researcher.
+
+## Two axes, one budget
+
+Think of the compute as a grid: **M attempts × k iterations each.**
+
+- **Pure breadth** (`k = 1`, large `M`): many fresh agents, each tries one
+  thing, the gate says yes/no. Embarrassingly parallel and robust — a stuck
+  agent never blocks the others. This is roughly where the system is today.
+- **Pure depth** (`M = 1`, large `k`): one agent iterating on its own results —
+  test-time scaling on the "keep thinking about *this* problem" axis.
+
+The right split is **problem-dependent**: some benchmarks reward one deep chain,
+others reward many cheap darts. So the split should be a **dial we can turn and
+measure**, never a constant baked into the architecture. Whether depth pays on a
+given benchmark is itself a question the system can answer.
+
+## Staleness is the tax of breadth-only — and depth is its cure
+
+Pure breadth has a hidden cost: every attempt starts **cold and amnesiac**. The
+only way one attempt learns from earlier ones is by reading their **reports**,
+and a report is (a) a *lossy compression* of the real reasoning and (b)
+possibly *stale* — the code moved under it. "Read the prior report more closely"
+is a patch on both problems, but it cannot beat either.
+
+Depth dissolves the problem instead of patching it: an agent iterating on its
+**own live results** never reads stale evidence — it knows exactly what it just
+ran and why, uncompressed. So the depth axis is not merely "more compute"; it is
+the principled fix for the staleness that breadth-only pays. (Cross-attempt
+reports still earn their keep as cheap, lossy memory across the outer loop — they
+are just not a substitute for a live research thread.)
+
+## One substrate, two things it can wake
+
+The pause/resume machinery is identical on both axes: **fire a job, end the
+session, come back when it finishes.** What differs is *who wakes up*:
+
+- Wake the **grader** → the gate's paired baseline/candidate/suite measurement
+  runs as jobs without a session holding a GPU. (The near-term build.)
+- Wake the **agent**, handing it the result → it keeps researching: another
+  experiment, a new hypothesis, a revision. (The depth axis.)
+
+The pre-PR panel revision — waking the author with blocking findings — is just a
+**crippled, one-step instance** of "wake the agent with evidence." Generalize it
+and you have the depth loop; the number of experiment-iterations an agent gets
+before it must ship a candidate is the dial `k`, with `k = 1` recovering today's
+breadth-only behavior.
+
+## The non-restrictive principle
+
+Because the machinery is shared, we do **not** have to choose breadth vs. depth
+up front, and we must not hardwire the narrow case:
+
+- Build the wake to **resume the agent in general**, not only to re-enter the
+  grader's decision. The gate-wake is the *first use* of that machinery, not its
+  shape.
+- Keep `k` a **tunable policy**, not a constant. `k = 1` is a setting, not an
+  assumption.
+- Treat "does depth pay here?" as an **empirical question** the outer loop can
+  measure, per benchmark.
+
+## What we build first, and why it isn't a commitment
+
+The **gate-wake** (dispatcher phase 1: measure the final candidate as jobs, wake
+to decide) comes first — it is needed regardless of the depth dial, it de-risks
+the exact pause/resume plumbing the depth loop reuses, and it unpauses the outer
+loop. Building it agent-first (resume with evidence, the panel revision as the
+first instance) means turning up depth later is a **knob, not a rewrite**.

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1396,9 +1396,18 @@ def main() -> int:
     arm_sigterm_containment()
 
     parser = argparse.ArgumentParser(description="One live climb on one benchmark.")
-    parser.add_argument("--target", required=True)
-    parser.add_argument("--benchmark", required=True)
+    # --target/--benchmark drive a fresh climb; they are read from the record
+    # on a --resume wake instead, so they are optional (validated below).
+    parser.add_argument("--target", default="")
+    parser.add_argument("--benchmark", default="")
     parser.add_argument("--run-root", required=True, type=Path)
+    parser.add_argument(
+        "--resume",
+        default="",
+        metavar="RUN_ID",
+        help="wake a parked dispatched run instead of starting a fresh climb",
+    )
+    parser.add_argument("--base-branch", default="main")
     # All three default from the chain env the tick sets on the climb job, so
     # a contained run with AUTORESEARCH_{IMAGE,ACCOUNT,PARTITION} set selects
     # dispatched measurement without extra flags. The image also containers the
@@ -1466,9 +1475,42 @@ def main() -> int:
     if not args.image and not args.uncontained:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")
 
+    bot_auth = FileTokenProvider(Path(args.pat_file))
+
+    # --resume WAKES a parked dispatched run: no session, no api key, no panel —
+    # just rebuild the dispatched measurer and re-enter the decision. The wake
+    # job the WakeDispatcher submits runs exactly this.
+    if args.resume:
+        if not (args.account and args.partition and args.image and Path(args.image).is_file()):
+            parser.error(
+                "--resume needs the cluster triple (--account/--partition/--image) "
+                "to rebuild the dispatched measurer"
+            )
+        from autoresearch.compute import SlurmCompute
+
+        resumed = resume_run(
+            args.run_root,
+            args.resume,
+            dispatch=DispatchSettings(
+                compute=SlurmCompute(),
+                image=args.image,
+                account=args.account,
+                partition=args.partition,
+            ),
+            github=GitHubClient(auth=bot_auth),
+            bot_auth=bot_auth,
+            now=time.time(),
+            secrets=(bot_auth.token(),),
+            base_branch=args.base_branch,
+        )
+        print(f"outcome={resumed.outcome} pr={resumed.pr_url or '-'} report={resumed.report_path}")
+        return 0
+
+    if not (args.target and args.benchmark):
+        parser.error("--target and --benchmark are required for a fresh climb")
+
     # same 0600 discipline as the PAT: this key spends real money
     api_key = FileTokenProvider(Path(args.key_file).expanduser()).token()
-    bot_auth = FileTokenProvider(Path(args.pat_file))
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_id = f"{args.benchmark}-{stamp}"
 

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -47,8 +47,6 @@ from autoresearch.orchestrator import (
     SubprocessEvaluator,
     SuiteMeasurement,
     _benchmark,
-    benchmark_floor,
-    clears_min_delta,
     climb_once,
     out_of_scope,
     pr_body,
@@ -59,7 +57,6 @@ from autoresearch.orchestrator import improved as orch_improved
 from autoresearch.panel import PanelLens, PanelVerdict, run_panel
 from autoresearch.progress import (
     PROGRESS_PATHS,
-    fmt_metric,
     load_leader,
     update_leader,
     write_progress,
@@ -89,12 +86,6 @@ log = logging.getLogger(__name__)
 # role separation) before claiming/submitting.
 PANEL_KEY_DEFAULT = "~/.config/autoresearch/verifier_key"
 HARNESS_KEY_DEFAULT = "~/.config/autoresearch/harness_key"
-
-
-class NoiseFloored(RuntimeError):
-    """The candidate beat the recorded best, but by less than the
-    benchmark's cross-seed noise floor — pool luck, not progress. An
-    honest negative result, never an abort."""
 
 
 class WorkspaceDrift(RuntimeError):
@@ -407,18 +398,22 @@ def resume_run(
             extra = [p for p in staged if p not in PROGRESS_PATHS]
             if extra:
                 raise WorkspaceDrift(f"wake commit would stage non-ledger paths: {extra[:10]}")
-            if not staged:
-                raise WorkspaceDrift("wake produced no ledger change to commit")
-            ws.git(
-                "-c",
-                f"user.name={config.bot_login}",
-                "-c",
-                f"user.email={config.bot_login}@users.noreply.github.com",
-                "commit",
-                "-m",
-                f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
-                f"\n\nAgent: {config.agent_id}",
-            )
+            # Commit the ledger update on top of the sealed candidate ONLY when
+            # it actually moved. When the candidate beat its baseline but not the
+            # recorded best, update_leader is a no-op (the ledger's `best` does
+            # not advance) — a valid composable win with no leaderboard change,
+            # so push the candidate as-is rather than an empty commit.
+            if staged:
+                ws.git(
+                    "-c",
+                    f"user.name={config.bot_login}",
+                    "-c",
+                    f"user.email={config.bot_login}@users.noreply.github.com",
+                    "commit",
+                    "-m",
+                    f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
+                    f"\n\nAgent: {config.agent_id}",
+                )
             ws.push(branch)
             body = pr_body(
                 result, config, redact_secrets=secrets, display_digits=bench.display_digits
@@ -1160,42 +1155,14 @@ def live_climb(
             # by the orchestrator from ITS measurements after the drift check
             # — read from the (possibly merged) tree, so the leader check runs
             # against the FRESH ledger, not the clone's snapshot.
-            prior = load_leader(workspace).get(config.benchmark)
-            if prior is not None:
-                rel_ok = orch_improved(
-                    prior.best, candidate, bench.direction, config.min_relative_improvement
-                )
-                if bench.min_delta or bench.min_delta_rel:
-                    # A resampled pool re-rolls between runs, so ANY
-                    # sub-floor delta over the recorded best — including
-                    # one below the relative threshold — is an expected
-                    # honest negative, never an anomaly (round-4 review
-                    # finding: the abort band contradicted the promise).
-                    floored = not clears_min_delta(
-                        prior.best, candidate, bench.direction, bench.min_delta, bench.min_delta_rel
-                    )
-                    if not rel_ok or floored:
-                        # name the check that actually failed, not just
-                        # whichever floor happens to exist
-                        floor = benchmark_floor(prior.best, bench.min_delta, bench.min_delta_rel)
-                        if floored and floor > 0:
-                            shown = fmt_metric(floor, bench.display_digits)
-                            why = f"the cross-seed noise floor ({shown})"
-                        elif floored:
-                            why = f"a usable baseline (recorded best {prior.best})"
-                        else:
-                            why = "the relative-improvement threshold"
-                        raise NoiseFloored(
-                            f"candidate {candidate} does not clear the recorded "
-                            f"best {prior.best} beyond {why}"
-                        )
-                elif not rel_ok:
-                    # fixed pool: the ledger says this run's own baseline
-                    # was stale — an anomaly worth a loud ending
-                    raise WorkspaceDrift(
-                        f"candidate {candidate} does not beat the recorded "
-                        f"best {prior.best} by the noise floor (stale clone or eval noise)"
-                    )
+            # We credit BEATING YOUR OWN BASELINE, not only beating the recorded
+            # best (docs/design/research-loop.md, "two kinds of win"): a clean
+            # composable win — improving over base_sha by the gate's threshold —
+            # is a valid PR even when it is not the new SOTA. So there is no
+            # recorded-best hard-fail here; the gate (`measure_and_decide`) has
+            # already required candidate to beat base_sha on paired seeds. The
+            # ledger's `best` still only advances on a genuine improvement over
+            # it (update_leader), so SOTA stays tracked — just not required.
             entries = update_leader(
                 load_leader(workspace),
                 benchmark=bench.name,
@@ -1276,19 +1243,6 @@ def live_climb(
                     "pr_url": pr_url,
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
-                }
-            )
-        except NoiseFloored as exc:
-            # honest negative: the work was fine, the delta is not evidence
-            outcome_name = "no-improvement"
-            result = dc_replace(result, outcome="no-improvement", note=str(exc))
-            log.info("noise-floored for %s: %s", run_id, exc)
-            final = RunRecord(
-                **{
-                    **record.__dict__,
-                    "state": ENDED,
-                    "ending": NEGATIVE_RESULT,
-                    "ending_note": redact(str(exc), secrets)[:480],
                 }
             )
         except SuiteRegressed as exc:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -491,8 +491,10 @@ def resume_run(
             run_id=run_id, outcome="improved", pr_url=pr_url, report_path=str(report_path)
         )
 
-    # a negative terminal: release the snapshot and end the record.
-    drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
+    # a negative terminal: end the record, THEN release the snapshot. Save
+    # BEFORE dropping (same ordering as the improved path): if the save fails,
+    # the run stays WAITING with its snapshot intact, so a re-wake can still
+    # reconstruct — never WAITING with the snapshot already gone.
     report_path = run_dir / "report.md"
     _best_effort(
         "run report",
@@ -509,7 +511,12 @@ def resume_run(
             }
         )
     )
-    _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
+    if _best_effort("final record", lambda: save_record(run_root, final, now), secrets):
+        drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
+    else:
+        log.warning(
+            "run %s: ended negative but record unsaved; snapshot kept for a re-wake", run_id
+        )
     return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
 
 

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -163,6 +163,23 @@ def _best_effort(what: str, fn: Callable[[], object], secrets: tuple[str, ...] =
         return False
 
 
+def _clear_stage(record: RunRecord) -> RunRecord:
+    """Strip the WAITING-only bookkeeping from a record leaving `waiting` for a
+    terminal state. Otherwise a dispatched run's `stage`, `deadline`, and
+    especially `wake_attempts` ride into `in-review`, where in-review follow-up
+    servicing reuses `wake_attempts` as its OWN retry cap — so a run that woke
+    once would reach review with a shrunk follow-up budget."""
+    return dc_replace(
+        record,
+        stage={},
+        experiment_job_id="",
+        deadline=0.0,
+        terminal_seen=0.0,
+        wake_job_id="",
+        wake_attempts=0,
+    )
+
+
 # A parked run's deadline is the FLOOR beneath the afterany wake: submit +
 # eval walltime + a generous queue/grace allowance. It must exceed the time a
 # healthy eval can legitimately sit queued-then-running, or `tick._sweep_one`
@@ -178,6 +195,7 @@ def _park_run(
     eval_minutes: int | None,
     now: float,
     secrets: tuple[str, ...] = (),
+    keep_wake_attempts: bool = False,
 ) -> None:
     """Persist a dispatched climb's re-entry point as a WAITING record: the
     committed shas, drawn seeds, candidate snapshot ref, and afterany set a
@@ -225,14 +243,14 @@ def _park_run(
             "resume_session_id": parked.session.session_id if parked.session else "",
             "deadline": deadline,
             "stage": stage,
-            # Reset only valid because THIS is the IMPLEMENTING->park entry: the
-            # run just LEFT waiting to do work (a session, a measure), so
-            # wake_attempts — "wakes since the run last left waiting" — is stale;
-            # a productive park/wake cycle must not creep toward the stuck cap.
-            # The wake path (a later PR) must NOT route a no-progress blind
-            # re-park (results still pending) back through here — resetting on
-            # that would defeat the stuck cap; a blind re-park keeps the counter.
-            "wake_attempts": 0,
+            # wake_attempts = "wakes since the run last made progress"; the
+            # stuck cap ends a run that keeps waking without advancing. Reset on
+            # a PRODUCTIVE park (the IMPLEMENTING->park entry ran a session; a
+            # wake that resolved its measures and dispatched NEW ones). A
+            # no-progress re-park — results still pending, or a blind re-park
+            # (squeue unreachable, nothing new dispatched) — must KEEP the
+            # counter (`keep_wake_attempts`), or the loop never reaches the cap.
+            "wake_attempts": record.wake_attempts if keep_wake_attempts else 0,
             "terminal_seen": 0.0,
             "wake_job_id": "",
         }
@@ -296,7 +314,11 @@ def resume_run(
     )
     # measured_paths from the COMMITTED base..candidate diff — the sealed
     # candidate, never `changed_paths()` on a live tree that may have drifted.
-    measured_paths = tuple(ws.git("diff", "--name-only", base_sha, candidate_sha).split())
+    # NUL-delimited (like Workspace.staged_paths) so a path with a space is one
+    # entry, not two that could each slip past the scope check.
+    measured_paths = tuple(
+        p for p in ws.git("diff", "--name-only", "-z", base_sha, candidate_sha).split("\0") if p
+    )
 
     # rebuild the session from what the park saved: the (redacted) write-up and
     # its real spend, so the report shows true cost/turns. It is never re-run.
@@ -325,7 +347,22 @@ def resume_run(
     except ClimbParked as parked:
         # another measure this wake dispatched is not done — re-park on the new
         # afterany, keeping the SAME candidate snapshot the next wake reads.
-        _park_run(run_root, record, parked, candidate_ref, eval_minutes, now, secrets)
+        # PROGRESS only if this wake dispatched a NEW job set (e.g. the candidate
+        # resolved and the suite pairs fanned out); a blind re-park (empty
+        # afterany) or the same jobs still pending is NO progress, so the stuck
+        # cap must keep counting.
+        old_afterany = str(record.stage.get("afterany", ""))
+        made_progress = bool(parked.afterany) and parked.afterany != old_afterany
+        _park_run(
+            run_root,
+            record,
+            parked,
+            candidate_ref,
+            eval_minutes,
+            now,
+            secrets,
+            keep_wake_attempts=not made_progress,
+        )
         return LiveClimbOutcome(run_id=run_id, outcome="parked")
 
     if result.outcome == "improved":
@@ -338,7 +375,11 @@ def resume_run(
         baseline, candidate = result.baseline, result.candidate
         branch = f"{config.branch_prefix}/{run_id}"
         try:
-            ws.git("checkout", "-B", branch, candidate_sha)
+            # FORCE-checkout the sealed candidate: at wake the workspace still
+            # holds the session's dirty tree (HEAD is pre_session_sha), so a
+            # plain checkout could be blocked; the sha already captured exactly
+            # the measured content.
+            ws.git("checkout", "-f", "-B", branch, candidate_sha)
             entries = update_leader(
                 load_leader(workspace),
                 benchmark=bench.name,
@@ -356,14 +397,27 @@ def resume_run(
                 config.target,
                 digits={b.name: b.display_digits for b in contract.benchmarks if b.display_digits},
             )
-            # only the ledger files change on top of the sealed candidate; the
-            # veto re-checks scope as defense in depth (the candidate diff was
-            # already scope-checked in measure_and_decide).
-            ws.commit_all(
+            # Stage ONLY the ledger files on top of the sealed candidate — never
+            # `git add -A`, which would sweep in untracked cruft the session left
+            # (eval caches) that was neither measured nor scope-checked. The
+            # candidate content is already vetted (measure_and_decide's scope
+            # check on measured_paths); assert nothing but the ledger is staged.
+            ws.git("add", "--", *PROGRESS_PATHS)
+            staged = ws.staged_paths()
+            extra = [p for p in staged if p not in PROGRESS_PATHS]
+            if extra:
+                raise WorkspaceDrift(f"wake commit would stage non-ledger paths: {extra[:10]}")
+            if not staged:
+                raise WorkspaceDrift("wake produced no ledger change to commit")
+            ws.git(
+                "-c",
+                f"user.name={config.bot_login}",
+                "-c",
+                f"user.email={config.bot_login}@users.noreply.github.com",
+                "commit",
+                "-m",
                 f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
                 f"\n\nAgent: {config.agent_id}",
-                author=config.bot_login,
-                forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
             )
             ws.push(branch)
             body = pr_body(
@@ -375,45 +429,53 @@ def resume_run(
                 head=branch,
                 base=base_branch,
                 body=body,
-                draft=result.panel_blocking_open or result.panel_degraded,
+                # the wake runs NO verification panel yet (panel-on-wake is a
+                # later slice), so the PR is never auto-merge-armed — a human
+                # reviews every dispatched improvement. Open non-draft; it is a
+                # real, measured improvement, just not panel-certified.
+                draft=False,
             )
-            pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
-            if pr_number.isdigit() and not (result.panel_blocking_open or result.panel_degraded):
-                _best_effort(
-                    "auto-merge arming",
-                    lambda: github.arm_auto_merge_when_review_required(
-                        config.target, int(pr_number)
-                    ),
-                    secrets,
-                )
         except Exception as exc:
-            # push / PR / commit failed — end as an error, KEEP the snapshot (a
-            # later wake can retry) and never delete a remote branch.
+            # push / PR / commit failed — end as an error. Drop the snapshot:
+            # ENDED runs are never swept, so keeping it would only LEAK the ref;
+            # a retry is a fresh climb, not a re-wake of this dead record. Never
+            # delete a remote branch (a push may have half-succeeded).
             note = redact(f"{type(exc).__name__}: {exc}", secrets)[:480]
             log.warning("wake publish failed for %s: %s", run_id, note)
-            failed = RunRecord(
-                **{**record.__dict__, "state": ENDED, "ending": ABORTED, "ending_note": note}
+            drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
+            failed = _clear_stage(
+                RunRecord(
+                    **{**record.__dict__, "state": ENDED, "ending": ABORTED, "ending_note": note}
+                )
             )
             _best_effort("ending record", lambda: save_record(run_root, failed, now), secrets)
             return LiveClimbOutcome(run_id=run_id, outcome="publish-error")
-        # PR opened: the snapshot is no longer needed (the candidate is pushed).
-        drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
+        # PR opened. Record IN_REVIEW *before* dropping the snapshot: if the save
+        # fails, the record stays `waiting` with the snapshot intact, so the run
+        # is recoverable rather than an ABORTED record over a live PR.
         report_path = run_dir / "report.md"
         _best_effort(
             "run report",
             lambda: report_path.write_text(result.report(config, redact_secrets=secrets)),
             secrets,
         )
-        final = RunRecord(
-            **{
-                **record.__dict__,
-                "state": IN_REVIEW,
-                "pr_url": pr_url,
-                "resume_session_id": result.session.session_id if result.session else "",
-                "ending_note": pr_url,
-            }
+        final = _clear_stage(
+            RunRecord(
+                **{
+                    **record.__dict__,
+                    "state": IN_REVIEW,
+                    "pr_url": pr_url,
+                    "resume_session_id": result.session.session_id if result.session else "",
+                    "ending_note": pr_url,
+                }
+            )
         )
-        _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
+        if _best_effort("final record", lambda: save_record(run_root, final, now), secrets):
+            drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
+        else:
+            log.warning(
+                "run %s: PR %s opened but in-review record unsaved; snapshot kept", run_id, pr_url
+            )
         return LiveClimbOutcome(
             run_id=run_id, outcome="improved", pr_url=pr_url, report_path=str(report_path)
         )
@@ -426,13 +488,15 @@ def resume_run(
         lambda: report_path.write_text(result.report(config, redact_secrets=secrets)),
         secrets,
     )
-    final = RunRecord(
-        **{
-            **record.__dict__,
-            "state": ENDED,
-            "ending": _ENDINGS_BY_OUTCOME[result.outcome],
-            "ending_note": redact(result.note, secrets),
-        }
+    final = _clear_stage(
+        RunRecord(
+            **{
+                **record.__dict__,
+                "state": ENDED,
+                "ending": _ENDINGS_BY_OUTCOME[result.outcome],
+                "ending_note": redact(result.note, secrets),
+            }
+        )
     )
     _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
     return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -41,6 +41,7 @@ from autoresearch.measure import DispatchSettings, LocalMeasurer
 from autoresearch.orchestrator import (
     ClimbConfig,
     ClimbParked,
+    EvalError,
     Evaluator,
     Measurer,
     SubprocessEvaluator,
@@ -276,6 +277,13 @@ def resume_run(
     contract = load_contract((workspace / ".autoresearch.yaml").read_text(), record.target)
     bench = _benchmark(contract, record.benchmark)
     config = ClimbConfig(target=record.target, benchmark=record.benchmark, agent_id=record.agent_id)
+
+    # Every dispatched park is a CANDIDATE park (the baseline is measured by the
+    # gate after the session, not before it), so a candidate sha must be
+    # present. Guard rather than crash on `git diff base ""` if a stray
+    # baseline-shaped record ever reached here.
+    if stage.get("phase") != "candidate" or not stage.get("candidate_sha"):
+        raise EvalError(f"resume_run: run {run_id} is not a candidate park (stage={stage!r})")
 
     base_sha = str(stage["base_sha"])
     candidate_sha = str(stage["candidate_sha"])
@@ -770,6 +778,9 @@ def live_climb(
         parked: ClimbParked | None = None
         kept_ref = ""  # the ONE candidate snapshot ref that must outlive a park
         try:
+            # the last-known score orients the brief only; the gate re-measures
+            # both sides after the session, so None (a first run) is fine.
+            prior_best = load_leader(workspace).get(config.benchmark)
             result = climb_once(
                 config,
                 contract_text,
@@ -785,6 +796,7 @@ def live_climb(
                 spec=spec,
                 panel_runner=panel_runner,
                 panel_revisions=panel_revisions,
+                brief_baseline=prior_best.best if prior_best else None,
             )
         except ClimbParked as p:
             # The climb dispatched its measures and hibernated. Persist the

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -36,7 +36,7 @@ from autoresearch.github import (
     GitHubClient,
     Workspace,
 )
-from autoresearch.harness import ClaudeCodeHarness, Harness, redact
+from autoresearch.harness import ClaudeCodeHarness, Harness, SessionResult, redact
 from autoresearch.measure import DispatchSettings, LocalMeasurer
 from autoresearch.orchestrator import (
     ClimbConfig,
@@ -176,6 +176,7 @@ def _park_run(
     candidate_ref: str,
     eval_minutes: int | None,
     now: float,
+    secrets: tuple[str, ...] = (),
 ) -> None:
     """Persist a dispatched climb's re-entry point as a WAITING record: the
     committed shas, drawn seeds, candidate snapshot ref, and afterany set a
@@ -194,11 +195,15 @@ def _park_run(
         "seed": parked.seed,
         "suite_seed": parked.suite_seed,
         "afterany": parked.afterany,
-        # the session's write-up, saved so a candidate wake can build the PR
-        # body and the panel claim WITHOUT re-running the session (its edits
-        # are already captured in candidate_sha). Empty for a baseline park —
-        # the session has not run yet.
-        "report": parked.session.final_text if parked.session else "",
+        # the session's write-up + spend, saved so a candidate wake can build
+        # the PR body / panel claim and report the real cost WITHOUT re-running
+        # the session (its edits are already in candidate_sha). REDACTED before
+        # it lands in the durable record, like every other persisted final_text
+        # — a session that echoed a credential must not leave it in record.json.
+        # Empty/zero for a baseline park (the session has not run yet).
+        "report": redact(parked.session.final_text, secrets) if parked.session else "",
+        "session_cost_usd": parked.session.cost_usd if parked.session else 0.0,
+        "session_turns": parked.session.num_turns if parked.session else 0,
     }
     # The sweep polls ONE experiment_job_id and wakes on its terminal+grace. That
     # is right for a single-job park (baseline, or a candidate with no siblings):
@@ -283,6 +288,17 @@ def resume_run(
     # candidate, never `changed_paths()` on a live tree that may have drifted.
     measured_paths = tuple(ws.git("diff", "--name-only", base_sha, candidate_sha).split())
 
+    # rebuild the session from what the park saved: the (redacted) write-up and
+    # its real spend, so the report shows true cost/turns. It is never re-run.
+    session = SessionResult(
+        stop_reason="resumed",
+        is_error=False,
+        cost_usd=float(stage.get("session_cost_usd", 0.0)),  # type: ignore[arg-type]
+        num_turns=int(stage.get("session_turns", 0)),  # type: ignore[call-overload]
+        session_id=record.resume_session_id,
+        final_text=str(stage.get("report", "")),
+        transcript_path="",
+    )
     try:
         result = resume_climb(
             contract,
@@ -292,15 +308,14 @@ def resume_run(
             seed=int(stage["seed"]),  # type: ignore[call-overload]
             suite_seed=int(stage["suite_seed"]),  # type: ignore[call-overload]
             measured_paths=measured_paths,
-            report=str(stage.get("report", "")),
-            resume_session_id=record.resume_session_id,
+            session=session,
             measurer=measurer,
             min_relative_improvement=config.min_relative_improvement,
         )
     except ClimbParked as parked:
         # another measure this wake dispatched is not done — re-park on the new
         # afterany, keeping the SAME candidate snapshot the next wake reads.
-        _park_run(run_root, record, parked, candidate_ref, eval_minutes, now)
+        _park_run(run_root, record, parked, candidate_ref, eval_minutes, now, secrets)
         return LiveClimbOutcome(run_id=run_id, outcome="parked")
 
     if result.outcome == "improved":
@@ -700,7 +715,7 @@ def live_climb(
             # not the run's start `now` — a session lasting hours would otherwise
             # eat the queue budget and let the sweep cancel a still-queued eval.
             try:
-                _park_run(run_root, record, p, kept_ref, eval_minutes, time.time())
+                _park_run(run_root, record, p, kept_ref, eval_minutes, time.time(), secrets)
             except Exception:
                 # The WAITING record did not persist, so nothing will ever wake
                 # the eval jobs this park already submitted. Cancel them so they

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -244,13 +244,15 @@ def resume_run(
     run_id: str,
     *,
     dispatch: DispatchSettings,
+    github: GitHubClient,
+    bot_auth: FileTokenProvider,
     now: float,
     secrets: tuple[str, ...] = (),
+    base_branch: str = "main",
 ) -> LiveClimbOutcome:
     """Wake a parked dispatched climb and re-enter its decision WITHOUT the
     session (`orchestrator.resume_climb`), from the record `_park_run` wrote.
-
-    Slice 1b handles the two exits that reuse existing machinery:
+    The three exits:
 
     * **re-park** — the wake dispatched a measure that is not done yet (the
       suite pairs an improving candidate fans out, "another round of
@@ -258,22 +260,22 @@ def resume_run(
       the WAITING stage on the new afterany, keeping the same candidate
       snapshot;
     * **a negative terminal** (no-improvement / suite-regression / eval-error):
-      drop the candidate snapshot and end the record.
-
-    The improved outcome commits `candidate_sha` (the SEALED snapshot, never the
-    live tree — it may have drifted since the park) to a branch and opens the
-    PR; that is the next slice. It is unreachable here because dispatch is not
-    yet activated on any target, so an improved wake raises `NotImplementedError`
-    rather than pretend to publish.
+      drop the candidate snapshot and end the record;
+    * **improved** — branch the SEALED `candidate_sha` (never the live tree,
+      which may have drifted since the park; the diff was scope-checked so it
+      carries only in-scope changes), layer the ledger update on top, push, and
+      open the PR. The mechanical moved-base merge the first pass does is
+      deliberately NOT here (docs/design/research-loop.md): a stale PR is a
+      re-wake, not an orchestrator auto-merge.
     """
     run_dir = run_root / "runs" / run_id
     workspace = run_dir / "ws"
     record = load_record(run_root, run_id)
     stage = record.stage
-    ws = Workspace(root=workspace)
+    ws = Workspace(root=workspace, auth=bot_auth)
     contract = load_contract((workspace / ".autoresearch.yaml").read_text(), record.target)
     bench = _benchmark(contract, record.benchmark)
-    config = ClimbConfig(target=record.target, benchmark=record.benchmark)
+    config = ClimbConfig(target=record.target, benchmark=record.benchmark, agent_id=record.agent_id)
 
     base_sha = str(stage["base_sha"])
     candidate_sha = str(stage["candidate_sha"])
@@ -319,7 +321,94 @@ def resume_run(
         return LiveClimbOutcome(run_id=run_id, outcome="parked")
 
     if result.outcome == "improved":
-        raise NotImplementedError("improved-wake publish (commit candidate_sha -> PR) is slice 1c")
+        # Publish: branch the SEALED candidate sha, fold in the ledger, push,
+        # open the PR. No moved-base merge (research-loop.md) — a stale PR is a
+        # re-wake, not an auto-merge.
+        from datetime import UTC, datetime
+
+        assert result.baseline is not None and result.candidate is not None
+        baseline, candidate = result.baseline, result.candidate
+        branch = f"{config.branch_prefix}/{run_id}"
+        try:
+            ws.git("checkout", "-B", branch, candidate_sha)
+            entries = update_leader(
+                load_leader(workspace),
+                benchmark=bench.name,
+                metric=bench.metric,
+                direction=bench.direction,
+                baseline=baseline,
+                candidate=candidate,
+                run_id=run_id,
+                date=datetime.fromtimestamp(now, UTC).strftime("%Y-%m-%d"),
+                run_seed=result.run_seed,
+            )
+            write_progress(
+                workspace,
+                entries,
+                config.target,
+                digits={b.name: b.display_digits for b in contract.benchmarks if b.display_digits},
+            )
+            # only the ledger files change on top of the sealed candidate; the
+            # veto re-checks scope as defense in depth (the candidate diff was
+            # already scope-checked in measure_and_decide).
+            ws.commit_all(
+                f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
+                f"\n\nAgent: {config.agent_id}",
+                author=config.bot_login,
+                forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
+            )
+            ws.push(branch)
+            body = pr_body(
+                result, config, redact_secrets=secrets, display_digits=bench.display_digits
+            )
+            pr_url = github.create_pull(
+                config.target,
+                title=f"[agent] {config.benchmark}: {_title_pair(baseline, candidate)}",
+                head=branch,
+                base=base_branch,
+                body=body,
+                draft=result.panel_blocking_open or result.panel_degraded,
+            )
+            pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
+            if pr_number.isdigit() and not (result.panel_blocking_open or result.panel_degraded):
+                _best_effort(
+                    "auto-merge arming",
+                    lambda: github.arm_auto_merge_when_review_required(
+                        config.target, int(pr_number)
+                    ),
+                    secrets,
+                )
+        except Exception as exc:
+            # push / PR / commit failed — end as an error, KEEP the snapshot (a
+            # later wake can retry) and never delete a remote branch.
+            note = redact(f"{type(exc).__name__}: {exc}", secrets)[:480]
+            log.warning("wake publish failed for %s: %s", run_id, note)
+            failed = RunRecord(
+                **{**record.__dict__, "state": ENDED, "ending": ABORTED, "ending_note": note}
+            )
+            _best_effort("ending record", lambda: save_record(run_root, failed, now), secrets)
+            return LiveClimbOutcome(run_id=run_id, outcome="publish-error")
+        # PR opened: the snapshot is no longer needed (the candidate is pushed).
+        drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
+        report_path = run_dir / "report.md"
+        _best_effort(
+            "run report",
+            lambda: report_path.write_text(result.report(config, redact_secrets=secrets)),
+            secrets,
+        )
+        final = RunRecord(
+            **{
+                **record.__dict__,
+                "state": IN_REVIEW,
+                "pr_url": pr_url,
+                "resume_session_id": result.session.session_id if result.session else "",
+                "ending_note": pr_url,
+            }
+        )
+        _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
+        return LiveClimbOutcome(
+            run_id=run_id, outcome="improved", pr_url=pr_url, report_path=str(report_path)
+        )
 
     # a negative terminal: release the snapshot and end the record.
     drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -45,11 +45,13 @@ from autoresearch.orchestrator import (
     Measurer,
     SubprocessEvaluator,
     SuiteMeasurement,
+    _benchmark,
     benchmark_floor,
     clears_min_delta,
     climb_once,
     out_of_scope,
     pr_body,
+    resume_climb,
     suite_regressed,
 )
 from autoresearch.orchestrator import improved as orch_improved
@@ -73,6 +75,7 @@ from autoresearch.runstate import (
     STUCK,
     WAITING,
     RunRecord,
+    load_record,
     save_record,
     stamp_outage,
 )
@@ -229,6 +232,98 @@ def _park_run(
         }
     )
     save_record(run_root, waiting, now)
+
+
+def resume_run(
+    run_root: Path,
+    run_id: str,
+    *,
+    dispatch: DispatchSettings,
+    now: float,
+    secrets: tuple[str, ...] = (),
+) -> LiveClimbOutcome:
+    """Wake a parked dispatched climb and re-enter its decision WITHOUT the
+    session (`orchestrator.resume_climb`), from the record `_park_run` wrote.
+
+    Slice 1b handles the two exits that reuse existing machinery:
+
+    * **re-park** — the wake dispatched a measure that is not done yet (the
+      suite pairs an improving candidate fans out, "another round of
+      experiments"): `resume_climb` raises `ClimbParked`, and this re-persists
+      the WAITING stage on the new afterany, keeping the same candidate
+      snapshot;
+    * **a negative terminal** (no-improvement / suite-regression / eval-error):
+      drop the candidate snapshot and end the record.
+
+    The improved outcome commits `candidate_sha` (the SEALED snapshot, never the
+    live tree — it may have drifted since the park) to a branch and opens the
+    PR; that is the next slice. It is unreachable here because dispatch is not
+    yet activated on any target, so an improved wake raises `NotImplementedError`
+    rather than pretend to publish.
+    """
+    run_dir = run_root / "runs" / run_id
+    workspace = run_dir / "ws"
+    record = load_record(run_root, run_id)
+    stage = record.stage
+    ws = Workspace(root=workspace)
+    contract = load_contract((workspace / ".autoresearch.yaml").read_text(), record.target)
+    bench = _benchmark(contract, record.benchmark)
+    config = ClimbConfig(target=record.target, benchmark=record.benchmark)
+
+    base_sha = str(stage["base_sha"])
+    candidate_sha = str(stage["candidate_sha"])
+    candidate_ref = str(stage["candidate_ref"])
+    eval_minutes = next(
+        (b.eval_minutes for b in contract.benchmarks if b.name == record.benchmark), None
+    )
+    measurer = dispatch.measurer(
+        run_dir, repo_root=workspace, eval_minutes=int(eval_minutes or 0), run_tag=run_id
+    )
+    # measured_paths from the COMMITTED base..candidate diff — the sealed
+    # candidate, never `changed_paths()` on a live tree that may have drifted.
+    measured_paths = tuple(ws.git("diff", "--name-only", base_sha, candidate_sha).split())
+
+    try:
+        result = resume_climb(
+            contract,
+            bench,
+            base_sha=base_sha,
+            candidate_sha=candidate_sha,
+            seed=int(stage["seed"]),  # type: ignore[call-overload]
+            suite_seed=int(stage["suite_seed"]),  # type: ignore[call-overload]
+            measured_paths=measured_paths,
+            report=str(stage.get("report", "")),
+            resume_session_id=record.resume_session_id,
+            measurer=measurer,
+            min_relative_improvement=config.min_relative_improvement,
+        )
+    except ClimbParked as parked:
+        # another measure this wake dispatched is not done — re-park on the new
+        # afterany, keeping the SAME candidate snapshot the next wake reads.
+        _park_run(run_root, record, parked, candidate_ref, eval_minutes, now)
+        return LiveClimbOutcome(run_id=run_id, outcome="parked")
+
+    if result.outcome == "improved":
+        raise NotImplementedError("improved-wake publish (commit candidate_sha -> PR) is slice 1c")
+
+    # a negative terminal: release the snapshot and end the record.
+    drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
+    report_path = run_dir / "report.md"
+    _best_effort(
+        "run report",
+        lambda: report_path.write_text(result.report(config, redact_secrets=secrets)),
+        secrets,
+    )
+    final = RunRecord(
+        **{
+            **record.__dict__,
+            "state": ENDED,
+            "ending": _ENDINGS_BY_OUTCOME[result.outcome],
+            "ending_note": redact(result.note, secrets),
+        }
+    )
+    _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
+    return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
 
 
 def _measure_committed(

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -218,7 +218,9 @@ def _park_run(
         # it lands in the durable record, like every other persisted final_text
         # — a session that echoed a credential must not leave it in record.json.
         # Empty/zero for a baseline park (the session has not run yet).
-        "report": redact(parked.session.final_text, secrets) if parked.session else "",
+        "report": redact(parked.session.final_text, secrets)[:MAX_CLAIM_CHARS]
+        if parked.session
+        else "",
         "session_cost_usd": parked.session.cost_usd if parked.session else 0.0,
         "session_turns": parked.session.num_turns if parked.session else 0,
     }
@@ -1652,6 +1654,7 @@ def main() -> int:
         try:
             outcome = live_climb(
                 config=ClimbConfig(target=args.target, benchmark=args.benchmark),
+                base_branch=args.base_branch,
                 run_root=args.run_root,
                 run_id=run_id,
                 harness=build_editor_harness(

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -98,6 +98,13 @@ class SuiteRegressed(RuntimeError):
     result wherever it is caught, never an abort."""
 
 
+def _target_clone_url(target: str) -> str:
+    """The canonical HTTPS clone URL for `owner/repo`. The one source of truth
+    for where a run's git pushes go — derived from the target, never read from
+    the session-writable `remote.origin.url`."""
+    return f"https://github.com/{target}.git"
+
+
 def _title_pair(a: float, b: float) -> str:
     """Compact but never ambiguous: widen precision until the two numbers
     render differently (a title reading '10.00 -> 10.00' looks like no
@@ -282,10 +289,11 @@ def resume_run(
     workspace = run_dir / "ws"
     record = load_record(run_root, run_id)
     stage = record.stage
-    ws = Workspace(root=workspace, auth=bot_auth)
-    contract = load_contract((workspace / ".autoresearch.yaml").read_text(), record.target)
-    bench = _benchmark(contract, record.benchmark)
-    config = ClimbConfig(target=record.target, benchmark=record.benchmark, agent_id=record.agent_id)
+    # Push to the CANONICAL target URL, never the workspace's remote.origin.url:
+    # the session could have rewritten that config to exfil the bot token / code
+    # to another remote. Passing `url` here means `Workspace.push` uses it
+    # instead of reading `remote.origin.url`.
+    ws = Workspace(root=workspace, auth=bot_auth, url=_target_clone_url(record.target))
 
     # Every dispatched park is a CANDIDATE park (the baseline is measured by the
     # gate after the session, not before it), so a candidate sha must be
@@ -297,6 +305,14 @@ def resume_run(
     base_sha = str(stage["base_sha"])
     candidate_sha = str(stage["candidate_sha"])
     candidate_ref = str(stage["candidate_ref"])
+
+    # The contract gates scope and names the eval command, so read it from the
+    # BASE commit (the tree the run started on), NOT the working tree the
+    # session left dirty — a session that widened its own scope in
+    # `.autoresearch.yaml` must not have the wake gate on the doctored rules.
+    contract = load_contract(ws.git("show", f"{base_sha}:.autoresearch.yaml"), record.target)
+    bench = _benchmark(contract, record.benchmark)
+    config = ClimbConfig(target=record.target, benchmark=record.benchmark, agent_id=record.agent_id)
     eval_minutes = next(
         (b.eval_minutes for b in contract.benchmarks if b.name == record.benchmark), None
     )
@@ -723,7 +739,7 @@ def live_climb(
 
     tree_hashes: list[str] = []
     try:
-        ws = Workspace.clone(f"https://github.com/{config.target}.git", workspace, auth=bot_auth)
+        ws = Workspace.clone(_target_clone_url(config.target), workspace, auth=bot_auth)
         # the BASE BRANCH tip, not HEAD: they differ if the PR base is ever
         # not the clone's default branch, and the freshness comparison below
         # must be against the branch the PR will actually land on

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -191,6 +191,11 @@ def _park_run(
         "seed": parked.seed,
         "suite_seed": parked.suite_seed,
         "afterany": parked.afterany,
+        # the session's write-up, saved so a candidate wake can build the PR
+        # body and the panel claim WITHOUT re-running the session (its edits
+        # are already captured in candidate_sha). Empty for a baseline park —
+        # the session has not run yet.
+        "report": parked.session.final_text if parked.session else "",
     }
     # The sweep polls ONE experiment_job_id and wakes on its terminal+grace. That
     # is right for a single-job park (baseline, or a candidate with no siblings):

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -845,17 +845,17 @@ def resume_climb(
     seed: int,
     suite_seed: int,
     measured_paths: Sequence[str],
-    report: str,
-    resume_session_id: str,
+    session: SessionResult,
     measurer: Measurer,
     min_relative_improvement: float,
 ) -> ClimbResult:
     """Re-enter a parked climb's post-session decision — the WAKE side of a
     dispatched candidate park. The candidate is already committed (its sha is in
     the record), so the session does NOT re-run: its edits are captured in
-    `candidate_sha` and its write-up in `report` (which reconstructs the PR body
-    and the panel claim without the session object). `measured_paths` is the
-    caller's re-derivation of the `base_sha..candidate_sha` diff.
+    `candidate_sha` and it was reconstructed by the caller from the record
+    (`session.final_text` is the saved write-up, and its cost/turns the saved
+    spend) so the PR body and panel claim need no live session. `measured_paths`
+    is the caller's re-derivation of the `base_sha..candidate_sha` diff.
 
     The measurer reads the cached eval results and this returns the decision, OR
     the decision needs a measure not yet done — the suite pairs after an
@@ -869,17 +869,6 @@ def resume_climb(
     """
     from autoresearch.measure import MeasurementPending
 
-    # the session is gone; rebuild just enough of it (the write-up + its id) for
-    # the outcome the caller renders. It is never re-run.
-    session = SessionResult(
-        stop_reason="resumed",
-        is_error=False,
-        cost_usd=0.0,
-        num_turns=0,
-        session_id=resume_session_id,
-        final_text=report,
-        transcript_path="",
-    )
     try:
         outcome = measure_and_decide(
             contract,
@@ -906,8 +895,13 @@ def resume_climb(
         ) from None
     if isinstance(outcome, ClimbResult):
         # a terminal measurement outcome (no-improvement / suite-regression /
-        # eval-error): carry the reconstructed session for the caller's report
-        return dc_replace(outcome, session=session)
+        # eval-error): carry the reconstructed session, and give a bare
+        # no-improvement the same framing the in-job path sets (a clear
+        # negative is a success), so a resumed negative does not end note-less.
+        note = outcome.note
+        if outcome.outcome == "no-improvement":
+            note = "a negative result reported clearly is a success"
+        return dc_replace(outcome, session=session, note=note)
     # credited: candidate cleared the threshold and no sibling regressed. The
     # caller sets `branch` when it opens the PR.
     return ClimbResult(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -836,6 +836,92 @@ def measure_and_decide(
     )
 
 
+def resume_climb(
+    contract: Contract,
+    bench: Benchmark,
+    *,
+    base_sha: str,
+    candidate_sha: str,
+    seed: int,
+    suite_seed: int,
+    measured_paths: Sequence[str],
+    report: str,
+    resume_session_id: str,
+    measurer: Measurer,
+    min_relative_improvement: float,
+) -> ClimbResult:
+    """Re-enter a parked climb's post-session decision — the WAKE side of a
+    dispatched candidate park. The candidate is already committed (its sha is in
+    the record), so the session does NOT re-run: its edits are captured in
+    `candidate_sha` and its write-up in `report` (which reconstructs the PR body
+    and the panel claim without the session object). `measured_paths` is the
+    caller's re-derivation of the `base_sha..candidate_sha` diff.
+
+    The measurer reads the cached eval results and this returns the decision, OR
+    the decision needs a measure not yet done — the suite pairs after an
+    improving candidate, "another round of experiments" — and it re-parks by
+    raising `ClimbParked`, exactly as the first pass did.
+
+    This is the seam the depth axis (docs/design/research-loop.md) grows from:
+    slice 1 wakes the GRADER with the panel off; waking the AGENT with the
+    result — a panel revision, or a deeper experiment round it drives itself —
+    reuses this same re-entry and lands next.
+    """
+    from autoresearch.measure import MeasurementPending
+
+    # the session is gone; rebuild just enough of it (the write-up + its id) for
+    # the outcome the caller renders. It is never re-run.
+    session = SessionResult(
+        stop_reason="resumed",
+        is_error=False,
+        cost_usd=0.0,
+        num_turns=0,
+        session_id=resume_session_id,
+        final_text=report,
+        transcript_path="",
+    )
+    try:
+        outcome = measure_and_decide(
+            contract,
+            bench,
+            base_sha=base_sha,
+            candidate_sha=candidate_sha,
+            seed=seed,
+            suite_seed=suite_seed,
+            measured_paths=measured_paths,
+            measurer=measurer,
+            min_relative_improvement=min_relative_improvement,
+        )
+    except MeasurementPending as pending:
+        # a measure is not done yet (the suite pairs this wake just dispatched):
+        # re-park on the new afterany set, same shape as the first candidate park
+        raise ClimbParked(
+            phase="candidate",
+            afterany=pending.afterany(),
+            base_sha=base_sha,
+            seed=seed,
+            suite_seed=suite_seed,
+            candidate_sha=candidate_sha,
+            session=session,
+        ) from None
+    if isinstance(outcome, ClimbResult):
+        # a terminal measurement outcome (no-improvement / suite-regression /
+        # eval-error): carry the reconstructed session for the caller's report
+        return dc_replace(outcome, session=session)
+    # credited: candidate cleared the threshold and no sibling regressed. The
+    # caller sets `branch` when it opens the PR.
+    return ClimbResult(
+        outcome="improved",
+        baseline=outcome.baseline,
+        candidate=outcome.candidate,
+        session=session,
+        measured_paths=tuple(measured_paths),
+        run_seed=seed,
+        suite=outcome.suite,
+        suite_seed=outcome.suite_seed,
+    )
+
+
 def climb_once(
     config: ClimbConfig,
     contract_text: str,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -624,11 +624,16 @@ def improved(baseline: float, candidate: float, direction: str, min_rel: float) 
 
 
 def make_task(
-    contract: Contract, benchmark_name: str, baseline: float, hypothesis: str = ""
+    contract: Contract, benchmark_name: str, baseline: float | None, hypothesis: str = ""
 ) -> Task:
     bench = _benchmark(contract, benchmark_name)
     better = "up" if bench.direction == "max" else "down"
     suite_gated = bool(contract.scope.shared) and len(contract.benchmarks) > 1
+    # `baseline` orients the brief only (the last-known score from the ledger);
+    # the GATE re-measures both sides after the session, so a missing baseline
+    # (a benchmark's first run) just drops the reference number, never the gate.
+    versus = f" from {baseline}" if baseline is not None else ""
+    against = f" versus {baseline}" if baseline is not None else ""
     return Task(
         hypothesis=hypothesis
         or (
@@ -637,10 +642,10 @@ def make_task(
             f"for why it underperforms, and implement it."
         ),
         benchmark=bench.name,
-        expected_effect=f"{bench.metric} {better} from {baseline}",
+        expected_effect=f"{bench.metric} {better}{versus}",
         done_criteria=(
-            f"`{bench.command}` runs clean and {bench.metric} moves {better} "
-            f"versus {baseline}; repository tests pass"
+            f"`{bench.command}` runs clean and {bench.metric} moves {better}"
+            f"{against}; repository tests pass"
             + (
                 "; a change touching shared paths is suite-gated — no sibling "
                 "benchmark may regress beyond its floor"
@@ -933,6 +938,7 @@ def climb_once(
     spec: RoleSpec | None = None,
     panel_runner: Callable[[float, float, str], PanelVerdict] | None = None,
     panel_revisions: int = 1,
+    brief_baseline: float | None = None,
 ) -> ClimbResult:
     """One implement→evaluate→verify cycle in an existing clean workspace.
 
@@ -971,7 +977,7 @@ def climb_once(
 
     # deferred like measure_and_decide's import (measure -> dispatch ->
     # orchestrator for the eval primitives).
-    from autoresearch.measure import MeasurementPending, plan_measures
+    from autoresearch.measure import MeasurementPending
 
     run_seed = draw_run_seed() if bench.seed_env else 0
     siblings = [b for b in contract.benchmarks if b.name != bench.name]
@@ -985,31 +991,13 @@ def climb_once(
         else 0
     )
 
-    # Baseline from the PRE-session tree (base_sha), through the measurer — the
-    # SAME number the gate re-reads from cache, so the brief and the decision
-    # agree (architecture: "baseline re-run at the merge-base, not a trusted
-    # static file"). Its worktree is the caller's pristine pre-session tree, so
-    # eval artifacts land outside what the session sees next (no pool
-    # foreknowledge).
-    baseline_plan = plan_measures(
-        bench.command, bench.metric, base_sha, base_sha, bench.seed_env or "", run_seed
-    )[0]
-    try:
-        baseline = measurer.results([baseline_plan])["baseline"]
-    except EvalError as exc:
-        # the measurer already names the failing measure ("baseline: ...").
-        return ClimbResult(outcome="eval-error", note=str(exc))
-    except MeasurementPending as pending:
-        # PARK 1 (dispatched baseline, before the session): the wake reads the
-        # baseline, then runs the session and re-enters. No candidate yet.
-        raise ClimbParked(
-            phase="baseline",
-            afterany=pending.afterany(),
-            base_sha=base_sha,
-            seed=run_seed,
-            suite_seed=suite_seed,
-        ) from None
-
+    # The baseline is NOT measured before the session — it is measured by the
+    # GATE (`measure_and_decide`, base_sha vs candidate_sha) after the session,
+    # so a dispatched climb has ONE park (the candidate), never a pre-session
+    # baseline park. `brief_baseline` is the last-known score from the ledger,
+    # for orienting the brief only ("improve from ~13.8"); it is None on a
+    # benchmark's first run, and the gate re-measures either way.
+    baseline: float | None = brief_baseline
     task = make_task(contract, config.benchmark, baseline, hypothesis=task_hypothesis)
     brief = build_brief(
         BriefInputs(
@@ -1047,7 +1035,7 @@ def climb_once(
     panel_sections: list[str] = []
     panel_blocking_open = False
     panel_degraded = False
-    candidate = baseline
+    candidate: float | None = baseline
     suite: tuple[SuiteMeasurement, ...] = ()
     suite_seed_ran = 0
     measured: tuple[str, ...] = ()
@@ -1116,7 +1104,9 @@ def climb_once(
         if isinstance(outcome, ClimbResult):
             # a terminal measurement outcome (scope-violation / eval-error /
             # no-improvement / suite-regression): add the session + panel
-            # context this function owns, and the credited baseline.
+            # context this function owns. The baseline stays whatever the GATE
+            # measured (None when it never got that far, e.g. scope-violation),
+            # never overwritten with the ledger's brief number.
             note = outcome.note
             if outcome.outcome == "no-improvement":
                 note = (
@@ -1126,7 +1116,6 @@ def climb_once(
                 )
             return dc_replace(
                 outcome,
-                baseline=baseline,
                 session=session,
                 note=note,
                 panel_transcript="\n\n".join(panel_sections),

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1673,6 +1673,30 @@ class JobWakeDispatcher:
         )
 
 
+def _wake_dispatcher_from_env(
+    compute: SlurmCompute, followup_spec: FollowupSpec | None, now: float
+) -> tuple[WakeDispatcher, bool]:
+    """The wake delivery for this tick, behind an EXPLICIT on-switch so the
+    dispatched-wake path lands DARK. Returns `(dispatcher, live)`:
+
+    * `AUTORESEARCH_DISPATCH_WAKE` set AND the chain env carries what a wake job
+      needs -> the real `JobWakeDispatcher` and a LIVE sweep;
+    * otherwise -> the `LoggingDispatcher` and a DRY sweep (today's behavior).
+
+    So an operator turns dispatched climbing on deliberately, and a
+    half-configured environment fails safe to dry rather than to a wake job
+    that cannot run."""
+    if not os.environ.get("AUTORESEARCH_DISPATCH_WAKE", "").strip():
+        return LoggingDispatcher(), False
+    if followup_spec is None:
+        log.warning(
+            "AUTORESEARCH_DISPATCH_WAKE set but the chain env is incomplete; wake stays dry"
+        )
+        return LoggingDispatcher(), False
+    log.info("dispatched-wake ON: the waiting-run sweep delivers real wakes this tick")
+    return JobWakeDispatcher(compute, followup_spec, now), True
+
+
 def _max_job_minutes_from_env() -> int:
     """AUTORESEARCH_MAX_JOB_MINUTES, clamped into what the code can honor:
     at least the climb-job floor (an operator on a short-MaxTime partition
@@ -1768,19 +1792,24 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     args.root.mkdir(parents=True, exist_ok=True)
-    # The waiting-run sweep stays dry until the experiment dispatcher lands;
-    # in-review servicing is LIVE when credentials + image are available in
-    # the chain environment.
+    # In-review servicing is LIVE when credentials + image are available in the
+    # chain environment. The waiting-run sweep delivers real wakes only when the
+    # operator flips AUTORESEARCH_DISPATCH_WAKE (and the env is complete); by
+    # default it stays dry with the LoggingDispatcher — dispatched climbing
+    # lands DARK.
     github, followup_spec = _followup_spec_from_env(args.root)
+    compute = SlurmCompute()
+    now = time.time()
+    dispatcher, wake_live = _wake_dispatcher_from_env(compute, followup_spec, now)
 
     report = tick(
         args.root,
-        SlurmCompute(),
-        LoggingDispatcher(),
-        now=time.time(),
+        compute,
+        dispatcher,
+        now=now,
         grace_s=args.grace_s,
         lease_ttl_s=args.lease_ttl_s,
-        dry_run=True,
+        dry_run=not wake_live,
         github=github,
         followup_spec=followup_spec,
         followup_dry_run=False,

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1623,6 +1623,56 @@ class LoggingDispatcher:
         return ""
 
 
+@dataclass
+class JobWakeDispatcher:
+    """Delivers a wake by submitting a Slurm job that runs the wake CLI
+    (`climb --resume <run_id>`), depending on the run's eval jobs (the record's
+    `afterany`) so it fires when they finish — or immediately if they already
+    have. CPU-only and short: a wake reads cached results and opens a PR, it
+    never holds a GPU. Returns the wake job id (async: it owns the lease until
+    it completes)."""
+
+    compute: SlurmCompute
+    spec: FollowupSpec
+    now: float
+    wake_minutes: int = 20
+
+    def dispatch(self, record: RunRecord, reason: str) -> str:
+        argv = [
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "autoresearch.climb",
+            "--resume",
+            record.run_id,
+            "--run-root",
+            str(self.spec.run_root),
+            "--image",
+            self.spec.image,
+            "--account",
+            self.spec.account,
+            "--partition",
+            self.spec.partition,
+        ]
+        if self.spec.pat_file:
+            argv += ["--pat-file", self.spec.pat_file]
+        name = f"wake-{record.run_id}"[:60]
+        afterany = str(record.stage.get("afterany", ""))
+        return self.compute.submit(
+            JobSpec(
+                job_name=name,
+                account=self.spec.account,
+                partition=self.spec.job_partition or self.spec.partition,
+                time_minutes=self.wake_minutes,
+                command=_flight_command(self.spec.home, name, self.now, argv),
+                dependency=afterany,
+                cpus=2,
+                mem="4G",
+            )
+        )
+
+
 def _max_job_minutes_from_env() -> int:
     """AUTORESEARCH_MAX_JOB_MINUTES, clamped into what the code can honor:
     at least the climb-job floor (an operator on a short-MaxTime partition

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1807,3 +1807,32 @@ def test_resume_reads_contract_from_base_not_the_dirty_tree(tmp_path, monkeypatc
     )
     assert outcome.outcome == "improved"  # base's contract was used, not the corrupt tree
     assert github.prs and github.prs[0]["base"] == "main"
+
+
+def test_resume_negative_keeps_snapshot_if_the_record_save_fails(tmp_path, monkeypatch) -> None:
+    # a negative wake must save the ENDED record BEFORE dropping the snapshot:
+    # if the save fails, the run stays recoverable (snapshot intact), never
+    # WAITING with the candidate gone.
+    from autoresearch import climb as climb_mod
+
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    real_save = climb_mod.save_record
+
+    def failing_save(root, record, now):
+        if record.state == "ended":
+            raise OSError("disk full")
+        return real_save(root, record, now)
+
+    monkeypatch.setattr(climb_mod, "save_record", failing_save)
+    resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    ws = state / "runs" / run_id / "ws"
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() != ""  # snapshot kept for a re-wake

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -75,6 +75,38 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
     assert r.stage["candidate_ref"] == "refs/dispatch/tok"  # for drop at the terminal
     assert r.stage["seed"] == 7 and r.stage["suite_seed"] == 9
     assert r.stage["afterany"] == "afterany:101:102"
+    # the session's write-up + spend ride the stage so a candidate wake can
+    # build the PR body and report the real cost without re-running the session
+    assert r.stage["report"] == "report"
+    assert r.stage["session_cost_usd"] == 1.0 and r.stage["session_turns"] == 5
+
+
+def test_park_run_redacts_the_saved_report(tmp_path) -> None:
+    # a session that echoed a secret must not leave it readable in record.json
+    record = RunRecord(
+        run_id="tsp-9", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
+    )
+    leaky = SessionResult(
+        stop_reason="end_turn",
+        is_error=False,
+        cost_usd=1.0,
+        num_turns=5,
+        session_id="s1",
+        final_text="used key sk-secret-123 to fetch",
+        transcript_path="",
+    )
+    parked = ClimbParked(
+        phase="candidate",
+        afterany="afterany:1",
+        base_sha="b" * 40,
+        seed=1,
+        suite_seed=1,
+        candidate_sha="c" * 40,
+        session=leaky,
+    )
+    _park_run(tmp_path, record, parked, "refs/dispatch/tok", 90, 1000.0, ("sk-secret-123",))
+    report = str(load_record(tmp_path, "tsp-9").stage["report"])
+    assert "sk-secret-123" not in report and "used key" in report
 
 
 def test_park_run_single_job_records_it_for_the_sweep(tmp_path) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -681,49 +681,6 @@ def test_branch_is_kept_and_recorded_after_pr_failure(tmp_path, target_repo) -> 
     assert "branch left on remote: feat/auto/agent-01/tsp-orphan" in record.ending_note
 
 
-def test_not_beating_recorded_best_is_rejected_loudly(tmp_path, target_repo) -> None:
-    """Improved vs a stale baseline but worse than the ledger's best: no PR,
-    and the reason is recorded."""
-    import json as _json
-
-    # seed a leader in the origin whose best is better than this run's candidate
-    seed = tmp_path / "leaderseed"
-    _git(tmp_path, "clone", "-q", str(target_repo), str(seed))
-    (seed / "results").mkdir(exist_ok=True)
-    (seed / "results" / "leader.json").write_text(
-        _json.dumps(
-            {
-                "tsp": {
-                    "benchmark": "tsp",
-                    "metric": "mean_tour_length",
-                    "direction": "min",
-                    "baseline": 13.876,
-                    "best": 12.0,
-                    "best_run": "r0",
-                    "updated": "d",
-                }
-            }
-        )
-    )
-    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
-    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "leader")
-    _git(seed, "push", "-q", "origin", "main")
-
-    outcome, github = run_live(
-        tmp_path,
-        target_repo,
-        edits={"src/pilot/solvers/tsp.py": "w=9\n"},
-        values=[13.876, 13.1],  # improved vs own baseline, worse than best 12.0
-        run_id="tsp-stale",
-    )
-    assert outcome.outcome == "publish-error"
-    assert github.prs == []
-    assert (
-        "does not beat the recorded best"
-        in load_record(tmp_path / "state", "tsp-stale").ending_note
-    )
-
-
 def _push_contract(tmp_path, target_repo, contract_text: str, name: str) -> None:
     seed = tmp_path / f"contract-{name}"
     _git(tmp_path, "clone", "-q", str(target_repo), str(seed))
@@ -733,18 +690,14 @@ def _push_contract(tmp_path, target_repo, contract_text: str, name: str) -> None
     _git(seed, "push", "-q", "origin", "main")
 
 
-def test_within_noise_floor_is_an_honest_negative(tmp_path, target_repo) -> None:
-    """Beats the recorded best, but by less than min_delta: the recorded
-    best was measured under a DIFFERENT seed, so the delta is pool luck —
-    an honest negative result, never a PR and never an abort."""
+def test_beats_baseline_but_not_recorded_best_still_opens_a_pr(tmp_path, target_repo) -> None:
+    """We credit beating YOUR baseline (docs/design/research-loop.md): a clean
+    win over base_sha opens a PR even when it does not beat the ledger's best.
+    The ledger's `best` is unchanged (SOTA tracked, not required), so the finish
+    pushes the candidate with no leaderboard commit on top."""
     import json as _json
 
-    _push_contract(
-        tmp_path,
-        target_repo,
-        CONTRACT.replace("    direction: min\n", "    direction: min\n    min_delta: 0.5\n", 1),
-        "floor",
-    )
+    # seed a leader whose best (12.0) is better than this run's candidate (13.1)
     seed = tmp_path / "leaderseed"
     _git(tmp_path, "clone", "-q", str(target_repo), str(seed))
     (seed / "results").mkdir(exist_ok=True)
@@ -771,64 +724,11 @@ def test_within_noise_floor_is_an_honest_negative(tmp_path, target_repo) -> None
         tmp_path,
         target_repo,
         edits={"src/pilot/solvers/tsp.py": "w=9\n"},
-        values=[13.876, 11.8],  # beats best 12.0, but only by 0.2 < 0.5
-        run_id="tsp-floor",
+        values=[13.876, 13.1],  # beats own baseline, worse than recorded best 12.0
+        run_id="tsp-composable",
     )
-    assert outcome.outcome == "no-improvement"
-    assert github.prs == []
-    record = load_record(tmp_path / "state", "tsp-floor")
-    assert record.ending == "negative-result"
-    assert "noise floor" in record.ending_note and "0.5" in record.ending_note
-
-
-def test_sub_threshold_delta_on_floored_benchmark_is_negative_not_abort(
-    tmp_path, target_repo
-) -> None:
-    """Round-4 finding: with min_delta declared, EVERY sub-floor delta over
-    the recorded best — including one below the relative threshold — is an
-    honest negative, not a stale-clone abort."""
-    import json as _json
-
-    _push_contract(
-        tmp_path,
-        target_repo,
-        CONTRACT.replace("    direction: min\n", "    direction: min\n    min_delta: 0.5\n", 1),
-        "subrel",
-    )
-    seed = tmp_path / "leaderseed2"
-    _git(tmp_path, "clone", "-q", str(target_repo), str(seed))
-    (seed / "results").mkdir(exist_ok=True)
-    (seed / "results" / "leader.json").write_text(
-        _json.dumps(
-            {
-                "tsp": {
-                    "benchmark": "tsp",
-                    "metric": "mean_tour_length",
-                    "direction": "min",
-                    "baseline": 13.876,
-                    "best": 12.0,
-                    "best_run": "r0",
-                    "updated": "d",
-                }
-            }
-        )
-    )
-    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
-    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "leader")
-    _git(seed, "push", "-q", "origin", "main")
-
-    outcome, github = run_live(
-        tmp_path,
-        target_repo,
-        edits={"src/pilot/solvers/tsp.py": "w=11\n"},
-        values=[13.876, 11.999],  # 0.001 over best: below rel threshold AND floor
-        run_id="tsp-subrel",
-    )
-    assert outcome.outcome == "no-improvement"
-    assert github.prs == []
-    record = load_record(tmp_path / "state", "tsp-subrel")
-    assert record.ending == "negative-result"
-    assert "noise floor" in record.ending_note
+    assert outcome.outcome == "improved"  # a composable win, not a rejection
+    assert github.prs and github.prs[0]["head"] == "feat/auto/agent-01/tsp-composable"
 
 
 def test_baseline_eval_runs_outside_the_session_workspace(tmp_path, target_repo) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1719,6 +1719,10 @@ def _write_parked_candidate(tmp_path, monkeypatch, *, values=None, raise_exc=Non
     _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-aqm", "candidate")
     candidate_sha = _git(ws, "rev-parse", "HEAD").strip()
     _git(ws, "update-ref", "refs/dispatch/tok", candidate_sha)
+    # a bare 'origin' so an improved wake can push its branch
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(ws), str(bare))
+    _git(ws, "remote", "add", "origin", str(bare))
 
     record = RunRecord(
         run_id=run_id,
@@ -1750,7 +1754,14 @@ def test_resume_negative_ends_run_and_drops_snapshot(tmp_path, monkeypatch) -> N
     state, run_id = _write_parked_candidate(
         tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
     )
-    outcome = resume_run(state, run_id, dispatch=_fake_dispatch(), now=1_000_100.0)
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
     assert outcome.outcome == "no-improvement"
     record = load_record(state, run_id)
     assert record.state == "ended" and record.ending == "negative-result"
@@ -1766,10 +1777,47 @@ def test_resume_reparks_when_a_measure_is_pending(tmp_path, monkeypatch) -> None
     state, run_id = _write_parked_candidate(
         tmp_path, monkeypatch, raise_exc=MeasurementPending(("601", "602"))
     )
-    outcome = resume_run(state, run_id, dispatch=_fake_dispatch(), now=1_000_100.0)
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
     assert outcome.outcome == "parked"
     record = load_record(state, run_id)
     assert record.state == "waiting"
     assert record.stage["afterany"] == "afterany:601:602"
     ws = state / "runs" / run_id / "ws"
     assert _git(ws, "for-each-ref", "refs/dispatch/").strip() != ""  # snapshot kept
+
+
+def test_resume_improved_pushes_and_opens_pr(tmp_path, monkeypatch) -> None:
+    # candidate beats baseline -> branch the sealed sha, fold in the ledger,
+    # push, open the PR against main; the record goes in-review.
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert outcome.outcome == "improved"
+    assert outcome.pr_url.endswith("/pull/1")
+    record = load_record(state, run_id)
+    assert record.state == "in-review" and "pull/1" in record.pr_url
+    # the PR opened against main from the run's branch, carrying the saved report
+    pr = github.prs[0]
+    assert pr["head"] == "feat/auto/agent-01/tsp-1" and pr["base"] == "main"
+    assert "swapped the construction heuristic" in pr["body"]
+    # the branch landed in the bare origin; the candidate snapshot was dropped
+    bare = tmp_path / "origin.git"
+    assert "feat/auto/agent-01/tsp-1" in _git(bare, "branch", "--list")
+    ws = state / "runs" / run_id / "ws"
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -8,11 +8,11 @@ from pathlib import Path
 
 import pytest
 
-from autoresearch.climb import _park_run, live_climb
+from autoresearch.climb import _park_run, live_climb, resume_run
 from autoresearch.dispatch import Snapshot
 from autoresearch.harness import SessionResult
 from autoresearch.orchestrator import ClimbConfig, ClimbParked
-from autoresearch.runstate import RunRecord, load_record
+from autoresearch.runstate import RunRecord, load_record, save_record
 
 CONTRACT = """\
 benchmarks:
@@ -1649,3 +1649,95 @@ def test_expensive_benchmark_without_coords_falls_back_inline(
     assert outcome.outcome == "improved"  # inline fallback measured it
     assert github.prs[0]["head"] == "feat/auto/agent-01/tsp-1"
     assert "wants dispatched eval" in caplog.text
+
+
+# --- resume_run: waking a parked candidate (slice 1b: re-park + negative end) ---
+
+
+class _FakeMeasurer:
+    """A measurer for the wake path: returns canned values by measure name, or
+    raises (e.g. MeasurementPending to force a re-park)."""
+
+    def __init__(self, values=None, raise_exc=None):
+        self.values = values or {}
+        self.raise_exc = raise_exc
+
+    def results(self, measures):
+        if self.raise_exc is not None:
+            raise self.raise_exc
+        return {m.name: self.values[m.name] for m in measures}
+
+
+def _write_parked_candidate(tmp_path, monkeypatch, *, values=None, raise_exc=None, run_id="tsp-1"):
+    """A candidate-parked run on disk: a ws with base+candidate commits and the
+    kept snapshot ref, plus a WAITING record carrying the re-entry stage. The
+    dispatched measurer is monkeypatched to a fake so no cluster is touched."""
+    from autoresearch.measure import DispatchSettings
+
+    state = tmp_path / "state"
+    ws = state / "runs" / run_id / "ws"
+    (ws / "src" / "pilot" / "solvers").mkdir(parents=True)
+    (ws / ".autoresearch.yaml").write_text(CONTRACT_DISPATCH)
+    (ws / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): ...\n")
+    _git(ws, "init", "-q", "-b", "main")
+    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
+    base_sha = _git(ws, "rev-parse", "HEAD").strip()
+    (ws / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): return 'better'\n")
+    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-aqm", "candidate")
+    candidate_sha = _git(ws, "rev-parse", "HEAD").strip()
+    _git(ws, "update-ref", "refs/dispatch/tok", candidate_sha)
+
+    record = RunRecord(
+        run_id=run_id,
+        target="org/pilot",
+        task_title="improve tsp",
+        benchmark="tsp",
+        state="waiting",
+        resume_session_id="s1",
+        stage={
+            "phase": "candidate",
+            "base_sha": base_sha,
+            "candidate_sha": candidate_sha,
+            "candidate_ref": "refs/dispatch/tok",
+            "seed": 7,
+            "suite_seed": 9,
+            "afterany": "afterany:501",
+            "report": "swapped the construction heuristic",
+        },
+    )
+    save_record(state, record, 1_000_000.0)
+    fake = _FakeMeasurer(values=values, raise_exc=raise_exc)
+    monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: fake)
+    return state, run_id
+
+
+def test_resume_negative_ends_run_and_drops_snapshot(tmp_path, monkeypatch) -> None:
+    # candidate did not beat baseline (min direction) -> honest negative: end
+    # the record and release the candidate snapshot.
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    outcome = resume_run(state, run_id, dispatch=_fake_dispatch(), now=1_000_100.0)
+    assert outcome.outcome == "no-improvement"
+    record = load_record(state, run_id)
+    assert record.state == "ended" and record.ending == "negative-result"
+    ws = state / "runs" / run_id / "ws"
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""  # snapshot dropped
+
+
+def test_resume_reparks_when_a_measure_is_pending(tmp_path, monkeypatch) -> None:
+    # a needed measure isn't done -> re-park on the new afterany, KEEP the
+    # candidate snapshot for the next wake.
+    from autoresearch.measure import MeasurementPending
+
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, raise_exc=MeasurementPending(("601", "602"))
+    )
+    outcome = resume_run(state, run_id, dispatch=_fake_dispatch(), now=1_000_100.0)
+    assert outcome.outcome == "parked"
+    record = load_record(state, run_id)
+    assert record.state == "waiting"
+    assert record.stage["afterany"] == "afterany:601:602"
+    ws = state / "runs" / run_id / "ws"
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() != ""  # snapshot kept

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1701,28 +1701,40 @@ class _FakeMeasurer:
 
 
 def _write_parked_candidate(tmp_path, monkeypatch, *, values=None, raise_exc=None, run_id="tsp-1"):
-    """A candidate-parked run on disk: a ws with base+candidate commits and the
-    kept snapshot ref, plus a WAITING record carrying the re-entry stage. The
-    dispatched measurer is monkeypatched to a fake so no cluster is touched."""
+    """A candidate-parked run on disk in the REAL park state: HEAD is still the
+    pre-session commit, the session's edits are UNCOMMITTED in the working tree,
+    there is untracked cruft an eval left behind, and `candidate_sha` is a
+    snapshot commit (via `snapshot_tree`, off any branch) kept alive by its ref.
+    Plus a WAITING record with the re-entry stage. The dispatched measurer is
+    monkeypatched to a fake so no cluster is touched."""
+    from autoresearch.dispatch import snapshot_tree
+    from autoresearch.github import Workspace
     from autoresearch.measure import DispatchSettings
 
     state = tmp_path / "state"
-    ws = state / "runs" / run_id / "ws"
-    (ws / "src" / "pilot" / "solvers").mkdir(parents=True)
-    (ws / ".autoresearch.yaml").write_text(CONTRACT_DISPATCH)
-    (ws / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): ...\n")
-    _git(ws, "init", "-q", "-b", "main")
-    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
-    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
-    base_sha = _git(ws, "rev-parse", "HEAD").strip()
-    (ws / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): return 'better'\n")
-    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-aqm", "candidate")
-    candidate_sha = _git(ws, "rev-parse", "HEAD").strip()
-    _git(ws, "update-ref", "refs/dispatch/tok", candidate_sha)
-    # a bare 'origin' so an improved wake can push its branch
-    bare = tmp_path / "origin.git"
-    _git(tmp_path, "clone", "-q", "--bare", str(ws), str(bare))
-    _git(ws, "remote", "add", "origin", str(bare))
+    wsroot = state / "runs" / run_id / "ws"
+    (wsroot / "src" / "pilot" / "solvers").mkdir(parents=True)
+    (wsroot / ".autoresearch.yaml").write_text(CONTRACT_DISPATCH)
+    (wsroot / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): ...\n")
+    _git(wsroot, "init", "-q", "-b", "main")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
+    base_sha = _git(wsroot, "rev-parse", "HEAD").strip()
+    # the session's edit, left UNCOMMITTED (HEAD stays at base) — the snapshot
+    # captures it into candidate_sha.
+    (wsroot / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): return 'better'\n")
+    ws = Workspace(root=wsroot)
+    snap = snapshot_tree(ws, base_sha)  # candidate_sha, retained under its ref
+    # cruft that appears AFTER the snapshot (a dispatched eval / session
+    # leftover): it is in the wake's working tree but NOT in candidate_sha, so
+    # the finish's force-checkout keeps it around and the ledger-only commit
+    # must NOT sweep it into the PR.
+    (wsroot / "eval-cache.tmp").write_text("junk an eval left behind\n")
+    candidate_sha = snap.commit
+    # a bare 'origin' (unique per run) so an improved wake can push its branch
+    bare = tmp_path / f"origin-{run_id}.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(wsroot), str(bare))
+    _git(wsroot, "remote", "add", "origin", str(bare))
 
     record = RunRecord(
         run_id=run_id,
@@ -1735,7 +1747,7 @@ def _write_parked_candidate(tmp_path, monkeypatch, *, values=None, raise_exc=Non
             "phase": "candidate",
             "base_sha": base_sha,
             "candidate_sha": candidate_sha,
-            "candidate_ref": "refs/dispatch/tok",
+            "candidate_ref": snap.ref,
             "seed": 7,
             "suite_seed": 9,
             "afterany": "afterany:501",
@@ -1817,7 +1829,56 @@ def test_resume_improved_pushes_and_opens_pr(tmp_path, monkeypatch) -> None:
     assert pr["head"] == "feat/auto/agent-01/tsp-1" and pr["base"] == "main"
     assert "swapped the construction heuristic" in pr["body"]
     # the branch landed in the bare origin; the candidate snapshot was dropped
-    bare = tmp_path / "origin.git"
+    bare = tmp_path / "origin-tsp-1.git"
     assert "feat/auto/agent-01/tsp-1" in _git(bare, "branch", "--list")
     ws = state / "runs" / run_id / "ws"
     assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""
+    # the pushed tree carries the sealed candidate edit + the two ledger files,
+    # and NOT the untracked eval cruft the session left in the workspace
+    files = set(_git(bare, "ls-tree", "-r", "--name-only", "feat/auto/agent-01/tsp-1").split())
+    assert "src/pilot/solvers/tsp.py" in files
+    assert {"BENCHMARKS.md", "results/leader.json"} <= files
+    assert "eval-cache.tmp" not in files
+    assert "def solve(): return 'better'" in _git(
+        bare, "show", "feat/auto/agent-01/tsp-1:src/pilot/solvers/tsp.py"
+    )
+    # no verification panel ran on the wake, so auto-merge is never armed
+    assert github.armed == []
+
+
+def test_resume_blind_repark_keeps_wake_attempts_but_progress_resets(tmp_path, monkeypatch):
+    # a no-progress re-park (blind: empty afterany) must KEEP wake_attempts so
+    # the stuck cap still bites; a productive re-park (a NEW job set) resets it.
+    import dataclasses
+
+    from autoresearch.measure import MeasurementPending
+
+    # blind re-park: MeasurementPending(()) -> empty afterany -> no progress
+    state, run_id = _write_parked_candidate(tmp_path, monkeypatch, raise_exc=MeasurementPending(()))
+    rec = dataclasses.replace(load_record(state, run_id), wake_attempts=2)
+    save_record(state, rec, 1_000_050.0)
+    resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert load_record(state, run_id).wake_attempts == 2  # kept, cap still counts
+
+    # productive re-park: a NEW afterany (old was afterany:501) -> progress
+    state2, rid2 = _write_parked_candidate(
+        tmp_path, monkeypatch, raise_exc=MeasurementPending(("601", "602")), run_id="tsp-2"
+    )
+    rec2 = dataclasses.replace(load_record(state2, rid2), wake_attempts=2)
+    save_record(state2, rec2, 1_000_050.0)
+    resume_run(
+        state2,
+        rid2,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert load_record(state2, rid2).wake_attempts == 0  # reset on progress

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1598,10 +1598,10 @@ def test_moved_base_gets_a_fresh_panel_read_and_blocking_drafts(tmp_path, target
     assert github.armed == []
 
 
-def test_expensive_benchmark_dispatches_baseline_and_parks(tmp_path, target_repo_dispatch) -> None:
-    # eval_minutes=30 is past the in-job runway, so the baseline measures as a
-    # dispatched job BEFORE the session — the climb parks (PARK 1) instead of
-    # running the harness.
+def test_expensive_benchmark_runs_session_then_parks_candidate(tmp_path, target_repo_dispatch):
+    # eval_minutes=30 is past the in-job runway. There is NO pre-session baseline
+    # park: the session runs, then the gate dispatches baseline+candidate
+    # together and the climb parks the CANDIDATE.
     outcome, github = run_live(
         tmp_path,
         target_repo_dispatch,
@@ -1610,17 +1610,17 @@ def test_expensive_benchmark_dispatches_baseline_and_parks(tmp_path, target_repo
         dispatch=_fake_dispatch(),
     )
     assert outcome.outcome == "parked"
-    assert github.prs == []  # session never ran; no PR
+    assert github.prs == []  # not decided yet; no PR
     record = load_record(tmp_path / "state", "tsp-1")
     assert record.state == "waiting"
-    # PARK 1 is the baseline (no candidate yet); the afterany carries the one
-    # submitted eval job the wake depends on.
-    assert record.stage["phase"] == "baseline"
-    assert record.stage["afterany"] == "afterany:1000"
-    assert record.experiment_job_id == "1000"  # single-job park: the sweep polls it
-    # the dispatched backend checks out each sha in its own job, so no local
-    # baseline worktree was ever created
-    assert not (tmp_path / "state" / "runs" / "tsp-1" / "measure-baseline").exists()
+    # the only park is the candidate; baseline+candidate dispatched together, so
+    # the afterany carries BOTH jobs and the run rides the multi-job deadline
+    assert record.stage["phase"] == "candidate"
+    assert record.stage["candidate_sha"]  # a real snapshot was taken
+    assert record.stage["afterany"] == "afterany:1000:1001"
+    assert record.experiment_job_id == ""  # multi-job park: rides the deadline floor
+    # the session ran and its write-up was saved for the wake
+    assert record.stage["report"]
 
 
 def test_cheap_benchmark_ignores_dispatch_and_measures_inline(tmp_path, target_repo) -> None:
@@ -1640,9 +1640,9 @@ def test_cheap_benchmark_ignores_dispatch_and_measures_inline(tmp_path, target_r
 def test_failed_park_write_cancels_orphaned_eval_jobs(
     tmp_path, target_repo_dispatch, monkeypatch
 ) -> None:
-    # the baseline dispatched one job; if the WAITING record then fails to
-    # write, nothing will ever wake that job, so it must be cancelled rather
-    # than left orphaned in the queue.
+    # the candidate park dispatched baseline+candidate (two jobs); if the
+    # WAITING record then fails to write, nothing will ever wake those jobs, so
+    # BOTH must be cancelled rather than left orphaned in the queue.
     from autoresearch import climb as climb_mod
 
     cancelled: list[str] = []
@@ -1660,7 +1660,7 @@ def test_failed_park_write_cancels_orphaned_eval_jobs(
         dispatch=dispatch,
     )
     assert outcome.outcome == "climb-error"  # the failed park ends the run
-    assert cancelled == ["1000"]  # the one dispatched baseline job was cancelled
+    assert cancelled == ["1000", "1001"]  # both dispatched jobs were cancelled
 
 
 def test_expensive_benchmark_without_coords_falls_back_inline(

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1657,6 +1657,9 @@ def _write_parked_candidate(tmp_path, monkeypatch, *, values=None, raise_exc=Non
     save_record(state, record, 1_000_000.0)
     fake = _FakeMeasurer(values=values, raise_exc=raise_exc)
     monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: fake)
+    # the wake pushes to the canonical target URL (never the ws git config);
+    # point that at this run's local bare so the improved-wake test can push.
+    monkeypatch.setattr("autoresearch.climb._target_clone_url", lambda target: str(bare))
     return state, run_id
 
 
@@ -1782,3 +1785,25 @@ def test_resume_blind_repark_keeps_wake_attempts_but_progress_resets(tmp_path, m
         now=1_000_100.0,
     )
     assert load_record(state2, rid2).wake_attempts == 0  # reset on progress
+
+
+def test_resume_reads_contract_from_base_not_the_dirty_tree(tmp_path, monkeypatch) -> None:
+    # a session could rewrite .autoresearch.yaml in the working tree to widen
+    # its own scope; the wake must gate on the BASE commit's contract, not the
+    # dirty tree. Corrupt the working-tree contract: if the wake read it, it
+    # would crash; reading base, it still succeeds.
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    (state / "runs" / run_id / "ws" / ".autoresearch.yaml").write_text("}{ not valid yaml :\n")
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert outcome.outcome == "improved"  # base's contract was used, not the corrupt tree
+    assert github.prs and github.prs[0]["base"] == "main"

--- a/tests/test_measure_and_decide.py
+++ b/tests/test_measure_and_decide.py
@@ -9,10 +9,12 @@ import pytest
 from autoresearch.contract import load_contract
 from autoresearch.measure import Measure, MeasurementPending
 from autoresearch.orchestrator import (
+    ClimbParked,
     EvalError,
     MeasureOK,
     _benchmark,
     measure_and_decide,
+    resume_climb,
 )
 
 # main benchmark + one sibling; a `shared` scope path drives the suite gate.
@@ -253,3 +255,64 @@ def test_empty_shared_scope_does_not_require_suite_seed():
     m = FakeMeasurer({"baseline": 0.50, "candidate": 0.60})
     out = _decide(m, measured_paths=("src/model.py",), suite_seed=0, text=CONTRACT_NO_SHARED)
     assert isinstance(out, MeasureOK)
+
+
+# --- resume_climb: the wake side, re-entering the decision without a session ---
+
+REPORT = "swapped the construction heuristic; tours shortened."
+
+
+def _resume(measurer, measured_paths=("src/model.py",), seed=7, suite_seed=99, text=CONTRACT):
+    contract = load_contract(text, "x/y")
+    return resume_climb(
+        contract,
+        _benchmark(contract, "main"),
+        base_sha=BASE,
+        candidate_sha=CAND,
+        seed=seed,
+        suite_seed=suite_seed,
+        measured_paths=measured_paths,
+        report=REPORT,
+        resume_session_id="s-woke",
+        measurer=measurer,
+        min_relative_improvement=0.005,
+    )
+
+
+def test_resume_improved_carries_the_saved_report():
+    out = _resume(FakeMeasurer({"baseline": 0.50, "candidate": 0.60}))
+    assert out.outcome == "improved"
+    assert out.baseline == 0.50 and out.candidate == 0.60
+    # the session never re-runs: it is rebuilt from the saved write-up + its id
+    assert out.session is not None
+    assert out.session.final_text == REPORT
+    assert out.session.session_id == "s-woke"
+    assert out.session.num_turns == 0  # a wake ran no turns
+    assert out.measured_paths == ("src/model.py",) and out.run_seed == 7
+
+
+def test_resume_no_improvement_is_terminal_with_the_report():
+    out = _resume(FakeMeasurer({"baseline": 0.50, "candidate": 0.50}))
+    assert out.outcome == "no-improvement"
+    assert out.session is not None and out.session.final_text == REPORT
+
+
+def test_resume_reparks_when_a_measure_is_not_done():
+    # a measure this wake needs isn't finished (its eval still queued) -> re-park
+    # on the new afterany set, same shape as the first candidate park, carrying
+    # the reconstructed session so a later wake still has the write-up.
+    m = FakeMeasurer(raise_exc=MeasurementPending(("501", "502")))
+    with pytest.raises(ClimbParked) as excinfo:
+        _resume(m)
+    parked = excinfo.value
+    assert parked.phase == "candidate"
+    assert parked.candidate_sha == CAND
+    assert parked.afterany == "afterany:501:502"
+    assert parked.seed == 7 and parked.suite_seed == 99
+    assert parked.session is not None and parked.session.final_text == REPORT
+
+
+def test_resume_eval_error_is_terminal():
+    out = _resume(FakeMeasurer(raise_exc=EvalError("candidate: no readable r2")))
+    assert out.outcome == "eval-error"
+    assert "no readable r2" in out.note

--- a/tests/test_measure_and_decide.py
+++ b/tests/test_measure_and_decide.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import pytest
 
 from autoresearch.contract import load_contract
+from autoresearch.harness import SessionResult
 from autoresearch.measure import Measure, MeasurementPending
 from autoresearch.orchestrator import (
     ClimbParked,
@@ -262,6 +263,18 @@ def test_empty_shared_scope_does_not_require_suite_seed():
 REPORT = "swapped the construction heuristic; tours shortened."
 
 
+def _woke_session():
+    return SessionResult(
+        stop_reason="resumed",
+        is_error=False,
+        cost_usd=0.0,
+        num_turns=0,
+        session_id="s-woke",
+        final_text=REPORT,
+        transcript_path="",
+    )
+
+
 def _resume(measurer, measured_paths=("src/model.py",), seed=7, suite_seed=99, text=CONTRACT):
     contract = load_contract(text, "x/y")
     return resume_climb(
@@ -272,8 +285,7 @@ def _resume(measurer, measured_paths=("src/model.py",), seed=7, suite_seed=99, t
         seed=seed,
         suite_seed=suite_seed,
         measured_paths=measured_paths,
-        report=REPORT,
-        resume_session_id="s-woke",
+        session=_woke_session(),
         measurer=measurer,
         min_relative_improvement=0.005,
     )
@@ -295,6 +307,9 @@ def test_resume_no_improvement_is_terminal_with_the_report():
     out = _resume(FakeMeasurer({"baseline": 0.50, "candidate": 0.50}))
     assert out.outcome == "no-improvement"
     assert out.session is not None and out.session.final_text == REPORT
+    # the wake gives a bare negative the same framing the in-job path sets,
+    # so a resumed negative never ends note-less
+    assert out.note == "a negative result reported clearly is a success"
 
 
 def test_resume_reparks_when_a_measure_is_not_done():

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -105,21 +105,32 @@ def run_climb(tmp_path, values, session=None, config=CONFIG, changed=None, **kw)
 
 
 def test_improvement_end_to_end(tmp_path: Path) -> None:
-    result, harness, evaluator = run_climb(tmp_path, [13.876, 13.10])
+    # brief_baseline is the ledger's last-known score, for the brief; the gate
+    # re-measures both sides ([13.876, 13.10]) after the session.
+    result, harness, evaluator = run_climb(tmp_path, [13.876, 13.10], brief_baseline=13.876)
     assert result.outcome == "improved"
-    assert result.baseline == 13.876
+    assert result.baseline == 13.876  # measured by the gate
     assert result.candidate == 13.10
     assert result.branch == "feat/auto/agent-01/tsp"
-    # the brief carried the real baseline and the contract verbatim
+    # the brief carried the ledger baseline and the contract verbatim
     brief_text = harness.calls[0][0]
     assert "13.876" in brief_text
     assert "mean_tour_length down from 13.876" in brief_text
     assert "src/pilot/solvers/" in brief_text
-    # eval ran twice with the contract's command
+    # eval ran twice (baseline + candidate) with the contract's command
     assert (
         evaluator.calls
         == [("uv run python -m pilot.eval --benchmark tsp --json", "mean_tour_length")] * 2
     )
+
+
+def test_first_run_brief_has_no_baseline_number(tmp_path: Path) -> None:
+    # a benchmark's first climb has no ledger entry -> the brief drops the
+    # reference number (never the gate, which still measures both sides).
+    result, harness, _ = run_climb(tmp_path, [13.876, 13.10])  # brief_baseline defaults None
+    assert result.outcome == "improved" and result.baseline == 13.876
+    brief_text = harness.calls[0][0]
+    assert "mean_tour_length down" in brief_text and "down from" not in brief_text
 
 
 def test_direction_min_regression_is_no_improvement(tmp_path: Path) -> None:
@@ -232,36 +243,14 @@ def _bare_snapshot():
     return snapshot
 
 
-def test_baseline_measure_parks_before_the_session(tmp_path: Path) -> None:
-    # PARK 1: a dispatched baseline hibernates before the session even runs.
-    from autoresearch.orchestrator import ClimbParked
-
-    harness = FakeHarness(result=ok_session())
-    m = ParkingMeasurer(park_on_call=1)  # baseline is the first measure
-    with pytest.raises(ClimbParked) as exc:
-        climb_once(
-            CONFIG,
-            CONTRACT,
-            tmp_path,
-            harness,
-            m,
-            "base",
-            _bare_snapshot(),
-            ruler="r",
-            changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
-            created="t",
-        )
-    assert exc.value.phase == "baseline" and exc.value.base_sha == "base"
-    assert exc.value.afterany == "afterany:101:102"
-    assert harness.calls == []  # the session never started
-
-
 def test_candidate_measure_parks_after_the_session(tmp_path: Path) -> None:
-    # PARK 2: baseline read, session ran, candidate dispatched -> hibernate.
+    # The ONLY park: the session runs (no pre-session baseline), then the gate
+    # dispatches baseline+candidate together and hibernates. A dispatched climb
+    # never has a baseline park.
     from autoresearch.orchestrator import ClimbParked
 
     harness = FakeHarness(result=ok_session())
-    m = ParkingMeasurer(park_on_call=2, values={"baseline": 13.876})
+    m = ParkingMeasurer(park_on_call=1)  # the gate's first (baseline+candidate) call parks
     with pytest.raises(ClimbParked) as exc:
         climb_once(
             CONFIG,
@@ -281,7 +270,9 @@ def test_candidate_measure_parks_after_the_session(tmp_path: Path) -> None:
     assert harness.calls  # the session did start
 
 
-def test_session_error_short_circuits_before_second_eval(tmp_path: Path) -> None:
+def test_session_error_runs_no_eval(tmp_path: Path) -> None:
+    # nothing is measured before the session, so a session error measures
+    # nothing at all (the gate, which measures baseline+candidate, never runs).
     bad = SessionResult(
         stop_reason="spawn-error",
         is_error=True,
@@ -293,8 +284,8 @@ def test_session_error_short_circuits_before_second_eval(tmp_path: Path) -> None
     )
     result, _, evaluator = run_climb(tmp_path, [13.876, 999.0], session=bad)
     assert result.outcome == "session-error"
-    assert len(evaluator.calls) == 1  # baseline only
-    assert result.baseline == 13.876
+    assert evaluator.calls == []  # no measurement without a candidate
+    assert result.baseline is None
 
 
 def test_exhausted_session_is_a_budget_ending_not_an_error(tmp_path: Path) -> None:
@@ -317,12 +308,6 @@ def test_exhausted_session_is_a_budget_ending_not_an_error(tmp_path: Path) -> No
         result, _, _evaluator = run_climb(tmp_path, [13.876, 999.0], session=dry)
         assert result.outcome == "session-budget"
         assert result.note == detail
-
-
-def test_baseline_eval_failure_never_starts_a_session(tmp_path: Path) -> None:
-    result, harness, _ = run_climb(tmp_path, [EvalError("boom")])
-    assert result.outcome == "eval-error"
-    assert harness.calls == []  # no session was paid for
 
 
 def test_candidate_eval_failure_is_eval_error_with_session(tmp_path: Path) -> None:
@@ -404,7 +389,7 @@ def test_scope_violation_blocks_before_candidate_eval(tmp_path: Path) -> None:
     )
     assert result.outcome == "scope-violation"
     assert "src/pilot/eval.py" in result.note
-    assert len(evaluator.calls) == 1  # baseline only; doctored tree unmeasured
+    assert evaluator.calls == []  # scope checked before any measure; nothing ran
 
 
 def test_forbidden_paths_are_scope_violations(tmp_path: Path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1838,3 +1838,48 @@ roadmap: docs/roadmap.md
     assert out2 is not None
     assert f"--time={MAX_CLIMB_JOB_MINUTES}" in submitted2[0]
     assert f"--job-minutes {MAX_CLIMB_JOB_MINUTES}" in submitted2[0]
+
+
+def test_job_wake_dispatcher_submits_a_resume_job_after_the_eval_jobs(tmp_path, monkeypatch):
+    # the production WakeDispatcher: a wake becomes a Slurm job that runs the
+    # wake CLI (`climb --resume <run_id>`), depending on the eval jobs so it
+    # fires when they finish.
+    from autoresearch.runstate import RunRecord
+    from autoresearch.tick import FollowupSpec, JobWakeDispatcher
+
+    submits = []
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            submits.append(list(argv))
+            return CommandResult(0, "9001\n", "")
+        raise AssertionError(argv)
+
+    compute = SlurmCompute(runner=runner)
+    spec = FollowupSpec(
+        account="acct",
+        partition="cpu_short",
+        run_root=tmp_path,
+        image="/img/a.sif",
+        home=tmp_path,
+        pat_file="/pat",
+    )
+    # isolate the dispatcher's job spec from flight_checkout's git dependency
+    monkeypatch.setattr(
+        "autoresearch.tick._flight_command", lambda home, name, now, argv: " ".join(argv)
+    )
+    record = RunRecord(
+        run_id="tsp-1",
+        target="org/pilot",
+        task_title="improve tsp",
+        benchmark="tsp",
+        state="waiting",
+        stage={"afterany": "afterany:501:502"},
+    )
+    job_id = JobWakeDispatcher(compute, spec, now=NOW).dispatch(record, "eval done")
+    assert job_id == "9001"  # async: the wake job now owns the lease
+    argv = submits[0]
+    joined = " ".join(argv)
+    assert "autoresearch.climb" in joined and "--resume tsp-1" in joined
+    assert "--dependency=afterany:501:502" in argv  # runs after the eval jobs
+    assert "--account=acct" in argv and "--partition=cpu_short" in argv

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1883,3 +1883,33 @@ def test_job_wake_dispatcher_submits_a_resume_job_after_the_eval_jobs(tmp_path, 
     assert "autoresearch.climb" in joined and "--resume tsp-1" in joined
     assert "--dependency=afterany:501:502" in argv  # runs after the eval jobs
     assert "--account=acct" in argv and "--partition=cpu_short" in argv
+
+
+def test_wake_dispatcher_on_switch_lands_dark_by_default(tmp_path, monkeypatch):
+    # dispatched climbing must NOT deliver wakes unless the operator flips the
+    # explicit on-switch AND the chain env is complete.
+    from autoresearch.tick import (
+        FollowupSpec,
+        JobWakeDispatcher,
+        LoggingDispatcher,
+        _wake_dispatcher_from_env,
+    )
+
+    compute = SlurmCompute(runner=lambda argv, t: CommandResult(0, "", ""))
+    spec = FollowupSpec(
+        account="a", partition="p", run_root=tmp_path, image="/i.sif", home=tmp_path
+    )
+
+    # default: no on-switch -> dry sweep, logging dispatcher
+    monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
+    dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW)
+    assert isinstance(dispatcher, LoggingDispatcher) and live is False
+
+    # on-switch + complete env -> live sweep, real dispatcher
+    monkeypatch.setenv("AUTORESEARCH_DISPATCH_WAKE", "1")
+    dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW)
+    assert isinstance(dispatcher, JobWakeDispatcher) and live is True
+
+    # on-switch but incomplete env -> fail SAFE to dry, not a wake that can't run
+    dispatcher, live = _wake_dispatcher_from_env(compute, None, NOW)
+    assert isinstance(dispatcher, LoggingDispatcher) and live is False


### PR DESCRIPTION
**Stacked on #108** (`base: feat/dispatch-select`) so this diff is *just* the wake. Lands as a unit with #108: both merge before dispatch is ever activated (yolo stays paused, no benchmark declares `eval_minutes>5` until then), which resolves #108's blocking slot-wedge finding — a park now has a consumer.

Dispatcher phase 1, stage B part 2c, **slice 1**: the "wake up and finish" core, built agent-first per `docs/design/research-loop.md` (carried on this branch).

## What

- **Save the report on pause** — a candidate park now stores the session's write-up in the WAITING `stage` (`report`). A wake reads it back to build the PR body / panel claim, so the session never re-runs (its edits are already in `candidate_sha`).
- **`resume_climb`** — the wake-side re-entry, as a pure tested function (mirrors how `measure_and_decide` landed before wiring). Re-runs the post-session decision over the committed shas the record persisted; reads the cached eval results and returns the verdict, or — a needed measure isn't done (the suite pairs an improving candidate dispatches, "another round of experiments") — **re-parks** by raising `ClimbParked`, same shape as the first pass. The session is rebuilt from the saved report (id + text, zero turns), never re-run.

Built so "wake the **grader**" (this slice) and "wake the **agent** with the result" (the depth axis in `research-loop.md`) are the *same* seam — turning up depth later is a knob, not a rewrite.

## Tests

resume returns improved carrying the saved report; no-improvement / eval-error terminal; a not-done measure re-parks on the new afterany set. Full gate green, 652 tests.

## Next slices

1b — the wake-entry CLI + terminal PR-open (shared with `live_climb`); 2 — the `WakeDispatcher` + flipping the tick's dry-run WOULD-WAKE stub + multi-job cancel reachability; 3 — panel-on-resume, baseline-park resume, and the first turn of the depth dial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
