### PR TITLE
Arm dispatched-wake with a DISPATCH_WAKE sentinel (mirrors PAUSE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- The dispatched-wake on-switch can now be armed with a `<root>/DISPATCH_WAKE`
+  sentinel file, mirroring the `PAUSE` sentinel — an operator arms/disarms with
+  a `touch`/`rm`, no tick-chain restart or env-var surgery on a live chain. The
+  `AUTORESEARCH_DISPATCH_WAKE` env var still works too (either arms it); a
+  half-configured chain env still fails safe to the dry `LoggingDispatcher`.
+
 - The improved-wake publish is now idempotent across a crash mid-open. A wake
   that opened the PR but died before recording it left the run WAITING; the
   re-wake would re-push non-fast-forward and open a duplicate (or record ABORTED

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -64,6 +64,11 @@ from autoresearch.runstate import (
 log = logging.getLogger(__name__)
 
 PAUSE_SENTINEL = "PAUSE"
+# Operator on-switch for dispatched-wake, mirroring PAUSE: a root-relative
+# sentinel an operator arms/disarms with a touch/rm — no chain restart, no
+# env-var surgery on a live tick. The AUTORESEARCH_DISPATCH_WAKE env var still
+# works too (either arms it); the sentinel is the reversible, restart-free path.
+DISPATCH_WAKE_SENTINEL = "DISPATCH_WAKE"
 HEARTBEAT_NAME = "heartbeat.json"
 
 # Grace between "experiment terminal" and the sweep stepping in: the afterany
@@ -1700,24 +1705,28 @@ def _wake_panel_minutes(spec: FollowupSpec) -> int:
 
 
 def _wake_dispatcher_from_env(
-    compute: SlurmCompute, followup_spec: FollowupSpec | None, now: float
+    compute: SlurmCompute, followup_spec: FollowupSpec | None, now: float, root: Path
 ) -> tuple[WakeDispatcher, bool]:
     """The wake delivery for this tick, behind an EXPLICIT on-switch so the
     dispatched-wake path lands DARK. Returns `(dispatcher, live)`:
 
-    * `AUTORESEARCH_DISPATCH_WAKE` set AND the chain env carries what a wake job
-      needs -> the real `JobWakeDispatcher` and a LIVE sweep;
+    * armed (the `AUTORESEARCH_DISPATCH_WAKE` env var OR a `<root>/DISPATCH_WAKE`
+      sentinel file) AND the chain env carries what a wake job needs -> the real
+      `JobWakeDispatcher` and a LIVE sweep;
     * otherwise -> the `LoggingDispatcher` and a DRY sweep (today's behavior).
 
-    So an operator turns dispatched climbing on deliberately, and a
+    The sentinel mirrors PAUSE: an operator arms/disarms with a touch/rm, no
+    chain restart. So dispatched climbing is turned on deliberately, and a
     half-configured environment fails safe to dry rather than to a wake job
     that cannot run."""
-    if not os.environ.get("AUTORESEARCH_DISPATCH_WAKE", "").strip():
+    armed = (
+        bool(os.environ.get("AUTORESEARCH_DISPATCH_WAKE", "").strip())
+        or (root / DISPATCH_WAKE_SENTINEL).exists()
+    )
+    if not armed:
         return LoggingDispatcher(), False
     if followup_spec is None:
-        log.warning(
-            "AUTORESEARCH_DISPATCH_WAKE set but the chain env is incomplete; wake stays dry"
-        )
+        log.warning("dispatch-wake armed but the chain env is incomplete; wake stays dry")
         return LoggingDispatcher(), False
     log.info("dispatched-wake ON: the waiting-run sweep delivers real wakes this tick")
     return JobWakeDispatcher(compute, followup_spec, now), True
@@ -1820,13 +1829,13 @@ def main() -> int:
     args.root.mkdir(parents=True, exist_ok=True)
     # In-review servicing is LIVE when credentials + image are available in the
     # chain environment. The waiting-run sweep delivers real wakes only when the
-    # operator flips AUTORESEARCH_DISPATCH_WAKE (and the env is complete); by
-    # default it stays dry with the LoggingDispatcher — dispatched climbing
-    # lands DARK.
+    # operator arms it — the AUTORESEARCH_DISPATCH_WAKE env var or a
+    # <root>/DISPATCH_WAKE sentinel — and the env is complete; by default it
+    # stays dry with the LoggingDispatcher — dispatched climbing lands DARK.
     github, followup_spec = _followup_spec_from_env(args.root)
     compute = SlurmCompute()
     now = time.time()
-    dispatcher, wake_live = _wake_dispatcher_from_env(compute, followup_spec, now)
+    dispatcher, wake_live = _wake_dispatcher_from_env(compute, followup_spec, now, args.root)
 
     report = tick(
         args.root,

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1891,6 +1891,7 @@ def test_wake_dispatcher_on_switch_lands_dark_by_default(tmp_path, monkeypatch):
     # dispatched climbing must NOT deliver wakes unless the operator flips the
     # explicit on-switch AND the chain env is complete.
     from autoresearch.tick import (
+        DISPATCH_WAKE_SENTINEL,
         FollowupSpec,
         JobWakeDispatcher,
         LoggingDispatcher,
@@ -1902,18 +1903,31 @@ def test_wake_dispatcher_on_switch_lands_dark_by_default(tmp_path, monkeypatch):
         account="a", partition="p", run_root=tmp_path, image="/i.sif", home=tmp_path
     )
 
-    # default: no on-switch -> dry sweep, logging dispatcher
+    # default: no env, no sentinel -> dry sweep, logging dispatcher
     monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
-    dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW)
+    dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW, tmp_path)
     assert isinstance(dispatcher, LoggingDispatcher) and live is False
 
-    # on-switch + complete env -> live sweep, real dispatcher
+    # env on-switch + complete env -> live sweep, real dispatcher
     monkeypatch.setenv("AUTORESEARCH_DISPATCH_WAKE", "1")
-    dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW)
+    dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW, tmp_path)
     assert isinstance(dispatcher, JobWakeDispatcher) and live is True
 
-    # on-switch but incomplete env -> fail SAFE to dry, not a wake that can't run
-    dispatcher, live = _wake_dispatcher_from_env(compute, None, NOW)
+    # env on-switch but incomplete env -> fail SAFE to dry, not a wake that can't run
+    dispatcher, live = _wake_dispatcher_from_env(compute, None, NOW, tmp_path)
+    assert isinstance(dispatcher, LoggingDispatcher) and live is False
+
+    # sentinel file arms it too (mirrors PAUSE) — no env var needed
+    monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
+    (tmp_path / DISPATCH_WAKE_SENTINEL).touch()
+    dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW, tmp_path)
+    assert isinstance(dispatcher, JobWakeDispatcher) and live is True
+    # ...still fail-safe to dry on an incomplete env
+    dispatcher, live = _wake_dispatcher_from_env(compute, None, NOW, tmp_path)
+    assert isinstance(dispatcher, LoggingDispatcher) and live is False
+    # disarming removes the sentinel -> back to dry (reversible, like PAUSE)
+    (tmp_path / DISPATCH_WAKE_SENTINEL).unlink()
+    dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW, tmp_path)
     assert isinstance(dispatcher, LoggingDispatcher) and live is False
 
 


### PR DESCRIPTION
## What

Adds a `<root>/DISPATCH_WAKE` sentinel file as an alternative way to arm the
dispatched-wake on-switch, mirroring the existing `PAUSE` sentinel.

## Why

The on-switch was env-only (`AUTORESEARCH_DISPATCH_WAKE`). The tick chain freezes
its env at start and propagates it via `--export=ALL`, so arming it on a **live**
chain meant restarting the chain with the exact `--export` env — fragile (a
missing var silently degrades followup/review, since `_followup_spec_from_env`
returns `None`) and not reversible without another restart.

A sentinel file is the same pattern operators already use for `PAUSE`: arm with
`touch <root>/DISPATCH_WAKE`, disarm with `rm` — no chain restart, reversible,
and it lands with the deploy like any code.

## Behavior

`_wake_dispatcher_from_env` is armed when **either** `AUTORESEARCH_DISPATCH_WAKE`
is set **or** the sentinel exists. Everything else is unchanged: a half-configured
chain env still fails safe to the dry `LoggingDispatcher`, so dispatched climbing
stays DARK until both armed **and** the env is complete.

## Test

`test_wake_dispatcher_on_switch_lands_dark_by_default` extended: sentinel arms it
(no env var), still fails safe on an incomplete env, and disarming (`unlink`)
returns to dry. 62 tick tests green; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
