### PR TITLE
Tick: drive the codex author across the climb-authoring lanes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,11 @@ Versions follow [SemVer](https://semver.org).
   verify/review panel keeps its own `AUTORESEARCH_PANEL_KEY_FILE`). A
   misconfigured codex author (missing or Claude `AUTORESEARCH_AUTHOR_MODEL`) is
   preflighted, so the self-initiated lane skips and intake skips *before*
-  claiming an issue, rather than submitting a job that dies at startup. The
-  default is unchanged — the Claude author.
+  claiming an issue, rather than submitting a job that dies at startup. A run's
+  author backend is persisted on its record, so a wake reproduces the *parked
+  run's* author rather than the current fleet default — a mid-flight fleet flip
+  never wakes a parked Claude run as codex (which cannot resume it). The default
+  is unchanged — the Claude author.
 
 - Tick coalescing: under partition congestion, queued ticks bunch up and become
   eligible together (the singleton dependency serializes them), so they would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,20 @@ Versions follow [SemVer](https://semver.org).
   (guarded early); `--codex-config KEY=VALUE` passes host-specific codex config.
   codex session resume is not bench-validated yet (`supports_resume=False`), so a
   blocking panel finding drafts rather than revising. The read-only codex/hermes
-  reviewer path is unchanged. (Reachable but unexercised end-to-end; needs codex
-  installed on the host.)
+  reviewer path is unchanged. Validated end-to-end on Slurm: the contained codex
+  author (codex 0.130.0, `gpt-5.6-terra`) logs in and edits inside apptainer with
+  zero sandbox errors; needs codex installed on the host.
+
+- The tick can drive the codex author for its self-initiated, intake, and wake
+  (revise) climb lanes: set `AUTORESEARCH_AUTHOR_BACKEND=codex` with
+  `AUTORESEARCH_AUTHOR_MODEL` (a non-Claude id, e.g. `gpt-5.6-terra`) and,
+  optionally, `AUTORESEARCH_CODEX_BIN`. The author backend is a fleet-wide
+  choice, so `AUTORESEARCH_HARNESS_KEY_FILE` then holds that backend's key (the
+  verify/review panel keeps its own `AUTORESEARCH_PANEL_KEY_FILE`). A
+  misconfigured codex author (missing or Claude `AUTORESEARCH_AUTHOR_MODEL`) is
+  preflighted, so the self-initiated lane skips and intake skips *before*
+  claiming an issue, rather than submitting a job that dies at startup. The
+  default is unchanged — the Claude author.
 
 - Tick coalescing: under partition congestion, queued ticks bunch up and become
   eligible together (the singleton dependency serializes them), so they would

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1137,6 +1137,7 @@ def live_climb(
     secrets: tuple[str, ...] = (),
     base_branch: str = "main",
     issue_number: int = 0,
+    author_backend: str = "claude",
     task_hypothesis: str = "",
     spec: RoleSpec | None = None,
     panel_lenses: tuple[PanelLens, ...] = (),
@@ -1166,6 +1167,7 @@ def live_climb(
         agent_id=config.agent_id,
         deadline=now + 24 * 3600,
         issue_number=issue_number,
+        author_backend=author_backend,
         climb_job_id=_os.environ.get("SLURM_JOB_ID", ""),
     )
     try:
@@ -2194,6 +2196,7 @@ def main() -> int:
                     if k
                 ),
                 issue_number=args.issue,
+                author_backend=args.author_backend,
                 task_hypothesis=(
                     __import__("base64").b64decode(args.hypothesis_b64).decode()
                     if args.hypothesis_b64

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -129,6 +129,10 @@ class RunRecord:
     resume_session_id: str = ""  # harness session to resume on wake
     pr_url: str = ""  # the run's open PR, once one exists
     benchmark: str = ""  # contract benchmark this run works on
+    # The author backend this run was STARTED with ("" = legacy/claude). A wake
+    # reproduces the parked run's author from this, not the current fleet default
+    # — a fleet flip must not wake a Claude run as codex (which cannot resume it).
+    author_backend: str = ""
     # Per-source comment cursors: issue comments, top-level reviews, and
     # inline review comments are three REST collections with independent id
     # sequences — one cursor across them drops comments forever.

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1800,6 +1800,14 @@ class JobWakeDispatcher:
     wake_minutes: int = 20
 
     def dispatch(self, record: RunRecord, reason: str) -> str:
+        # Fail safe rather than submit a doomed resume: a misconfigured codex
+        # author would die at the climb's startup validation. Raising lets _wake
+        # release the lease and count the attempt toward the stuck threshold
+        # (same as any dispatch failure), instead of burning a Slurm job each
+        # tick. Fresh climbs preflight this before submit; the wake does too.
+        author_error = _author_preflight_error(self.spec)
+        if author_error:
+            raise ValueError(f"author misconfigured for wake: {author_error}")
         argv = [
             "uv",
             "run",

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -190,6 +190,14 @@ class FollowupSpec:
     # Partition MaxTime for work jobs — the panel-augmented walltime clamps
     # here (see MAX_CLIMB_JOB_MINUTES). Raise together with job_partition.
     max_job_minutes: int = MAX_CLIMB_JOB_MINUTES
+    # Author backend for climb jobs. "" / "claude" = the default Claude author
+    # (key_file is an Anthropic key). "codex" runs the contained codex author,
+    # in which case author_model must be a non-Claude id and key_file holds that
+    # backend's key (e.g. an OpenAI key for terra). The verify/review panel keeps
+    # its own key (panel_key_file) regardless of the author backend.
+    author_backend: str = ""
+    author_model: str = ""  # required (non-claude) when author_backend == "codex"
+    codex_bin: str = ""  # "" = the climb CLI's default codex path
 
 
 # Generous vs the ~2 h job walltimes plus queue wait, tight enough that
@@ -1246,6 +1254,44 @@ def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
     return argv
 
 
+def _climb_author_argv(spec: FollowupSpec) -> list[str]:
+    """Author-backend flags for a climb job; empty for the default Claude author.
+
+    The panel keeps its own backend/key (`_climb_panel_argv`); this only selects
+    who does the *authoring*. `key_file` is passed by the caller as `--key-file`
+    and holds the author backend's key, so it is not repeated here."""
+    backend = spec.author_backend.strip()
+    if not backend or backend == "claude":
+        return []
+    argv = ["--author-backend", backend]
+    if spec.author_model:
+        argv += ["--model", spec.author_model]
+    if spec.codex_bin:
+        argv += ["--codex-bin", spec.codex_bin]
+    return argv
+
+
+def _author_preflight_error(spec: FollowupSpec) -> str:
+    """Why a climb would die at startup on this author config ("" when it won't).
+
+    The Claude author is always valid. The codex author needs a non-Claude model
+    (the climb CLI rejects a Claude id on a non-Claude backend); its container
+    image is already guaranteed by the tick's env-load. Preflighted so a lane
+    skips rather than submits a job that would fail at startup — and, for intake,
+    skips before it claims an issue."""
+    backend = spec.author_backend.strip()
+    if not backend or backend == "claude":
+        return ""
+    if backend != "codex":
+        return f"unknown author backend {backend!r} (expected 'claude' or 'codex')"
+    model = spec.author_model.strip()
+    if not model or model.startswith("claude"):
+        return (
+            f"author backend 'codex' needs a non-Claude AUTORESEARCH_AUTHOR_MODEL (got {model!r})"
+        )
+    return ""
+
+
 def _panel_preflight_error(spec: FollowupSpec) -> str:
     """Why the climb would die at startup on this panel config ("" when it
     won't): the lens spec, then the key file — each checked with the climb's
@@ -1411,6 +1457,15 @@ def service_self_initiated(
         benchmark = pick_self_initiated(records, contract, spec.target, now, pending_attempt)
         if benchmark is None:
             return None
+        author_error = _author_preflight_error(spec)
+        if author_error:
+            log.error(
+                "climb on %s not launched: author misconfigured — %s "
+                "(fix AUTORESEARCH_AUTHOR_* or unset AUTORESEARCH_AUTHOR_BACKEND)",
+                benchmark,
+                author_error,
+            )
+            return None
         panel_error = _panel_preflight_error(spec)
         if panel_error:
             log.error(
@@ -1439,6 +1494,7 @@ def service_self_initiated(
             spec.image,
             *_climb_limit_argv(limits, job_minutes),
             *_climb_panel_argv(spec),
+            *_climb_author_argv(spec),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
@@ -1625,6 +1681,15 @@ def service_intake(
         task = pick_issue(github, target, contract, spec.bot_login)
         if task is None:
             return None
+        author_error = _author_preflight_error(spec)
+        if author_error:
+            log.error(
+                "issue #%d not claimed: author misconfigured — %s "
+                "(fix AUTORESEARCH_AUTHOR_* or unset AUTORESEARCH_AUTHOR_BACKEND)",
+                task.number,
+                author_error,
+            )
+            return None
         panel_error = _panel_preflight_error(spec)
         if panel_error:
             log.error(
@@ -1670,6 +1735,7 @@ def service_intake(
             hypothesis_b64,
             *_climb_limit_argv(limits, job_minutes),
             *_climb_panel_argv(spec),
+            *_climb_author_argv(spec),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
@@ -1753,6 +1819,10 @@ class JobWakeDispatcher:
             # the wake runs the SAME verification panel as the fresh climb, so a
             # dispatched improvement is verified before it is published.
             *_climb_panel_argv(self.spec),
+            # the author backend must match the parked run's: a no-resume backend
+            # (codex) drafts the blocking finding instead of resuming (the climb's
+            # supports_resume gate), and key_file below is that backend's key.
+            *_climb_author_argv(self.spec),
             # session budget for the depth-axis REVISION (a blocking panel
             # finding wakes the author to revise).
             "--max-turns",
@@ -1939,6 +2009,9 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
                 panel_key_file=os.environ.get("AUTORESEARCH_PANEL_KEY_FILE", ""),
                 job_partition=os.environ.get("AUTORESEARCH_JOB_PARTITION", ""),
                 max_job_minutes=_max_job_minutes_from_env(),
+                author_backend=os.environ.get("AUTORESEARCH_AUTHOR_BACKEND", ""),
+                author_model=os.environ.get("AUTORESEARCH_AUTHOR_MODEL", ""),
+                codex_bin=os.environ.get("AUTORESEARCH_CODEX_BIN", ""),
             )
             return github, followup_spec
         except Exception as exc:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1277,14 +1277,17 @@ def _climb_author_argv(spec: FollowupSpec) -> list[str]:
     return _author_argv(spec.author_backend, spec.author_model, spec.codex_bin)
 
 
-def _author_config_error(backend: str, model: str) -> str:
+def _author_config_error(backend: str, model: str, codex_bin: str = "") -> str:
     """Why a climb would die at startup on this author config ("" when it won't).
 
     The Claude author is always valid. The codex author needs a non-Claude model
     (the climb CLI rejects a Claude id on a non-Claude backend); its container
-    image is already guaranteed by the tick's env-load. Preflighted so a lane
-    skips rather than submits a job that would fail at startup — and, for intake,
-    skips before it claims an issue."""
+    image is already guaranteed by the tick's env-load. A set `codex_bin` must be
+    absolute — the climb runs from a flight dir, not the tick's cwd, so a relative
+    path both misses there and trips CodexHarness's own absolute-path guard (empty
+    is fine: the climb CLI falls back to its default codex path). Preflighted so a
+    lane skips rather than submits a job that would fail at startup — and, for
+    intake, skips before it claims an issue."""
     backend = backend.strip()
     if not backend or backend == "claude":
         return ""
@@ -1295,12 +1298,14 @@ def _author_config_error(backend: str, model: str) -> str:
             "author backend 'codex' needs a non-Claude "
             f"AUTORESEARCH_AUTHOR_MODEL (got {model.strip()!r})"
         )
+    if codex_bin and not os.path.isabs(os.path.expanduser(codex_bin)):
+        return f"AUTORESEARCH_CODEX_BIN {codex_bin!r} is relative; only absolute paths fly"
     return ""
 
 
 def _author_preflight_error(spec: FollowupSpec) -> str:
     """`_author_config_error` for the fleet's configured author backend."""
-    return _author_config_error(spec.author_backend, spec.author_model)
+    return _author_config_error(spec.author_backend, spec.author_model, spec.codex_bin)
 
 
 def _panel_preflight_error(spec: FollowupSpec) -> str:
@@ -1815,14 +1820,23 @@ class JobWakeDispatcher:
         # fleet flip (claude->codex) must not wake a parked Claude run as codex,
         # which cannot resume its Claude session. The backend is persisted on the
         # record ("" = legacy, before this field -> fall back to the spec). The
-        # codex model/binary come from the spec (stable fleet config).
+        # codex model/binary/key come from the spec (stable fleet config).
+        #
+        # A backend is NOT hot-swappable with runs in flight: the fleet has one
+        # author key (repointed at a flip), so a parked codex run cannot wake once
+        # the fleet is on claude (its key is gone), and vice versa. That case
+        # fails safe HERE — the preflight below raises before any sbatch, so no
+        # Slurm job is burned; _wake counts the attempt and the run converges to
+        # the stuck terminal. Operationally: DRAIN in-flight parked runs before
+        # flipping AUTORESEARCH_AUTHOR_BACKEND. (Dispatch/park is dark on the pilot,
+        # so no run is in flight to strand today.)
         backend = record.author_backend or self.spec.author_backend
         # Fail safe rather than submit a doomed resume: a misconfigured codex
         # author would die at the climb's startup validation. Raising lets _wake
         # release the lease and count the attempt toward the stuck threshold
         # (same as any dispatch failure), instead of burning a Slurm job each
         # tick. Fresh climbs preflight this before submit; the wake does too.
-        author_error = _author_config_error(backend, self.spec.author_model)
+        author_error = _author_config_error(backend, self.spec.author_model, self.spec.codex_bin)
         if author_error:
             raise ValueError(f"author misconfigured for wake: {author_error}")
         argv = [

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1254,24 +1254,30 @@ def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
     return argv
 
 
-def _climb_author_argv(spec: FollowupSpec) -> list[str]:
+def _author_argv(backend: str, model: str, codex_bin: str) -> list[str]:
     """Author-backend flags for a climb job; empty for the default Claude author.
 
     The panel keeps its own backend/key (`_climb_panel_argv`); this only selects
     who does the *authoring*. `key_file` is passed by the caller as `--key-file`
-    and holds the author backend's key, so it is not repeated here."""
-    backend = spec.author_backend.strip()
+    and holds the author backend's key, so it is not repeated here. `model` is
+    stripped so a stray-whitespace env value does not reach codex as a bad id."""
+    backend = backend.strip()
     if not backend or backend == "claude":
         return []
     argv = ["--author-backend", backend]
-    if spec.author_model:
-        argv += ["--model", spec.author_model]
-    if spec.codex_bin:
-        argv += ["--codex-bin", spec.codex_bin]
+    if model.strip():
+        argv += ["--model", model.strip()]
+    if codex_bin:
+        argv += ["--codex-bin", codex_bin]
     return argv
 
 
-def _author_preflight_error(spec: FollowupSpec) -> str:
+def _climb_author_argv(spec: FollowupSpec) -> list[str]:
+    """Author flags for the fleet's configured backend (self-initiated, intake)."""
+    return _author_argv(spec.author_backend, spec.author_model, spec.codex_bin)
+
+
+def _author_config_error(backend: str, model: str) -> str:
     """Why a climb would die at startup on this author config ("" when it won't).
 
     The Claude author is always valid. The codex author needs a non-Claude model
@@ -1279,17 +1285,22 @@ def _author_preflight_error(spec: FollowupSpec) -> str:
     image is already guaranteed by the tick's env-load. Preflighted so a lane
     skips rather than submits a job that would fail at startup — and, for intake,
     skips before it claims an issue."""
-    backend = spec.author_backend.strip()
+    backend = backend.strip()
     if not backend or backend == "claude":
         return ""
     if backend != "codex":
         return f"unknown author backend {backend!r} (expected 'claude' or 'codex')"
-    model = spec.author_model.strip()
-    if not model or model.startswith("claude"):
+    if not model.strip() or model.strip().startswith("claude"):
         return (
-            f"author backend 'codex' needs a non-Claude AUTORESEARCH_AUTHOR_MODEL (got {model!r})"
+            "author backend 'codex' needs a non-Claude "
+            f"AUTORESEARCH_AUTHOR_MODEL (got {model.strip()!r})"
         )
     return ""
+
+
+def _author_preflight_error(spec: FollowupSpec) -> str:
+    """`_author_config_error` for the fleet's configured author backend."""
+    return _author_config_error(spec.author_backend, spec.author_model)
 
 
 def _panel_preflight_error(spec: FollowupSpec) -> str:
@@ -1800,12 +1811,18 @@ class JobWakeDispatcher:
     wake_minutes: int = 20
 
     def dispatch(self, record: RunRecord, reason: str) -> str:
+        # Reproduce the PARKED run's author, not the current fleet default: a
+        # fleet flip (claude->codex) must not wake a parked Claude run as codex,
+        # which cannot resume its Claude session. The backend is persisted on the
+        # record ("" = legacy, before this field -> fall back to the spec). The
+        # codex model/binary come from the spec (stable fleet config).
+        backend = record.author_backend or self.spec.author_backend
         # Fail safe rather than submit a doomed resume: a misconfigured codex
         # author would die at the climb's startup validation. Raising lets _wake
         # release the lease and count the attempt toward the stuck threshold
         # (same as any dispatch failure), instead of burning a Slurm job each
         # tick. Fresh climbs preflight this before submit; the wake does too.
-        author_error = _author_preflight_error(self.spec)
+        author_error = _author_config_error(backend, self.spec.author_model)
         if author_error:
             raise ValueError(f"author misconfigured for wake: {author_error}")
         argv = [
@@ -1830,7 +1847,7 @@ class JobWakeDispatcher:
             # the author backend must match the parked run's: a no-resume backend
             # (codex) drafts the blocking finding instead of resuming (the climb's
             # supports_resume gate), and key_file below is that backend's key.
-            *_climb_author_argv(self.spec),
+            *_author_argv(backend, self.spec.author_model, self.spec.codex_bin),
             # session budget for the depth-axis REVISION (a blocking panel
             # finding wakes the author to revise).
             "--max-turns",

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -273,7 +273,9 @@ class NoAuth:
         return "unused"
 
 
-def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None) -> tuple:
+def run_live(
+    tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None, author_backend="claude"
+) -> tuple:
     github = FakeGitHub()
     outcome = live_climb(
         config=ClimbConfig(target="org/pilot", benchmark="tsp"),
@@ -287,6 +289,7 @@ def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None
         created="2026-08-06T00:00:00Z",
         secrets=("sk-live-key",),
         dispatch=dispatch,
+        author_backend=author_backend,
     )
     return outcome, github
 
@@ -346,6 +349,19 @@ def test_improvement_produces_branch_commit_and_pr(tmp_path, target_repo) -> Non
     # report exists and is redacted-safe
     report = Path(outcome.report_path).read_text()
     assert "improved" in report
+
+
+def test_run_record_persists_the_author_backend(tmp_path, target_repo) -> None:
+    # a wake must reproduce the parked run's author, so the backend it was
+    # started with is stamped on the record (the default is the Claude author).
+    run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+        values=[13.876, 13.1],
+        author_backend="codex",
+    )
+    assert load_record(tmp_path / "state", "tsp-1").author_backend == "codex"
 
 
 def test_snapshot_refs_are_dropped_after_a_climb(tmp_path, target_repo) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2062,19 +2062,33 @@ def test_wake_dispatcher_threads_the_author_backend(tmp_path: Path, monkeypatch:
         author_model="gpt-5.6-terra",
         codex_bin="/opt/codex",
     )
-    record = RunRecord(
-        run_id="tsp-1",
-        target="org/pilot",
-        task_title="improve tsp",
-        benchmark="tsp",
-        state="waiting",
-        stage={"afterany": "afterany:501"},
-    )
-    JobWakeDispatcher(SlurmCompute(runner=runner), spec, now=NOW).dispatch(record, "eval done")
+
+    def record(**kw: Any) -> RunRecord:
+        return RunRecord(
+            run_id="tsp-1",
+            target="org/pilot",
+            task_title="improve tsp",
+            benchmark="tsp",
+            state="waiting",
+            stage={"afterany": "afterany:501"},
+            **kw,
+        )
+
+    # a legacy record (no persisted backend) falls back to the fleet spec
+    JobWakeDispatcher(SlurmCompute(runner=runner), spec, now=NOW).dispatch(record(), "done")
     joined = " ".join(submits[0])
     assert "--resume tsp-1" in joined
     assert "--author-backend codex" in joined and "--model gpt-5.6-terra" in joined
     assert "--codex-bin /opt/codex" in joined
+
+    # the record's backend WINS over the fleet's: a parked Claude run under a
+    # now-codex fleet wakes as Claude (resumes its session), not codex (drafts)
+    submits.clear()
+    JobWakeDispatcher(SlurmCompute(runner=runner), spec, now=NOW).dispatch(
+        record(author_backend="claude"), "done"
+    )
+    joined = " ".join(submits[0])
+    assert "--resume tsp-1" in joined and "--author-backend" not in joined
 
     # a misconfigured codex author raises instead of submitting a doomed resume:
     # _wake then releases the lease (a raising dispatch is a failed delivery),
@@ -2084,7 +2098,7 @@ def test_wake_dispatcher_threads_the_author_backend(tmp_path: Path, monkeypatch:
     submits.clear()
     bad = replace(spec, author_model="")
     with pytest.raises(ValueError, match="author misconfigured"):
-        JobWakeDispatcher(SlurmCompute(runner=runner), bad, now=NOW).dispatch(record, "eval done")
+        JobWakeDispatcher(SlurmCompute(runner=runner), bad, now=NOW).dispatch(record(), "done")
     assert submits == []
 
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1833,8 +1833,8 @@ def test_climb_author_argv(tmp_path: Path) -> None:
 
 
 def test_author_preflight_error(tmp_path: Path) -> None:
-    """Claude is always valid; codex needs a non-Claude model; an unknown
-    backend is rejected."""
+    """Claude is always valid; codex needs a non-Claude model and an absolute
+    (or empty) binary path; an unknown backend is rejected."""
     from autoresearch.tick import FollowupSpec, _author_preflight_error
 
     def make(**kw: Any) -> FollowupSpec:
@@ -1856,6 +1856,11 @@ def test_author_preflight_error(tmp_path: Path) -> None:
     )  # a Claude id on the codex backend
     assert _author_preflight_error(make(author_backend="codex", author_model="gpt-5.6-terra")) == ""
     assert _author_preflight_error(make(author_backend="hermes")) != ""  # unknown
+    # codex_bin: empty is fine (CLI default), absolute is fine, relative strands
+    ok = dict(author_backend="codex", author_model="gpt-5.6-terra")
+    assert _author_preflight_error(make(**ok, codex_bin="/opt/codex")) == ""
+    assert _author_preflight_error(make(**ok, codex_bin="~/.local/bin/codex")) == ""
+    assert "relative" in _author_preflight_error(make(**ok, codex_bin="bin/codex"))
 
 
 def test_author_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2076,6 +2076,17 @@ def test_wake_dispatcher_threads_the_author_backend(tmp_path: Path, monkeypatch:
     assert "--author-backend codex" in joined and "--model gpt-5.6-terra" in joined
     assert "--codex-bin /opt/codex" in joined
 
+    # a misconfigured codex author raises instead of submitting a doomed resume:
+    # _wake then releases the lease (a raising dispatch is a failed delivery),
+    # rather than burning a Slurm job that would die at startup every tick.
+    import pytest
+
+    submits.clear()
+    bad = replace(spec, author_model="")
+    with pytest.raises(ValueError, match="author misconfigured"):
+        JobWakeDispatcher(SlurmCompute(runner=runner), bad, now=NOW).dispatch(record, "eval done")
+    assert submits == []
+
 
 def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch: Any) -> None:
     """Panel on + a key the climb would reject (missing, group-readable,

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1803,6 +1803,280 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
     assert capped is not None and capped.max_job_minutes == 600
 
 
+def test_climb_author_argv(tmp_path: Path) -> None:
+    """The default (claude) author adds no flags; codex rides its backend,
+    model, and (optional) binary into the climb argv."""
+    from autoresearch.tick import FollowupSpec, _climb_author_argv
+
+    def make(**kw: Any) -> FollowupSpec:
+        return FollowupSpec(
+            target="org/pilot",
+            account="a",
+            partition="p",
+            run_root=tmp_path,
+            image="i.sif",
+            home=tmp_path,
+            **kw,
+        )
+
+    assert _climb_author_argv(make()) == []
+    assert _climb_author_argv(make(author_backend="claude")) == []
+    assert _climb_author_argv(make(author_backend="codex", author_model="gpt-5.6-terra")) == [
+        "--author-backend",
+        "codex",
+        "--model",
+        "gpt-5.6-terra",
+    ]
+    assert _climb_author_argv(
+        make(author_backend="codex", author_model="gpt-5.6-terra", codex_bin="/opt/codex")
+    ) == ["--author-backend", "codex", "--model", "gpt-5.6-terra", "--codex-bin", "/opt/codex"]
+
+
+def test_author_preflight_error(tmp_path: Path) -> None:
+    """Claude is always valid; codex needs a non-Claude model; an unknown
+    backend is rejected."""
+    from autoresearch.tick import FollowupSpec, _author_preflight_error
+
+    def make(**kw: Any) -> FollowupSpec:
+        return FollowupSpec(
+            target="org/pilot",
+            account="a",
+            partition="p",
+            run_root=tmp_path,
+            image="i.sif",
+            home=tmp_path,
+            **kw,
+        )
+
+    assert _author_preflight_error(make()) == ""
+    assert _author_preflight_error(make(author_backend="claude")) == ""
+    assert _author_preflight_error(make(author_backend="codex")) != ""  # no model
+    assert (
+        _author_preflight_error(make(author_backend="codex", author_model="claude-opus-5")) != ""
+    )  # a Claude id on the codex backend
+    assert _author_preflight_error(make(author_backend="codex", author_model="gpt-5.6-terra")) == ""
+    assert _author_preflight_error(make(author_backend="hermes")) != ""  # unknown
+
+
+def test_author_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) -> None:
+    """AUTORESEARCH_AUTHOR_BACKEND/_MODEL and AUTORESEARCH_CODEX_BIN reach the
+    FollowupSpec through the chain environment."""
+    from autoresearch.tick import _followup_spec_from_env
+
+    image = tmp_path / "agent.sif"
+    image.write_text("")
+    pat = tmp_path / "pat"
+    pat.write_text("t")
+    env = {
+        "AUTORESEARCH_PAT_FILE": str(pat),
+        "AUTORESEARCH_ACCOUNT": "a",
+        "AUTORESEARCH_PARTITION": "p",
+        "AUTORESEARCH_IMAGE": str(image),
+        "AUTORESEARCH_HOME": str(tmp_path),
+        "AUTORESEARCH_AUTHOR_BACKEND": "codex",
+        "AUTORESEARCH_AUTHOR_MODEL": "gpt-5.6-terra",
+        "AUTORESEARCH_CODEX_BIN": "/opt/codex",
+    }
+    import autoresearch.tick as tick_mod
+
+    monkeypatch.setattr(tick_mod.os, "environ", env)
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is not None
+    assert spec.author_backend == "codex"
+    assert spec.author_model == "gpt-5.6-terra"
+    assert spec.codex_bin == "/opt/codex"
+
+
+def test_self_initiated_launches_the_codex_author(tmp_path: Path) -> None:
+    """A codex-configured spec threads --author-backend/--model/--codex-bin into
+    the submitted climb argv; a codex backend without a model submits nothing."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import FollowupSpec, service_self_initiated
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets:
+  gpu_hours_per_run: 1
+  runs_per_week: 3
+  session_max_turns: 30
+  session_minutes: 25
+  climb_job_minutes: 60
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    panel_key = tmp_path / "verifier_key"
+    panel_key.write_text("k")
+    panel_key.chmod(0o600)
+
+    def spec(**kw: Any) -> FollowupSpec:
+        return FollowupSpec(
+            target="org/pilot",
+            account="acct",
+            partition="part",
+            run_root=tmp_path,
+            image="img.sif",
+            home=tmp_path,
+            panel_key_file=str(panel_key),
+            **kw,
+        )
+
+    submitted: list[list[str]] = []
+
+    def runner(argv, timeout_s):
+        submitted.append(list(argv))
+        return CommandResult(0, "123\n", "")
+
+    ok = spec(author_backend="codex", author_model="gpt-5.6-terra", codex_bin="/opt/codex")
+    out = service_self_initiated(tmp_path, SlurmCompute(runner=runner), ok, contract, NOW)
+    assert out == ("tsp", "123")
+    wrap = submitted[0][-1]
+    assert "--author-backend codex" in wrap
+    assert "--model gpt-5.6-terra" in wrap
+    assert "--codex-bin /opt/codex" in wrap
+
+    # a codex backend missing its model is caught before submit (nothing runs).
+    # Fresh root so no pending marker from the first submit masks the reason.
+    submitted.clear()
+    bad_root = tmp_path / "bad"
+    bad_root.mkdir()
+    bad = spec(author_backend="codex")
+    assert service_self_initiated(bad_root, SlurmCompute(runner=runner), bad, contract, NOW) is None
+    assert submitted == []
+
+
+def test_intake_launches_the_codex_author(tmp_path: Path) -> None:
+    """The intake lane threads the author backend into its climb argv, and a
+    codex backend without a model is caught before the issue is claimed."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import FollowupSpec, service_intake
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets:
+  gpu_hours_per_run: 1
+  runs_per_week: 3
+  session_max_turns: 30
+  session_minutes: 25
+  climb_job_minutes: 60
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    panel_key = tmp_path / "verifier_key"
+    panel_key.write_text("k")
+    panel_key.chmod(0o600)
+
+    class IntakeGitHub:
+        def __init__(self) -> None:
+            self.comments: list[str] = []
+
+        def list_open_issues(self, repo: str) -> list[dict[str, Any]]:
+            return [
+                {
+                    "number": 5,
+                    "title": "improve tsp",
+                    "body": "",
+                    "user": {"login": "mengye"},
+                    "author_association": "OWNER",
+                    "labels": [],
+                }
+            ]
+
+        def list_comments(self, repo: str, number: int) -> list[Any]:
+            return []
+
+        def comment(self, repo: str, number: int, body: str) -> None:
+            self.comments.append(body)
+
+    def spec(**kw: Any) -> FollowupSpec:
+        return FollowupSpec(
+            target="org/pilot",
+            account="acct",
+            partition="part",
+            run_root=tmp_path,
+            image="img.sif",
+            home=tmp_path,
+            panel_key_file=str(panel_key),
+            **kw,
+        )
+
+    submitted: list[list[str]] = []
+
+    def runner(argv, timeout_s):
+        submitted.append(list(argv))
+        return CommandResult(0, "123\n", "")
+
+    gh = IntakeGitHub()
+    ok = spec(author_backend="codex", author_model="gpt-5.6-terra", codex_bin="/opt/codex")
+    out = service_intake(tmp_path, gh, SlurmCompute(runner=runner), ok, NOW, contract=contract)
+    assert out is not None
+    wrap = submitted[0][-1]
+    assert "--author-backend codex" in wrap and "--model gpt-5.6-terra" in wrap
+    assert "--codex-bin /opt/codex" in wrap
+
+    # a codex backend missing its model is caught BEFORE the claim comment
+    gh2 = IntakeGitHub()
+    submitted.clear()
+    bad = spec(author_backend="codex")
+    assert (
+        service_intake(tmp_path, gh2, SlurmCompute(runner=runner), bad, NOW, contract=contract)
+        is None
+    )
+    assert submitted == [] and gh2.comments == []  # nothing claimed, nothing submitted
+
+
+def test_wake_dispatcher_threads_the_author_backend(tmp_path: Path, monkeypatch: Any) -> None:
+    """A parked run's wake carries the author backend so a codex resume drafts
+    (via the climb's supports_resume gate) instead of resuming with the wrong
+    harness."""
+    from autoresearch.runstate import RunRecord
+    from autoresearch.tick import FollowupSpec, JobWakeDispatcher
+
+    submits: list[list[str]] = []
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            submits.append(list(argv))
+            return CommandResult(0, "9001\n", "")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(
+        "autoresearch.tick._flight_command", lambda home, name, now, argv: " ".join(argv)
+    )
+    spec = FollowupSpec(
+        account="acct",
+        partition="cpu_short",
+        run_root=tmp_path,
+        image="/img/a.sif",
+        home=tmp_path,
+        pat_file="/pat",
+        panel="verify,review",
+        author_backend="codex",
+        author_model="gpt-5.6-terra",
+        codex_bin="/opt/codex",
+    )
+    record = RunRecord(
+        run_id="tsp-1",
+        target="org/pilot",
+        task_title="improve tsp",
+        benchmark="tsp",
+        state="waiting",
+        stage={"afterany": "afterany:501"},
+    )
+    JobWakeDispatcher(SlurmCompute(runner=runner), spec, now=NOW).dispatch(record, "eval done")
+    joined = " ".join(submits[0])
+    assert "--resume tsp-1" in joined
+    assert "--author-backend codex" in joined and "--model gpt-5.6-terra" in joined
+    assert "--codex-bin /opt/codex" in joined
+
+
 def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch: Any) -> None:
     """Panel on + a key the climb would reject (missing, group-readable,
     empty): the intake lane claims nothing and the self-initiated lane


### PR DESCRIPTION
## What

Let the **tick** drive the codex/terra author for its climb-authoring lanes, so
the live loop can author on codex instead of Claude. Three env knobs, threaded
through a shared helper into the self-initiated, intake, and wake (revise) lanes:

- `AUTORESEARCH_AUTHOR_BACKEND` — `""`/`claude` (default) or `codex`
- `AUTORESEARCH_AUTHOR_MODEL` — required non-Claude id for codex (e.g. `gpt-5.6-terra`)
- `AUTORESEARCH_CODEX_BIN` — optional; falls back to the climb CLI default

## Design

- **The author backend is a fleet-wide choice.** All three authoring lanes share
  `key_file`, so they must all use the same backend — otherwise a Claude author
  would be handed the codex/OpenAI key. `AUTORESEARCH_HARNESS_KEY_FILE` therefore
  holds *the author's* key (Anthropic for claude, OpenAI for codex); the verify/
  review panel keeps its own `AUTORESEARCH_PANEL_KEY_FILE` regardless. The steward
  is a separate role with its own key and is unaffected.
- **Preflight before side effects.** A codex author missing a (non-Claude) model
  is caught up front: the self-initiated lane skips, and intake skips *before
  claiming* an issue — no job submitted that would die at startup, no stranded
  claim.
- **Wake carries the backend.** A parked codex run resumes with the right harness;
  codex has no headless resume (`supports_resume=False`), so the climb's existing
  gate drafts the blocking finding instead of resuming — rather than a Claude
  harness receiving an OpenAI key.

Default behavior is unchanged (the Claude author). This is the code stage; the
live flip (setting the env on the tick host) is a separate, deliberate step.

## Test plan

- New: `_climb_author_argv` / `_author_preflight_error` units; self-initiated,
  intake, and wake integration tests (codex flags reach the argv; codex-without-
  model skips before submit, and intake skips before claiming).
- `uv run pytest` — 695 passed. Full gate (ruff check + format, mypy) — green.

## Context

Builds on #121 (codex author validated end-to-end on Slurm). Author network-egress
hardening is tracked separately in #122.

## No secrets / no large files

Confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
