### PR TITLE
Phase 1: extract the climb loop's decide step into a composition seam

### DIFF
--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -955,8 +955,8 @@ def _panel_revise_policy(
     """The one decision policy today: a blocking panel finding wakes the author to
     revise, bounded by `revisions`, unless the backend cannot resume (then draft).
     A pure function of the read + the session's resumability — the loop owns the
-    stateful bits (running the panel, executing the wake). `credited` (the gate
-    result) is available to future results-driven policies; this one ignores it."""
+    stateful bits (running the panel, executing the wake). A future results-driven
+    (depth) policy will also take the gate result; this one needs only the verdict."""
     if not verdict.blocking:
         # clean (or degraded-but-clean) read: nothing to fix -> publish
         return _Halt()

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -921,6 +921,55 @@ def resume_climb(
     )
 
 
+# --- the composition seam (docs/design/research-loop-buildout.md, Phase 1) ---
+# climb_once's inner loop is run -> measure -> decide. `run` (run_role) and
+# `measure` (measure_and_decide) are already factored; this is the "decide the
+# next invocation" half, pulled out of the loop as a pluggable policy so the loop
+# is agnostic to WHY it iterates. Today one policy exists (panel-driven revision);
+# the depth axis (Phase 2a) will add a results-driven one, and parallel (Phase 3)
+# will fan out the `run` step — each an app on this seam, not a new driver.
+
+
+@dataclass(frozen=True)
+class _Revise:
+    """Iterate: re-run the editing role with this prompt, then re-measure."""
+
+    prompt: str
+
+
+@dataclass(frozen=True)
+class _Halt:
+    """Stop the loop and publish. `blocking_open` -> the caller drafts the PR
+    with the open findings rather than arming it."""
+
+    blocking_open: bool = False
+
+
+def _panel_revise_policy(
+    verdict: PanelVerdict,
+    session: SessionResult,
+    harness: Harness,
+    reads: int,
+    revisions: int,
+) -> _Revise | _Halt:
+    """The one decision policy today: a blocking panel finding wakes the author to
+    revise, bounded by `revisions`, unless the backend cannot resume (then draft).
+    A pure function of the read + the session's resumability — the loop owns the
+    stateful bits (running the panel, executing the wake). `credited` (the gate
+    result) is available to future results-driven policies; this one ignores it."""
+    if not verdict.blocking:
+        # clean (or degraded-but-clean) read: nothing to fix -> publish
+        return _Halt()
+    if not session.session_id or not getattr(harness, "supports_resume", True):
+        # cannot resume: a fresh session would revise blind, and a resume the
+        # backend can't do would lose the verified improvement -> draft instead
+        return _Halt(blocking_open=True)
+    if reads > revisions:
+        # capped with findings still open: the human must see the unconverged loop
+        return _Halt(blocking_open=True)
+    return _Revise(verdict.wake_text)
+
+
 def climb_once(
     config: ClimbConfig,
     contract_text: str,
@@ -1136,28 +1185,17 @@ def climb_once(
         # only the FINAL read's degradation matters: an earlier outage that a
         # later clean read supersedes is history, not state
         panel_degraded = verdict.degraded
-        if not verdict.blocking:
-            # a degraded clean read is NOT a certified pass: no wake (nothing
-            # for the author to fix), but the caller drafts the PR
-            break
-        if not session.session_id or not getattr(harness, "supports_resume", True):
-            # cannot resume: no session id, OR a no-resume backend (hermes;
-            # claude and codex both resume). A FRESH session seeing only the
-            # findings would revise blind, and a resume the backend can't do
-            # would lose this verified improvement as a session-error — so fail
-            # closed to the draft path (review question, #95 round 1).
-            panel_blocking_open = True
-            break
-        if panel_reads > panel_revisions:
-            # capped out with blocking findings still open: an unconverged
-            # loop is information the human must see, never suppressed —
-            # the caller posts a DRAFT PR with these findings on top
-            panel_blocking_open = True
+        # decide the next invocation (the composition seam): today the panel-revise
+        # policy. A _Halt ends the loop (drafting if findings stay open); a _Revise
+        # wakes the author with the policy's prompt and re-enters run -> measure.
+        decision = _panel_revise_policy(verdict, session, harness, panel_reads, panel_revisions)
+        if isinstance(decision, _Halt):
+            panel_blocking_open = decision.blocking_open
             break
         wake_result = run_role(
             spec,
             harness,
-            verdict.wake_text,
+            decision.prompt,
             workspace,
             resume_session_id=session.session_id or None,
         )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -969,6 +969,32 @@ def test_blocking_then_clean_revises_and_remeasures(tmp_path: Path) -> None:
     assert "round 1" in result.panel_transcript and "round 2" in result.panel_transcript
 
 
+def test_panel_revise_policy_decisions() -> None:
+    """The composition seam's decision policy (Phase 1): a pure function of the
+    read + the session's resumability. Clean -> halt; blocking+resumable+under-cap
+    -> revise; blocking but unresumable or capped -> halt-and-draft."""
+    from dataclasses import replace as dc_replace
+
+    from autoresearch.orchestrator import _Halt, _panel_revise_policy, _Revise
+
+    resumable = _SeqHarness([], supports_resume=True)
+    noresume = _SeqHarness([], supports_resume=False)
+    sess = ok_session()  # has session_id="s1"
+    no_id = dc_replace(sess, session_id="")
+
+    # clean read -> publish
+    assert _panel_revise_policy(_verdict(False, 1), sess, resumable, 1, 1) == _Halt()
+    # blocking, resumable, under the cap -> revise with the wake text
+    d = _panel_revise_policy(_verdict(True, 1), sess, resumable, 1, 1)
+    assert isinstance(d, _Revise) and d.prompt == _verdict(True, 1).wake_text
+    # blocking but no session id -> draft (can't resume)
+    assert _panel_revise_policy(_verdict(True, 1), no_id, resumable, 1, 1) == _Halt(True)
+    # blocking but a no-resume backend -> draft
+    assert _panel_revise_policy(_verdict(True, 1), sess, noresume, 1, 1) == _Halt(True)
+    # blocking but past the revision cap -> draft
+    assert _panel_revise_policy(_verdict(True, 2), sess, resumable, 2, 1) == _Halt(True)
+
+
 def test_a_backend_that_cannot_resume_drafts_a_blocking_finding(tmp_path: Path) -> None:
     """a no-resume backend (hermes) declares supports_resume=False: a blocking
     finding must DRAFT the verified improvement, never attempt a resume the


### PR DESCRIPTION
## What

**Phase 1** of the research-loop buildout (`docs/design/research-loop-buildout.md`, merged in #127): extract the climb loop's *decide-next* step into a pluggable **composition seam**.

`climb_once`'s inner loop is already run → measure → decide. `run` (`run_role`) and `measure` (`measure_and_decide`) were factored; the "decide the next invocation" half was inlined in the loop. This pulls it out as a pure policy:

- `_panel_revise_policy(verdict, session, harness, reads, revisions) -> _Revise | _Halt`
- the loop now just runs the policy: `_Halt` ends (drafting if findings stay open), `_Revise` wakes the author with the policy's prompt and re-enters run → measure.

## Why

Depth (Phase 2a) is a *results-driven* decision policy; parallel (Phase 3) fans out the `run` step. With the decision behind a seam, they become **apps on the loop, not new drivers** — the whole point of Phase 1, and the antidote to the per-lane-orchestration mistake (#123).

## No behavior change

The one policy today is the existing panel-driven revision rule, making byte-for-byte the same decisions (clean → halt; blocking + resumable + under cap → revise; unresumable or capped → halt-and-draft). This is deliberately **thin** — `run_role` consolidation was already done (consolidation.md), so Phase 1 is only this decide-seam extraction.

## Test plan

- New `test_panel_revise_policy_decisions` covers each decision branch directly (the seam).
- The full existing climb/orchestrator suite stays green (no behavior change): `uv run pytest` — 697 passed. Full gate (ruff check + format, mypy) — green.

## No secrets / no large files

Confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
