### PR TITLE
Codex author: fix + validate headless resume (supports_resume=True)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,12 @@ Versions follow [SemVer](https://semver.org).
   swapping one host binary. `--image` and a non-claude `--model` are required
   (guarded early); `--codex-config KEY=VALUE` passes host-specific codex config.
   Headless session resume is validated on codex-cli 0.130.0 (`supports_resume=True`):
-  `codex exec resume <thread_id>` recalls the session, so a blocking panel finding
-  WAKES codex to revise like Claude (`codex exec resume` takes neither `--sandbox`
-  nor `--cd` — it uses `--dangerously-bypass-approvals-and-sandbox` and the
-  recorded cwd). The read-only codex/hermes reviewer path is unchanged. (The
-  author path is validated end-to-end on Slurm; needs codex installed on the host.)
+  a contained `codex exec resume <thread_id>` recalled prior-turn context, so a
+  blocking panel finding WAKES codex to revise like Claude. `codex exec resume`
+  takes neither `--sandbox` nor `--cd`: it inherits the recorded session's sandbox
+  (a resumed read-only reviewer stays read-only — verified) and cwd; the author
+  adds `--dangerously-bypass-approvals-and-sandbox` to also skip approvals. The
+  read-only codex/hermes reviewer path is unchanged. (Needs codex on the host.)
 
 - Tick coalescing: under partition congestion, queued ticks bunch up and become
   eligible together (the singleton dependency serializes them), so they would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ Versions follow [SemVer](https://semver.org).
   like `--claude-bin`) so the image stays codex-free and codex updates by
   swapping one host binary. `--image` and a non-claude `--model` are required
   (guarded early); `--codex-config KEY=VALUE` passes host-specific codex config.
-  codex session resume is not bench-validated yet (`supports_resume=False`), so a
-  blocking panel finding drafts rather than revising. The read-only codex/hermes
-  reviewer path is unchanged. (Reachable but unexercised end-to-end; needs codex
-  installed on the host.)
+  Headless session resume is validated on codex-cli 0.130.0 (`supports_resume=True`):
+  `codex exec resume <thread_id>` recalls the session, so a blocking panel finding
+  WAKES codex to revise like Claude (`codex exec resume` takes neither `--sandbox`
+  nor `--cd` — it uses `--dangerously-bypass-approvals-and-sandbox` and the
+  recorded cwd). The read-only codex/hermes reviewer path is unchanged. (The
+  author path is validated end-to-end on Slurm; needs codex installed on the host.)
 
 - Tick coalescing: under partition congestion, queued ticks bunch up and become
   eligible together (the singleton dependency serializes them), so they would

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -709,7 +709,8 @@ def resume_run(
                 can_revise = (
                     bool(verdict.blocking)
                     and harness is not None
-                    # codex/hermes declare supports_resume=False -> draft, don't resume
+                    # a no-resume backend (hermes) declares supports_resume=False
+                    # -> draft, don't resume (claude and codex both resume)
                     and getattr(harness, "supports_resume", True)
                     and spec is not None
                     and bool(record.resume_session_id)
@@ -994,11 +995,12 @@ def build_editor_harness(
       (no inner OS sandbox) and relies on apptainer as the boundary, exactly as
       the claude author does — codex's own sandbox needs bubblewrap, absent in
       the image. An author MUST be contained (it writes+executes), so
-      container_image is REQUIRED — the read-only reviewer could skip it. Codex declares
-      `supports_resume=False` (its headless resume is not bench-validated), so a
-      blocking panel finding DRAFTS instead of attempting a resume — both the
-      inline and wake revise paths gate on `supports_resume`, so there is no
-      blind revise and no improvement lost to a failed resume."""
+      container_image is REQUIRED — the read-only reviewer could skip it. Codex
+      resumes like claude (`codex exec resume`, validated on 0.130.0), so a
+      blocking panel finding WAKES it to revise. A no-resume backend (hermes)
+      would DRAFT instead — the inline and wake revise paths gate on
+      `supports_resume`, so a backend that cannot resume never blind-revises and
+      never loses an improvement to a failed resume."""
     spec = spec or author_spec()
     if not spec.execution.can_execute:
         raise ValueError("build_editor_harness is for editing roles")

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -79,11 +79,12 @@ class Harness(Protocol):
     HOME next to the workspace, so wakes survive orchestrator restarts and can
     land on a different cluster node (shared filesystem).
 
-    A backend MAY declare a class attribute `supports_resume = False` when its
-    headless resume is not trustworthy (codex/hermes). The revise loop checks it
-    (via getattr, default True) and DRAFTS instead of calling run() with a resume
-    id — an untrusted resume that starts fresh or fails would revise blind or
-    lose a verified improvement. Optional, so test doubles need not declare it."""
+    A backend MAY declare a class attribute `supports_resume = False` when it
+    has no trustworthy headless resume (hermes). The revise loop checks it (via
+    getattr, default True) and DRAFTS instead of calling run() with a resume id —
+    a resume that silently starts fresh or fails would revise blind or lose a
+    verified improvement. Claude and codex both resume (`supports_resume=True`).
+    Optional, so test doubles need not declare it."""
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
@@ -547,12 +548,15 @@ def _codex_command(
     --output-last-message, --skip-git-repo-check, and the stdin prompt behavior.
 
     Fresh and resume take DIFFERENT flags. `codex exec` has `--sandbox` and
-    `--cd`; `codex exec resume <id>` has NEITHER — it restores the recorded
-    session (and its cwd; the process cwd is the workspace anyway) and expresses
-    danger-full-access as `--dangerously-bypass-approvals-and-sandbox`. Passing
-    the fresh flags to resume is an argparse error (verified). Resume is an
-    author-only path (readers are stateless), so the bypass flag is emitted only
-    for the author's danger-full-access sandbox.
+    `--cd`; `codex exec resume <id>` has NEITHER (passing them is an argparse
+    error) — it restores the recorded session, INCLUDING that session's sandbox
+    and cwd. Verified on codex-cli 0.130.0: resuming a `--sandbox read-only`
+    session with no sandbox flag still refuses writes, so a resumed read-only
+    reviewer stays jailed by inheritance, not by luck. The author adds
+    `--dangerously-bypass-approvals-and-sandbox` on resume anyway — its
+    danger-full-access is inherited, but the flag also skips approvals so a
+    headless write-heavy revise turn cannot stall. (Both authors and readers can
+    resume — readers via the structured-output repair turn.)
     """
     # --model is omitted when empty so codex uses its configured default; a
     # wrong model id is a 404 ("Model not found"), so only pin a verified one.
@@ -564,7 +568,9 @@ def _codex_command(
         *extra_args,
     ]
     if resume_session_id:
-        # no --sandbox/--cd on resume; bypass == danger-full-access
+        # no --sandbox/--cd on resume: the recorded session's sandbox is
+        # inherited (read-only stays read-only). The author adds the bypass flag
+        # to also skip approvals headlessly; a reader inherits its read-only jail.
         bypass = (
             ["--dangerously-bypass-approvals-and-sandbox"]
             if sandbox == "danger-full-access"

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -543,26 +543,44 @@ def _codex_command(
     The prompt is NOT an argument: `codex exec` reads it from stdin when no
     positional prompt is given, keeping the brief out of world-readable /proc
     argv (the same rule as the Claude adapter). Flags verified against
-    codex-cli 0.130.0 (`codex exec --help`): exec/resume, --json, --model,
-    --sandbox read-only, --cd, --output-last-message, --skip-git-repo-check,
-    and the stdin prompt behavior.
+    codex-cli 0.130.0 (`codex exec[ resume] --help`): --json, --model,
+    --output-last-message, --skip-git-repo-check, and the stdin prompt behavior.
+
+    Fresh and resume take DIFFERENT flags. `codex exec` has `--sandbox` and
+    `--cd`; `codex exec resume <id>` has NEITHER — it restores the recorded
+    session (and its cwd; the process cwd is the workspace anyway) and expresses
+    danger-full-access as `--dangerously-bypass-approvals-and-sandbox`. Passing
+    the fresh flags to resume is an argparse error (verified). Resume is an
+    author-only path (readers are stateless), so the bypass flag is emitted only
+    for the author's danger-full-access sandbox.
     """
-    head = [binary, "exec", "resume", resume_session_id] if resume_session_id else [binary, "exec"]
     # --model is omitted when empty so codex uses its configured default; a
     # wrong model id is a 404 ("Model not found"), so only pin a verified one.
     model_flag = ["--model", model] if model else []
-    return [
-        *head,
-        "--json",  # JSONL events on stdout (session id, usage)
-        *model_flag,
-        "--sandbox",
-        sandbox,  # "read-only" for judge roles; "workspace-write" for authors
-        "--cd",
-        str(workspace),
+    tail = [
         "--output-last-message",  # final message -> file (reliable final_text)
         str(last_message_path),
         "--skip-git-repo-check",
         *extra_args,
+    ]
+    if resume_session_id:
+        # no --sandbox/--cd on resume; bypass == danger-full-access
+        bypass = (
+            ["--dangerously-bypass-approvals-and-sandbox"]
+            if sandbox == "danger-full-access"
+            else []
+        )
+        return [binary, "exec", "resume", resume_session_id, "--json", *model_flag, *bypass, *tail]
+    return [
+        binary,
+        "exec",
+        "--json",  # JSONL events on stdout (session id, usage)
+        *model_flag,
+        "--sandbox",
+        sandbox,  # "read-only" for judge roles; "danger-full-access" for authors
+        "--cd",
+        str(workspace),
+        *tail,
     ]
 
 
@@ -572,11 +590,10 @@ def _parse_codex_result(
     """Best-effort SessionResult from `codex exec --json` output.
 
     `final_text` comes from the --output-last-message file, which is reliable.
-    `session_id` is pulled from the JSONL events defensively; the CLI flags are
-    verified (codex-cli 0.130.0), but the exact `--json` event field names still
-    need a live authed run, so resume may be unavailable until then. Cost is left
-    at 0 (these backends are subscription or token metered; the budget layer
-    meters them by a session/token proxy). Never raises.
+    `session_id` is the `thread.started` event's `thread_id`, verified against
+    codex-cli 0.130.0 (a `codex exec resume <thread_id>` recalls the session).
+    Cost is left at 0 (these backends are subscription or token metered; the
+    budget layer meters them by a session/token proxy). Never raises.
     """
     # Event schema verified against codex-cli 0.130.0 (cluster0):
     #   thread.started -> thread_id (the session id)
@@ -636,9 +653,10 @@ class CodexHarness:
 
     Stage 1's swappability proof, first used for the read-only reviewer
     (docs/design/consolidation.md): Codex's own `--sandbox read-only` plus a
-    judge RoleSpec's tool set. CLI flags are verified against codex-cli 0.130.0;
-    the `--json` event field names still need a live authed run, so `session_id`
-    and cost parsing are best-effort until then.
+    judge RoleSpec's tool set. CLI flags AND headless resume are verified against
+    codex-cli 0.130.0 (`session_id` = the `thread.started` `thread_id`; resume
+    recalls it); cost parsing stays best-effort (these backends are metered by a
+    session/token proxy in the budget layer).
 
     AUTHOR mode (`container_image` set): both `codex login` and `codex exec` run
     inside `apptainer exec --containall --cleanenv`, sharing a bound `--home` so
@@ -674,10 +692,11 @@ class CodexHarness:
     # is updated by swapping one host binary, no rebuild). A bare class attribute
     # (no annotation) so the dataclass does not treat it as a field.
     CONTAINER_CODEX = "/opt/agent/codex"
-    # codex --json session-id parsing is best-effort until a live authed run
-    # verifies the event fields, so headless resume is NOT trusted yet: the
-    # revise loop drafts instead of resuming (flip to True once validated).
-    supports_resume = False
+    # Headless resume is validated on codex-cli 0.130.0: a contained
+    # `codex exec resume <thread_id>` recalls prior-turn context (the session id
+    # is the `thread.started` event's `thread_id`, restored from the bound
+    # --home). So the revise/wake/followup loops resume codex like Claude.
+    supports_resume = True
 
     def _apptainer_argv(
         self, inner: list[str], session_home: Path, workspace: Path | None

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1141,11 +1141,11 @@ def climb_once(
             # for the author to fix), but the caller drafts the PR
             break
         if not session.session_id or not getattr(harness, "supports_resume", True):
-            # cannot resume: no session id, OR a backend whose headless resume
-            # is not bench-validated (codex/hermes). A FRESH session seeing only
-            # the findings would revise blind, and an unvalidated resume that
-            # fails would lose this verified improvement as a session-error —
-            # so fail closed to the draft path (review question, #95 round 1).
+            # cannot resume: no session id, OR a no-resume backend (hermes;
+            # claude and codex both resume). A FRESH session seeing only the
+            # findings would revise blind, and a resume the backend can't do
+            # would lose this verified improvement as a session-error — so fail
+            # closed to the draft path (review question, #95 round 1).
             panel_blocking_open = True
             break
         if panel_reads > panel_revisions:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1382,7 +1382,7 @@ def test_editor_harness_codex_backend_is_contained() -> None:
     assert harness.model == "gpt-5.6-terra"
     assert harness.timeout_s == 300
     assert harness.extra_args == ("-c", "use_legacy_landlock=true")  # host codex config
-    assert harness.supports_resume is False  # revise loop drafts, never resumes
+    assert harness.supports_resume is True  # codex exec resume, validated on 0.130.0
     # an author MUST be contained
     with pytest.raises(ValueError, match="container_image"):
         build_editor_harness("sk-o", spec, backend="codex", container_image="")

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -640,10 +640,12 @@ def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
 
 def test_codex_command_resume_uses_bypass_not_sandbox_cd(tmp_path: Path) -> None:
     """`codex exec resume` has neither --sandbox nor --cd (passing them is an
-    argparse error, verified on 0.130.0): resume expresses danger-full-access as
-    --dangerously-bypass-approvals-and-sandbox, and a fresh exec keeps
-    --sandbox/--cd. Resume is author-only, so the bypass rides only for the
-    author's danger-full-access sandbox."""
+    argparse error, verified on 0.130.0). A fresh exec keeps --sandbox/--cd. On
+    resume the recorded session's sandbox is inherited: the author adds the
+    bypass flag (to also skip approvals), a read-only reader (the structured-
+    output repair turn also resumes) adds NO sandbox flag and stays read-only by
+    inheritance — verified on 0.130.0 that a resumed read-only session still
+    refuses writes."""
     from autoresearch.harness import _codex_command
 
     ws = tmp_path / "ws"
@@ -654,12 +656,19 @@ def test_codex_command_resume_uses_bypass_not_sandbox_cd(tmp_path: Path) -> None
     assert "--cd" in fresh and str(ws) in fresh
     assert "--dangerously-bypass-approvals-and-sandbox" not in fresh
 
-    resumed = _codex_command("codex", "gpt-5.6-terra", "danger-full-access", ws, last, "sess-7", ())
-    assert resumed[:4] == ["codex", "exec", "resume", "sess-7"]
-    assert "--dangerously-bypass-approvals-and-sandbox" in resumed
-    assert "--sandbox" not in resumed  # rejected by `exec resume`
-    assert "--cd" not in resumed  # rejected by `exec resume`
-    assert "--json" in resumed and "--output-last-message" in resumed
+    author = _codex_command("codex", "gpt-5.6-terra", "danger-full-access", ws, last, "sess-7", ())
+    assert author[:4] == ["codex", "exec", "resume", "sess-7"]
+    assert "--dangerously-bypass-approvals-and-sandbox" in author
+    assert "--sandbox" not in author  # rejected by `exec resume`
+    assert "--cd" not in author  # rejected by `exec resume`
+    assert "--json" in author and "--output-last-message" in author
+
+    # a read-only reader resume: NO bypass (that would unjail it), NO --sandbox
+    # (rejected) — read-only is inherited from the recorded session
+    reader = _codex_command("codex", "", "read-only", ws, last, "sess-7", ())
+    assert reader[:4] == ["codex", "exec", "resume", "sess-7"]
+    assert "--dangerously-bypass-approvals-and-sandbox" not in reader
+    assert "--sandbox" not in reader and "--cd" not in reader
 
 
 def test_codex_author_resumes_contained(tmp_path: Path) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -638,6 +638,55 @@ def test_codex_author_runs_contained_in_apptainer(tmp_path: Path) -> None:
     assert envs.read_text().count("APPTAINERENV_OPENAI_API_KEY=sk-o") == 2
 
 
+def test_codex_command_resume_uses_bypass_not_sandbox_cd(tmp_path: Path) -> None:
+    """`codex exec resume` has neither --sandbox nor --cd (passing them is an
+    argparse error, verified on 0.130.0): resume expresses danger-full-access as
+    --dangerously-bypass-approvals-and-sandbox, and a fresh exec keeps
+    --sandbox/--cd. Resume is author-only, so the bypass rides only for the
+    author's danger-full-access sandbox."""
+    from autoresearch.harness import _codex_command
+
+    ws = tmp_path / "ws"
+    last = tmp_path / "last.txt"
+    fresh = _codex_command("codex", "gpt-5.6-terra", "danger-full-access", ws, last, None, ())
+    assert "resume" not in fresh
+    assert "--sandbox" in fresh and "danger-full-access" in fresh
+    assert "--cd" in fresh and str(ws) in fresh
+    assert "--dangerously-bypass-approvals-and-sandbox" not in fresh
+
+    resumed = _codex_command("codex", "gpt-5.6-terra", "danger-full-access", ws, last, "sess-7", ())
+    assert resumed[:4] == ["codex", "exec", "resume", "sess-7"]
+    assert "--dangerously-bypass-approvals-and-sandbox" in resumed
+    assert "--sandbox" not in resumed  # rejected by `exec resume`
+    assert "--cd" not in resumed  # rejected by `exec resume`
+    assert "--json" in resumed and "--output-last-message" in resumed
+
+
+def test_codex_author_resumes_contained(tmp_path: Path) -> None:
+    """A contained resume runs `codex exec resume <id>` inside apptainer with the
+    same bound --home (so the recorded session is visible) and the bypass flag,
+    never --sandbox/--cd."""
+    binary, calls, _envs = _recording_apptainer(tmp_path, json.dumps(CANNED))
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    harness = CodexHarness(
+        api_key="sk-o",
+        binary="/real/codex",
+        model="gpt-5.6-terra",
+        sandbox="danger-full-access",
+        container_image="/img/agent.sif",
+        apptainer_binary=binary,
+    )
+    assert harness.supports_resume is True
+    harness.run("revise per the finding", ws, resume_session_id="01a0-thread")
+    exec_ = next(ln for ln in calls.read_text().splitlines() if "codex exec resume" in ln)
+    home = f"--home {tmp_path / 'ws-home'}:{tmp_path / 'ws-home'}"
+    assert "/img/agent.sif /opt/agent/codex exec resume 01a0-thread" in exec_
+    assert home in exec_  # same run-home -> recorded session is visible
+    assert "--dangerously-bypass-approvals-and-sandbox" in exec_
+    assert "--sandbox" not in exec_ and "--cd" not in exec_
+
+
 def test_codex_author_resolves_a_relative_workspace(tmp_path: Path, monkeypatch) -> None:
     """apptainer bind sources must be absolute; a relative workspace is resolved
     (else the mount fails deep inside apptainer)."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -970,9 +970,10 @@ def test_blocking_then_clean_revises_and_remeasures(tmp_path: Path) -> None:
 
 
 def test_a_backend_that_cannot_resume_drafts_a_blocking_finding(tmp_path: Path) -> None:
-    """codex/hermes declare supports_resume=False: a blocking finding must DRAFT
-    the verified improvement, never attempt an unvalidated resume that would lose
-    it as a session-error (review #119 r2, terra)."""
+    """a no-resume backend (hermes) declares supports_resume=False: a blocking
+    finding must DRAFT the verified improvement, never attempt a resume the
+    backend can't do that would lose it as a session-error (review #119 r2,
+    terra). Claude and codex both resume; hermes exercises this path."""
     result, harness, evaluator, _panel = _run_panel_climb(
         tmp_path, [13.9, 13.1], [_verdict(True, 1)], supports_resume=False
     )


### PR DESCRIPTION
## What

Fix and validate headless **session resume** for the codex author, and flip
`CodexHarness.supports_resume` to `True`.

## Why

codex was marked `supports_resume=False` **conservatively** — the `--json`
session-id parsing was unverified, so the revise / wake / followup loops DRAFTED
for codex instead of resuming. That premise was wrong, and it's what made codex
look fundamentally incompatible with the resume-centric lanes.

Validated on Torch (codex-cli 0.130.0, fully contained in apptainer): a
`codex exec resume <thread_id>` recalls prior-turn context (planted "4242" in
turn 1, recalled it in turn 2). **Codex can resume.**

The real blocker was a bug in `_codex_command`: it passed `--sandbox` and `--cd`
to `codex exec resume`, which accepts **neither** (argparse error, rc=2 — I hit
exactly this in the validation before fixing it). `codex exec resume`:
- expresses danger-full-access as `--dangerously-bypass-approvals-and-sandbox`,
- has no `--cd` (uses the recorded session cwd; the process cwd is the workspace).

## Changes

- `_codex_command`: split fresh vs resume argv. Fresh keeps `--sandbox`/`--cd`;
  resume uses `--dangerously-bypass-approvals-and-sandbox` (only for the author's
  danger-full-access; resume is author-only) and drops `--sandbox`/`--cd`.
- `CodexHarness.supports_resume = True`; the `session_id` = `thread.started`
  `thread_id` is now verified by the live resume.
- Docstrings/comments updated: only a no-resume backend (hermes) drafts; claude
  and codex both resume. CHANGELOG updated.

## Test plan

- New: `test_codex_command_resume_uses_bypass_not_sandbox_cd` (argv split) and
  `test_codex_author_resumes_contained` (contained `exec resume` with the bound
  `--home`, bypass flag, no `--sandbox`/`--cd`).
- The generic no-resume→DRAFT path stays covered by hermes
  (`test_a_backend_that_cannot_resume_drafts_a_blocking_finding`, fake at
  `supports_resume=False`).
- `uv run pytest` — 691 passed. Full gate (ruff check + format, mypy) — green.

## Context

This removes the premise that forced most of the "codex is special" complexity in
the abandoned tick-wiring approach (#123). The follow-up is a config-driven
backend selection so enabling a backend needs ~zero per-lane change.

## No secrets / no large files

Confirmed. (The OpenAI key was only ever read from a 0600 `.env` on the host and
never printed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
