### PR TITLE
Fix outage() missing an API refusal masked by a "success" subtype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,18 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- `outage()` now catches an API refusal the CLI reports as a `subtype: "success"`
+  error with the real cause in `final_text`. Surfaced on Torch: a session hit the
+  author key's workspace usage cap and came back `is_error` with
+  `error_detail="success"` and `result="API Error: 400 ... usage limits"`. The
+  old classifier treated a non-empty `error_detail` as authoritative, scanned
+  `"success"`, matched nothing, and billed a genuine outage as a `session-error`
+  — so the lanes would NOT pause and the failure would count against the run's
+  retry caps. `outage()` now unions the machine-shaped (`"API Error ..."`)
+  `final_text` into the surface even when `error_detail` is non-empty, while
+  still never consulting agent prose (the round-1/2 anti-false-latch invariant
+  holds — prose does not carry that shape).
+
 - Wake-path hardening from the self-review + advisory review of the dispatched
   wake (all pre-activation, the path is still dark):
   - the improved wake now FORCE-checks-out the sealed candidate sha (at wake the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,17 +64,20 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- `outage()` now catches an API refusal the CLI reports as a `subtype: "success"`
-  error with the real cause in `final_text`. Surfaced on Torch: a session hit the
-  author key's workspace usage cap and came back `is_error` with
-  `error_detail="success"` and `result="API Error: 400 ... usage limits"`. The
-  old classifier treated a non-empty `error_detail` as authoritative, scanned
-  `"success"`, matched nothing, and billed a genuine outage as a `session-error`
-  — so the lanes would NOT pause and the failure would count against the run's
-  retry caps. `outage()` now unions the machine-shaped (`"API Error ..."`)
-  `final_text` into the surface even when `error_detail` is non-empty, while
-  still never consulting agent prose (the round-1/2 anti-false-latch invariant
-  holds — prose does not carry that shape).
+- A genuine API refusal the Claude CLI reports as a `subtype: "success"` error
+  is no longer misclassified as a `session-error`. Surfaced on Torch: a session
+  hit the author key's workspace usage cap and came back `is_error` with a
+  content-free `subtype: "success"` and the real cause only in
+  `result="API Error: 400 ... usage limits"`. The parse stamped `"success"` into
+  `error_detail`, so `outage()` scanned `"success"`, matched nothing, and billed
+  a genuine outage as a `session-error` — the lanes would NOT pause and the
+  failure would count against the run's retry caps. The Claude harness parse now
+  lifts that machine-shaped (`"API Error ..."`) `result` into `error_detail`, so
+  the real cause reaches the operator log AND the outage latch — both its
+  classifier and its throttle-duration check (which reads `rate_limit`/
+  `overloaded` off the detail). Fixed at the parse, not in `outage()`, so the
+  classifier keeps consulting `final_text` only when `error_detail` is empty —
+  agent prose (Codex/Hermes `final_text`) still cannot trip the latch.
 
 - Wake-path hardening from the self-review + advisory review of the dispatched
   wake (all pre-activation, the path is still dark):

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -159,20 +159,17 @@ def outage(result: SessionResult) -> bool:
     work order's attempts."""
     if not result.is_error:
         return False
-    # Union two backend surfaces: error_detail, and the machine "API Error ..."
-    # shape a CLI may put in final_text. The latter is backend text too, never
-    # agent prose, so it must count even when error_detail is non-empty — some
-    # backends stamp a content-free subtype ("success") into error_detail while
-    # the real cause (e.g. "API Error: 400 ... usage limits") sits only in
-    # final_text. final_text is taken ONLY in that "api error" shape, so a
-    # report that merely MENTIONS billing or limits still cannot trip a latch
+    # error_detail is backend error text and always wins; final_text is
+    # consulted ONLY when no detail exists AND it carries the legacy CLI
+    # error shape ("API Error ..."), never agent prose — a failed session's
+    # report that merely MENTIONS billing or limits must not trip a latch
     # that pauses every lane (review findings, rounds 1 and 2).
     surface = result.error_detail.casefold()
-    text = result.final_text.strip().casefold()
-    if text.startswith("api error"):
-        surface = f"{surface}\n{text}"
-    if not surface.strip():
-        return False
+    if not surface:
+        text = result.final_text.strip().casefold()
+        if not text.startswith("api error"):
+            return False
+        surface = text
     return any(pattern in surface for pattern in OUTAGE_PATTERNS)
 
 
@@ -452,6 +449,17 @@ class ClaudeCodeHarness:
         errors = data.get("errors")
         messages = "; ".join(str(e) for e in errors if e) if isinstance(errors, list) else ""
         detail = f"{subtype}: {messages}" if subtype and messages else (subtype or messages)
+        final_text = str(data.get("result") or "")
+        # The CLI can flag is_error while stamping a content-free subtype
+        # ("success") and leaving the real cause only in `result` — observed on
+        # Torch: is_error, subtype "success", result "API Error: 400 ... usage
+        # limits". That machine "API Error ..." text (never agent prose) is the
+        # authoritative cause, so surface it as the detail: downstream notes,
+        # the operator log, and the outage latch (its classifier AND its
+        # throttle-duration check, which reads rate_limit/overloaded off the
+        # detail) all then see the real error instead of "success".
+        if is_error and final_text.strip().casefold().startswith("api error"):
+            detail = final_text.strip()
         # bounded here so every downstream note/report/comment inherits it
         detail = detail[:500]
         return SessionResult(
@@ -461,7 +469,7 @@ class ClaudeCodeHarness:
             cost_usd=_float(data.get("total_cost_usd")),
             num_turns=_int(data.get("num_turns")),
             session_id=str(data.get("session_id") or ""),
-            final_text=str(data.get("result") or ""),
+            final_text=final_text,
             transcript_path=transcript_path,
         )
 

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -458,15 +458,16 @@ class ClaudeCodeHarness:
         # the operator log, and the outage latch (its classifier AND its
         # throttle-duration check, which reads rate_limit/overloaded off the
         # detail) all then see the real error instead of "success". Lift ONLY
-        # when the CLI left no real cause: a bare/contradictory subtype ("" or
-        # "success") AND no `errors` messages. A genuine ending subtype
-        # (error_max_turns, error_during_execution) is KEPT so budget_exhausted()
-        # /the classifier still see it, and real backend `errors` text is kept
-        # too (a "success" subtype can still carry messages).
+        # when the CLI left no real cause: no `errors` messages, and not the one
+        # subtype a caller reads off the detail — budget_exhausted() keys on the
+        # `error_max_turns` prefix, and it is the ONLY such reader. Every other
+        # subtype ("success", "error_during_execution", empty) is a content-free
+        # wrapper whose real cause is the result text; keeping error_max_turns
+        # intact preserves the budget-ending classification.
         if (
             is_error
             and not messages
-            and subtype in ("", "success")
+            and not subtype.startswith("error_max_turns")
             and final_text.strip().casefold().startswith("api error")
         ):
             detail = final_text.strip()

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -458,16 +458,19 @@ class ClaudeCodeHarness:
         # the operator log, and the outage latch (its classifier AND its
         # throttle-duration check, which reads rate_limit/overloaded off the
         # detail) all then see the real error instead of "success". Lift ONLY
-        # when the CLI left no real cause: no `errors` messages, and not the one
-        # subtype a caller reads off the detail — budget_exhausted() keys on the
-        # `error_max_turns` prefix, and it is the ONLY such reader. Every other
-        # subtype ("success", "error_during_execution", empty) is a content-free
-        # wrapper whose real cause is the result text; keeping error_max_turns
-        # intact preserves the budget-ending classification.
+        # for the contradiction we have actually observed: an is_error whose
+        # subtype is empty or the self-contradictory "success", with no `errors`
+        # of any form. Under those, `result` is machine error text, not agent
+        # prose. A REAL subtype (error_max_turns, error_during_execution, ...) is
+        # left alone: `result` there may be the agent's own closing message, and
+        # lifting a message that merely starts "API Error" would let agent prose
+        # trip the latch — a false outage pausing every lane is worse than the
+        # rare mis-scoped one. `not errors` (the raw field) also holds when the
+        # CLI returns errors in a non-list form.
         if (
             is_error
-            and not messages
-            and not subtype.startswith("error_max_turns")
+            and not errors
+            and subtype in ("", "success")
             and final_text.strip().casefold().startswith("api error")
         ):
             detail = final_text.strip()

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -159,17 +159,20 @@ def outage(result: SessionResult) -> bool:
     work order's attempts."""
     if not result.is_error:
         return False
-    # error_detail is backend error text and always wins; final_text is
-    # consulted ONLY when no detail exists AND it carries the legacy CLI
-    # error shape ("API Error ..."), never agent prose — a failed session's
-    # report that merely MENTIONS billing or limits must not trip a latch
+    # Union two backend surfaces: error_detail, and the machine "API Error ..."
+    # shape a CLI may put in final_text. The latter is backend text too, never
+    # agent prose, so it must count even when error_detail is non-empty — some
+    # backends stamp a content-free subtype ("success") into error_detail while
+    # the real cause (e.g. "API Error: 400 ... usage limits") sits only in
+    # final_text. final_text is taken ONLY in that "api error" shape, so a
+    # report that merely MENTIONS billing or limits still cannot trip a latch
     # that pauses every lane (review findings, rounds 1 and 2).
     surface = result.error_detail.casefold()
-    if not surface:
-        text = result.final_text.strip().casefold()
-        if not text.startswith("api error"):
-            return False
-        surface = text
+    text = result.final_text.strip().casefold()
+    if text.startswith("api error"):
+        surface = f"{surface}\n{text}"
+    if not surface.strip():
+        return False
     return any(pattern in surface for pattern in OUTAGE_PATTERNS)
 
 

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -447,7 +447,15 @@ class ClaudeCodeHarness:
         is_error = bool(data.get("is_error", process.returncode != 0))
         subtype = str(data.get("subtype") or "")
         errors = data.get("errors")
-        messages = "; ".join(str(e) for e in errors if e) if isinstance(errors, list) else ""
+        # capture a real backend cause in ANY form — a list of messages, or a
+        # non-list (dict/str) the CLI might return — so the lift guard below
+        # never mistakes a present cause for an absent one.
+        if isinstance(errors, list):
+            messages = "; ".join(str(e) for e in errors if e)
+        elif errors:
+            messages = str(errors)
+        else:
+            messages = ""
         detail = f"{subtype}: {messages}" if subtype and messages else (subtype or messages)
         final_text = str(data.get("result") or "")
         # The CLI can flag is_error while stamping a content-free subtype
@@ -459,17 +467,16 @@ class ClaudeCodeHarness:
         # throttle-duration check, which reads rate_limit/overloaded off the
         # detail) all then see the real error instead of "success". Lift ONLY
         # for the contradiction we have actually observed: an is_error whose
-        # subtype is empty or the self-contradictory "success", with no `errors`
-        # of any form. Under those, `result` is machine error text, not agent
+        # subtype is empty or the self-contradictory "success", with no backend
+        # `messages`. Under those, `result` is machine error text, not agent
         # prose. A REAL subtype (error_max_turns, error_during_execution, ...) is
         # left alone: `result` there may be the agent's own closing message, and
         # lifting a message that merely starts "API Error" would let agent prose
         # trip the latch — a false outage pausing every lane is worse than the
-        # rare mis-scoped one. `not errors` (the raw field) also holds when the
-        # CLI returns errors in a non-list form.
+        # rare mis-scoped one.
         if (
             is_error
-            and not errors
+            and not messages
             and subtype in ("", "success")
             and final_text.strip().casefold().startswith("api error")
         ):

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -458,13 +458,15 @@ class ClaudeCodeHarness:
         # the operator log, and the outage latch (its classifier AND its
         # throttle-duration check, which reads rate_limit/overloaded off the
         # detail) all then see the real error instead of "success". Lift ONLY
-        # when the CLI left no real cause — the contradictory "success" subtype
-        # or an empty detail — so a genuine ending subtype (error_max_turns,
-        # error_during_execution) is KEPT and budget_exhausted()/the classifier
-        # still see it.
+        # when the CLI left no real cause: a bare/contradictory subtype ("" or
+        # "success") AND no `errors` messages. A genuine ending subtype
+        # (error_max_turns, error_during_execution) is KEPT so budget_exhausted()
+        # /the classifier still see it, and real backend `errors` text is kept
+        # too (a "success" subtype can still carry messages).
         if (
             is_error
-            and (not detail or subtype == "success")
+            and not messages
+            and subtype in ("", "success")
             and final_text.strip().casefold().startswith("api error")
         ):
             detail = final_text.strip()

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -457,8 +457,16 @@ class ClaudeCodeHarness:
         # authoritative cause, so surface it as the detail: downstream notes,
         # the operator log, and the outage latch (its classifier AND its
         # throttle-duration check, which reads rate_limit/overloaded off the
-        # detail) all then see the real error instead of "success".
-        if is_error and final_text.strip().casefold().startswith("api error"):
+        # detail) all then see the real error instead of "success". Lift ONLY
+        # when the CLI left no real cause — the contradictory "success" subtype
+        # or an empty detail — so a genuine ending subtype (error_max_turns,
+        # error_during_execution) is KEPT and budget_exhausted()/the classifier
+        # still see it.
+        if (
+            is_error
+            and (not detail or subtype == "success")
+            and final_text.strip().casefold().startswith("api error")
+        ):
             detail = final_text.strip()
         # bounded here so every downstream note/report/comment inherits it
         detail = detail[:500]

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -313,6 +313,27 @@ def test_parse_keeps_backend_error_messages_over_a_success_subtype(tmp_path: Pat
     assert outage(res)  # classified from the real cause (overloaded_error)
 
 
+def test_parse_lifts_the_api_error_for_a_content_free_wrapper_subtype(tmp_path: Path) -> None:
+    """`error_during_execution` is a generic wrapper, not a specific cause: with
+    no messages and a machine API-error result, the real cause must be lifted so
+    the latch sees it. The gate protects only `error_max_turns` (the one prefix
+    budget_exhausted reads), so every other wrapper subtype is lifted."""
+    payload = json.dumps(
+        {
+            "is_error": True,
+            "subtype": "error_during_execution",
+            "result": "API Error: 429 rate_limit_error — too many requests.",
+        }
+    )
+    binary = fake_claude(tmp_path, payload)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    res = ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
+    assert res.error_detail.startswith("API Error: 429")  # wrapper lifted
+    assert outage(res)  # classified from the real cause
+    assert not budget_exhausted(res)
+
+
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:
     binary = fake_claude(tmp_path, json.dumps(CANNED))
     ws = tmp_path / "ws"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -235,25 +235,34 @@ def test_outage_classification_matches_api_refusals_only() -> None:
     # empty detail: prose is consulted only in the legacy "API Error" shape
     assert outage(result(True, text="API Error (400): credit balance is too low"))
     assert not outage(result(True, text="Report: raise the usage limit, cut billing costs."))
-    # a content-free subtype ("success") in error_detail must NOT mask a real
-    # API-refusal that the CLI put in final_text (observed on Torch: is_error
-    # with subtype "success" and result "API Error: 400 ... usage limits")
-    assert outage(
-        result(
-            True,
-            detail="success",
-            text="API Error: 400 You have reached your specified workspace API usage limits.",
-        )
+
+
+def test_error_detail_carries_the_real_cause_when_subtype_is_success(tmp_path: Path) -> None:
+    """The CLI can flag is_error while stamping a content-free subtype
+    ("success"), leaving the real cause only in `result`. The parse must lift
+    that machine "API Error ..." text into error_detail so the outage latch
+    sees it (classifier AND throttle-duration read the detail), not "success".
+    Observed on Torch: a session hit the workspace usage cap this exact way."""
+    payload = json.dumps(
+        {
+            "is_error": True,
+            "subtype": "success",
+            "stop_reason": "stop_sequence",
+            "num_turns": 14,
+            "total_cost_usd": 0.95,
+            "result": "API Error: 400 You have reached your specified workspace API usage limits.",
+        }
     )
-    # ...but a real non-outage detail plus agent prose still never latches,
-    # even when that prose is the machine-shaped path's near-miss
-    assert not outage(
-        result(
-            True,
-            detail="error_max_turns: Reached maximum number of turns",
-            text="Report: we hit the usage limit on our billing plan; cache more.",
-        )
-    )
+    binary = fake_claude(tmp_path, payload)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    res = ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
+    assert res.is_error
+    # the detail is the real error, not the useless "success" subtype
+    assert res.error_detail.startswith("API Error: 400")
+    assert "usage limits" in res.error_detail
+    # so the outage latch fires off the detail (no final_text fallback needed)
+    assert outage(res)
 
 
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -265,6 +265,31 @@ def test_error_detail_carries_the_real_cause_when_subtype_is_success(tmp_path: P
     assert outage(res)
 
 
+def test_parse_keeps_a_real_subtype_when_the_result_quotes_an_api_error(tmp_path: Path) -> None:
+    """The result-lift is ONLY for the content-free "success" subtype. A
+    caps-hit ending (error_max_turns) whose last message happens to quote an
+    API error must KEEP its subtype, so budget_exhausted() still fires and the
+    ending is not reclassified as an outage. Drives the real parse, not a hand-
+    built SessionResult (the outage() unit test cannot exercise the lift)."""
+    payload = json.dumps(
+        {
+            "is_error": True,
+            "subtype": "error_max_turns",
+            "stop_reason": "error_max_turns",
+            "num_turns": 50,
+            "result": "API Error: 429 rate limit — retried, then hit the turn cap.",
+        }
+    )
+    binary = fake_claude(tmp_path, payload)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    res = ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
+    assert res.is_error
+    assert res.error_detail.startswith("error_max_turns")  # subtype NOT clobbered
+    assert budget_exhausted(res)  # still a budget ending
+    assert not outage(res)  # and NOT misclassified as an outage
+
+
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:
     binary = fake_claude(tmp_path, json.dumps(CANNED))
     ws = tmp_path / "ws"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -334,6 +334,27 @@ def test_parse_does_not_lift_a_real_subtype_so_agent_prose_cannot_latch(tmp_path
     assert not outage(res)  # agent prose does not trip the latch
 
 
+def test_parse_captures_a_non_list_errors_cause_and_skips_the_lift(tmp_path: Path) -> None:
+    """A real backend cause in a non-list `errors` form (a dict) is still
+    captured into the detail, so the lift does not fire and does not leave a
+    bare "success" — classification comes from the real cause, not the result."""
+    payload = json.dumps(
+        {
+            "is_error": True,
+            "subtype": "success",
+            "errors": {"type": "overloaded_error", "message": "temporarily overloaded"},
+            "result": "API Error: 400 something the agent echoed",
+        }
+    )
+    binary = fake_claude(tmp_path, payload)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    res = ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
+    assert "overloaded_error" in res.error_detail  # non-list cause captured
+    assert not res.error_detail.startswith("API Error")  # lift skipped
+    assert outage(res)  # classified from the real cause
+
+
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:
     binary = fake_claude(tmp_path, json.dumps(CANNED))
     ws = tmp_path / "ws"

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -313,25 +313,25 @@ def test_parse_keeps_backend_error_messages_over_a_success_subtype(tmp_path: Pat
     assert outage(res)  # classified from the real cause (overloaded_error)
 
 
-def test_parse_lifts_the_api_error_for_a_content_free_wrapper_subtype(tmp_path: Path) -> None:
-    """`error_during_execution` is a generic wrapper, not a specific cause: with
-    no messages and a machine API-error result, the real cause must be lifted so
-    the latch sees it. The gate protects only `error_max_turns` (the one prefix
-    budget_exhausted reads), so every other wrapper subtype is lifted."""
+def test_parse_does_not_lift_a_real_subtype_so_agent_prose_cannot_latch(tmp_path: Path) -> None:
+    """The lift is scoped to the observed "success"/empty contradiction. For a
+    REAL subtype (error_during_execution), `result` may be the agent's own
+    closing message, so a message that merely starts "API Error" must NOT be
+    lifted — a false outage that pauses every lane is worse than a rare
+    mis-scoped one. The subtype is kept and the latch does not fire on prose."""
     payload = json.dumps(
         {
             "is_error": True,
             "subtype": "error_during_execution",
-            "result": "API Error: 429 rate_limit_error — too many requests.",
+            "result": "API Error: 429 the agent quoted while writing its report.",
         }
     )
     binary = fake_claude(tmp_path, payload)
     ws = tmp_path / "ws"
     ws.mkdir()
     res = ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
-    assert res.error_detail.startswith("API Error: 429")  # wrapper lifted
-    assert outage(res)  # classified from the real cause
-    assert not budget_exhausted(res)
+    assert res.error_detail.startswith("error_during_execution")  # NOT lifted
+    assert not outage(res)  # agent prose does not trip the latch
 
 
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -235,6 +235,25 @@ def test_outage_classification_matches_api_refusals_only() -> None:
     # empty detail: prose is consulted only in the legacy "API Error" shape
     assert outage(result(True, text="API Error (400): credit balance is too low"))
     assert not outage(result(True, text="Report: raise the usage limit, cut billing costs."))
+    # a content-free subtype ("success") in error_detail must NOT mask a real
+    # API-refusal that the CLI put in final_text (observed on Torch: is_error
+    # with subtype "success" and result "API Error: 400 ... usage limits")
+    assert outage(
+        result(
+            True,
+            detail="success",
+            text="API Error: 400 You have reached your specified workspace API usage limits.",
+        )
+    )
+    # ...but a real non-outage detail plus agent prose still never latches,
+    # even when that prose is the machine-shaped path's near-miss
+    assert not outage(
+        result(
+            True,
+            detail="error_max_turns: Reached maximum number of turns",
+            text="Report: we hit the usage limit on our billing plan; cache more.",
+        )
+    )
 
 
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -290,6 +290,29 @@ def test_parse_keeps_a_real_subtype_when_the_result_quotes_an_api_error(tmp_path
     assert not outage(res)  # and NOT misclassified as an outage
 
 
+def test_parse_keeps_backend_error_messages_over_a_success_subtype(tmp_path: Path) -> None:
+    """A "success" subtype can still carry real `errors` — the lift must NOT
+    clobber them with the result text. The backend message is the authoritative
+    cause and classification must come from it, not the quoted result."""
+    payload = json.dumps(
+        {
+            "is_error": True,
+            "subtype": "success",
+            "errors": ["overloaded_error: the model is temporarily overloaded"],
+            "result": "API Error: 400 something the agent echoed",
+        }
+    )
+    binary = fake_claude(tmp_path, payload)
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    res = ClaudeCodeHarness(api_key="k", binary=binary).run("task", ws)
+    assert res.is_error
+    # the real backend cause is kept, not replaced by the result text
+    assert "overloaded_error" in res.error_detail
+    assert not res.error_detail.startswith("API Error")
+    assert outage(res)  # classified from the real cause (overloaded_error)
+
+
 def test_clean_sessions_and_real_failures_are_not_budget_endings(tmp_path: Path) -> None:
     binary = fake_claude(tmp_path, json.dumps(CANNED))
     ws = tmp_path / "ws"


### PR DESCRIPTION
## What

The first watched dispatch activation on Torch surfaced a real error-handling
gap. A session hit the author key's **workspace usage cap** and the Claude CLI
returned it as `is_error` with a content-free `subtype: "success"` in
`error_detail`, while the real cause sat only in `result`:

```
is_error   = True
subtype    = "success"      # -> error_detail
result     = "API Error: 400 You have reached your specified workspace API usage limits."
```

So `outage()` scanned `error_detail="success"`, matched no `OUTAGE_PATTERN`, and
a genuine API refusal was classified `session-error` (a malfunction) instead of
`session-outage`.

## Why it matters

- **`session-outage`** → pause the lanes, don't bill the failure against retry caps.
- **`session-error`** → neither.

On a real API cap, yolo would keep hammering the capped API each tick and burn
the run's retries — the exact thrash the outage latch exists to prevent.

## Fix (at the parse, not in `outage()`)

The root cause is the Claude harness parse stamping the content-free `"success"`
subtype into `error_detail` while the real cause sits in `result`. Fixed there:
when `is_error` and `result` is machine `"API Error ..."`-shaped, that becomes
the `error_detail` — **but only when the CLI left no real cause** (the `"success"`
subtype or an empty detail), so a genuine ending subtype (`error_max_turns`,
`error_during_execution`) is kept and `budget_exhausted()`/the classifier still
see it.

Then the real cause reaches the operator log, the latch stamp, and the outage
latch — both its classifier and its throttle-duration check (which reads
`rate_limit`/`overloaded` off the detail). `outage()` itself is **unchanged**
(it still consults `final_text` only when `error_detail` is empty), so agent
prose in a Codex/Hermes `final_text` cannot trip the latch.

## Tests

Two parse-level tests drive the real `ClaudeCodeHarness.run`:
- the exact Torch shape (`subtype:"success"`, `result:"API Error: 400 ... usage
  limits"`) → `error_detail` carries the real cause and `outage()` fires;
- an `error_max_turns` ending whose `result` quotes an API error → subtype
  survives, `budget_exhausted()` fires, `outage()` does not.

Plus the existing `outage()` unit suite. Full harness/orchestrator/followup/
runstate suites green; ruff + mypy clean.

## Review history
- **R1** — terra flagged that an earlier `outage()`-level fix widened the
  prose-latch surface (blocking); claude flagged the latch-stamp/throttle-
  duration gap. Both correct → moved the fix to the parse (`28b8313`).
- **R2** — claude flagged the wholesale-replace clobbering a real subtype →
  gated the lift (`5a7261c`). (terra R2 hit a transient model-API error and is
  being re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
