### PR TITLE
Config-driven author selection (tick stays backend-agnostic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,9 @@ Versions follow [SemVer](https://semver.org).
   record with no backend is treated as claude, not the fleet's; an explicit
   `--key-file` survives resume). A mid-flight fleet flip therefore never resumes a
   run on the wrong backend, pairs a codex backend with a claude model, or reaches
-  for the wrong key. The codex author is validated on the EFFECTIVE
+  for the wrong key. The tick preflights the fleet author config (a codex backend
+  needs a non-claude model + image) before self-initiated submits or intake
+  claims, so a misconfig never strands a claimed issue. The codex author is validated on the EFFECTIVE
   author per path (fresh args vs the parked run's persisted pair), so the check
   never judges a fleet backend against a run's model.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,14 @@ Versions follow [SemVer](https://semver.org).
   change, not a key swap, and no in-flight run breaks. The tick no longer threads
   the author backend or key into the climb/intake/wake/follow-up jobs — a new
   author backend needs ZERO tick change (only the steward keeps its own explicit
-  key, a distinct role). A run's backend is persisted on its record, so a wake or
-  follow-up reproduces that run's OWN author (and key), not the current fleet
-  default — a mid-flight fleet flip never resumes a run on the wrong backend.
+  key, a distinct role). A run's author `(backend, model)` PAIR is persisted on
+  its record, so a wake or follow-up reproduces that run's OWN author, model, and
+  key — never the current fleet default (a legacy record with no backend is
+  treated as claude, not the fleet's). A mid-flight fleet flip therefore never
+  resumes a run on the wrong backend, pairs a codex backend with a claude model,
+  or reaches for the wrong key. The codex author is validated on the EFFECTIVE
+  author per path (fresh args vs the parked run's persisted pair), so the check
+  never judges a fleet backend against a run's model.
 
 - Tick coalescing: under partition congestion, queued ticks bunch up and become
   eligible together (the singleton dependency serializes them), so they would

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,13 @@ Versions follow [SemVer](https://semver.org).
   change, not a key swap, and no in-flight run breaks. The tick no longer threads
   the author backend or key into the climb/intake/wake/follow-up jobs — a new
   author backend needs ZERO tick change (only the steward keeps its own explicit
-  key, a distinct role). A run's author `(backend, model)` PAIR is persisted on
-  its record, so a wake or follow-up reproduces that run's OWN author, model, and
-  key — never the current fleet default (a legacy record with no backend is
-  treated as claude, not the fleet's). A mid-flight fleet flip therefore never
-  resumes a run on the wrong backend, pairs a codex backend with a claude model,
-  or reaches for the wrong key. The codex author is validated on the EFFECTIVE
+  key, a distinct role). A run's full author identity — `(backend, model,
+  key-file path)` — is persisted on its record, so a wake or follow-up reproduces
+  that run's OWN author, model, and key, never the current fleet default (a legacy
+  record with no backend is treated as claude, not the fleet's; an explicit
+  `--key-file` survives resume). A mid-flight fleet flip therefore never resumes a
+  run on the wrong backend, pairs a codex backend with a claude model, or reaches
+  for the wrong key. The codex author is validated on the EFFECTIVE
   author per path (fresh args vs the parked run's persisted pair), so the check
   never judges a fleet backend against a run's model.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,21 @@ Versions follow [SemVer](https://semver.org).
   adds `--dangerously-bypass-approvals-and-sandbox` to also skip approvals. The
   read-only codex/hermes reviewer path is unchanged. (Needs codex on the host.)
 
+- Config-driven author selection: the author backend is now a CONFIG choice the
+  role runners resolve themselves, not something the tick threads per lane. The
+  `climb` and `followup` CLIs default `--author-backend`/`--model`/`--codex-bin`
+  from `AUTORESEARCH_AUTHOR_BACKEND`/`_MODEL` and `AUTORESEARCH_CODEX_BIN` (same
+  env-default pattern already used for `--image`/`--account`/`--partition`), and
+  the author key resolves PER BACKEND — `AUTORESEARCH_HARNESS_KEY_FILE` for
+  claude, `AUTORESEARCH_CODEX_KEY_FILE` for codex — with the two keys COEXISTING
+  on disk (`resolve_author_key_file`). So flipping the fleet is a one-line env
+  change, not a key swap, and no in-flight run breaks. The tick no longer threads
+  the author backend or key into the climb/intake/wake/follow-up jobs — a new
+  author backend needs ZERO tick change (only the steward keeps its own explicit
+  key, a distinct role). A run's backend is persisted on its record, so a wake or
+  follow-up reproduces that run's OWN author (and key), not the current fleet
+  default — a mid-flight fleet flip never resumes a run on the wrong backend.
+
 - Tick coalescing: under partition congestion, queued ticks bunch up and become
   eligible together (the singleton dependency serializes them), so they would
   run back-to-back and redundantly re-sweep. A tick now no-ops if another tick

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -86,7 +86,25 @@ log = logging.getLogger(__name__)
 # tick preflights the panel key (and compares it against the author key —
 # role separation) before claiming/submitting.
 PANEL_KEY_DEFAULT = "~/.config/autoresearch/verifier_key"
-HARNESS_KEY_DEFAULT = "~/.config/autoresearch/harness_key"
+HARNESS_KEY_DEFAULT = "~/.config/autoresearch/harness_key"  # the claude author key
+CODEX_KEY_DEFAULT = "~/.config/autoresearch/codex_key"  # the codex author key
+
+
+def resolve_author_key_file(backend: str, explicit: str = "") -> str:
+    """The author key file for `backend`. Per-backend keys COEXIST (claude's and
+    codex's both on disk), selected by backend — so the author backend is a
+    config choice, not a key swap, and an in-flight run of either backend can
+    still be woken/serviced after a fleet flip. An explicit path always wins;
+    otherwise the per-backend env var, then the packaged default path."""
+    if explicit:
+        return explicit
+    if backend == "codex":
+        return os.environ.get("AUTORESEARCH_CODEX_KEY_FILE") or os.path.expanduser(
+            CODEX_KEY_DEFAULT
+        )
+    return os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE") or os.path.expanduser(
+        HARNESS_KEY_DEFAULT
+    )
 
 
 class WorkspaceDrift(RuntimeError):
@@ -1139,6 +1157,7 @@ def live_climb(
     secrets: tuple[str, ...] = (),
     base_branch: str = "main",
     issue_number: int = 0,
+    author_backend: str = "claude",
     task_hypothesis: str = "",
     spec: RoleSpec | None = None,
     panel_lenses: tuple[PanelLens, ...] = (),
@@ -1168,6 +1187,7 @@ def live_climb(
         agent_id=config.agent_id,
         deadline=now + 24 * 3600,
         issue_number=issue_number,
+        author_backend=author_backend,
         climb_job_id=_os.environ.get("SLURM_JOB_ID", ""),
     )
     try:
@@ -1940,18 +1960,22 @@ def main() -> int:
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument(
         "--codex-bin",
-        default=os.path.expanduser("~/.local/bin/codex"),
+        default=os.environ.get("AUTORESEARCH_CODEX_BIN")
+        or os.path.expanduser("~/.local/bin/codex"),
         help="host codex binary for the codex author; bind-mounted into apptainer "
         "(must be an absolute path).",
     )
-    parser.add_argument("--model", default="claude-opus-5")
+    parser.add_argument(
+        "--model", default=os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5"
+    )
     parser.add_argument(
         "--author-backend",
         choices=("claude", "codex"),
-        default="claude",
-        help="agent backend for the author/editor role. codex runs contained "
-        "(apptainer + --sandbox workspace-write) and REQUIRES --image and a "
-        "codex/openai --model (e.g. gpt-5.6-terra).",
+        default=os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude",
+        help="agent backend for the author/editor role (config-driven: default "
+        "from AUTORESEARCH_AUTHOR_BACKEND). codex runs contained (apptainer + "
+        "--sandbox danger-full-access) and REQUIRES --image and a codex/openai "
+        "--model (e.g. gpt-5.6-terra).",
     )
     parser.add_argument(
         "--codex-config",
@@ -1992,7 +2016,12 @@ def main() -> int:
         help="how long before the walltime the self-deadline fires (floor 60)",
     )
     parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
-    parser.add_argument("--key-file", default=os.path.expanduser(HARNESS_KEY_DEFAULT))
+    parser.add_argument(
+        "--key-file",
+        default="",
+        help="author key file; default resolves per backend (config-driven): "
+        "AUTORESEARCH_HARNESS_KEY_FILE for claude, AUTORESEARCH_CODEX_KEY_FILE for codex",
+    )
     parser.add_argument("--issue", type=int, default=0)
     parser.add_argument(
         "--min-free-gb",
@@ -2032,8 +2061,19 @@ def main() -> int:
                 "to rebuild the dispatched measurer"
             )
         from autoresearch.compute import SlurmCompute
-        from autoresearch.runstate import release_lease
+        from autoresearch.runstate import load_record, release_lease
 
+        # Reproduce the PARKED run's author, not the current fleet default: the
+        # backend is persisted on the record (a fleet flip must not wake a codex
+        # run as claude, or vice versa), falling back to the CLI/env default for
+        # legacy records or an unreadable record. The key then resolves for THAT
+        # backend (keys coexist).
+        try:
+            wake_backend = load_record(args.run_root, args.resume).author_backend
+        except (OSError, ValueError):
+            wake_backend = ""
+        wake_backend = wake_backend or args.author_backend
+        wake_key_file = resolve_author_key_file(wake_backend, args.key_file)
         # the wake runs the SAME verification panel as a fresh climb, so a
         # dispatched improvement is not published unverified.
         try:
@@ -2050,13 +2090,13 @@ def main() -> int:
         # read-decide-publish job and must not require the author key.
         if wake_lenses:
             wake_panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
-            wake_api_key = FileTokenProvider(Path(args.key_file).expanduser()).token()
+            wake_api_key = FileTokenProvider(Path(wake_key_file).expanduser()).token()
             wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
             wake_harness = build_editor_harness(
                 wake_api_key,
                 wake_spec,
-                backend=args.author_backend,
-                binary=args.claude_bin if args.author_backend == "claude" else args.codex_bin,
+                backend=wake_backend,
+                binary=args.claude_bin if wake_backend == "claude" else args.codex_bin,
                 model=args.model,
                 container_image=args.image,
                 codex_extra_args=codex_extra,
@@ -2093,6 +2133,9 @@ def main() -> int:
     if not (args.target and args.benchmark):
         parser.error("--target and --benchmark are required for a fresh climb")
 
+    # config-driven: the author key defaults per backend (claude vs codex) so the
+    # tick never threads it — see resolve_author_key_file.
+    args.key_file = resolve_author_key_file(args.author_backend, args.key_file)
     # same 0600 discipline as the PAT: this key spends real money
     api_key = FileTokenProvider(Path(args.key_file).expanduser()).token()
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
@@ -2196,6 +2239,7 @@ def main() -> int:
                     if k
                 ),
                 issue_number=args.issue,
+                author_backend=args.author_backend,
                 task_hypothesis=(
                     __import__("base64").b64decode(args.hypothesis_b64).decode()
                     if args.hypothesis_b64

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -124,19 +124,23 @@ def codex_author_config_error(backend: str, model: str, image: str) -> str:
     return ""
 
 
-def resume_author(record: object, fleet_model: str) -> tuple[str, str]:
-    """The (backend, model) a wake/follow-up must reproduce for a parked run.
+def resume_author(record: object, fleet_model: str) -> tuple[str, str, str]:
+    """The (backend, model, key_file) a wake/follow-up must reproduce for a parked
+    run — all from the RECORD, not the current fleet.
 
-    Both come from the RECORD, not the current fleet: an empty backend is a
-    legacy record (written before the field) and is therefore CLAUDE, never the
-    fleet default; the model pairs with that backend (a claude backend falls back
-    to the claude default, a codex backend to the fleet model only as a last
-    resort — codex records always carry their model)."""
+    An empty backend is a legacy record (written before the field) and is
+    therefore CLAUDE, never the fleet default; the model pairs with that backend
+    (a claude backend falls back to the claude default, a codex backend to the
+    fleet model only as a last resort — codex records always carry their model);
+    the key file is the exact resolved path the run used (so an explicit
+    --key-file survives), falling back to the per-backend resolution for legacy
+    records that never recorded it."""
     backend = getattr(record, "author_backend", "") or "claude"
     model = getattr(record, "author_model", "") or (
         "claude-opus-5" if backend == "claude" else fleet_model
     )
-    return backend, model
+    key_file = getattr(record, "author_key_file", "") or resolve_author_key_file(backend)
+    return backend, model, key_file
 
 
 class WorkspaceDrift(RuntimeError):
@@ -1191,6 +1195,7 @@ def live_climb(
     issue_number: int = 0,
     author_backend: str = "claude",
     author_model: str = "",
+    author_key_file: str = "",
     task_hypothesis: str = "",
     spec: RoleSpec | None = None,
     panel_lenses: tuple[PanelLens, ...] = (),
@@ -1222,6 +1227,7 @@ def live_climb(
         issue_number=issue_number,
         author_backend=author_backend,
         author_model=author_model,
+        author_key_file=author_key_file,
         climb_job_id=_os.environ.get("SLURM_JOB_ID", ""),
     )
     try:
@@ -2102,11 +2108,13 @@ def main() -> int:
             # a wake must never crash on an unreadable/odd record — fall back to
             # the claude author (resume_author), same fail-safe as the sweep
             _wake_record = None
-        wake_backend, wake_model = resume_author(_wake_record, args.model)
+        wake_backend, wake_model, wake_key_file = resume_author(_wake_record, args.model)
+        # an explicit --key-file still overrides (a manual re-run pinning a key)
+        if args.key_file:
+            wake_key_file = os.path.expanduser(args.key_file)
         _err = codex_author_config_error(wake_backend, wake_model, args.image)
         if _err:
             parser.error(f"parked run {args.resume}: {_err}")
-        wake_key_file = resolve_author_key_file(wake_backend, args.key_file)
         # the wake runs the SAME verification panel as a fresh climb, so a
         # dispatched improvement is not published unverified.
         try:
@@ -2279,6 +2287,7 @@ def main() -> int:
                 issue_number=args.issue,
                 author_backend=args.author_backend,
                 author_model=args.model,
+                author_key_file=args.key_file,
                 task_hypothesis=(
                     __import__("base64").b64decode(args.hypothesis_b64).decode()
                     if args.hypothesis_b64

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -2114,6 +2114,10 @@ def main() -> int:
             wake_key_file = os.path.expanduser(args.key_file)
         _err = codex_author_config_error(wake_backend, wake_model, args.image)
         if _err:
+            # this wake job HOLDS the run's lease (transferred on dispatch); release
+            # it before exiting so a misconfig doesn't strand the run until the TTL
+            # reap (the resume_run finally below only runs once we reach it)
+            release_lease(args.run_root, args.resume)
             parser.error(f"parked run {args.resume}: {_err}")
         # the wake runs the SAME verification panel as a fresh climb, so a
         # dispatched improvement is not published unverified.

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -112,6 +112,12 @@ def codex_author_config_error(backend: str, model: str, image: str) -> str:
     passes the PARKED RUN's persisted pair — so backend and model are checked as
     a unit and never a fleet backend against a run's model. codex writes+executes,
     so it must be contained (--image) and needs a non-claude model."""
+    if backend not in ("claude", "codex"):
+        # a typo'd AUTORESEARCH_AUTHOR_BACKEND passes the env DEFAULT silently
+        # (argparse validates the flag, not its default) and the climb rejects it
+        # at build_editor_harness — catch it on the tick host so a claimed intake
+        # issue never strands on it
+        return f"unknown author backend {backend!r} (expected 'claude' or 'codex')"
     if backend != "codex":
         return ""
     if not image:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -95,16 +95,48 @@ def resolve_author_key_file(backend: str, explicit: str = "") -> str:
     codex's both on disk), selected by backend — so the author backend is a
     config choice, not a key swap, and an in-flight run of either backend can
     still be woken/serviced after a fleet flip. An explicit path always wins;
-    otherwise the per-backend env var, then the packaged default path."""
-    if explicit:
-        return explicit
-    if backend == "codex":
-        return os.environ.get("AUTORESEARCH_CODEX_KEY_FILE") or os.path.expanduser(
-            CODEX_KEY_DEFAULT
+    otherwise the per-backend env var, then the packaged default path. The result
+    is always ~-expanded, so every caller gets a real path (an env value like
+    "~/.config/..." must not reach the token provider verbatim)."""
+    if not explicit:
+        if backend == "codex":
+            explicit = os.environ.get("AUTORESEARCH_CODEX_KEY_FILE") or CODEX_KEY_DEFAULT
+        else:
+            explicit = os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE") or HARNESS_KEY_DEFAULT
+    return os.path.expanduser(explicit)
+
+
+def codex_author_config_error(backend: str, model: str, image: str) -> str:
+    """Why a codex author would die at startup ("" when it won't). Validates the
+    EFFECTIVE (backend, model) — the fresh climb passes args; a wake/follow-up
+    passes the PARKED RUN's persisted pair — so backend and model are checked as
+    a unit and never a fleet backend against a run's model. codex writes+executes,
+    so it must be contained (--image) and needs a non-claude model."""
+    if backend != "codex":
+        return ""
+    if not image:
+        return "author-backend codex requires --image (it runs contained)"
+    if not model or model.startswith("claude"):
+        return (
+            "author-backend codex needs a codex/openai model "
+            f"(e.g. gpt-5.6-terra), not the claude default (got {model!r})"
         )
-    return os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE") or os.path.expanduser(
-        HARNESS_KEY_DEFAULT
+    return ""
+
+
+def resume_author(record: object, fleet_model: str) -> tuple[str, str]:
+    """The (backend, model) a wake/follow-up must reproduce for a parked run.
+
+    Both come from the RECORD, not the current fleet: an empty backend is a
+    legacy record (written before the field) and is therefore CLAUDE, never the
+    fleet default; the model pairs with that backend (a claude backend falls back
+    to the claude default, a codex backend to the fleet model only as a last
+    resort — codex records always carry their model)."""
+    backend = getattr(record, "author_backend", "") or "claude"
+    model = getattr(record, "author_model", "") or (
+        "claude-opus-5" if backend == "claude" else fleet_model
     )
+    return backend, model
 
 
 class WorkspaceDrift(RuntimeError):
@@ -1158,6 +1190,7 @@ def live_climb(
     base_branch: str = "main",
     issue_number: int = 0,
     author_backend: str = "claude",
+    author_model: str = "",
     task_hypothesis: str = "",
     spec: RoleSpec | None = None,
     panel_lenses: tuple[PanelLens, ...] = (),
@@ -1188,6 +1221,7 @@ def live_climb(
         deadline=now + 24 * 3600,
         issue_number=issue_number,
         author_backend=author_backend,
+        author_model=author_model,
         climb_job_id=_os.environ.get("SLURM_JOB_ID", ""),
     )
     try:
@@ -2036,16 +2070,10 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     if not args.image and not args.uncontained:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")
-    if args.author_backend == "codex":
-        # a codex author writes+executes: it must be contained, and the claude
-        # default model would 404 on codex — fail early, before any spend.
-        if not args.image:
-            parser.error("--author-backend codex requires --image (it runs contained)")
-        if args.model.startswith("claude"):
-            parser.error(
-                "--author-backend codex needs a codex/openai --model "
-                "(e.g. gpt-5.6-terra), not the claude default"
-            )
+    # NOTE: the codex author is validated on the EFFECTIVE author per path — the
+    # fresh climb on args (below), a wake on the parked run's persisted pair — not
+    # here, where args.author_backend is the FLEET default and would misjudge a
+    # resume after a fleet flip (review: terra blocking).
     # each --codex-config KEY=VALUE becomes a `-c KEY=VALUE` pair for codex
     codex_extra = tuple(a for c in args.codex_config for a in ("-c", c))
 
@@ -2064,15 +2092,18 @@ def main() -> int:
         from autoresearch.runstate import load_record, release_lease
 
         # Reproduce the PARKED run's author, not the current fleet default: the
-        # backend is persisted on the record (a fleet flip must not wake a codex
-        # run as claude, or vice versa), falling back to the CLI/env default for
-        # legacy records or an unreadable record. The key then resolves for THAT
-        # backend (keys coexist).
+        # (backend, model) PAIR is persisted on the record — a fleet flip must not
+        # wake a codex run as claude (or with the new fleet's model). A legacy or
+        # unreadable record is treated as claude (resume_author). The key then
+        # resolves for THAT backend (keys coexist).
         try:
-            wake_backend = load_record(args.run_root, args.resume).author_backend
+            _wake_record: object | None = load_record(args.run_root, args.resume)
         except (OSError, ValueError):
-            wake_backend = ""
-        wake_backend = wake_backend or args.author_backend
+            _wake_record = None
+        wake_backend, wake_model = resume_author(_wake_record, args.model)
+        _err = codex_author_config_error(wake_backend, wake_model, args.image)
+        if _err:
+            parser.error(f"parked run {args.resume}: {_err}")
         wake_key_file = resolve_author_key_file(wake_backend, args.key_file)
         # the wake runs the SAME verification panel as a fresh climb, so a
         # dispatched improvement is not published unverified.
@@ -2090,14 +2121,14 @@ def main() -> int:
         # read-decide-publish job and must not require the author key.
         if wake_lenses:
             wake_panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
-            wake_api_key = FileTokenProvider(Path(wake_key_file).expanduser()).token()
+            wake_api_key = FileTokenProvider(Path(wake_key_file)).token()
             wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
             wake_harness = build_editor_harness(
                 wake_api_key,
                 wake_spec,
                 backend=wake_backend,
                 binary=args.claude_bin if wake_backend == "claude" else args.codex_bin,
-                model=args.model,
+                model=wake_model,
                 container_image=args.image,
                 codex_extra_args=codex_extra,
             )
@@ -2133,11 +2164,16 @@ def main() -> int:
     if not (args.target and args.benchmark):
         parser.error("--target and --benchmark are required for a fresh climb")
 
+    # a fresh climb authors on the FLEET's configured backend; validate it (codex
+    # writes+executes, so --image + a non-claude model) before any spend.
+    _err = codex_author_config_error(args.author_backend, args.model, args.image)
+    if _err:
+        parser.error(_err)
     # config-driven: the author key defaults per backend (claude vs codex) so the
-    # tick never threads it — see resolve_author_key_file.
+    # tick never threads it — see resolve_author_key_file (result is ~-expanded).
     args.key_file = resolve_author_key_file(args.author_backend, args.key_file)
     # same 0600 discipline as the PAT: this key spends real money
-    api_key = FileTokenProvider(Path(args.key_file).expanduser()).token()
+    api_key = FileTokenProvider(Path(args.key_file)).token()
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_id = f"{args.benchmark}-{stamp}"
 
@@ -2240,6 +2276,7 @@ def main() -> int:
                 ),
                 issue_number=args.issue,
                 author_backend=args.author_backend,
+                author_model=args.model,
                 task_hypothesis=(
                     __import__("base64").b64decode(args.hypothesis_b64).decode()
                     if args.hypothesis_b64

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -2098,7 +2098,9 @@ def main() -> int:
         # resolves for THAT backend (keys coexist).
         try:
             _wake_record: object | None = load_record(args.run_root, args.resume)
-        except (OSError, ValueError):
+        except Exception:
+            # a wake must never crash on an unreadable/odd record — fall back to
+            # the claude author (resume_author), same fail-safe as the sweep
             _wake_record = None
         wake_backend, wake_model = resume_author(_wake_record, args.model)
         _err = codex_author_config_error(wake_backend, wake_model, args.image)

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -118,7 +118,12 @@ def codex_author_config_error(backend: str, model: str, image: str) -> str:
         # at build_editor_harness — catch it on the tick host so a claimed intake
         # issue never strands on it
         return f"unknown author backend {backend!r} (expected 'claude' or 'codex')"
-    if backend != "codex":
+    if backend == "claude":
+        # symmetric to the codex check: a claude harness 404s on a non-claude
+        # model (e.g. AUTORESEARCH_AUTHOR_MODEL left on a codex id while the
+        # backend is claude) — catch that misconfig before spend
+        if model and not model.startswith("claude"):
+            return f"author-backend claude needs a claude model (got {model!r})"
         return ""
     if not image:
         return "author-backend codex requires --image (it runs contained)"
@@ -2006,8 +2011,9 @@ def main() -> int:
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument(
         "--codex-bin",
-        default=os.environ.get("AUTORESEARCH_CODEX_BIN")
-        or os.path.expanduser("~/.local/bin/codex"),
+        default=os.path.expanduser(
+            os.environ.get("AUTORESEARCH_CODEX_BIN") or "~/.local/bin/codex"
+        ),
         help="host codex binary for the codex author; bind-mounted into apptainer "
         "(must be an absolute path).",
     )

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -682,8 +682,9 @@ def main() -> int:
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument(
         "--codex-bin",
-        default=os.environ.get("AUTORESEARCH_CODEX_BIN")
-        or os.path.expanduser("~/.local/bin/codex"),
+        default=os.path.expanduser(
+            os.environ.get("AUTORESEARCH_CODEX_BIN") or "~/.local/bin/codex"
+        ),
     )
     parser.add_argument(
         "--model",

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -742,11 +742,14 @@ def main() -> int:
         # never crash on an unreadable/odd record — fall back to the claude
         # author (resume_author); respond_once re-reads and handles a missing one
         _rec = None
-    author_backend, author_model = resume_author(_rec, args.model)
+    author_backend, author_model, author_key = resume_author(_rec, args.model)
     _err = codex_author_config_error(author_backend, author_model, args.image)
     if _err:
         parser.error(f"run {args.run_id}: {_err}")
-    args.key_file = resolve_author_key_file(author_backend, args.key_file)
+    # an explicit --key-file still overrides; otherwise the run's recorded key
+    args.key_file = (
+        resolve_author_key_file(author_backend, args.key_file) if args.key_file else author_key
+    )
     codex_extra = tuple(a for c in args.codex_config for a in ("-c", c))
     api_key = FileTokenProvider(Path(args.key_file)).token()
     bot_auth = FileTokenProvider(Path(args.pat_file))

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -680,7 +680,28 @@ def main() -> int:
     parser.add_argument("--image", default="")
     parser.add_argument("--uncontained", action="store_true")
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
-    parser.add_argument("--model", default="claude-opus-5")
+    parser.add_argument(
+        "--codex-bin",
+        default=os.environ.get("AUTORESEARCH_CODEX_BIN")
+        or os.path.expanduser("~/.local/bin/codex"),
+    )
+    parser.add_argument(
+        "--model", default=os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5"
+    )
+    parser.add_argument(
+        "--author-backend",
+        choices=("claude", "codex"),
+        default=os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude",
+        help="fallback author backend when the run's record has none (legacy); a "
+        "run's OWN backend, persisted on its record, always wins.",
+    )
+    parser.add_argument(
+        "--codex-config",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="codex `-c KEY=VALUE` config for the codex author (repeatable)",
+    )
     # the tick passes the effective limit explicitly; this fallback follows
     # the harness ceiling so a bare CLI run is never silently starved (a
     # 40-turn default cost a live steward follow-up its whole session)
@@ -694,7 +715,10 @@ def main() -> int:
     )
     parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
     parser.add_argument(
-        "--key-file", default=os.path.expanduser("~/.config/autoresearch/harness_key")
+        "--key-file",
+        default="",
+        help="author key file; default resolves per backend (config-driven): "
+        "AUTORESEARCH_HARNESS_KEY_FILE for claude, AUTORESEARCH_CODEX_KEY_FILE for codex",
     )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
@@ -703,6 +727,20 @@ def main() -> int:
 
     from datetime import UTC, datetime
 
+    from autoresearch.climb import resolve_author_key_file
+
+    # a follow-up services ONE run: reproduce THAT run's author (persisted on the
+    # record), not the current fleet default, so a codex-authored PR is revised
+    # by codex (native resume of its session) and picks the codex key. Legacy
+    # records with no backend (or an unreadable one) fall back to the CLI/env
+    # default; respond_once re-reads the record and handles a truly missing one.
+    try:
+        author_backend = load_record(args.run_root, args.run_id).author_backend
+    except (OSError, ValueError):
+        author_backend = ""
+    author_backend = author_backend or args.author_backend
+    args.key_file = resolve_author_key_file(author_backend, args.key_file)
+    codex_extra = tuple(a for c in args.codex_config for a in ("-c", c))
     api_key = FileTokenProvider(Path(args.key_file)).token()
     bot_auth = FileTokenProvider(Path(args.pat_file))
 
@@ -733,9 +771,11 @@ def main() -> int:
             harness=build_editor_harness(
                 api_key,
                 spec,
-                binary=args.claude_bin,
+                backend=author_backend,
+                binary=args.claude_bin if author_backend == "claude" else args.codex_bin,
                 model=args.model,
                 container_image=args.image,
+                codex_extra_args=codex_extra,
             ),
             spec=spec,
             evaluator=SubprocessEvaluator(container_image=args.image),

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -738,7 +738,9 @@ def main() -> int:
     # re-reads the record and handles a truly missing one.
     try:
         _rec: object | None = load_record(args.run_root, args.run_id)
-    except (OSError, ValueError):
+    except Exception:
+        # never crash on an unreadable/odd record — fall back to the claude
+        # author (resume_author); respond_once re-reads and handles a missing one
         _rec = None
     author_backend, author_model = resume_author(_rec, args.model)
     _err = codex_author_config_error(author_backend, author_model, args.image)

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -686,15 +686,13 @@ def main() -> int:
         or os.path.expanduser("~/.local/bin/codex"),
     )
     parser.add_argument(
-        "--model", default=os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5"
+        "--model",
+        default=os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5",
+        help="fallback model only; a run's OWN (backend, model) from its record wins",
     )
-    parser.add_argument(
-        "--author-backend",
-        choices=("claude", "codex"),
-        default=os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude",
-        help="fallback author backend when the run's record has none (legacy); a "
-        "run's OWN backend, persisted on its record, always wins.",
-    )
+    # No --author-backend: a follow-up services ONE run, whose backend+model are
+    # persisted on its record (legacy records are claude). It never uses a fleet
+    # default that could mismatch the run.
     parser.add_argument(
         "--codex-config",
         action="append",
@@ -727,18 +725,25 @@ def main() -> int:
 
     from datetime import UTC, datetime
 
-    from autoresearch.climb import resolve_author_key_file
+    from autoresearch.climb import (
+        codex_author_config_error,
+        resolve_author_key_file,
+        resume_author,
+    )
 
-    # a follow-up services ONE run: reproduce THAT run's author (persisted on the
-    # record), not the current fleet default, so a codex-authored PR is revised
-    # by codex (native resume of its session) and picks the codex key. Legacy
-    # records with no backend (or an unreadable one) fall back to the CLI/env
-    # default; respond_once re-reads the record and handles a truly missing one.
+    # a follow-up services ONE run: reproduce THAT run's author (the persisted
+    # (backend, model) PAIR), not the current fleet default, so a codex-authored
+    # PR is revised by codex (native resume of its session), with the codex model
+    # and codex key. Legacy/unreadable records are treated as claude; respond_once
+    # re-reads the record and handles a truly missing one.
     try:
-        author_backend = load_record(args.run_root, args.run_id).author_backend
+        _rec: object | None = load_record(args.run_root, args.run_id)
     except (OSError, ValueError):
-        author_backend = ""
-    author_backend = author_backend or args.author_backend
+        _rec = None
+    author_backend, author_model = resume_author(_rec, args.model)
+    _err = codex_author_config_error(author_backend, author_model, args.image)
+    if _err:
+        parser.error(f"run {args.run_id}: {_err}")
     args.key_file = resolve_author_key_file(author_backend, args.key_file)
     codex_extra = tuple(a for c in args.codex_config for a in ("-c", c))
     api_key = FileTokenProvider(Path(args.key_file)).token()
@@ -773,7 +778,7 @@ def main() -> int:
                 spec,
                 backend=author_backend,
                 binary=args.claude_bin if author_backend == "claude" else args.codex_bin,
-                model=args.model,
+                model=author_model,
                 container_image=args.image,
                 codex_extra_args=codex_extra,
             ),

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -129,11 +129,13 @@ class RunRecord:
     resume_session_id: str = ""  # harness session to resume on wake
     pr_url: str = ""  # the run's open PR, once one exists
     benchmark: str = ""  # contract benchmark this run works on
-    # The author backend this run was STARTED with ("" = legacy/claude). A wake
-    # or follow-up reproduces the run's OWN author from this, not the current
-    # fleet default, so a fleet backend flip never resumes a run on the wrong
-    # backend (and picks that backend's key).
+    # The author this run was STARTED with ("" backend = legacy/claude). A wake or
+    # follow-up reproduces the run's OWN author from these, not the current fleet
+    # default, so a fleet backend flip never resumes a run on the wrong backend,
+    # model, or key. backend and model are a PAIR — a claude backend needs a
+    # claude model and vice versa — so both are persisted together.
     author_backend: str = ""
+    author_model: str = ""
     # Per-source comment cursors: issue comments, top-level reviews, and
     # inline review comments are three REST collections with independent id
     # sequences — one cursor across them drops comments forever.

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -136,6 +136,11 @@ class RunRecord:
     # claude model and vice versa — so both are persisted together.
     author_backend: str = ""
     author_model: str = ""
+    # The resolved author key FILE PATH (not the key) this run used, so a wake or
+    # follow-up reproduces the exact key — an explicit --key-file survives, and an
+    # in-flight run is immune to a later env change. "" = resolve per backend
+    # (legacy records, and the common config-driven case).
+    author_key_file: str = ""
     # Per-source comment cursors: issue comments, top-level reviews, and
     # inline review comments are three REST collections with independent id
     # sequences — one cursor across them drops comments forever.

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -129,6 +129,11 @@ class RunRecord:
     resume_session_id: str = ""  # harness session to resume on wake
     pr_url: str = ""  # the run's open PR, once one exists
     benchmark: str = ""  # contract benchmark this run works on
+    # The author backend this run was STARTED with ("" = legacy/claude). A wake
+    # or follow-up reproduces the run's OWN author from this, not the current
+    # fleet default, so a fleet backend flip never resumes a run on the wrong
+    # backend (and picks that backend's key).
+    author_backend: str = ""
     # Per-source comment cursors: issue comments, top-level reviews, and
     # inline review comments are three REST collections with independent id
     # sequences — one cursor across them drops comments forever.

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1262,7 +1262,7 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
     if not spec.panel.strip():
         return ""
     try:
-        from autoresearch.climb import HARNESS_KEY_DEFAULT, PANEL_KEY_DEFAULT
+        from autoresearch.climb import PANEL_KEY_DEFAULT, resolve_author_key_file
         from autoresearch.github import FileTokenProvider
         from autoresearch.panel import parse_lenses
 
@@ -1275,7 +1275,12 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
             # the climb runs from a flight directory, not the tick's cwd — a
             # relative path that resolves here could still miss there
             return f"panel key path {path} is relative; only absolute paths fly"
-        author = Path(spec.key_file or HARNESS_KEY_DEFAULT).expanduser()
+        # the AUTHOR key the climb will actually use resolves per the fleet backend
+        # (claude vs codex keys coexist), config-driven like the climb itself — so
+        # the role-separation check compares the panel key against the RIGHT author
+        # key, and a codex run is never judged by a stray Claude key.
+        fleet_backend = os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude"
+        author = Path(resolve_author_key_file(fleet_backend))
         if not author.is_absolute():
             # same rule as the panel key: the climb resolves paths from a
             # flight directory, so a relative author path both misconfigures

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -166,7 +166,6 @@ class FollowupSpec:
     time_minutes: int = 90  # min()'d with the contract's followup_job_minutes
     max_turns: int = DEFAULT_MAX_TURNS  # session turn budget for follow-up jobs
     pat_file: str = ""  # forwarded to the job; "" = the followup CLI default
-    key_file: str = ""
     target: str = ""  # the repo the intake pass scans for requested-lane issues
     # the STEWARD'S OWN key (role separation): the steward lane stays off
     # until the operator provisions it
@@ -1248,6 +1247,19 @@ def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
     return argv
 
 
+def _author_config_error(spec: FollowupSpec) -> str:
+    """Why the config-driven author would die at the climb's startup ("" when it
+    won't), checked on the tick host BEFORE a claim/submit so a codex misconfig
+    (e.g. AUTORESEARCH_AUTHOR_BACKEND=codex with no non-claude model) never
+    strands a claimed intake issue. Reads the fleet author config from env — the
+    same source the climb defaults from — and the image the tick already knows."""
+    from autoresearch.climb import codex_author_config_error
+
+    backend = os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude"
+    model = os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5"
+    return codex_author_config_error(backend, model, spec.image)
+
+
 def _panel_preflight_error(spec: FollowupSpec) -> str:
     """Why the climb would die at startup on this panel config ("" when it
     won't): the lens spec, then the key file — each checked with the climb's
@@ -1417,6 +1429,15 @@ def service_self_initiated(
                 pending_attempt = (str(pending.get("benchmark", "")), submitted_at)
         benchmark = pick_self_initiated(records, contract, spec.target, now, pending_attempt)
         if benchmark is None:
+            return None
+        author_error = _author_config_error(spec)
+        if author_error:
+            log.error(
+                "climb on %s not launched: author misconfigured — %s "
+                "(fix AUTORESEARCH_AUTHOR_BACKEND/_MODEL)",
+                benchmark,
+                author_error,
+            )
             return None
         panel_error = _panel_preflight_error(spec)
         if panel_error:
@@ -1632,6 +1653,15 @@ def service_intake(
         limits = limits if limits is not None else effective_limits(contract.budgets)
         task = pick_issue(github, target, contract, spec.bot_login)
         if task is None:
+            return None
+        author_error = _author_config_error(spec)
+        if author_error:
+            log.error(
+                "issue #%d not claimed: author misconfigured — %s "
+                "(fix AUTORESEARCH_AUTHOR_BACKEND/_MODEL)",
+                task.number,
+                author_error,
+            )
             return None
         panel_error = _panel_preflight_error(spec)
         if panel_error:
@@ -1939,7 +1969,6 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
                 image=image,
                 home=Path(home),
                 pat_file=pat_file,
-                key_file=os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE", ""),
                 target=os.environ.get(
                     "AUTORESEARCH_TARGET", "agentic-learning-ai-lab/autoresearch-pilot"
                 ),

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -530,9 +530,11 @@ def service_in_review(
             ]
             if spec.pat_file:
                 argv += ["--pat-file", spec.pat_file]
-            key_file = spec.steward_key_file if is_steward else spec.key_file
-            if key_file:
-                argv += ["--key-file", key_file]
+            # config-driven author: the author follow-up resolves its key per the
+            # RUN's backend (from the record) inside followup.main — the tick does
+            # not thread it. The steward is a distinct role with its own key.
+            if is_steward and spec.steward_key_file:
+                argv += ["--key-file", spec.steward_key_file]
             job_id = compute.submit(
                 JobSpec(
                     job_name=f"followup-{record.run_id}"[:60],
@@ -1442,8 +1444,9 @@ def service_self_initiated(
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
-        if spec.key_file:
-            argv += ["--key-file", spec.key_file]
+        # config-driven author: climb resolves the author backend/model/key from
+        # AUTORESEARCH_AUTHOR_* env (inherited by the job), so the tick threads
+        # neither the backend nor its key — a new backend needs zero tick change.
         job_id = compute.submit(
             JobSpec(
                 job_name=f"climb-{benchmark}"[:60],
@@ -1673,8 +1676,8 @@ def service_intake(
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
-        if spec.key_file:
-            argv += ["--key-file", spec.key_file]
+        # config-driven author: climb resolves the author key from the
+        # AUTORESEARCH_AUTHOR_* env by backend; the tick does not thread it.
         try:
             job_id = compute.submit(
                 JobSpec(
@@ -1760,8 +1763,9 @@ class JobWakeDispatcher:
         ]
         if self.spec.pat_file:
             argv += ["--pat-file", self.spec.pat_file]
-        if self.spec.key_file:
-            argv += ["--key-file", self.spec.key_file]
+        # config-driven author: `climb --resume` resolves the author key from the
+        # PARKED RUN's backend (persisted on its record) inside climb.main — the
+        # tick does not thread the key, so a fleet flip picks the right one.
         name = f"wake-{record.run_id}"[:60]
         afterany = str(record.stage.get("afterany", ""))
         return self.compute.submit(

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -426,6 +426,8 @@ def test_codex_author_config_error() -> None:
     assert "requires --image" in codex_author_config_error("codex", "gpt-5.6-terra", "")
     assert "claude default" in codex_author_config_error("codex", "claude-opus-5", "img.sif")
     assert "claude default" in codex_author_config_error("codex", "", "img.sif")
+    # an unknown backend (typo'd env default) is rejected, not silently accepted
+    assert "unknown author backend" in codex_author_config_error("hermes", "m", "img.sif")
 
 
 def test_resolve_author_key_file(monkeypatch) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -282,6 +282,7 @@ def run_live(
     dispatch=None,
     author_backend="claude",
     author_model="claude-opus-5",
+    author_key_file="",
 ) -> tuple:
     github = FakeGitHub()
     outcome = live_climb(
@@ -298,6 +299,7 @@ def run_live(
         dispatch=dispatch,
         author_backend=author_backend,
         author_model=author_model,
+        author_key_file=author_key_file,
     )
     return outcome, github
 
@@ -370,26 +372,49 @@ def test_run_record_persists_the_author_pair(tmp_path, target_repo) -> None:
         values=[13.876, 13.1],
         author_backend="codex",
         author_model="gpt-5.6-terra",
+        author_key_file="/keys/codex",
     )
     rec = load_record(tmp_path / "state", "tsp-1")
     assert rec.author_backend == "codex" and rec.author_model == "gpt-5.6-terra"
+    assert rec.author_key_file == "/keys/codex"  # exact key survives for the wake
 
 
-def test_resume_author_reproduces_the_run_not_the_fleet() -> None:
-    """A wake/follow-up derives (backend, model) from the record, never the fleet:
-    a legacy record is claude (not the fleet default), a claude record keeps a
-    claude model, a codex record keeps its own model."""
+def test_resume_author_reproduces_the_run_not_the_fleet(monkeypatch) -> None:
+    """A wake/follow-up derives (backend, model, key_file) from the record, never
+    the fleet: a legacy record is claude (not the fleet default), a claude record
+    keeps a claude model, a codex record keeps its own model, and an explicit
+    recorded key path survives (else it resolves per backend)."""
     from types import SimpleNamespace
 
     from autoresearch.climb import resume_author
 
-    legacy = SimpleNamespace(author_backend="", author_model="")
-    assert resume_author(legacy, fleet_model="gpt-5.6-terra") == ("claude", "claude-opus-5")
-    claude_rec = SimpleNamespace(author_backend="claude", author_model="claude-opus-5")
-    assert resume_author(claude_rec, fleet_model="gpt-5.6-terra") == ("claude", "claude-opus-5")
-    codex_rec = SimpleNamespace(author_backend="codex", author_model="gpt-5.6-terra")
-    assert resume_author(codex_rec, fleet_model="claude-opus-5") == ("codex", "gpt-5.6-terra")
-    assert resume_author(None, fleet_model="x") == ("claude", "claude-opus-5")
+    monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", "/h")
+    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", "/c")
+
+    legacy = SimpleNamespace(author_backend="", author_model="", author_key_file="")
+    assert resume_author(legacy, fleet_model="gpt-5.6-terra") == ("claude", "claude-opus-5", "/h")
+    claude_rec = SimpleNamespace(
+        author_backend="claude", author_model="claude-opus-5", author_key_file=""
+    )
+    assert resume_author(claude_rec, fleet_model="gpt-5.6-terra") == (
+        "claude",
+        "claude-opus-5",
+        "/h",
+    )
+    codex_rec = SimpleNamespace(
+        author_backend="codex", author_model="gpt-5.6-terra", author_key_file=""
+    )
+    assert resume_author(codex_rec, fleet_model="claude-opus-5") == (
+        "codex",
+        "gpt-5.6-terra",
+        "/c",
+    )
+    # an explicit recorded key path wins over the per-backend env
+    pinned = SimpleNamespace(
+        author_backend="codex", author_model="gpt-5.6-terra", author_key_file="/custom/key"
+    )
+    assert resume_author(pinned, fleet_model="x") == ("codex", "gpt-5.6-terra", "/custom/key")
+    assert resume_author(None, fleet_model="x") == ("claude", "claude-opus-5", "/h")
 
 
 def test_codex_author_config_error() -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -273,7 +273,9 @@ class NoAuth:
         return "unused"
 
 
-def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None) -> tuple:
+def run_live(
+    tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None, author_backend="claude"
+) -> tuple:
     github = FakeGitHub()
     outcome = live_climb(
         config=ClimbConfig(target="org/pilot", benchmark="tsp"),
@@ -287,6 +289,7 @@ def run_live(tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None
         created="2026-08-06T00:00:00Z",
         secrets=("sk-live-key",),
         dispatch=dispatch,
+        author_backend=author_backend,
     )
     return outcome, github
 
@@ -346,6 +349,41 @@ def test_improvement_produces_branch_commit_and_pr(tmp_path, target_repo) -> Non
     # report exists and is redacted-safe
     report = Path(outcome.report_path).read_text()
     assert "improved" in report
+
+
+def test_run_record_persists_the_author_backend(tmp_path, target_repo) -> None:
+    # a wake/follow-up reproduces the parked run's author, so the backend it was
+    # started with is stamped on the record (the default is the claude author).
+    run_live(
+        tmp_path,
+        target_repo,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+        values=[13.876, 13.1],
+        author_backend="codex",
+    )
+    assert load_record(tmp_path / "state", "tsp-1").author_backend == "codex"
+
+
+def test_resolve_author_key_file(monkeypatch) -> None:
+    """Per-backend author keys COEXIST and are selected by backend; an explicit
+    path wins, else the per-backend env var, else the packaged default."""
+    import os
+
+    from autoresearch.climb import (
+        CODEX_KEY_DEFAULT,
+        HARNESS_KEY_DEFAULT,
+        resolve_author_key_file,
+    )
+
+    monkeypatch.delenv("AUTORESEARCH_HARNESS_KEY_FILE", raising=False)
+    monkeypatch.delenv("AUTORESEARCH_CODEX_KEY_FILE", raising=False)
+    assert resolve_author_key_file("codex", "/x/key") == "/x/key"  # explicit wins
+    assert resolve_author_key_file("claude") == os.path.expanduser(HARNESS_KEY_DEFAULT)
+    assert resolve_author_key_file("codex") == os.path.expanduser(CODEX_KEY_DEFAULT)
+    monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", "/h-key")
+    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", "/c-key")
+    assert resolve_author_key_file("claude") == "/h-key"
+    assert resolve_author_key_file("codex") == "/c-key"
 
 
 def test_snapshot_refs_are_dropped_after_a_climb(tmp_path, target_repo) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -274,7 +274,14 @@ class NoAuth:
 
 
 def run_live(
-    tmp_path, target_repo, edits, values, run_id="tsp-1", dispatch=None, author_backend="claude"
+    tmp_path,
+    target_repo,
+    edits,
+    values,
+    run_id="tsp-1",
+    dispatch=None,
+    author_backend="claude",
+    author_model="claude-opus-5",
 ) -> tuple:
     github = FakeGitHub()
     outcome = live_climb(
@@ -290,6 +297,7 @@ def run_live(
         secrets=("sk-live-key",),
         dispatch=dispatch,
         author_backend=author_backend,
+        author_model=author_model,
     )
     return outcome, github
 
@@ -351,17 +359,48 @@ def test_improvement_produces_branch_commit_and_pr(tmp_path, target_repo) -> Non
     assert "improved" in report
 
 
-def test_run_record_persists_the_author_backend(tmp_path, target_repo) -> None:
-    # a wake/follow-up reproduces the parked run's author, so the backend it was
-    # started with is stamped on the record (the default is the claude author).
+def test_run_record_persists_the_author_pair(tmp_path, target_repo) -> None:
+    # a wake/follow-up reproduces the parked run's author, so the (backend, model)
+    # PAIR it was started with is stamped on the record — a codex record must not
+    # be resumed with a claude model.
     run_live(
         tmp_path,
         target_repo,
         edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
         values=[13.876, 13.1],
         author_backend="codex",
+        author_model="gpt-5.6-terra",
     )
-    assert load_record(tmp_path / "state", "tsp-1").author_backend == "codex"
+    rec = load_record(tmp_path / "state", "tsp-1")
+    assert rec.author_backend == "codex" and rec.author_model == "gpt-5.6-terra"
+
+
+def test_resume_author_reproduces_the_run_not_the_fleet() -> None:
+    """A wake/follow-up derives (backend, model) from the record, never the fleet:
+    a legacy record is claude (not the fleet default), a claude record keeps a
+    claude model, a codex record keeps its own model."""
+    from types import SimpleNamespace
+
+    from autoresearch.climb import resume_author
+
+    legacy = SimpleNamespace(author_backend="", author_model="")
+    assert resume_author(legacy, fleet_model="gpt-5.6-terra") == ("claude", "claude-opus-5")
+    claude_rec = SimpleNamespace(author_backend="claude", author_model="claude-opus-5")
+    assert resume_author(claude_rec, fleet_model="gpt-5.6-terra") == ("claude", "claude-opus-5")
+    codex_rec = SimpleNamespace(author_backend="codex", author_model="gpt-5.6-terra")
+    assert resume_author(codex_rec, fleet_model="claude-opus-5") == ("codex", "gpt-5.6-terra")
+    assert resume_author(None, fleet_model="x") == ("claude", "claude-opus-5")
+
+
+def test_codex_author_config_error() -> None:
+    """codex needs --image and a non-claude model; claude is always fine."""
+    from autoresearch.climb import codex_author_config_error
+
+    assert codex_author_config_error("claude", "claude-opus-5", "") == ""
+    assert codex_author_config_error("codex", "gpt-5.6-terra", "img.sif") == ""
+    assert "requires --image" in codex_author_config_error("codex", "gpt-5.6-terra", "")
+    assert "claude default" in codex_author_config_error("codex", "claude-opus-5", "img.sif")
+    assert "claude default" in codex_author_config_error("codex", "", "img.sif")
 
 
 def test_resolve_author_key_file(monkeypatch) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1860,14 +1860,17 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
         make(panel="verify:hermes", panel_key_file=str(good))
     )
     assert "relative" in _panel_preflight_error(make(panel_key_file="good"))
-    # role separation: the panel key must not BE the author key
-    same = make(panel_key_file=str(good), key_file=str(good))
-    assert "author key" in _panel_preflight_error(same)
-    # ... and a RELATIVE author path fails too: the climb resolves it from a
-    # flight dir, so the comparison above could pass where the runtime collides
-    rel = make(panel_key_file=str(good), key_file="keys/author")
-    assert "author key path" in _panel_preflight_error(rel)
-    assert "relative" in _panel_preflight_error(rel)
+    # role separation: the panel key must not BE the (resolved) author key. The
+    # author key is now config-driven — resolved per the fleet backend from env —
+    # so the collision is set via AUTORESEARCH_HARNESS_KEY_FILE, not spec.key_file.
+    monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", str(good))
+    assert "author key" in _panel_preflight_error(make(panel_key_file=str(good)))
+    # ... and a RELATIVE author key path fails too (the climb resolves from a
+    # flight dir): a relative env value survives ~-expansion as non-absolute
+    monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", "keys/author")
+    rel_err = _panel_preflight_error(make(panel_key_file=str(good)))
+    assert "author key path" in rel_err and "relative" in rel_err
+    monkeypatch.delenv("AUTORESEARCH_HARNESS_KEY_FILE")
 
     # both lanes consult it BEFORE side effects: nothing claimed or submitted
     bad = make(panel_key_file=str(tmp_path / "nope"))

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1036,6 +1036,9 @@ roadmap: docs/roadmap.md
     assert "--session-minutes 25" in wrap
     assert "--job-minutes 325" in wrap  # the ACTUAL walltime, for the alarm
     assert "--panel verify,review" in wrap  # the pre-PR panel is ON by default
+    # config-driven author: the tick threads neither the author key nor the
+    # backend — climb resolves them from AUTORESEARCH_AUTHOR_* env by backend
+    assert "--key-file" not in wrap and "--author-backend" not in wrap
 
 
 def test_followup_jobs_carry_the_session_turn_budget(tmp_path: Path) -> None:
@@ -1655,8 +1658,10 @@ roadmap: docs/roadmap.md
 
 
 def test_followup_key_routing_by_role(tmp_path: Path) -> None:
-    """Steward records get the STEWARD'S key in the follow-up job; without
-    one the steward record is skipped while solver servicing continues."""
+    """The STEWARD follow-up carries the steward's key explicitly; the author
+    (solver) follow-up threads NO key — it resolves its key per the run's backend
+    from env (config-driven). Without a steward key the steward record is skipped
+    while solver servicing continues."""
     from autoresearch.runstate import IN_REVIEW
     from autoresearch.tick import FollowupSpec, service_in_review
 
@@ -1716,7 +1721,7 @@ def test_followup_key_routing_by_role(tmp_path: Path) -> None:
     assert len(subs) == 2
     solver_cmd = next(c for c in submitted if "followup-tsp-r1" in c)
     steward_cmd = next(c for c in submitted if "steward-tsp-r1" in c)
-    assert "--key-file /solver-key" in solver_cmd
+    assert "--key-file" not in solver_cmd  # author resolves its key from env
     assert "--key-file /steward-key" in steward_cmd
     # no steward key -> steward record skipped, solver still serviced
     submitted.clear()

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1016,6 +1016,7 @@ roadmap: docs/roadmap.md
         image="img.sif",
         home=tmp_path,
         panel_key_file=str(panel_key),
+        key_file="/legacy/harness-key",  # set, to prove the tick DROPS it (config-driven)
     )
     submitted: list[list[str]] = []
 
@@ -1037,8 +1038,10 @@ roadmap: docs/roadmap.md
     assert "--job-minutes 325" in wrap  # the ACTUAL walltime, for the alarm
     assert "--panel verify,review" in wrap  # the pre-PR panel is ON by default
     # config-driven author: the tick threads neither the author key nor the
-    # backend — climb resolves them from AUTORESEARCH_AUTHOR_* env by backend
-    assert "--key-file" not in wrap and "--author-backend" not in wrap
+    # backend — climb resolves them from AUTORESEARCH_AUTHOR_* env by backend.
+    # spec.key_file is SET above, so this proves the tick actively drops it.
+    assert "--key-file" not in wrap and "/legacy/harness-key" not in wrap
+    assert "--author-backend" not in wrap
 
 
 def test_followup_jobs_carry_the_session_turn_budget(tmp_path: Path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1016,7 +1016,6 @@ roadmap: docs/roadmap.md
         image="img.sif",
         home=tmp_path,
         panel_key_file=str(panel_key),
-        key_file="/legacy/harness-key",  # set, to prove the tick DROPS it (config-driven)
     )
     submitted: list[list[str]] = []
 
@@ -1039,9 +1038,8 @@ roadmap: docs/roadmap.md
     assert "--panel verify,review" in wrap  # the pre-PR panel is ON by default
     # config-driven author: the tick threads neither the author key nor the
     # backend — climb resolves them from AUTORESEARCH_AUTHOR_* env by backend.
-    # spec.key_file is SET above, so this proves the tick actively drops it.
-    assert "--key-file" not in wrap and "/legacy/harness-key" not in wrap
-    assert "--author-backend" not in wrap
+    # (FollowupSpec has no author key_file field at all — the tick can't thread it.)
+    assert "--key-file" not in wrap and "--author-backend" not in wrap
 
 
 def test_followup_jobs_carry_the_session_turn_budget(tmp_path: Path) -> None:
@@ -1096,7 +1094,6 @@ def test_followup_jobs_carry_the_session_turn_budget(tmp_path: Path) -> None:
         run_root=tmp_path,
         image="img.sif",
         home=tmp_path,
-        key_file="/k",
     )
     _, followups = service_in_review(tmp_path, G(), SlurmCompute(runner=runner), spec, NOW)
     assert followups
@@ -1497,7 +1494,6 @@ roadmap: docs/roadmap.md
         run_root=tmp_path,
         image="img.sif",
         home=tmp_path,
-        key_file="/k",
         steward_key_file="/k",
         panel="",  # the outage latch must be what returns None, not the preflight
     )
@@ -1717,7 +1713,6 @@ def test_followup_key_routing_by_role(tmp_path: Path) -> None:
         run_root=tmp_path,
         image="img.sif",
         home=tmp_path,
-        key_file="/solver-key",
         steward_key_file="/steward-key",
     )
     _, subs = service_in_review(tmp_path, G(), SlurmCompute(runner=runner), spec, NOW)
@@ -1735,7 +1730,6 @@ def test_followup_key_routing_by_role(tmp_path: Path) -> None:
         run_root=tmp_path,
         image="img.sif",
         home=tmp_path,
-        key_file="/solver-key",
     )
     for run_id in ("tsp-r1", "steward-tsp-r1"):
         rec = load_record(tmp_path, run_id)
@@ -1809,6 +1803,46 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
     env["AUTORESEARCH_MAX_JOB_MINUTES"] = "9000"  # above the ceiling
     _github, capped = _followup_spec_from_env(tmp_path)
     assert capped is not None and capped.max_job_minutes == 600
+
+
+def test_author_config_preflight_blocks_before_side_effects(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """A codex misconfig (backend=codex, no non-claude model) is caught on the
+    tick host BEFORE self-initiated submits or intake claims — the same
+    strand-safety the panel preflight has, now for the config-driven author."""
+    from autoresearch.tick import FollowupSpec, _author_config_error, service_self_initiated
+
+    def make(**kw: Any) -> FollowupSpec:
+        return FollowupSpec(
+            target="org/pilot",
+            account="a",
+            partition="p",
+            run_root=tmp_path,
+            image="img.sif",
+            home=tmp_path,
+            **kw,
+        )
+
+    monkeypatch.delenv("AUTORESEARCH_AUTHOR_MODEL", raising=False)
+    # claude (default) is always fine; codex with the claude default model is not
+    monkeypatch.setenv("AUTORESEARCH_AUTHOR_BACKEND", "claude")
+    assert _author_config_error(make()) == ""
+    monkeypatch.setenv("AUTORESEARCH_AUTHOR_BACKEND", "codex")
+    assert _author_config_error(make()) != ""  # codex + default claude model
+    # a codex fleet with no valid model submits NOTHING (no wasted job)
+    contract = _self_contract()
+    submitted: list[str] = []
+
+    def runner(argv, timeout_s):
+        submitted.append(" ".join(argv))
+        return CommandResult(0, "1\n", "")
+
+    out = service_self_initiated(tmp_path, SlurmCompute(runner=runner), make(), contract, NOW)
+    assert out is None and submitted == []
+    # once the model is set, codex is accepted
+    monkeypatch.setenv("AUTORESEARCH_AUTHOR_MODEL", "gpt-5.6-terra")
+    assert _author_config_error(make()) == ""
 
 
 def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch: Any) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1813,6 +1813,12 @@ def test_author_config_preflight_blocks_before_side_effects(
     strand-safety the panel preflight has, now for the config-driven author."""
     from autoresearch.tick import FollowupSpec, _author_config_error, service_self_initiated
 
+    # a VALID panel key, so the panel preflight passes and the AUTHOR gate is what
+    # blocks below (else "submits nothing" could be the panel preflight, not us)
+    panel_key = tmp_path / "verifier_key"
+    panel_key.write_text("k")
+    panel_key.chmod(0o600)
+
     def make(**kw: Any) -> FollowupSpec:
         return FollowupSpec(
             target="org/pilot",
@@ -1821,6 +1827,7 @@ def test_author_config_preflight_blocks_before_side_effects(
             run_root=tmp_path,
             image="img.sif",
             home=tmp_path,
+            panel_key_file=str(panel_key),
             **kw,
         )
 


### PR DESCRIPTION
## What

Make the author backend a **config choice the role runners resolve themselves**,
instead of something the tick threads into every lane. This is the clean answer to
"why should editing each role's backend take per-lane changes" — it shouldn't.

## How

- `climb` and `followup` default `--author-backend` / `--model` / `--codex-bin`
  from `AUTORESEARCH_AUTHOR_BACKEND` / `_MODEL` / `AUTORESEARCH_CODEX_BIN` — the
  **same env-default pattern already used** for `--image` / `--account` /
  `--partition`.
- The author key resolves **per backend** (`resolve_author_key_file`):
  `AUTORESEARCH_HARNESS_KEY_FILE` for claude, `AUTORESEARCH_CODEX_KEY_FILE` for
  codex, with the two keys **coexisting** on disk. Flipping the fleet is a
  one-line env change, not a key swap — and no in-flight run of the other backend
  breaks.
- The tick no longer threads the author backend or key into the
  climb / intake / wake / follow-up jobs. **A new author backend needs zero tick
  change.** (Only the steward keeps its own explicit `--key-file` — a distinct
  role with its own key.)
- A run's backend is **persisted on its record** (`RunRecord.author_backend`).
  The wake (`climb --resume`) and follow-up reproduce **that run's own** author +
  key from the record, not the current fleet default — so a mid-flight fleet flip
  never resumes a run on the wrong backend (or with the wrong key).

## Why this shape

Builds on #124 (codex resume validated). With resume working, codex is a normal
resumable backend, so there is no per-backend special-casing left — every lane
just asks "who is the author for this run?" and the resolver answers from config
(fresh) or the record (resume/follow-up). This replaces the abandoned per-lane
threading approach (#123), which the review showed was fragile precisely because
it special-cased each lane.

## Test plan

- New: `test_resolve_author_key_file` (per-backend keys, explicit > env >
  default); `test_run_record_persists_the_author_backend` (live_climb stamps it);
  `test_self_initiated_carries_contract_limits_into_the_job` now asserts the tick
  threads neither `--key-file` nor `--author-backend`; `test_followup_key_routing_
  by_role` updated (author resolves its key from env, steward keeps its explicit
  key).
- `uv run pytest` — 693 passed. Full gate (ruff check + format, mypy) — green.

## Follow-ups (separate)

- Deploy plumbing: `scripts/install_codex.sh` (idempotent) + `tick_chain.sbatch`
  sources `~/.config/autoresearch/.env`.
- The live flip (`AUTORESEARCH_AUTHOR_BACKEND=codex` + the codex key file) —
  gated on the PI.

## No secrets / no large files

Confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
