### PR TITLE
Codex author: --sandbox danger-full-access (apptainer is the boundary)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Versions follow [SemVer](https://semver.org).
   role on the OpenAI Codex CLI instead of Claude, to try a cheaper author (e.g.
   `--model gpt-5.6-terra`). It runs **contained** — `codex login` and `codex
   exec` both inside `apptainer exec --containall --cleanenv` (shared bound
-  `--home` for auth.json) around codex's own `--sandbox workspace-write`, so an
-  author's writes+execution are fenced the same way the Claude author is. The
+  `--home` for auth.json). codex runs `--sandbox danger-full-access` and relies
+  on apptainer as the boundary (codex's own sandbox needs bubblewrap, absent in
+  the image) — the same single-boundary posture as the Claude author. The
   host codex binary is bind-mounted read-only into the container (`--codex-bin`,
   like `--claude-bin`) so the image stays codex-free and codex updates by
   swapping one host binary. `--image` and a non-claude `--model` are required

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -990,9 +990,11 @@ def build_editor_harness(
     The seam (`run_role`, `climb_once`) takes any Harness, so a backend is one
     branch here, zero kernel change (the reviewer's rollout):
     - claude: native tool set, apptainer-contained; the trusted default.
-    - codex: apptainer-contained + `--sandbox workspace-write`. An author MUST
-      be contained (it writes+executes), so container_image is REQUIRED — the
-      read-only reviewer could skip it, an author cannot. Codex declares
+    - codex: apptainer-contained; codex runs `--sandbox danger-full-access`
+      (no inner OS sandbox) and relies on apptainer as the boundary, exactly as
+      the claude author does — codex's own sandbox needs bubblewrap, absent in
+      the image. An author MUST be contained (it writes+executes), so
+      container_image is REQUIRED — the read-only reviewer could skip it. Codex declares
       `supports_resume=False` (its headless resume is not bench-validated), so a
       blocking panel finding DRAFTS instead of attempting a resume — both the
       inline and wake revise paths gate on `supports_resume`, so there is no
@@ -1008,11 +1010,15 @@ def build_editor_harness(
             api_key=api_key,
             binary=binary or "codex",
             model=model or "",  # "" -> codex's configured default; pin a verified id
-            sandbox="workspace-write",
+            # apptainer IS the sandbox here (like the claude author, which has no
+            # inner OS sandbox). codex's own `workspace-write` needs bubblewrap,
+            # which isn't in the image and is unreliable nested inside apptainer;
+            # `danger-full-access` skips codex's sandbox and relies on apptainer's
+            # boundary (no host FS beyond the ws+home binds, scrubbed env), which
+            # already confines writes to the workspace.
+            sandbox="danger-full-access",
             timeout_s=spec.budget.walltime_s,
             container_image=container_image,
-            # host-specific codex config (e.g. -c use_legacy_landlock=true),
-            # mirroring the reviewer branch's sandbox_extra
             extra_args=codex_extra_args,
         )
     if backend != "claude":

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -642,14 +642,16 @@ class CodexHarness:
 
     AUTHOR mode (`container_image` set): both `codex login` and `codex exec` run
     inside `apptainer exec --containall --cleanenv`, sharing a bound `--home` so
-    the login's auth.json is visible to the exec. That layers TWO boundaries:
-    apptainer (no host FS beyond the two binds; `--cleanenv` scrubs the env down
-    to the author's own key, so the process tree carries no foreign token for a
-    /proc read to lift — the boundary is the scrubbed env, not PID isolation,
-    the same posture as the Claude author) around codex's own `--sandbox
-    workspace-write` (writes confined to the clone). The host codex binary is
-    bind-mounted read-only into the container (like the claude author), so the
-    image stays codex-free and codex updates by swapping one host binary. The
+    the login's auth.json is visible to the exec. apptainer is the boundary — no
+    host FS beyond the two binds; `--cleanenv` scrubs the env down to the
+    author's own key, so the process tree carries no foreign token for a /proc
+    read to lift (the boundary is the scrubbed env, not PID isolation) — exactly
+    the posture of the Claude author. The AUTHOR passes `--sandbox
+    danger-full-access`: codex's own sandbox (`workspace-write`) needs bubblewrap,
+    absent in the image and unreliable nested in apptainer, and it is redundant
+    when apptainer already confines writes to the bound workspace+home. The host
+    codex binary is bind-mounted read-only into the container (like claude), so
+    the image stays codex-free and codex updates by swapping one host binary. The
     reviewer path (no `container_image`) is unchanged: uncontained,
     `--sandbox read-only`.
 

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1361,8 +1361,8 @@ def test_author_harness_is_built_from_the_spec() -> None:
 
 def test_editor_harness_codex_backend_is_contained() -> None:
     """The codex author backend is one branch, zero kernel change: contained
-    (apptainer) + --sandbox workspace-write, and container_image is REQUIRED
-    (an author writes+executes, so it must not run uncontained)."""
+    (apptainer) with --sandbox danger-full-access (apptainer is the boundary; no
+    bwrap), and container_image is REQUIRED (an author writes+executes)."""
     from autoresearch.climb import build_editor_harness
     from autoresearch.harness import CodexHarness
     from autoresearch.roles import author_spec
@@ -1377,7 +1377,7 @@ def test_editor_harness_codex_backend_is_contained() -> None:
         codex_extra_args=("-c", "use_legacy_landlock=true"),
     )
     assert isinstance(harness, CodexHarness)
-    assert harness.sandbox == "workspace-write"
+    assert harness.sandbox == "danger-full-access"  # apptainer is the boundary; no bwrap
     assert harness.container_image == "img.sif"
     assert harness.model == "gpt-5.6-terra"
     assert harness.timeout_s == 300

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -603,7 +603,7 @@ def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
     (--containall/--cleanenv), so neither exposes the author key to the host —
     login is contained too, not only the exec. The host codex binary is
     bind-mounted read-only to /opt/agent/codex (like claude); exec binds the
-    workspace + --pwd, author sandbox workspace-write, key via APPTAINERENV_
+    workspace + --pwd, passes the given --sandbox, key via APPTAINERENV_
     (never argv)."""
     binary, calls, envs = _recording_apptainer(tmp_path, json.dumps(CANNED))
     ws = tmp_path / "ws"
@@ -612,7 +612,7 @@ def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
         api_key="sk-o",
         binary="/real/codex",
         model="gpt-5.6-terra",
-        sandbox="workspace-write",
+        sandbox="danger-full-access",
         container_image="/img/agent.sif",
         apptainer_binary=binary,
     )
@@ -632,7 +632,7 @@ def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
     assert f"--bind {ws}:{ws}" in exec_ and f"--pwd {ws}" in exec_ and home in exec_
     assert codex_bind in exec_
     assert "/img/agent.sif /opt/agent/codex exec" in exec_
-    assert "--sandbox workspace-write" in exec_
+    assert "--sandbox danger-full-access" in exec_
     # the key is never in ANY argv, and rides APPTAINERENV for both calls
     assert "sk-o" not in logged
     assert envs.read_text().count("APPTAINERENV_OPENAI_API_KEY=sk-o") == 2


### PR DESCRIPTION
## What

Run the contained codex author with `--sandbox danger-full-access` and rely on
apptainer as the boundary, instead of codex's own `--sandbox workspace-write`.

## Why

Watched validation on Torch (codex-cli 0.130.0, `gpt-5.6-terra`) surfaced two
layered blockers with `workspace-write`:

1. codex's `workspace-write` sandbox needs bubblewrap (`bwrap`), which is not in
   the agent image — codex aborts with *"the sandbox failed because bubblewrap
   (bwrap) is unavailable"*. Nested `bwrap`-inside-apptainer is unreliable even
   where present.
2. codex's own OS sandbox is redundant here. The author already runs inside
   `apptainer exec --containall --cleanenv` with only the workspace + session
   home bound and a scrubbed env — exactly how the **Claude** author runs (which
   has no inner OS sandbox at all). One boundary, owned by apptainer.

`danger-full-access` also keeps codex's network access for the model API, which
`workspace-write` can restrict.

## Validation (Torch, this branch)

Ran the watched codex/terra climb against `autoresearch-pilot` / `tsp` off this
branch (HEAD `4a49ae1`, codex-cli 0.130.0):

- `codex login --with-api-key` succeeded inside apptainer (`auth.json` written).
- The author edited `src/pilot/solvers/tsp.py` — a real, coherent change
  (multi-start nearest-neighbor construction, `CONSTRUCTION_STARTS=16`,
  `_best_nearest_neighbor_tour`, matching docstring).
- Inline eval ran; gate returned **no-improvement → negative-result** (correct:
  the multi-start construction is refined away by the ILS 2-opt, no net gain).
- Job COMPLETED (0:0), 4:08 elapsed. **Zero** `bwrap`/sandbox errors anywhere.

## Test plan

- `test_editor_harness_codex_backend_is_contained` and
  `test_codex_author_runs_contained_in_apptainer` updated to assert
  `--sandbox danger-full-access`.
- `uv run pytest tests/test_harness.py tests/test_climb.py` — green.
- Full gate (ruff check + format, mypy) — green.

## No secrets / no large files

Confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
