### PR TITLE
Alternative author backend: contained codex (--author-backend codex)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Alternative AUTHOR backend: `climb --author-backend codex` runs the editing
+  role on the OpenAI Codex CLI instead of Claude, to try a cheaper author (e.g.
+  `--model gpt-5.6-terra`). It runs **contained** — `codex login` and `codex
+  exec` both inside `apptainer exec --containall --cleanenv` (shared bound
+  `--home` for auth.json) around codex's own `--sandbox workspace-write`, so an
+  author's writes+execution are fenced the same way the Claude author is.
+  `--image` and a non-claude `--model` are required (guarded early). codex
+  session resume is not bench-validated yet, so a blocking panel finding drafts
+  rather than revising. The read-only codex/hermes reviewer path is unchanged.
+  (Reachable but unexercised end-to-end; needs codex added to the `.sif` image.)
+
 - Tick coalescing: under partition congestion, queued ticks bunch up and become
   eligible together (the singleton dependency serializes them), so they would
   run back-to-back and redundantly re-sweep. A tick now no-ops if another tick

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -979,6 +979,7 @@ def build_editor_harness(
     binary: str | None = None,
     model: str | None = None,
     container_image: str = "",
+    codex_extra_args: tuple[str, ...] = (),
 ) -> Harness:
     """Construct an editing role's harness from its RoleSpec, for the chosen
     backend — the same deployment wiring the judges use (`spec.budget` drives
@@ -1010,6 +1011,9 @@ def build_editor_harness(
             sandbox="workspace-write",
             timeout_s=spec.budget.walltime_s,
             container_image=container_image,
+            # host-specific codex config (e.g. -c use_legacy_landlock=true),
+            # mirroring the reviewer branch's sandbox_extra
+            extra_args=codex_extra_args,
         )
     if backend != "claude":
         raise ValueError(f"unknown editor backend: {backend!r}")
@@ -1935,6 +1939,14 @@ def main() -> int:
         "(apptainer + --sandbox workspace-write) and REQUIRES --image and a "
         "codex/openai --model (e.g. gpt-5.6-terra).",
     )
+    parser.add_argument(
+        "--codex-config",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="codex `-c KEY=VALUE` config for the codex author (repeatable), "
+        "e.g. --codex-config use_legacy_landlock=true for a host that needs it.",
+    )
     parser.add_argument("--max-turns", type=int, default=60)
     parser.add_argument("--session-minutes", type=int, default=60)
     parser.add_argument(
@@ -1991,6 +2003,8 @@ def main() -> int:
                 "--author-backend codex needs a codex/openai --model "
                 "(e.g. gpt-5.6-terra), not the claude default"
             )
+    # each --codex-config KEY=VALUE becomes a `-c KEY=VALUE` pair for codex
+    codex_extra = tuple(a for c in args.codex_config for a in ("-c", c))
 
     bot_auth = FileTokenProvider(Path(args.pat_file))
 
@@ -2031,6 +2045,7 @@ def main() -> int:
                 binary=args.claude_bin if args.author_backend == "claude" else None,
                 model=args.model,
                 container_image=args.image,
+                codex_extra_args=codex_extra,
             )
         try:
             resumed = resume_run(
@@ -2144,6 +2159,7 @@ def main() -> int:
                     binary=args.claude_bin if args.author_backend == "claude" else None,
                     model=args.model,
                     container_image=args.image,
+                    codex_extra_args=codex_extra,
                 ),
                 spec=spec,
                 panel_lenses=panel_lenses,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -36,7 +36,7 @@ from autoresearch.github import (
     GitHubClient,
     Workspace,
 )
-from autoresearch.harness import ClaudeCodeHarness, Harness, SessionResult, redact
+from autoresearch.harness import ClaudeCodeHarness, CodexHarness, Harness, SessionResult, redact
 from autoresearch.measure import DispatchSettings, LocalMeasurer
 from autoresearch.orchestrator import (
     ClimbConfig,
@@ -973,24 +973,42 @@ def build_editor_harness(
     api_key: str,
     spec: RoleSpec | None = None,
     *,
+    backend: str = "claude",
     binary: str | None = None,
     model: str | None = None,
     container_image: str = "",
-) -> ClaudeCodeHarness:
-    """Construct an editing role's harness from its RoleSpec — the same
-    deployment wiring the judges use (`spec.budget` drives turns and walltime,
-    `spec.tools` the tool set, so manifest and harness cannot disagree). The
-    session runs contained (apptainer) and KEEPS instruction-file discovery —
-    the target repo's CLAUDE.md is legitimate guidance for an editing role,
-    unlike a judge's untrusted checkout.
+) -> Harness:
+    """Construct an editing role's harness from its RoleSpec, for the chosen
+    backend — the same deployment wiring the judges use (`spec.budget` drives
+    turns and walltime). The session runs contained (apptainer) and KEEPS
+    instruction-file discovery — the target repo's CLAUDE.md is legitimate
+    guidance for an editing role, unlike a judge's untrusted checkout.
 
-    Claude-only by validation status, not by design: the seam (`run_role`,
-    `climb_once`) takes any Harness. A codex or hermes editor needs its
-    resume and write+execute containment story bench-validated first; then
-    it is a new branch here, zero kernel change (the reviewer's rollout)."""
+    The seam (`run_role`, `climb_once`) takes any Harness, so a backend is one
+    branch here, zero kernel change (the reviewer's rollout):
+    - claude: native tool set, apptainer-contained; the trusted default.
+    - codex: apptainer-contained + `--sandbox workspace-write`. An author MUST
+      be contained (it writes+executes), so container_image is REQUIRED — the
+      read-only reviewer could skip it, an author cannot. Session RESUME is not
+      bench-validated for codex yet, so the revise loop degrades safely: no
+      session id (or a failed resume) drafts instead of revising."""
     spec = spec or author_spec()
     if not spec.execution.can_execute:
         raise ValueError("build_editor_harness is for editing roles")
+    if backend == "codex":
+        if not container_image:
+            # an author writes+executes; it must not run uncontained
+            raise ValueError("codex editor backend requires a container_image (apptainer)")
+        return CodexHarness(
+            api_key=api_key,
+            binary=binary or "codex",
+            model=model or "",  # "" -> codex's configured default; pin a verified id
+            sandbox="workspace-write",
+            timeout_s=spec.budget.walltime_s,
+            container_image=container_image,
+        )
+    if backend != "claude":
+        raise ValueError(f"unknown editor backend: {backend!r}")
     return ClaudeCodeHarness(
         api_key=api_key,
         binary=binary or "claude",
@@ -1905,6 +1923,14 @@ def main() -> int:
     )
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument("--model", default="claude-opus-5")
+    parser.add_argument(
+        "--author-backend",
+        choices=("claude", "codex"),
+        default="claude",
+        help="agent backend for the author/editor role. codex runs contained "
+        "(apptainer + --sandbox workspace-write) and REQUIRES --image and a "
+        "codex/openai --model (e.g. gpt-5.6-terra).",
+    )
     parser.add_argument("--max-turns", type=int, default=60)
     parser.add_argument("--session-minutes", type=int, default=60)
     parser.add_argument(
@@ -1951,6 +1977,16 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     if not args.image and not args.uncontained:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")
+    if args.author_backend == "codex":
+        # a codex author writes+executes: it must be contained, and the claude
+        # default model would 404 on codex — fail early, before any spend.
+        if not args.image:
+            parser.error("--author-backend codex requires --image (it runs contained)")
+        if args.model.startswith("claude"):
+            parser.error(
+                "--author-backend codex needs a codex/openai --model "
+                "(e.g. gpt-5.6-terra), not the claude default"
+            )
 
     bot_auth = FileTokenProvider(Path(args.pat_file))
 
@@ -1987,7 +2023,8 @@ def main() -> int:
             wake_harness = build_editor_harness(
                 wake_api_key,
                 wake_spec,
-                binary=args.claude_bin,
+                backend=args.author_backend,
+                binary=args.claude_bin if args.author_backend == "claude" else None,
                 model=args.model,
                 container_image=args.image,
             )
@@ -2099,7 +2136,8 @@ def main() -> int:
                 harness=build_editor_harness(
                     api_key,
                     spec,
-                    binary=args.claude_bin,
+                    backend=args.author_backend,
+                    binary=args.claude_bin if args.author_backend == "claude" else None,
                     model=args.model,
                     container_image=args.image,
                 ),

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -709,6 +709,8 @@ def resume_run(
                 can_revise = (
                     bool(verdict.blocking)
                     and harness is not None
+                    # codex/hermes declare supports_resume=False -> draft, don't resume
+                    and getattr(harness, "supports_resume", True)
                     and spec is not None
                     and bool(record.resume_session_id)
                     and reads <= panel_revisions
@@ -989,9 +991,11 @@ def build_editor_harness(
     - claude: native tool set, apptainer-contained; the trusted default.
     - codex: apptainer-contained + `--sandbox workspace-write`. An author MUST
       be contained (it writes+executes), so container_image is REQUIRED — the
-      read-only reviewer could skip it, an author cannot. Session RESUME is not
-      bench-validated for codex yet, so the revise loop degrades safely: no
-      session id (or a failed resume) drafts instead of revising."""
+      read-only reviewer could skip it, an author cannot. Codex declares
+      `supports_resume=False` (its headless resume is not bench-validated), so a
+      blocking panel finding DRAFTS instead of attempting a resume — both the
+      inline and wake revise paths gate on `supports_resume`, so there is no
+      blind revise and no improvement lost to a failed resume."""
     spec = spec or author_spec()
     if not spec.execution.can_execute:
         raise ValueError("build_editor_harness is for editing roles")

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -724,6 +724,12 @@ class CodexHarness:
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
     ) -> SessionResult:
+        # Contained runs bind workspace + home into apptainer, whose bind sources
+        # must be ABSOLUTE (a relative one fails at mount time); resolving here
+        # also keeps codex's --cd / --output-last-message aligned with the mount
+        # points inside the container.
+        if self.container_image:
+            workspace = workspace.resolve()
         transcript_stem = f"{workspace.name}-codex"
         session_home = workspace.parent / f"{workspace.name}-home"
         try:

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -635,11 +635,14 @@ class CodexHarness:
 
     AUTHOR mode (`container_image` set): both `codex login` and `codex exec` run
     inside `apptainer exec --containall --cleanenv`, sharing a bound `--home` so
-    the login's auth.json is visible to the exec. That layers TWO boundaries —
-    apptainer (no host FS, scrubbed env, no /proc reach to a parent token) around
-    codex's own `--sandbox workspace-write` (writes confined to the clone). codex
-    is taken from the image (on PATH), not bound from the host. The reviewer path
-    (no `container_image`) is unchanged: uncontained, `--sandbox read-only`.
+    the login's auth.json is visible to the exec. That layers TWO boundaries:
+    apptainer (no host FS beyond the two binds; `--cleanenv` scrubs the env down
+    to the author's own key, so the process tree carries no foreign token for a
+    /proc read to lift — the boundary is the scrubbed env, not PID isolation,
+    the same posture as the Claude author) around codex's own `--sandbox
+    workspace-write` (writes confined to the clone). codex is taken from the
+    image (on PATH), not bound from the host. The reviewer path (no
+    `container_image`) is unchanged: uncontained, `--sandbox read-only`.
 
     `run` never raises: every failure comes back as an error SessionResult.
     """

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -77,7 +77,13 @@ class Harness(Protocol):
     agent with `resume_session_id` — restoring its full working context — and
     a wake prompt carrying the results. Session state lives in the per-run
     HOME next to the workspace, so wakes survive orchestrator restarts and can
-    land on a different cluster node (shared filesystem)."""
+    land on a different cluster node (shared filesystem).
+
+    A backend MAY declare a class attribute `supports_resume = False` when its
+    headless resume is not trustworthy (codex/hermes). The revise loop checks it
+    (via getattr, default True) and DRAFTS instead of calling run() with a resume
+    id — an untrusted resume that starts fresh or fails would revise blind or
+    lose a verified improvement. Optional, so test doubles need not declare it."""
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
@@ -308,6 +314,7 @@ class ClaudeCodeHarness:
     apptainer_binary: str = "apptainer"
 
     CONTAINER_CLAUDE = "/opt/agent/claude"
+    supports_resume = True  # native --resume, bench-validated
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
@@ -662,6 +669,10 @@ class CodexHarness:
     # bare class attribute (no annotation) so the dataclass does not treat it
     # as a field, matching ClaudeCodeHarness.CONTAINER_CLAUDE.
     CONTAINER_CODEX = "codex"
+    # codex --json session-id parsing is best-effort until a live authed run
+    # verifies the event fields, so headless resume is NOT trusted yet: the
+    # revise loop drafts instead of resuming (flip to True once validated).
+    supports_resume = False
 
     def _apptainer_argv(
         self, inner: list[str], session_home: Path, workspace: Path | None
@@ -958,6 +969,10 @@ class HermesHarness:
     `run` never raises: every failure comes back as an error SessionResult.
     """
 
+    # no headless resume seam (run() refuses a resume id), so the revise loop
+    # drafts rather than resuming.
+    supports_resume = False
+
     api_key: str  # exported via key_env (never argv)
     repo_dir: Path  # pinned hermes-agent checkout
     # hermes resolves credentials from provider-specific env vars (a registry:
@@ -1104,6 +1119,7 @@ class FakeHarness:
     result: SessionResult
     script: Any = None  # optional callable(brief_text, workspace) for side effects
     calls: list[tuple[str, str, str | None]] = field(default_factory=list)
+    supports_resume: bool = True  # a field so tests can exercise the no-resume path
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -631,8 +631,15 @@ class CodexHarness:
     (docs/design/consolidation.md): Codex's own `--sandbox read-only` plus a
     judge RoleSpec's tool set. CLI flags are verified against codex-cli 0.130.0;
     the `--json` event field names still need a live authed run, so `session_id`
-    and cost parsing are best-effort until then. No apptainer wrapper yet (the
-    reviewer runs read-only); the author-on-Codex path adds one later.
+    and cost parsing are best-effort until then.
+
+    AUTHOR mode (`container_image` set): both `codex login` and `codex exec` run
+    inside `apptainer exec --containall --cleanenv`, sharing a bound `--home` so
+    the login's auth.json is visible to the exec. That layers TWO boundaries —
+    apptainer (no host FS, scrubbed env, no /proc reach to a parent token) around
+    codex's own `--sandbox workspace-write` (writes confined to the clone). codex
+    is taken from the image (on PATH), not bound from the host. The reviewer path
+    (no `container_image`) is unchanged: uncontained, `--sandbox read-only`.
 
     `run` never raises: every failure comes back as an error SessionResult.
     """
@@ -644,14 +651,52 @@ class CodexHarness:
     sandbox: str = "read-only"  # judge default; authors pass "workspace-write"
     timeout_s: int = DEFAULT_TIMEOUT_S
     extra_args: tuple[str, ...] = field(default_factory=tuple)
+    # AUTHOR mode: when set, login+exec run inside this apptainer image. Empty =
+    # uncontained (the read-only reviewer path).
+    container_image: str = ""
+    apptainer_binary: str = "apptainer"
+    # codex on the image PATH (contained runs never bind the host binary); a
+    # bare class attribute (no annotation) so the dataclass does not treat it
+    # as a field, matching ClaudeCodeHarness.CONTAINER_CLAUDE.
+    CONTAINER_CODEX = "codex"
+
+    def _apptainer_argv(
+        self, inner: list[str], session_home: Path, workspace: Path | None
+    ) -> list[str]:
+        """Wrap a codex argv in `apptainer exec --containall --cleanenv`. The
+        run-home is bound via `--home` (auth.json survives login->exec and lands
+        on the shared FS); the workspace is bound and set as --pwd only for the
+        exec, never the login."""
+        argv = [
+            self.apptainer_binary,
+            "exec",
+            "--containall",
+            "--cleanenv",
+            "--home",
+            f"{session_home}:{session_home}",
+        ]
+        if workspace is not None:
+            argv += ["--bind", f"{workspace}:{workspace}", "--pwd", str(workspace)]
+        return [*argv, self.container_image, *inner]
 
     def _login(self, session_home: Path) -> SessionResult | None:
         """Write auth.json into the per-run HOME. None on success, an error
-        SessionResult on failure. The key travels on stdin, never argv."""
+        SessionResult on failure. The key travels on stdin, never argv. In
+        AUTHOR mode the login runs inside apptainer with the same bound --home,
+        so auth.json lands where the contained exec will read it."""
         env = session_env(self.api_key, "OPENAI_API_KEY", session_home)
+        if self.container_image:
+            # --cleanenv drops host env inside the container except APPTAINERENV_*
+            # (prefix stripped by apptainer): the key travels via env, not argv.
+            env["APPTAINERENV_OPENAI_API_KEY"] = self.api_key
+            login_argv = self._apptainer_argv(
+                [self.CONTAINER_CODEX, "login", "--with-api-key"], session_home, None
+            )
+        else:
+            login_argv = [self.binary, "login", "--with-api-key"]
         try:
             proc = subprocess.run(
-                [self.binary, "login", "--with-api-key"],
+                login_argv,
                 input=self.api_key,
                 cwd=session_home,
                 env=env,
@@ -701,8 +746,10 @@ class CodexHarness:
         last_message_path = session_home / "codex-last-message.txt"
         with contextlib.suppress(OSError):
             last_message_path.unlink()
-        command = _codex_command(
-            self.binary,
+        # contained runs invoke the image's codex (on PATH); uncontained the
+        # host binary. The exec binds the workspace and sets it as --pwd.
+        codex_argv = _codex_command(
+            self.CONTAINER_CODEX if self.container_image else self.binary,
             self.model,
             self.sandbox,
             workspace,
@@ -710,8 +757,15 @@ class CodexHarness:
             resume_session_id,
             self.extra_args,
         )
+        command = (
+            self._apptainer_argv(codex_argv, session_home, workspace)
+            if self.container_image
+            else codex_argv
+        )
         try:
             env = session_env(self.api_key, "OPENAI_API_KEY", session_home)
+            if self.container_image:
+                env["APPTAINERENV_OPENAI_API_KEY"] = self.api_key
             process = subprocess.Popen(
                 command,
                 cwd=workspace,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1140,10 +1140,12 @@ def climb_once(
             # a degraded clean read is NOT a certified pass: no wake (nothing
             # for the author to fix), but the caller drafts the PR
             break
-        if not session.session_id:
-            # cannot resume a session with no id, and a FRESH session seeing
-            # only the findings text would revise blind — fail closed to the
-            # draft path instead (review question, #95 round 1)
+        if not session.session_id or not getattr(harness, "supports_resume", True):
+            # cannot resume: no session id, OR a backend whose headless resume
+            # is not bench-validated (codex/hermes). A FRESH session seeing only
+            # the findings would revise blind, and an unvalidated resume that
+            # fails would lose this verified improvement as a session-error —
+            # so fail closed to the draft path (review question, #95 round 1).
             panel_blocking_open = True
             break
         if panel_reads > panel_revisions:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1369,13 +1369,20 @@ def test_editor_harness_codex_backend_is_contained() -> None:
 
     spec = author_spec(max_turns=9, walltime_s=300)
     harness = build_editor_harness(
-        "sk-o", spec, backend="codex", model="gpt-5.6-terra", container_image="img.sif"
+        "sk-o",
+        spec,
+        backend="codex",
+        model="gpt-5.6-terra",
+        container_image="img.sif",
+        codex_extra_args=("-c", "use_legacy_landlock=true"),
     )
     assert isinstance(harness, CodexHarness)
     assert harness.sandbox == "workspace-write"
     assert harness.container_image == "img.sif"
     assert harness.model == "gpt-5.6-terra"
     assert harness.timeout_s == 300
+    assert harness.extra_args == ("-c", "use_legacy_landlock=true")  # host codex config
+    assert harness.supports_resume is False  # revise loop drafts, never resumes
     # an author MUST be contained
     with pytest.raises(ValueError, match="container_image"):
         build_editor_harness("sk-o", spec, backend="codex", container_image="")

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1346,15 +1346,41 @@ def test_author_harness_is_built_from_the_spec() -> None:
     """The spec is the single source for the session budget: manifest and
     harness cannot disagree (the judges' build_reviewer_harness pattern)."""
     from autoresearch.climb import build_editor_harness
+    from autoresearch.harness import ClaudeCodeHarness
     from autoresearch.roles import author_spec, reviewer_spec
 
     spec = author_spec(max_turns=7, walltime_s=120)
     harness = build_editor_harness("sk-key", spec, container_image="img.sif")
+    assert isinstance(harness, ClaudeCodeHarness)  # default backend; narrows the type
     assert harness.max_turns == 7
     assert harness.timeout_s == 120
     assert harness.container_image == "img.sif"
     with pytest.raises(ValueError, match="editing roles"):
         build_editor_harness("sk-key", reviewer_spec())
+
+
+def test_editor_harness_codex_backend_is_contained() -> None:
+    """The codex author backend is one branch, zero kernel change: contained
+    (apptainer) + --sandbox workspace-write, and container_image is REQUIRED
+    (an author writes+executes, so it must not run uncontained)."""
+    from autoresearch.climb import build_editor_harness
+    from autoresearch.harness import CodexHarness
+    from autoresearch.roles import author_spec
+
+    spec = author_spec(max_turns=9, walltime_s=300)
+    harness = build_editor_harness(
+        "sk-o", spec, backend="codex", model="gpt-5.6-terra", container_image="img.sif"
+    )
+    assert isinstance(harness, CodexHarness)
+    assert harness.sandbox == "workspace-write"
+    assert harness.container_image == "img.sif"
+    assert harness.model == "gpt-5.6-terra"
+    assert harness.timeout_s == 300
+    # an author MUST be contained
+    with pytest.raises(ValueError, match="container_image"):
+        build_editor_harness("sk-o", spec, backend="codex", container_image="")
+    with pytest.raises(ValueError, match="unknown editor backend"):
+        build_editor_harness("sk-o", spec, backend="bogus", container_image="img.sif")
 
 
 def _panel_judge(texts):

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -582,13 +582,29 @@ def test_container_image_wraps_in_apptainer(tmp_path: Path) -> None:
     assert "APPTAINERENV_ANTHROPIC_API_KEY=sk-c" in seen_env
 
 
+def _recording_apptainer(tmp_path: Path, payload: str) -> tuple[str, Path, Path]:
+    """A fake apptainer that APPENDS every invocation's argv+env to logs, so a
+    test can assert BOTH codex calls (login then exec) — not just the last."""
+    calls, envs = tmp_path / "calls.log", tmp_path / "envs.log"
+    script = tmp_path / "fake-apptainer"
+    script.write_text(
+        "#!/bin/sh\n"
+        f'printf "%s\\n" "$*" >> {calls}\n'
+        f"env | grep APPTAINERENV >> {envs}\n"
+        f"cat <<'EOF'\n{payload}\nEOF\n"
+        "exit 0\n"
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return str(script), calls, envs
+
+
 def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
-    """AUTHOR mode: codex exec runs inside apptainer (--containall/--cleanenv,
-    workspace + run-home bound, --pwd the workspace), codex from the image PATH,
-    author sandbox workspace-write, key via APPTAINERENV_ (never argv)."""
-    # the fake stands in for apptainer; codex login then exec both go through it,
-    # so seen_argv holds the last (exec) call's arguments.
-    binary = fake_claude(tmp_path, json.dumps(CANNED))
+    """AUTHOR mode: BOTH codex login and codex exec run inside apptainer
+    (--containall/--cleanenv), so neither exposes the author key to the host —
+    login is contained too, not only the exec. exec binds the workspace + --pwd,
+    codex from the image PATH, author sandbox workspace-write, key via
+    APPTAINERENV_ (never argv)."""
+    binary, calls, envs = _recording_apptainer(tmp_path, json.dumps(CANNED))
     ws = tmp_path / "ws"
     ws.mkdir()
     harness = CodexHarness(
@@ -600,17 +616,23 @@ def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
         apptainer_binary=binary,
     )
     harness.run("task", ws)
-    argv = (tmp_path / "seen_argv").read_text()
-    assert argv.startswith("exec --containall --cleanenv")
-    assert f"--bind {ws}:{ws}" in argv
-    assert f"--home {tmp_path / 'ws-home'}:{tmp_path / 'ws-home'}" in argv
-    assert f"--pwd {ws}" in argv
-    # codex is taken from the image PATH (not the host /real/codex), author sandbox
-    assert "/img/agent.sif codex exec" in argv
-    assert "--sandbox workspace-write" in argv
-    assert "sk-o" not in argv  # key travels via env, never argv
-    seen_env = (tmp_path / "seen_env").read_text()
-    assert "APPTAINERENV_OPENAI_API_KEY=sk-o" in seen_env
+    logged = calls.read_text()
+    login = next(ln for ln in logged.splitlines() if "codex login" in ln)
+    exec_ = next(ln for ln in logged.splitlines() if "codex exec" in ln)
+    home = f"--home {tmp_path / 'ws-home'}:{tmp_path / 'ws-home'}"
+    # the LOGIN is contained too (the finding: an uncontained login leaks the key)
+    assert login.startswith("exec --containall --cleanenv")
+    assert home in login
+    assert "/img/agent.sif codex login --with-api-key" in login
+    assert f"--bind {ws}" not in login  # login needs no workspace
+    # the EXEC is contained, binds+pwd the workspace, author sandbox, image codex
+    assert exec_.startswith("exec --containall --cleanenv")
+    assert f"--bind {ws}:{ws}" in exec_ and f"--pwd {ws}" in exec_ and home in exec_
+    assert "/img/agent.sif codex exec" in exec_
+    assert "--sandbox workspace-write" in exec_
+    # the key is never in ANY argv, and rides APPTAINERENV for both calls
+    assert "sk-o" not in logged
+    assert envs.read_text().count("APPTAINERENV_OPENAI_API_KEY=sk-o") == 2
 
 
 def test_codex_author_resolves_a_relative_workspace(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -13,6 +13,7 @@ import pytest
 from autoresearch.harness import (
     SESSION_ENV_ALLOWLIST,
     ClaudeCodeHarness,
+    CodexHarness,
     FakeHarness,
     SessionResult,
     budget_exhausted,
@@ -579,6 +580,37 @@ def test_container_image_wraps_in_apptainer(tmp_path: Path) -> None:
     assert "sk-c" not in argv  # the key travels via env, never argv
     seen_env = (tmp_path / "seen_env").read_text()
     assert "APPTAINERENV_ANTHROPIC_API_KEY=sk-c" in seen_env
+
+
+def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
+    """AUTHOR mode: codex exec runs inside apptainer (--containall/--cleanenv,
+    workspace + run-home bound, --pwd the workspace), codex from the image PATH,
+    author sandbox workspace-write, key via APPTAINERENV_ (never argv)."""
+    # the fake stands in for apptainer; codex login then exec both go through it,
+    # so seen_argv holds the last (exec) call's arguments.
+    binary = fake_claude(tmp_path, json.dumps(CANNED))
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    harness = CodexHarness(
+        api_key="sk-o",
+        binary="/real/codex",
+        model="gpt-5.6-terra",
+        sandbox="workspace-write",
+        container_image="/img/agent.sif",
+        apptainer_binary=binary,
+    )
+    harness.run("task", ws)
+    argv = (tmp_path / "seen_argv").read_text()
+    assert argv.startswith("exec --containall --cleanenv")
+    assert f"--bind {ws}:{ws}" in argv
+    assert f"--home {tmp_path / 'ws-home'}:{tmp_path / 'ws-home'}" in argv
+    assert f"--pwd {ws}" in argv
+    # codex is taken from the image PATH (not the host /real/codex), author sandbox
+    assert "/img/agent.sif codex exec" in argv
+    assert "--sandbox workspace-write" in argv
+    assert "sk-o" not in argv  # key travels via env, never argv
+    seen_env = (tmp_path / "seen_env").read_text()
+    assert "APPTAINERENV_OPENAI_API_KEY=sk-o" in seen_env
 
 
 def test_container_requires_absolute_binary(tmp_path: Path) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -613,6 +613,24 @@ def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
     assert "APPTAINERENV_OPENAI_API_KEY=sk-o" in seen_env
 
 
+def test_codex_author_resolves_a_relative_workspace(tmp_path: Path, monkeypatch) -> None:
+    """apptainer bind sources must be absolute; a relative workspace is resolved
+    (else the mount fails deep inside apptainer)."""
+    binary = fake_claude(tmp_path, json.dumps(CANNED))
+    (tmp_path / "ws").mkdir()
+    monkeypatch.chdir(tmp_path)
+    harness = CodexHarness(
+        api_key="k",
+        sandbox="workspace-write",
+        container_image="/img/agent.sif",
+        apptainer_binary=binary,
+    )
+    harness.run("task", Path("ws"))  # relative
+    argv = (tmp_path / "seen_argv").read_text()
+    assert f"--bind {tmp_path / 'ws'}:{tmp_path / 'ws'}" in argv  # absolute
+    assert "--bind ws:ws" not in argv
+
+
 def test_container_requires_absolute_binary(tmp_path: Path) -> None:
     """A relative bind source fails at mount time deep inside apptainer —
     catch the misconfiguration before any money is spent."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -867,9 +867,10 @@ def test_shared_match_is_case_folded_like_the_other_path_checks(tmp_path: Path) 
 class _SeqHarness:
     """Queued session results; records resume ids like the real backends."""
 
-    def __init__(self, texts: list[str]) -> None:
+    def __init__(self, texts: list[str], supports_resume: bool = True) -> None:
         self._texts = list(texts)
         self.resumes: list[str | None] = []
+        self.supports_resume = supports_resume
 
     def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
         self.resumes.append(resume_session_id)
@@ -921,8 +922,8 @@ def _verdict(blocking: bool, round_no: int):
     )
 
 
-def _run_panel_climb(tmp_path, values, verdicts, texts=None, revisions=1):
-    harness = _SeqHarness(texts or ["report r1", "report r2"])
+def _run_panel_climb(tmp_path, values, verdicts, texts=None, revisions=1, supports_resume=True):
+    harness = _SeqHarness(texts or ["report r1", "report r2"], supports_resume=supports_resume)
     evaluator = FakeEvaluator(values=list(values))
     panel = _QueuedPanel(verdicts)
     measurer, snapshot = _wire(evaluator, tmp_path)
@@ -966,6 +967,19 @@ def test_blocking_then_clean_revises_and_remeasures(tmp_path: Path) -> None:
     assert len(evaluator.calls) == 3  # baseline + candidate + revised candidate
     assert result.candidate == 13.0
     assert "round 1" in result.panel_transcript and "round 2" in result.panel_transcript
+
+
+def test_a_backend_that_cannot_resume_drafts_a_blocking_finding(tmp_path: Path) -> None:
+    """codex/hermes declare supports_resume=False: a blocking finding must DRAFT
+    the verified improvement, never attempt an unvalidated resume that would lose
+    it as a session-error (review #119 r2, terra)."""
+    result, harness, evaluator, _panel = _run_panel_climb(
+        tmp_path, [13.9, 13.1], [_verdict(True, 1)], supports_resume=False
+    )
+    assert result.outcome == "improved"  # improvement preserved, not session-error
+    assert result.panel_blocking_open and result.panel_rounds == 1
+    assert harness.resumes == [None]  # NO resume attempted
+    assert len(evaluator.calls) == 2  # baseline + candidate only (no revise re-measure)
 
 
 def test_capped_out_blocking_stays_open_for_a_draft_pr(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

An alternative **author** backend: `climb --author-backend codex` runs the editing role on the OpenAI Codex CLI instead of Claude, to try a cheaper author (e.g. `--model gpt-5.6-terra`). The seam (`run_role`/`climb_once`) already takes any `Harness`, so this is one branch in `build_editor_harness` — zero kernel change, the reviewer-backend rollout applied to the author side.

## Why

Author sessions are the cost driver (~$1.4/hr observed; the waste is non-converging runs). The org's OpenAI account is tax-exempt, so a codex/terra author is effectively cheaper — worth an A/B.

## Containment (the crux — an author writes + executes)

Unlike the read-only reviewer, an author must be contained. In author mode (`container_image` set), **both** `codex login` and `codex exec` run inside `apptainer exec --containall --cleanenv`, sharing a bound `--home` so the login's `auth.json` is visible to the exec. Two layered boundaries:
- **apptainer** — no host FS beyond the workspace + home binds; `--cleanenv` scrubs the env to the author's own key, so the process tree carries no foreign token for a `/proc` read to lift (the boundary is the scrubbed env, not PID isolation — the same posture as the Claude author).
- **codex `--sandbox workspace-write`** — writes confined to the clone.

codex is taken from the image PATH; the key travels via `APPTAINERENV_OPENAI_API_KEY`, never argv. The read-only codex/hermes **reviewer** path is untouched (uncontained, `--sandbox read-only`).

## Guards & degradation

- `--author-backend codex` requires `--image` and a non-claude `--model` (guarded at parse time — the claude default would 404 on codex).
- codex session **resume** is not bench-validated yet, so the panel→revise loop degrades safely: no session id (or a failed resume) **drafts** rather than revising.
- codex has no per-turn cap (walltime-only), so `--session-minutes` is the cost lever.

## Tests

- `test_codex_author_runs_contained_in_apptainer` — the exec argv (`--containall/--cleanenv`, workspace+home bound, `--pwd`, image codex, `workspace-write`) and key-via-env-not-argv.
- `test_codex_author_resolves_a_relative_workspace` — bind sources resolved to absolute (self-review catch).
- `test_editor_harness_codex_backend_is_contained` — the `build_editor_harness` branch, container_image required, unknown-backend rejected.

Full gate green (mypy 69 files, harness + climb + orchestrator/review/tick/verify suites).

## Not in this PR (Stage 3)

End-to-end validation: **codex must be added to the `.sif` image**, an OpenAI key placed on Torch, then a **watched A/B climb** (codex/terra vs claude) comparing cost and gate-clearance. Reachable but dormant until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
