### PR TITLE
Panel-on-wake slice 1: verify dispatched improvements before publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Panel-on-wake, slice 1 — a dispatched improvement now runs the SAME pre-PR
+  verification panel as an inline climb (docs/design/orchestrator-verify.md), so
+  it is not published unverified. `resume_run` runs the read-only lenses over
+  `base_sha` vs the sealed `candidate_sha` (checked out first, so the panel
+  judges exactly what was measured — the dispatched evals ran on node-local
+  scratch, so the tree is unchanged); a blocking or degraded verdict opens a
+  DRAFT PR carrying the findings and never arms auto-merge, a clean verdict (or
+  no panel) arms only where branch protection requires a review — same policy as
+  the inline path. The `--resume` CLI and `JobWakeDispatcher` forward
+  `--panel`/`--panel-key-file` (via the shared `_panel_lenses_from_args` and
+  `_climb_panel_argv`), and `build_panel_runner`/lens-building are now shared by
+  both paths. Slice 2 — WAKING the agent to REVISE on a blocking finding (the
+  first depth-axis build, docs/design/research-loop.md) — is next; for now a
+  human triages the draft.
+
 ### Changed
 
 - We credit **beating your own baseline**, not only beating the recorded best

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -308,6 +308,7 @@ def resume_run(
     now: float,
     secrets: tuple[str, ...] = (),
     base_branch: str = "main",
+    panel_lenses: tuple[PanelLens, ...] = (),
 ) -> LiveClimbOutcome:
     """Wake a parked dispatched climb and re-enter its decision WITHOUT the
     session (`orchestrator.resume_climb`), from the record `_park_run` wrote.
@@ -357,7 +358,8 @@ def resume_run(
     # BASE commit (the tree the run started on), NOT the working tree the
     # session left dirty — a session that widened its own scope in
     # `.autoresearch.yaml` must not have the wake gate on the doctored rules.
-    contract = load_contract(ws.git("show", f"{base_sha}:.autoresearch.yaml"), record.target)
+    contract_text = ws.git("show", f"{base_sha}:.autoresearch.yaml")
+    contract = load_contract(contract_text, record.target)
     bench = _benchmark(contract, record.benchmark)
     config = ClimbConfig(target=record.target, benchmark=record.benchmark, agent_id=record.agent_id)
     eval_minutes = next(
@@ -441,6 +443,10 @@ def resume_run(
             )
             _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
             return LiveClimbOutcome(run_id=run_id, outcome="no-improvement")
+
+        from datetime import UTC as _UTC
+        from datetime import datetime as _dt
+
         branch = f"{config.branch_prefix}/{run_id}"
         try:
             # FORCE-checkout the sealed candidate: at wake the workspace still
@@ -448,6 +454,37 @@ def resume_run(
             # plain checkout could be blocked; the sha already captured exactly
             # the measured content.
             ws.git("checkout", "-f", "-B", branch, candidate_sha)
+
+            # Verification panel on the credited claim — the SAME gate the
+            # inline path runs (docs/design/orchestrator-verify.md), so a
+            # dispatched improvement is not published unverified. It reads the
+            # workspace tree, now checked out to the SEALED candidate_sha (the
+            # dispatched evals ran on node-local scratch, so the tree is exactly
+            # what was measured), over base_sha. Slice 1: a blocking or degraded
+            # verdict opens a DRAFT PR carrying the findings and never arms
+            # auto-merge; a clean verdict (or no panel) arms. Waking the agent
+            # to REVISE on a blocking finding — the depth axis — is the next
+            # slice; for now a human triages the draft.
+            if panel_lenses:
+                verdict = build_panel_runner(
+                    ws,
+                    run_dir,
+                    base_sha,
+                    panel_lenses,
+                    contract_text,
+                    config.target,
+                    config.benchmark,
+                    config.bot_login,
+                    _dt.fromtimestamp(now, _UTC).strftime("%Y-%m-%d"),
+                )(baseline, candidate, str(stage.get("report", "")))
+                result = dc_replace(
+                    result,
+                    panel_transcript=verdict.transcript,
+                    panel_rounds=1,
+                    panel_blocking_open=bool(verdict.blocking),
+                    panel_degraded=verdict.degraded,
+                )
+
             entries = update_leader(
                 load_leader(workspace),
                 benchmark=bench.name,
@@ -497,18 +534,29 @@ def resume_run(
             )
             if issue_number:
                 body = f"Addresses #{issue_number}.\n\n{body}"
+            # blocking findings still open at the panel, or a degraded final
+            # read, mean a human must look: open a DRAFT and never arm. A clean
+            # verdict (or no panel configured) opens non-draft and arms
+            # auto-merge only where branch protection requires a review — same
+            # policy as the inline path.
+            draft = result.panel_blocking_open or result.panel_degraded
             pr_url = github.create_pull(
                 config.target,
                 title=f"[agent] {config.benchmark}: {_title_pair(baseline, candidate)}",
                 head=branch,
                 base=base_branch,
                 body=body,
-                # the wake runs NO verification panel yet (panel-on-wake is a
-                # later slice), so the PR is never auto-merge-armed — a human
-                # reviews every dispatched improvement. Open non-draft; it is a
-                # real, measured improvement, just not panel-certified.
-                draft=False,
+                draft=draft,
             )
+            pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
+            if pr_number.isdigit() and not draft:
+                _best_effort(
+                    "auto-merge arming",
+                    lambda: github.arm_auto_merge_when_review_required(
+                        config.target, int(pr_number)
+                    ),
+                    secrets,
+                )
         except Exception as exc:
             # push / PR / commit failed — end as an error. Save the ENDED record
             # BEFORE dropping the snapshot (same ordering as the other terminals):
@@ -638,6 +686,39 @@ def _measure_committed(
             # directory itself first
             _best_effort("worktree dir removal", lambda: shutil.rmtree(wt, ignore_errors=True))
             _best_effort("worktree prune", lambda: ws.git("worktree", "prune"))
+
+
+def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
+    """Build the verification-panel lenses from the CLI args (empty `--panel`
+    disables it). Shared by the fresh-climb and the `--resume` wake paths so a
+    dispatched improvement runs the SAME panel as an inline one. Raises
+    ValueError on a bad panel/backend config — a configured gate must never
+    silently vanish."""
+    import os
+
+    if not args.panel.strip():
+        return ()
+    from autoresearch.panel import parse_lenses
+    from autoresearch.review_agent import build_reviewer_harness
+
+    panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+    lenses = []
+    for kind, backend, model in parse_lenses(args.panel):
+        hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
+        try:
+            judge = build_reviewer_harness(
+                panel_key,
+                backend=backend,
+                binary=args.claude_bin if backend == "claude" else None,
+                model=model or None,
+                container_image=args.image if backend == "claude" else "",
+                hermes_repo=Path(hermes_repo_env) if hermes_repo_env else None,
+                provider=os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter"),
+            )
+        except ValueError as exc:
+            raise ValueError(f"panel entry {kind}:{backend}: {exc}") from exc
+        lenses.append(PanelLens(kind=kind, harness=judge))
+    return tuple(lenses)
 
 
 def build_editor_harness(
@@ -1637,6 +1718,17 @@ def main() -> int:
         from autoresearch.compute import SlurmCompute
         from autoresearch.runstate import release_lease
 
+        # the wake runs the SAME verification panel as a fresh climb, so a
+        # dispatched improvement is not published unverified.
+        try:
+            wake_lenses = _panel_lenses_from_args(args)
+        except ValueError as exc:
+            parser.error(str(exc))
+        wake_panel_key = (
+            FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+            if args.panel.strip()
+            else ""
+        )
         try:
             resumed = resume_run(
                 args.run_root,
@@ -1650,8 +1742,9 @@ def main() -> int:
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,
                 now=time.time(),
-                secrets=(bot_auth.token(),),
+                secrets=tuple(k for k in (bot_auth.token(), wake_panel_key) if k),
                 base_branch=args.base_branch,
+                panel_lenses=wake_lenses,
             )
         finally:
             # This wake job HOLDS the run's lease (the sweep transferred it on
@@ -1706,37 +1799,17 @@ def main() -> int:
 
     # Pre-PR panel lenses: judge sessions on the verifier's own key (separate
     # identity from the author). kind[:backend[:model]]; claude by default.
-    panel_lenses: tuple[PanelLens, ...] = ()
-    panel_key = ""
-    if args.panel.strip():
-        from autoresearch.panel import parse_lenses
-        from autoresearch.review_agent import build_reviewer_harness
-
-        panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
-        try:
-            # grammar + claude-only rule live in parse_lenses (one owner,
-            # shared with the tick's pre-claim preflight): a typo'd kind or
-            # backend must never silently disable a gate
-            entries = parse_lenses(args.panel)
-        except ValueError as exc:
-            parser.error(str(exc))
-        lenses = []
-        for kind, backend, model in entries:
-            hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
-            try:
-                judge = build_reviewer_harness(
-                    panel_key,
-                    backend=backend,
-                    binary=args.claude_bin if backend == "claude" else None,
-                    model=model or None,
-                    container_image=args.image if backend == "claude" else "",
-                    hermes_repo=Path(hermes_repo_env) if hermes_repo_env else None,
-                    provider=os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter"),
-                )
-            except ValueError as exc:
-                parser.error(f"panel entry {kind}:{backend}: {exc}")
-            lenses.append(PanelLens(kind=kind, harness=judge))
-        panel_lenses = tuple(lenses)
+    try:
+        panel_lenses = _panel_lenses_from_args(args)
+    except ValueError as exc:
+        parser.error(str(exc))
+    # the panel key joins the redaction set: judge error text can echo request
+    # material like any other model error.
+    panel_key = (
+        FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+        if args.panel.strip()
+        else ""
+    )
 
     # Dispatched measurement needs the full cluster triple AND a real image
     # file to bind against; missing any, the climb measures inline (the tick

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -454,6 +454,12 @@ def resume_run(
             # plain checkout could be blocked; the sha already captured exactly
             # the measured content.
             ws.git("checkout", "-f", "-B", branch, candidate_sha)
+            # `checkout -f` does NOT remove untracked files, and the panel's
+            # `git add -A` (in build_panel_runner) would sweep any post-snapshot
+            # cruft into the tree it judges. Clean untracked (non-ignored) files
+            # so the panel reads EXACTLY candidate_sha. The ledger commit stages
+            # only PROGRESS_PATHS, so it was never affected.
+            ws.git("clean", "-fd")
 
             # Verification panel on the credited claim — the SAME gate the
             # inline path runs (docs/design/orchestrator-verify.md), so a

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -472,24 +472,42 @@ def resume_run(
             # to REVISE on a blocking finding — the depth axis — is the next
             # slice; for now a human triages the draft.
             if panel_lenses:
-                verdict = build_panel_runner(
-                    ws,
-                    run_dir,
-                    base_sha,
-                    panel_lenses,
-                    contract_text,
-                    config.target,
-                    config.benchmark,
-                    config.bot_login,
-                    _dt.fromtimestamp(now, _UTC).strftime("%Y-%m-%d"),
-                )(baseline, candidate, str(stage.get("report", "")))
-                result = dc_replace(
-                    result,
-                    panel_transcript=verdict.transcript,
-                    panel_rounds=1,
-                    panel_blocking_open=bool(verdict.blocking),
-                    panel_degraded=verdict.degraded,
-                )
+                # A panel ERROR (a git op in build_panel_runner, not a finding)
+                # must NOT abort the publish and drop the candidate snapshot —
+                # the improvement is real and measured. Fail closed to DEGRADED:
+                # open a DRAFT for a human, keep the candidate. (run_panel itself
+                # already fails closed per-lens; this catches the git setup.)
+                try:
+                    verdict = build_panel_runner(
+                        ws,
+                        run_dir,
+                        base_sha,
+                        panel_lenses,
+                        contract_text,
+                        config.target,
+                        config.benchmark,
+                        config.bot_login,
+                        _dt.fromtimestamp(now, _UTC).strftime("%Y-%m-%d"),
+                    )(baseline, candidate, str(stage.get("report", "")))
+                    result = dc_replace(
+                        result,
+                        panel_transcript=verdict.transcript,
+                        panel_rounds=1,
+                        panel_blocking_open=bool(verdict.blocking),
+                        panel_degraded=verdict.degraded,
+                    )
+                except Exception as exc:
+                    log.warning(
+                        "wake panel errored for %s (%s); opening a DRAFT",
+                        run_id,
+                        redact(f"{type(exc).__name__}: {exc}", secrets),
+                    )
+                    result = dc_replace(
+                        result,
+                        panel_degraded=True,
+                        panel_transcript="panel setup failed — NOT a clean read",
+                        panel_rounds=1,
+                    )
 
             entries = update_leader(
                 load_leader(workspace),

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1654,6 +1654,9 @@ class JobWakeDispatcher:
             self.spec.account,
             "--partition",
             self.spec.partition,
+            # the wake runs the SAME verification panel as the fresh climb, so a
+            # dispatched improvement is verified before it is published.
+            *_climb_panel_argv(self.spec),
         ]
         if self.spec.pat_file:
             argv += ["--pat-file", self.spec.pat_file]

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1667,13 +1667,28 @@ class JobWakeDispatcher:
                 job_name=name,
                 account=self.spec.account,
                 partition=self.spec.job_partition or self.spec.partition,
-                time_minutes=self.wake_minutes,
+                time_minutes=self.wake_minutes + _wake_panel_minutes(self.spec),
                 command=_flight_command(self.spec.home, name, self.now, argv),
                 dependency=afterany,
                 cpus=2,
                 mem="4G",
             )
         )
+
+
+def _wake_panel_minutes(spec: FollowupSpec) -> int:
+    """Extra wake walltime for the verification panel it now runs — the base
+    `wake_minutes` covers only reading results + opening the PR. One read per
+    lens on the judge budget (slice 1: no revision yet). Grounded in the same
+    judge budgets `_panel_job_minutes` uses; the revision wake's session budget
+    is added when slice 2 lands."""
+    lenses = [entry for entry in spec.panel.split(",") if entry.strip()]
+    if not lenses:
+        return 0
+    from autoresearch.roles import reviewer_spec, verifier_spec
+
+    judge_minutes = max(reviewer_spec().budget.walltime_s, verifier_spec().budget.walltime_s) // 60
+    return len(lenses) * judge_minutes
 
 
 def _wake_dispatcher_from_env(

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2032,3 +2032,45 @@ def test_resume_blocking_panel_opens_a_draft_and_never_arms(tmp_path, monkeypatc
     assert outcome.outcome == "improved"  # PR still opens...
     assert github.prs[0]["draft"] is True  # ...as a DRAFT
     assert github.armed == []  # and never armed
+
+
+def test_resume_panel_does_not_see_untracked_workspace_cruft(tmp_path, monkeypatch) -> None:
+    # after checkout -f candidate_sha the workspace keeps post-snapshot untracked
+    # files (the fixture's eval-cache.tmp); the panel's git add -A would sweep
+    # them into the judged tree unless they are cleaned first. A judge inspects
+    # its pr-head checkout to prove the cruft is absent.
+    import json as _json
+    from dataclasses import dataclass, field
+
+    from autoresearch.panel import PanelLens
+
+    @dataclass
+    class _SpyJudge:
+        saw_cruft: list = field(default_factory=list)
+
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            self.saw_cruft.append((Path(workspace) / "eval-cache.tmp").exists())
+            return SessionResult(
+                stop_reason="end_turn",
+                is_error=False,
+                cost_usd=0.0,
+                num_turns=1,
+                session_id="judge",
+                final_text=_json.dumps({"findings": [], "notes": "clean"}),
+                transcript_path="",
+            )
+
+    judge = _SpyJudge()
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=FakeGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        panel_lenses=(PanelLens("review", judge),),
+    )
+    assert judge.saw_cruft == [False]  # the panel judged candidate_sha, not the cruft

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1756,8 +1756,10 @@ def test_resume_improved_pushes_and_opens_pr(tmp_path, monkeypatch) -> None:
     assert "def solve(): return 'better'" in _git(
         bare, "show", "feat/auto/agent-01/tsp-1:src/pilot/solvers/tsp.py"
     )
-    # no verification panel ran on the wake, so auto-merge is never armed
-    assert github.armed == []
+    # no panel configured here -> a clean improvement arms auto-merge (only
+    # where branch protection requires a review), same policy as the inline path
+    assert github.armed and github.armed[0][0] == "org/pilot"
+    assert github.prs[0]["draft"] is False
 
 
 def test_resume_blind_repark_keeps_wake_attempts_but_progress_resets(tmp_path, monkeypatch):
@@ -1962,3 +1964,71 @@ def test_resume_negative_releases_the_issue_claim(tmp_path, monkeypatch) -> None
     num, body = github.issue_comments[-1]
     assert num == 7 and "finished (no-improvement)" in body
     assert RELEASE_MARKER in body  # the claim is freed for re-selection
+
+
+def _panel_lens(text):
+    from autoresearch.panel import PanelLens
+
+    return (PanelLens("review", _panel_judge([text])),)
+
+
+def test_resume_clean_panel_arms_and_records_transcript(tmp_path, monkeypatch) -> None:
+    # a dispatched improvement now runs the SAME verification panel as inline; a
+    # clean read -> non-draft PR + arm auto-merge, with the transcript in the body.
+    import json as _json
+
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        panel_lenses=_panel_lens(_json.dumps({"findings": [], "notes": "clean"})),
+    )
+    assert outcome.outcome == "improved"
+    assert github.prs[0]["draft"] is False
+    assert github.armed and github.armed[0][0] == "org/pilot"
+    assert "Verification" in github.prs[0]["body"]  # transcript rode the PR body
+
+
+def test_resume_blocking_panel_opens_a_draft_and_never_arms(tmp_path, monkeypatch) -> None:
+    # a blocking panel finding -> DRAFT PR carrying the findings, no arm (slice 1:
+    # a human triages; waking the agent to revise is the next slice).
+    import json as _json
+
+    blocking = _json.dumps(
+        {
+            "findings": [
+                {
+                    "file": "src/pilot/solvers/tsp.py",
+                    "line": 1,
+                    "confidence": "high",
+                    "summary": "suspicious",
+                    "detail": "looks structural",
+                    "blocking": True,
+                }
+            ],
+            "notes": "",
+        }
+    )
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        panel_lenses=_panel_lens(blocking),
+    )
+    assert outcome.outcome == "improved"  # PR still opens...
+    assert github.prs[0]["draft"] is True  # ...as a DRAFT
+    assert github.armed == []  # and never armed

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2074,3 +2074,30 @@ def test_resume_panel_does_not_see_untracked_workspace_cruft(tmp_path, monkeypat
         panel_lenses=(PanelLens("review", judge),),
     )
     assert judge.saw_cruft == [False]  # the panel judged candidate_sha, not the cruft
+
+
+def test_resume_panel_error_drafts_and_keeps_candidate(tmp_path, monkeypatch) -> None:
+    # a panel ERROR (not a finding) must not abort the publish and drop the
+    # candidate snapshot — the improvement is real. Fail closed to a DRAFT.
+    from autoresearch import climb as climb_mod
+    from autoresearch.panel import PanelLens
+
+    def boom(*a, **k):
+        raise RuntimeError("worktree add failed")
+
+    monkeypatch.setattr(climb_mod, "build_panel_runner", boom)
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        panel_lenses=(PanelLens("review", object()),),  # type: ignore[arg-type]  # runner monkeypatched to raise
+    )
+    assert outcome.outcome == "improved"  # NOT publish-error
+    assert github.prs[0]["draft"] is True and github.armed == []  # degraded -> draft, no arm

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1915,3 +1915,35 @@ def test_wake_dispatcher_on_switch_lands_dark_by_default(tmp_path, monkeypatch):
     # on-switch but incomplete env -> fail SAFE to dry, not a wake that can't run
     dispatcher, live = _wake_dispatcher_from_env(compute, None, NOW)
     assert isinstance(dispatcher, LoggingDispatcher) and live is False
+
+
+def test_job_wake_dispatcher_walltime_includes_the_panel(tmp_path, monkeypatch):
+    # the wake now runs the verification panel, so its Slurm walltime must be
+    # more than the bare read+PR base when a panel is configured.
+    from autoresearch.runstate import RunRecord
+    from autoresearch.tick import FollowupSpec, JobWakeDispatcher, _wake_panel_minutes
+
+    times = []
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            for a in argv:
+                if a.startswith("--time="):
+                    times.append(int(a.split("=")[1]))
+            return CommandResult(0, "9001\n", "")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(
+        "autoresearch.tick._flight_command", lambda home, name, now, argv: " ".join(argv)
+    )
+    record = RunRecord(
+        run_id="tsp-1", target="o/r", task_title="t", benchmark="tsp", state="waiting", stage={}
+    )
+    base = dict(account="a", partition="p", run_root=tmp_path, image="/i.sif", home=tmp_path)
+    with_panel = FollowupSpec(**base, panel="verify,review")
+    no_panel = FollowupSpec(**base, panel="")
+    JobWakeDispatcher(SlurmCompute(runner=runner), with_panel, now=NOW).dispatch(record, "x")
+    JobWakeDispatcher(SlurmCompute(runner=runner), no_panel, now=NOW).dispatch(record, "x")
+    assert _wake_panel_minutes(with_panel) > 0 and _wake_panel_minutes(no_panel) == 0
+    assert times[0] == 20 + _wake_panel_minutes(with_panel)  # panel allowance added
+    assert times[1] == 20  # no panel -> just the base

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1863,6 +1863,7 @@ def test_job_wake_dispatcher_submits_a_resume_job_after_the_eval_jobs(tmp_path, 
         image="/img/a.sif",
         home=tmp_path,
         pat_file="/pat",
+        panel="verify,review",
     )
     # isolate the dispatcher's job spec from flight_checkout's git dependency
     monkeypatch.setattr(
@@ -1882,6 +1883,7 @@ def test_job_wake_dispatcher_submits_a_resume_job_after_the_eval_jobs(tmp_path, 
     joined = " ".join(argv)
     assert "autoresearch.climb" in joined and "--resume tsp-1" in joined
     assert "--dependency=afterany:501:502" in argv  # runs after the eval jobs
+    assert "--panel verify,review" in joined  # the wake runs the verification panel
     assert "--account=acct" in argv and "--partition=cpu_short" in argv
 
 


### PR DESCRIPTION
The most important wake **activation-blocker**: dispatched improvements bypassed the pre-PR verification panel. Now `resume_run` runs the **same** panel as the inline climb.

This is **slice 1** of the depth-axis panel-on-wake — the panel **gate**. Slice 2 (waking the agent to *revise* on a blocking finding) is the first real "wake the agent with evidence" build and comes next.

## What

- After a credited improvement, `resume_run` checks out the sealed `candidate_sha` (so the panel judges exactly what was measured — dispatched evals run on node-local scratch, so the tree is unchanged) and runs the read-only lenses over `base_sha` vs candidate.
- **Blocking / degraded** → DRAFT PR with the findings, **no arm**. **Clean** (or no panel) → non-draft, arms auto-merge only where branch protection requires a review — same policy as inline (also restores arming, which the pre-panel wake had disabled).
- Plumbing: `--resume` CLI + `JobWakeDispatcher` forward `--panel`/`--panel-key-file`; lens-building extracted into a shared `_panel_lenses_from_args`.

## Tests

Clean panel → non-draft + armed + transcript in body; blocking → draft + no arm; `JobWakeDispatcher` forwards `--panel`. Full gate green, 664 tests.

## Next (slice 2)
Wake the agent to **revise** on a blocking finding — re-run the session with the findings, re-measure (→ re-park), re-gate — the first depth-axis build (`docs/design/research-loop.md`). For now a human triages the draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
