### PR TITLE
Codex author: bind the host codex binary (deployment fix for #119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,15 @@ Versions follow [SemVer](https://semver.org).
   `--model gpt-5.6-terra`). It runs **contained** — `codex login` and `codex
   exec` both inside `apptainer exec --containall --cleanenv` (shared bound
   `--home` for auth.json) around codex's own `--sandbox workspace-write`, so an
-  author's writes+execution are fenced the same way the Claude author is.
-  `--image` and a non-claude `--model` are required (guarded early). codex
-  session resume is not bench-validated yet, so a blocking panel finding drafts
-  rather than revising. The read-only codex/hermes reviewer path is unchanged.
-  (Reachable but unexercised end-to-end; needs codex added to the `.sif` image.)
+  author's writes+execution are fenced the same way the Claude author is. The
+  host codex binary is bind-mounted read-only into the container (`--codex-bin`,
+  like `--claude-bin`) so the image stays codex-free and codex updates by
+  swapping one host binary. `--image` and a non-claude `--model` are required
+  (guarded early); `--codex-config KEY=VALUE` passes host-specific codex config.
+  codex session resume is not bench-validated yet (`supports_resume=False`), so a
+  blocking panel finding drafts rather than revising. The read-only codex/hermes
+  reviewer path is unchanged. (Reachable but unexercised end-to-end; needs codex
+  installed on the host.)
 
 - Tick coalescing: under partition congestion, queued ticks bunch up and become
   eligible together (the singleton dependency serializes them), so they would

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1930,6 +1930,12 @@ def main() -> int:
         "same-user files, including credential files)",
     )
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
+    parser.add_argument(
+        "--codex-bin",
+        default=os.path.expanduser("~/.local/bin/codex"),
+        help="host codex binary for the codex author; bind-mounted into apptainer "
+        "(must be an absolute path).",
+    )
     parser.add_argument("--model", default="claude-opus-5")
     parser.add_argument(
         "--author-backend",
@@ -2042,7 +2048,7 @@ def main() -> int:
                 wake_api_key,
                 wake_spec,
                 backend=args.author_backend,
-                binary=args.claude_bin if args.author_backend == "claude" else None,
+                binary=args.claude_bin if args.author_backend == "claude" else args.codex_bin,
                 model=args.model,
                 container_image=args.image,
                 codex_extra_args=codex_extra,
@@ -2156,7 +2162,7 @@ def main() -> int:
                     api_key,
                     spec,
                     backend=args.author_backend,
-                    binary=args.claude_bin if args.author_backend == "claude" else None,
+                    binary=args.claude_bin if args.author_backend == "claude" else args.codex_bin,
                     model=args.model,
                     container_image=args.image,
                     codex_extra_args=codex_extra,

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -647,9 +647,11 @@ class CodexHarness:
     to the author's own key, so the process tree carries no foreign token for a
     /proc read to lift — the boundary is the scrubbed env, not PID isolation,
     the same posture as the Claude author) around codex's own `--sandbox
-    workspace-write` (writes confined to the clone). codex is taken from the
-    image (on PATH), not bound from the host. The reviewer path (no
-    `container_image`) is unchanged: uncontained, `--sandbox read-only`.
+    workspace-write` (writes confined to the clone). The host codex binary is
+    bind-mounted read-only into the container (like the claude author), so the
+    image stays codex-free and codex updates by swapping one host binary. The
+    reviewer path (no `container_image`) is unchanged: uncontained,
+    `--sandbox read-only`.
 
     `run` never raises: every failure comes back as an error SessionResult.
     """
@@ -665,10 +667,11 @@ class CodexHarness:
     # uncontained (the read-only reviewer path).
     container_image: str = ""
     apptainer_binary: str = "apptainer"
-    # codex on the image PATH (contained runs never bind the host binary); a
-    # bare class attribute (no annotation) so the dataclass does not treat it
-    # as a field, matching ClaudeCodeHarness.CONTAINER_CLAUDE.
-    CONTAINER_CODEX = "codex"
+    # in-container path the host codex binary is bound to (bind-from-host, like
+    # ClaudeCodeHarness.CONTAINER_CLAUDE — the image stays codex-free, and codex
+    # is updated by swapping one host binary, no rebuild). A bare class attribute
+    # (no annotation) so the dataclass does not treat it as a field.
+    CONTAINER_CODEX = "/opt/agent/codex"
     # codex --json session-id parsing is best-effort until a live authed run
     # verifies the event fields, so headless resume is NOT trusted yet: the
     # revise loop drafts instead of resuming (flip to True once validated).
@@ -679,7 +682,8 @@ class CodexHarness:
     ) -> list[str]:
         """Wrap a codex argv in `apptainer exec --containall --cleanenv`. The
         run-home is bound via `--home` (auth.json survives login->exec and lands
-        on the shared FS); the workspace is bound and set as --pwd only for the
+        on the shared FS); the host codex binary is bind-mounted read-only (like
+        the claude author); the workspace is bound and set as --pwd only for the
         exec, never the login."""
         argv = [
             self.apptainer_binary,
@@ -688,6 +692,8 @@ class CodexHarness:
             "--cleanenv",
             "--home",
             f"{session_home}:{session_home}",
+            "--bind",
+            f"{self.binary}:{self.CONTAINER_CODEX}:ro",
         ]
         if workspace is not None:
             argv += ["--bind", f"{workspace}:{workspace}", "--pwd", str(workspace)]
@@ -744,6 +750,11 @@ class CodexHarness:
         # points inside the container.
         if self.container_image:
             workspace = workspace.resolve()
+            if not os.path.isabs(self.binary):
+                # the host codex is bind-mounted; a relative bind source fails at
+                # mount time deep inside apptainer — catch it here instead
+                log.warning("contained codex needs an absolute binary path")
+                return _error_result("config-error")
         transcript_stem = f"{workspace.name}-codex"
         session_home = workspace.parent / f"{workspace.name}-home"
         try:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -601,9 +601,10 @@ def _recording_apptainer(tmp_path: Path, payload: str) -> tuple[str, Path, Path]
 def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
     """AUTHOR mode: BOTH codex login and codex exec run inside apptainer
     (--containall/--cleanenv), so neither exposes the author key to the host —
-    login is contained too, not only the exec. exec binds the workspace + --pwd,
-    codex from the image PATH, author sandbox workspace-write, key via
-    APPTAINERENV_ (never argv)."""
+    login is contained too, not only the exec. The host codex binary is
+    bind-mounted read-only to /opt/agent/codex (like claude); exec binds the
+    workspace + --pwd, author sandbox workspace-write, key via APPTAINERENV_
+    (never argv)."""
     binary, calls, envs = _recording_apptainer(tmp_path, json.dumps(CANNED))
     ws = tmp_path / "ws"
     ws.mkdir()
@@ -620,15 +621,17 @@ def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
     login = next(ln for ln in logged.splitlines() if "codex login" in ln)
     exec_ = next(ln for ln in logged.splitlines() if "codex exec" in ln)
     home = f"--home {tmp_path / 'ws-home'}:{tmp_path / 'ws-home'}"
+    codex_bind = "--bind /real/codex:/opt/agent/codex:ro"  # host codex, read-only
     # the LOGIN is contained too (the finding: an uncontained login leaks the key)
     assert login.startswith("exec --containall --cleanenv")
-    assert home in login
-    assert "/img/agent.sif codex login --with-api-key" in login
+    assert home in login and codex_bind in login
+    assert "/img/agent.sif /opt/agent/codex login --with-api-key" in login
     assert f"--bind {ws}" not in login  # login needs no workspace
-    # the EXEC is contained, binds+pwd the workspace, author sandbox, image codex
+    # the EXEC is contained, binds+pwd the workspace, author sandbox, bound codex
     assert exec_.startswith("exec --containall --cleanenv")
     assert f"--bind {ws}:{ws}" in exec_ and f"--pwd {ws}" in exec_ and home in exec_
-    assert "/img/agent.sif codex exec" in exec_
+    assert codex_bind in exec_
+    assert "/img/agent.sif /opt/agent/codex exec" in exec_
     assert "--sandbox workspace-write" in exec_
     # the key is never in ANY argv, and rides APPTAINERENV for both calls
     assert "sk-o" not in logged
@@ -643,6 +646,7 @@ def test_codex_author_resolves_a_relative_workspace(tmp_path: Path, monkeypatch)
     monkeypatch.chdir(tmp_path)
     harness = CodexHarness(
         api_key="k",
+        binary="/real/codex",  # absolute (bind source)
         sandbox="workspace-write",
         container_image="/img/agent.sif",
         apptainer_binary=binary,
@@ -651,6 +655,18 @@ def test_codex_author_resolves_a_relative_workspace(tmp_path: Path, monkeypatch)
     argv = (tmp_path / "seen_argv").read_text()
     assert f"--bind {tmp_path / 'ws'}:{tmp_path / 'ws'}" in argv  # absolute
     assert "--bind ws:ws" not in argv
+
+
+def test_contained_codex_requires_an_absolute_binary(tmp_path: Path) -> None:
+    """A relative codex binary is a bind source that fails at mount time — caught
+    before any spend (mirrors the claude author's guard)."""
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    harness = CodexHarness(
+        api_key="k", binary="codex", container_image="/img/agent.sif", apptainer_binary="apptainer"
+    )
+    result = harness.run("task", ws)
+    assert result.is_error and result.stop_reason == "config-error"
 
 
 def test_container_requires_absolute_binary(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Follow-up to #119: the codex author now **binds the host codex binary** into apptainer (read-only, `/opt/agent/codex`) instead of taking codex from the image PATH.

## Why

Checking Torch for enablement surfaced the deployment reality: **codex is installed nowhere** — not baked into the `.sif` (built Aug 6), not on the host — and **claude itself is bind-mounted from the host** (`/opt/agent/claude`), not baked in. So #119's image-PATH assumption would force an image rebuild. Matching the claude pattern (bind-from-host) keeps the image codex-free and lets codex update by swapping one host binary — no 370 MB rebuild.

## Change

- `CONTAINER_CODEX` is now the in-container bound path; `_apptainer_argv` adds `--bind <host-codex>:/opt/agent/codex:ro` to **both** the login and exec calls; `run()` guards an absolute binary (like the claude author).
- CLI `--codex-bin` (default `~/.local/bin/codex`), wired into both author-harness call sites for the codex backend.
- Tests updated for the bound path (login + exec) + a relative-codex-binary → `config-error` guard.

Full harness + climb suites green (111), ruff + mypy clean.

## Still needed to actually enable (not in this PR)

1. **Install codex on the Torch host** (native x86_64 binary → `~/.local/bin/codex`; no npm/node/brew on the host) — automatable as an idempotent deploy step.
2. **An OpenAI key** on Torch (`~/.config/autoresearch/…`).
3. **Thread `--author-backend` into the live tick** (chain env → self-initiated climb argv).
4. **A watched A/B climb** (codex/terra vs claude) before flipping the live loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
