### PR TITLE
Panel-on-wake slice 2: wake the agent to revise (the depth axis)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Panel-on-wake, slice 2 — the first depth-axis build (docs/design/research-loop.md,
+  "wake the agent with evidence"): a BLOCKING panel finding on a dispatched
+  improvement now WAKES THE AGENT to revise instead of drafting. `resume_run`
+  re-runs the author session with the findings (`run_role` over the checked-out
+  candidate), re-snapshots the revised tree, and re-measures through the
+  dispatched measurer — which re-parks, so the NEXT wake runs the panel again.
+  Each revision is one park/wake cycle; `panel_reads` persists in the stage and
+  bounds the loop at `panel_revisions`, after which a still-blocking finding
+  DRAFTs for a human. The revision keeps the new candidate snapshot and drops
+  the superseded one; a revision that goes out of scope (or otherwise fails the
+  gate) ends the run. The `--resume` CLI builds the editor harness (author key)
+  and `JobWakeDispatcher` forwards `--key-file`/`--max-turns` + sizes the wake
+  walltime for the revision session (`_wake_panel_minutes`). A revision session
+  that cannot run falls back to a DRAFT — the improvement is real, just
+  unrevised.
+
 - Panel-on-wake, slice 1 — a dispatched improvement now runs the SAME pre-PR
   verification panel as an inline climb (docs/design/orchestrator-verify.md), so
   it is not published unverified. `resume_run` runs the read-only lenses over

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -62,6 +62,7 @@ from autoresearch.progress import (
     write_progress,
 )
 from autoresearch.review import PullRequest
+from autoresearch.role_runner import run_role
 from autoresearch.roles import author_spec
 from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
@@ -230,6 +231,7 @@ def _park_run(
     secrets: tuple[str, ...] = (),
     keep_wake_attempts: bool = False,
     base_branch: str = "main",
+    panel_reads: int = 0,
 ) -> None:
     """Persist a dispatched climb's re-entry point as a WAITING record: the
     committed shas, drawn seeds, candidate snapshot ref, and afterany set a
@@ -252,6 +254,9 @@ def _park_run(
         # branch a non-default `--base-branch` selected — the wake CLI otherwise
         # defaults to main and would mis-target.
         "base_branch": base_branch,
+        # verification-panel revisions taken so far — persisted so the next wake
+        # knows the cap position after a panel-driven revision re-park.
+        "panel_reads": panel_reads,
         # the session's write-up + spend, saved so a candidate wake can build
         # the PR body / panel claim and report the real cost WITHOUT re-running
         # the session (its edits are already in candidate_sha). REDACTED before
@@ -309,6 +314,9 @@ def resume_run(
     secrets: tuple[str, ...] = (),
     base_branch: str = "main",
     panel_lenses: tuple[PanelLens, ...] = (),
+    harness: Harness | None = None,
+    spec: RoleSpec | None = None,
+    panel_revisions: int = 1,
 ) -> LiveClimbOutcome:
     """Wake a parked dispatched climb and re-enter its decision WITHOUT the
     session (`orchestrator.resume_climb`), from the record `_park_run` wrote.
@@ -375,6 +383,9 @@ def resume_run(
     measured_paths = tuple(
         p for p in ws.git("diff", "--name-only", "-z", base_sha, candidate_sha).split("\0") if p
     )
+    seed = int(stage["seed"])  # type: ignore[call-overload]
+    suite_seed = int(stage["suite_seed"])  # type: ignore[call-overload]
+    panel_reads = int(stage.get("panel_reads", 0))  # type: ignore[call-overload]
 
     # rebuild the session from what the park saved: the (redacted) write-up and
     # its real spend, so the report shows true cost/turns. It is never re-run.
@@ -393,8 +404,8 @@ def resume_run(
             bench,
             base_sha=base_sha,
             candidate_sha=candidate_sha,
-            seed=int(stage["seed"]),  # type: ignore[call-overload]
-            suite_seed=int(stage["suite_seed"]),  # type: ignore[call-overload]
+            seed=seed,
+            suite_seed=suite_seed,
             measured_paths=measured_paths,
             session=session,
             measurer=measurer,
@@ -419,8 +430,97 @@ def resume_run(
             secrets,
             keep_wake_attempts=not made_progress,
             base_branch=base_branch,
+            panel_reads=panel_reads,
         )
         return LiveClimbOutcome(run_id=run_id, outcome="parked")
+
+    def _do_revise(verdict: PanelVerdict, reads: int) -> LiveClimbOutcome | None:
+        """A blocking panel finding -> wake the agent to revise (the depth
+        axis). Re-run the session with the findings, re-snapshot the revised
+        tree, and re-measure — which re-parks (dispatched) so the NEXT wake
+        runs the panel again. Returns the parked/terminal outcome, or None when
+        the revision session could not run (the caller then DRAFTs the original
+        candidate — the improvement is real, it just could not be revised)."""
+        assert harness is not None and spec is not None
+        wake_result = run_role(
+            spec, harness, verdict.wake_text, workspace, resume_session_id=record.resume_session_id
+        )
+        if not wake_result.ok:
+            log.warning("wake revision session failed for %s; drafting the original", run_id)
+            return None
+        # the revised tree is a NEW candidate; snapshot it (parented on base) and
+        # re-measure through the dispatched measurer, which re-parks.
+        new_snap = snapshot_tree(ws, base_sha)
+        new_measured = tuple(
+            p
+            for p in ws.git("diff", "--name-only", "-z", base_sha, new_snap.commit).split("\0")
+            if p
+        )
+        old_snap = Snapshot(commit=candidate_sha, tree="", ref=candidate_ref)
+        try:
+            revised = resume_climb(
+                contract,
+                bench,
+                base_sha=base_sha,
+                candidate_sha=new_snap.commit,
+                seed=seed,
+                suite_seed=suite_seed,
+                measured_paths=new_measured,
+                session=wake_result.session,
+                measurer=measurer,
+                min_relative_improvement=config.min_relative_improvement,
+            )
+        except ClimbParked as p:
+            # re-park on the NEW candidate; carry the revision count so the next
+            # wake honors the cap. Keep the new snapshot, drop the superseded old.
+            _park_run(
+                run_root,
+                record,
+                p,
+                new_snap.ref,
+                eval_minutes,
+                now,
+                secrets,
+                base_branch=base_branch,
+                panel_reads=reads,
+            )
+            drop_snapshot(ws, old_snap)
+            return LiveClimbOutcome(run_id=run_id, outcome="parked")
+        # the re-measure returned a TERMINAL (e.g. the revision went out of scope,
+        # or a dispatch-free measurer decided): end the run, drop BOTH snapshots.
+        drop_snapshot(ws, old_snap)
+        drop_snapshot(ws, new_snap)
+        report_path = run_dir / "report.md"
+        _best_effort(
+            "run report",
+            lambda: report_path.write_text(revised.report(config, redact_secrets=secrets)),
+            secrets,
+        )
+        ending = _ENDINGS_BY_OUTCOME.get(revised.outcome, ABORTED)
+        final = _clear_stage(
+            RunRecord(
+                **{
+                    **record.__dict__,
+                    "state": ENDED,
+                    "ending": ending,
+                    "ending_note": redact(revised.note, secrets),
+                }
+            )
+        )
+        _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
+        _post_issue_finished(
+            github,
+            config.target,
+            issue_number,
+            run_id,
+            revised.outcome,
+            "",
+            redact(revised.report(config, redact_secrets=secrets), secrets)[:8000],
+            secrets,
+        )
+        return LiveClimbOutcome(
+            run_id=run_id, outcome=revised.outcome, report_path=str(report_path)
+        )
 
     if result.outcome == "improved":
         # Publish: branch the SEALED candidate sha, fold in the ledger, push,
@@ -489,24 +589,49 @@ def resume_run(
                         config.bot_login,
                         _dt.fromtimestamp(now, _UTC).strftime("%Y-%m-%d"),
                     )(baseline, candidate, str(stage.get("report", "")))
-                    result = dc_replace(
-                        result,
-                        panel_transcript=verdict.transcript,
-                        panel_rounds=1,
-                        panel_blocking_open=bool(verdict.blocking),
-                        panel_degraded=verdict.degraded,
-                    )
                 except Exception as exc:
                     log.warning(
                         "wake panel errored for %s (%s); opening a DRAFT",
                         run_id,
                         redact(f"{type(exc).__name__}: {exc}", secrets),
                     )
+                    verdict = PanelVerdict(
+                        blocking=(),
+                        transcript="panel setup failed — NOT a clean read",
+                        wake_text="",
+                        degraded=True,
+                    )
+                reads = panel_reads + 1
+                # DEPTH AXIS (docs/design/research-loop.md): a blocking finding
+                # WAKES THE AGENT to revise — re-run the session with the
+                # findings, re-snapshot, re-measure (-> re-park) — instead of
+                # drafting, bounded by panel_revisions. Fall through to a DRAFT
+                # when we cannot resume (no harness/session) or the cap is hit.
+                can_revise = (
+                    bool(verdict.blocking)
+                    and harness is not None
+                    and spec is not None
+                    and bool(record.resume_session_id)
+                    and reads <= panel_revisions
+                )
+                if can_revise:
+                    revised = _do_revise(verdict, reads)
+                    if revised is not None:
+                        return revised
+                    # the revision session could not run — DRAFT the original
                     result = dc_replace(
                         result,
-                        panel_degraded=True,
-                        panel_transcript="panel setup failed — NOT a clean read",
-                        panel_rounds=1,
+                        panel_transcript=verdict.transcript,
+                        panel_rounds=reads,
+                        panel_blocking_open=True,
+                    )
+                else:
+                    result = dc_replace(
+                        result,
+                        panel_transcript=verdict.transcript,
+                        panel_rounds=reads,
+                        panel_blocking_open=bool(verdict.blocking),
+                        panel_degraded=verdict.degraded,
                     )
 
             entries = update_leader(
@@ -1753,6 +1878,17 @@ def main() -> int:
             if args.panel.strip()
             else ""
         )
+        # the editor harness for the depth-axis REVISION: a blocking panel
+        # finding wakes the author to revise, which spends the author key.
+        wake_api_key = FileTokenProvider(Path(args.key_file).expanduser()).token()
+        wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
+        wake_harness = build_editor_harness(
+            wake_api_key,
+            wake_spec,
+            binary=args.claude_bin,
+            model=args.model,
+            container_image=args.image,
+        )
         try:
             resumed = resume_run(
                 args.run_root,
@@ -1766,9 +1902,12 @@ def main() -> int:
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,
                 now=time.time(),
-                secrets=tuple(k for k in (bot_auth.token(), wake_panel_key) if k),
+                secrets=tuple(k for k in (bot_auth.token(), wake_panel_key, wake_api_key) if k),
                 base_branch=args.base_branch,
                 panel_lenses=wake_lenses,
+                harness=wake_harness,
+                spec=wake_spec,
+                panel_revisions=args.panel_revisions,
             )
         finally:
             # This wake job HOLDS the run's lease (the sweep transferred it on

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -497,8 +497,29 @@ def resume_run(
             )
             drop_snapshot(ws, old_snap)
             return LiveClimbOutcome(run_id=run_id, outcome="parked")
-        # the re-measure returned a TERMINAL (e.g. the revision went out of scope,
-        # or a dispatch-free measurer decided): end the run, drop BOTH snapshots.
+        except Exception as exc:
+            # the re-measure could not even dispatch (e.g. Slurm submit) — do NOT
+            # discard the ORIGINAL's real, measured improvement; drop the new
+            # snapshot and DRAFT the original (the caller keeps candidate_sha).
+            log.warning(
+                "wake revision re-measure failed for %s (%s); drafting the original",
+                run_id,
+                redact(f"{type(exc).__name__}: {exc}", secrets),
+            )
+            drop_snapshot(ws, new_snap)
+            return None
+        if revised.outcome == "improved":
+            # the dispatched re-measure should have PARKED; an inline 'improved'
+            # here (a cached result) is unexpected and unverified — draft the
+            # original rather than ABORT with no PR.
+            log.warning(
+                "wake revision re-measure returned improved without parking for %s; drafting",
+                run_id,
+            )
+            drop_snapshot(ws, new_snap)
+            return None
+        # the re-measure returned a NEGATIVE terminal (the revision went out of
+        # scope, regressed, or eval-errored): end the run, drop BOTH snapshots.
         drop_snapshot(ws, old_snap)
         drop_snapshot(ws, new_snap)
         report_path = run_dir / "report.md"

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1873,22 +1873,25 @@ def main() -> int:
             wake_lenses = _panel_lenses_from_args(args)
         except ValueError as exc:
             parser.error(str(exc))
-        wake_panel_key = (
-            FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
-            if args.panel.strip()
-            else ""
-        )
-        # the editor harness for the depth-axis REVISION: a blocking panel
-        # finding wakes the author to revise, which spends the author key.
-        wake_api_key = FileTokenProvider(Path(args.key_file).expanduser()).token()
-        wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
-        wake_harness = build_editor_harness(
-            wake_api_key,
-            wake_spec,
-            binary=args.claude_bin,
-            model=args.model,
-            container_image=args.image,
-        )
+        wake_panel_key = ""
+        wake_api_key = ""
+        wake_harness = None
+        wake_spec = None
+        # The editor harness for the depth-axis REVISION is built ONLY when a
+        # panel is configured — no panel means no blocking finding, so no
+        # revision and no author key to read. A panel-less wake stays a pure
+        # read-decide-publish job and must not require the author key.
+        if wake_lenses:
+            wake_panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+            wake_api_key = FileTokenProvider(Path(args.key_file).expanduser()).token()
+            wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
+            wake_harness = build_editor_harness(
+                wake_api_key,
+                wake_spec,
+                binary=args.claude_bin,
+                model=args.model,
+                container_image=args.image,
+            )
         try:
             resumed = resume_run(
                 args.run_root,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -448,9 +448,20 @@ def resume_run(
         if not wake_result.ok:
             log.warning("wake revision session failed for %s; drafting the original", run_id)
             return None
-        # the revised tree is a NEW candidate; snapshot it (parented on base) and
-        # re-measure through the dispatched measurer, which re-parks.
-        new_snap = snapshot_tree(ws, base_sha)
+        # the revised tree is a NEW candidate; snapshot it (parented on base).
+        # A snapshot failure (git write-tree, disk) must NOT escape and leave the
+        # run WAITING to retry — that would re-spend a revision session on the
+        # same finding. Fall back to DRAFTING the original (its improvement is
+        # real and measured); the caller commits candidate_sha, not the revision.
+        try:
+            new_snap = snapshot_tree(ws, base_sha)
+        except Exception as exc:
+            log.warning(
+                "wake revision snapshot failed for %s (%s); drafting the original",
+                run_id,
+                redact(f"{type(exc).__name__}: {exc}", secrets),
+            )
+            return None
         new_measured = tuple(
             p
             for p in ws.git("diff", "--name-only", "-z", base_sha, new_snap.commit).split("\0")

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1657,9 +1657,15 @@ class JobWakeDispatcher:
             # the wake runs the SAME verification panel as the fresh climb, so a
             # dispatched improvement is verified before it is published.
             *_climb_panel_argv(self.spec),
+            # session budget for the depth-axis REVISION (a blocking panel
+            # finding wakes the author to revise).
+            "--max-turns",
+            str(self.spec.max_turns),
         ]
         if self.spec.pat_file:
             argv += ["--pat-file", self.spec.pat_file]
+        if self.spec.key_file:
+            argv += ["--key-file", self.spec.key_file]
         name = f"wake-{record.run_id}"[:60]
         afterany = str(record.stage.get("afterany", ""))
         return self.compute.submit(
@@ -1678,17 +1684,19 @@ class JobWakeDispatcher:
 
 def _wake_panel_minutes(spec: FollowupSpec) -> int:
     """Extra wake walltime for the verification panel it now runs — the base
-    `wake_minutes` covers only reading results + opening the PR. One read per
-    lens on the judge budget (slice 1: no revision yet). Grounded in the same
-    judge budgets `_panel_job_minutes` uses; the revision wake's session budget
-    is added when slice 2 lands."""
+    `wake_minutes` covers only reading results + opening the PR. Budgeted for
+    the worst case a single wake reaches: one read per lens PLUS one revision
+    author session (the depth-axis wake-to-revise). The revision's re-measure
+    only DISPATCHES (then the job ends, parked), so it needs no extra time.
+    Grounded in the same judge/author budgets the climb job uses."""
     lenses = [entry for entry in spec.panel.split(",") if entry.strip()]
     if not lenses:
         return 0
-    from autoresearch.roles import reviewer_spec, verifier_spec
+    from autoresearch.roles import author_spec, reviewer_spec, verifier_spec
 
     judge_minutes = max(reviewer_spec().budget.walltime_s, verifier_spec().budget.walltime_s) // 60
-    return len(lenses) * judge_minutes
+    session_minutes = author_spec().budget.walltime_s // 60
+    return len(lenses) * judge_minutes + session_minutes
 
 
 def _wake_dispatcher_from_env(

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1883,9 +1883,10 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
     (tmp_path / "runs" / run_id).mkdir(parents=True)
     (tmp_path / "pat").write_text("ghp_x\n")
     (tmp_path / "pat").chmod(0o600)  # token() enforces 0600
-    (tmp_path / "key").write_text("sk-x\n")  # author key for the revision harness
-    (tmp_path / "key").chmod(0o600)
     (tmp_path / "img.sif").write_text("")  # just needs to be a file
+    # deliberately NO --panel and NO author key file: a panel-less wake never
+    # revises, so it must not require the author key (regression: the CLI once
+    # always read it and failed).
     assert acquire_lease(tmp_path, run_id, "wake-job:1", "1", 1_000.0)
     assert (run_dir(tmp_path, run_id) / "lease.json").exists()
 
@@ -1911,8 +1912,8 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
             str(tmp_path / "img.sif"),
             "--pat-file",
             str(tmp_path / "pat"),
-            "--key-file",
-            str(tmp_path / "key"),
+            "--panel",
+            "",  # no panel -> no revision -> no author key needed
         ],
     )
     assert main() == 0

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1883,6 +1883,8 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
     (tmp_path / "runs" / run_id).mkdir(parents=True)
     (tmp_path / "pat").write_text("ghp_x\n")
     (tmp_path / "pat").chmod(0o600)  # token() enforces 0600
+    (tmp_path / "key").write_text("sk-x\n")  # author key for the revision harness
+    (tmp_path / "key").chmod(0o600)
     (tmp_path / "img.sif").write_text("")  # just needs to be a file
     assert acquire_lease(tmp_path, run_id, "wake-job:1", "1", 1_000.0)
     assert (run_dir(tmp_path, run_id) / "lease.json").exists()
@@ -1909,6 +1911,8 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
             str(tmp_path / "img.sif"),
             "--pat-file",
             str(tmp_path / "pat"),
+            "--key-file",
+            str(tmp_path / "key"),
         ],
     )
     assert main() == 0
@@ -2101,3 +2105,136 @@ def test_resume_panel_error_drafts_and_keeps_candidate(tmp_path, monkeypatch) ->
     )
     assert outcome.outcome == "improved"  # NOT publish-error
     assert github.prs[0]["draft"] is True and github.armed == []  # degraded -> draft, no arm
+
+
+def test_resume_blocking_panel_wakes_the_agent_to_revise_and_reparks(tmp_path, monkeypatch) -> None:
+    # THE DEPTH-AXIS CORE: a blocking panel finding wakes the agent to revise —
+    # re-run the session with the findings, re-snapshot, re-measure -> re-park
+    # (panel_reads incremented), instead of drafting.
+    import json as _json
+    from dataclasses import dataclass
+
+    from autoresearch.orchestrator import author_spec
+    from autoresearch.panel import PanelLens
+
+    @dataclass
+    class RevisingHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            # the agent revises in response to the findings
+            (workspace / "src" / "pilot" / "solvers" / "tsp.py").write_text(
+                "def solve(): return 'revised'\n"
+            )
+            return SessionResult(
+                stop_reason="end_turn",
+                is_error=False,
+                cost_usd=0.5,
+                num_turns=3,
+                session_id="s1",
+                final_text="addressed the finding",
+                transcript_path="",
+            )
+
+    blocking = _json.dumps(
+        {
+            "findings": [
+                {
+                    "file": "src/pilot/solvers/tsp.py",
+                    "line": 1,
+                    "confidence": "high",
+                    "summary": "suspicious",
+                    "detail": "structural",
+                    "blocking": True,
+                }
+            ],
+            "notes": "",
+        }
+    )
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    # the INITIAL measure returns improved (-> panel -> revise); the re-measure
+    # of the revised candidate PARKS, exactly as the dispatched backend does.
+    from autoresearch.measure import DispatchSettings, MeasurementPending
+
+    class _TwoPhase:
+        def __init__(self):
+            self.calls = 0
+
+        def results(self, measures):
+            self.calls += 1
+            if self.calls == 1:
+                return {"baseline": 13.0, "candidate": 12.0}
+            raise MeasurementPending(("601", "602"))
+
+    monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: _TwoPhase())
+    old = load_record(state, run_id).stage["candidate_sha"]
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
+        harness=RevisingHarness(),
+        spec=author_spec(),
+        panel_revisions=1,
+    )
+    assert outcome.outcome == "parked"  # re-parked to measure the REVISED candidate
+    assert github.prs == []  # no PR — the revision must be verified first
+    rec = load_record(state, run_id)
+    assert rec.state == "waiting"
+    assert rec.stage["panel_reads"] == 1  # one revision taken; the cap advances
+    assert rec.stage["candidate_sha"] != old  # a NEW candidate (the revision)
+    # the revised edit landed in the new candidate; the old snapshot was dropped
+    ws = state / "runs" / run_id / "ws"
+    kept = _git(ws, "for-each-ref", "--format=%(objectname)", "refs/dispatch/").split()
+    assert str(rec.stage["candidate_sha"]) in kept and str(old) not in kept
+
+
+def test_resume_blocking_panel_at_the_cap_drafts_without_revising(tmp_path, monkeypatch) -> None:
+    # once panel_reads has hit panel_revisions, a further blocking finding stops
+    # revising and DRAFTs (the human sees the unconverged findings).
+    import json as _json
+
+    from autoresearch.orchestrator import author_spec
+    from autoresearch.panel import PanelLens
+
+    blocking = _json.dumps(
+        {
+            "findings": [
+                {
+                    "file": "x",
+                    "line": 1,
+                    "confidence": "high",
+                    "summary": "s",
+                    "detail": "d",
+                    "blocking": True,
+                }
+            ],
+            "notes": "",
+        }
+    )
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    # simulate a run that already used its one revision
+    rec = load_record(state, run_id)
+    rec.stage["panel_reads"] = 1
+    save_record(state, rec, 1_000_050.0)
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
+        harness=object(),  # type: ignore[arg-type]
+        spec=author_spec(),
+        panel_revisions=1,
+    )
+    assert outcome.outcome == "improved"  # publishes...
+    assert github.prs[0]["draft"] is True and github.armed == []  # ...as a DRAFT, no revise

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2292,9 +2292,9 @@ def test_resume_revision_snapshot_failure_drafts_the_original(tmp_path, monkeypa
         state,
         run_id,
         dispatch=_fake_dispatch(),
-        github=github,
-        bot_auth=NoAuth(),
-        now=1_000_100.0,  # type: ignore[arg-type]
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
         panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
         harness=RevisingHarness(),
         spec=author_spec(),
@@ -2303,3 +2303,72 @@ def test_resume_revision_snapshot_failure_drafts_the_original(tmp_path, monkeypa
     assert outcome.outcome == "improved"  # drafted, not parked/aborted
     assert github.prs[0]["draft"] is True and github.armed == []
     assert load_record(state, run_id).state == "in-review"  # ended, not left waiting
+
+
+def test_resume_revision_remeasure_failure_drafts_the_original(tmp_path, monkeypatch) -> None:
+    # if the revision's re-measure cannot even dispatch (e.g. Slurm submit), the
+    # ORIGINAL's real improvement must NOT be discarded — draft it.
+    import json as _json
+    from dataclasses import dataclass
+
+    from autoresearch.measure import DispatchSettings
+    from autoresearch.orchestrator import author_spec
+    from autoresearch.panel import PanelLens
+
+    @dataclass
+    class RevisingHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            return SessionResult(
+                stop_reason="end_turn",
+                is_error=False,
+                cost_usd=0.5,
+                num_turns=3,
+                session_id="s1",
+                final_text="revised",
+                transcript_path="",
+            )
+
+    class _RaiseOnRemeasure:
+        def __init__(self):
+            self.calls = 0
+
+        def results(self, measures):
+            self.calls += 1
+            if self.calls == 1:
+                return {"baseline": 13.0, "candidate": 12.0}
+            raise RuntimeError("sbatch failed")  # not EvalError/MeasurementPending
+
+    blocking = _json.dumps(
+        {
+            "findings": [
+                {
+                    "file": "src/pilot/solvers/tsp.py",
+                    "line": 1,
+                    "confidence": "high",
+                    "summary": "s",
+                    "detail": "d",
+                    "blocking": True,
+                }
+            ],
+            "notes": "",
+        }
+    )
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: _RaiseOnRemeasure())
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
+        harness=RevisingHarness(),
+        spec=author_spec(),
+        panel_revisions=1,
+    )
+    assert outcome.outcome == "improved"  # the original is drafted, not aborted
+    assert github.prs[0]["draft"] is True and load_record(state, run_id).state == "in-review"

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2239,3 +2239,67 @@ def test_resume_blocking_panel_at_the_cap_drafts_without_revising(tmp_path, monk
     )
     assert outcome.outcome == "improved"  # publishes...
     assert github.prs[0]["draft"] is True and github.armed == []  # ...as a DRAFT, no revise
+
+
+def test_resume_revision_snapshot_failure_drafts_the_original(tmp_path, monkeypatch) -> None:
+    # if the revised tree cannot be snapshotted (git/disk), the wake must NOT
+    # leave the run parked to retry (re-spending a session) — it DRAFTs the
+    # original, whose improvement is real and measured.
+    import json as _json
+    from dataclasses import dataclass
+
+    from autoresearch import climb as climb_mod
+    from autoresearch.orchestrator import EvalError, author_spec
+    from autoresearch.panel import PanelLens
+
+    @dataclass
+    class RevisingHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            return SessionResult(
+                stop_reason="end_turn",
+                is_error=False,
+                cost_usd=0.5,
+                num_turns=3,
+                session_id="s1",
+                final_text="revised",
+                transcript_path="",
+            )
+
+    def boom(ws, base_sha):
+        raise EvalError("git write-tree failed")
+
+    monkeypatch.setattr(climb_mod, "snapshot_tree", boom)
+    blocking = _json.dumps(
+        {
+            "findings": [
+                {
+                    "file": "src/pilot/solvers/tsp.py",
+                    "line": 1,
+                    "confidence": "high",
+                    "summary": "s",
+                    "detail": "d",
+                    "blocking": True,
+                }
+            ],
+            "notes": "",
+        }
+    )
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,
+        bot_auth=NoAuth(),
+        now=1_000_100.0,  # type: ignore[arg-type]
+        panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
+        harness=RevisingHarness(),
+        spec=author_spec(),
+        panel_revisions=1,
+    )
+    assert outcome.outcome == "improved"  # drafted, not parked/aborted
+    assert github.prs[0]["draft"] is True and github.armed == []
+    assert load_record(state, run_id).state == "in-review"  # ended, not left waiting


### PR DESCRIPTION
The **first real depth-axis build** (`docs/design/research-loop.md`, "wake the agent with evidence"). When the verification panel blocks a dispatched improvement, `resume_run` now **wakes the agent to revise** instead of drafting.

## The loop

```
wake → measure (cached) → panel → BLOCKING finding (under the cap)
     → run the author session with the findings  (run_role)
     → re-snapshot the revised tree              (new candidate)
     → re-measure through the dispatched measurer → RE-PARK
next wake → panel again → clean → PR+arm  |  still blocking at the cap → DRAFT
```

Each revision is one park/wake cycle; `panel_reads` rides the stage and bounds the loop at `panel_revisions`.

## Details

- Keeps the new candidate snapshot, drops the superseded one; an out-of-scope (or gate-failing) revision ends the run.
- A revision session that can't run falls back to a DRAFT of the original (the improvement is real, just unrevised).
- Plumbing: the `--resume` CLI builds the editor harness (author key) + spec + `panel_revisions`; `JobWakeDispatcher` forwards `--key-file`/`--max-turns` and sizes the wake walltime for the revision session.

## Tests

A blocking finding wakes the agent → re-snapshots → re-parks with `panel_reads=1` and a new candidate (old dropped); at the cap it drafts without revising. Full gate green, 669 tests.

## Where this leaves the depth axis
This is `k=1` (one revision) by default, tunable via `--panel-revisions` — the dial from `research-loop.md`. The substrate now genuinely *wakes the agent with evidence and lets it iterate*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
