### PR TITLE
Phase 2a part 1: depth primitives (dial, resume-entry, candidate sha)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Per-benchmark depth dial `depth_k` on the contract's benchmark
+  (docs/design/research-loop-buildout.md, Phase 2a): how many times the author
+  may iterate on its own measured result within one climb, keeping the best gated
+  candidate. Defaults to `1` (today's single pass), bounded `[1, 8]`. This is the
+  declared knob; the depth loop that reads it lands next.
+
 - Alternative AUTHOR backend: `climb --author-backend codex` runs the editing
   role on the OpenAI Codex CLI instead of Claude, to try a cheaper author (e.g.
   `--model gpt-5.6-terra`). It runs **contained** — `codex login` and `codex

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -92,6 +92,13 @@ class Benchmark(_StrictModel):
     # the first eval once measured durations exist. None = in-job (today's
     # behavior).
     eval_minutes: int | None = Field(default=None, ge=1)
+    # Depth dial (docs/design/research-loop-buildout.md, Phase 2a): how many times
+    # the author may iterate on its OWN measured result within a climb, keeping the
+    # best gated candidate across iterations. 1 = today's single pass (no depth).
+    # A per-benchmark dial so "does depth pay here?" is answerable per benchmark;
+    # the trigger is fixed-k today (always run k), with stall/agent-judged policies
+    # as future configs.
+    depth_k: int = Field(default=1, ge=1, le=8)
 
     @field_validator("seed_env")
     @classmethod

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -92,6 +92,14 @@ class Benchmark(_StrictModel):
     # the first eval once measured durations exist. None = in-job (today's
     # behavior).
     eval_minutes: int | None = Field(default=None, ge=1)
+    # Depth dial (docs/design/research-loop-buildout.md, Phase 2a): how many times
+    # the author may iterate on its OWN measured result within one climb, keeping
+    # the best gated candidate across iterations. 1 = today's single pass (no
+    # depth). A per-benchmark dial so "does depth pay here?" is answerable per
+    # benchmark; the fixed-k trigger (always run k) is what reads this, with
+    # stall/agent-judged triggers as future configs. The depth LOOP that consumes
+    # it lands in part 2; this is the declared knob (a contract can set it now).
+    depth_k: int = Field(default=1, ge=1, le=8)
 
     @field_validator("seed_env")
     @classmethod

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -92,13 +92,6 @@ class Benchmark(_StrictModel):
     # the first eval once measured durations exist. None = in-job (today's
     # behavior).
     eval_minutes: int | None = Field(default=None, ge=1)
-    # Depth dial (docs/design/research-loop-buildout.md, Phase 2a): how many times
-    # the author may iterate on its OWN measured result within a climb, keeping the
-    # best gated candidate across iterations. 1 = today's single pass (no depth).
-    # A per-benchmark dial so "does depth pay here?" is answerable per benchmark;
-    # the trigger is fixed-k today (always run k), with stall/agent-judged policies
-    # as future configs.
-    depth_k: int = Field(default=1, ge=1, le=8)
 
     @field_validator("seed_env")
     @classmethod

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -407,8 +407,9 @@ class ClimbResult:
     # must refuse to commit anything beyond this set
     measured_paths: tuple[str, ...] = ()
     # the sealed candidate snapshot this result was measured on (set on
-    # `improved`); the caller publishes THIS tree, and a depth loop selects the
-    # best across passes by it. "" on non-improved outcomes.
+    # `improved`); a caller can publish THIS tree (the wake path already does,
+    # climb.py) and a depth loop can select the best across passes by it. "" on
+    # non-improved outcomes. (The in-job depth publish is wired in part 2.)
     candidate_sha: str = ""
     session: SessionResult | None = None
     note: str = ""
@@ -1052,10 +1053,11 @@ def climb_once(
         # silently dropped — the same silent-discard hazard the coupling check
         # above prevents. Reject them loudly; a resume pass is lean by design.
         # This is the EXHAUSTIVE set of OPTIONAL brief-only params: a new one added
-        # to build_brief must be added here too. (`ruler` is also brief-only but is
-        # required, so a caller cannot omit it — it is unavoidably passed and
-        # ignored on a resume. `contract_text` is NOT brief-only — scope/gate use
-        # it either way.)
+        # to build_brief must be added here too. Required params that also feed only
+        # the brief are NOT guarded because a caller cannot omit them — `ruler`, and
+        # the brief-only fields of the required `config` (e.g. `config.budget`) — so
+        # they are unavoidably passed and simply ignored on a resume. `contract_text`
+        # is NOT brief-only — scope/gate use it either way.
         raise ValueError(
             "resume_session_id resumes an existing session (no fresh brief); the brief-only "
             "inputs (task_hypothesis/lessons/recent_reports/created/brief_baseline) have no "

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1045,17 +1045,21 @@ def climb_once(
         # same optional-attr idiom as the panel policy
         raise ValueError("resume_session_id given but the harness does not support resume")
     if resume_session_id and (
-        task_hypothesis or lessons or recent_reports or brief_baseline is not None
+        task_hypothesis or lessons or recent_reports or created or brief_baseline is not None
     ):
         # a resume skips build_brief entirely (the session already carries this
         # context from its first pass), so these brief-only inputs would be
         # silently dropped — the same silent-discard hazard the coupling check
         # above prevents. Reject them loudly; a resume pass is lean by design.
-        # (contract_text is NOT brief-only — the scope/gate use it either way.)
+        # This is the EXHAUSTIVE set of OPTIONAL brief-only params: a new one added
+        # to build_brief must be added here too. (`ruler` is also brief-only but is
+        # required, so a caller cannot omit it — it is unavoidably passed and
+        # ignored on a resume. `contract_text` is NOT brief-only — scope/gate use
+        # it either way.)
         raise ValueError(
             "resume_session_id resumes an existing session (no fresh brief); the brief-only "
-            "inputs (task_hypothesis/lessons/recent_reports/brief_baseline) have no effect "
-            "on a resume — omit them"
+            "inputs (task_hypothesis/lessons/recent_reports/created/brief_baseline) have no "
+            "effect on a resume — omit them"
         )
 
     # deferred like measure_and_decide's import (measure -> dispatch ->

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -922,6 +922,7 @@ def resume_climb(
         run_seed=seed,
         suite=outcome.suite,
         suite_seed=outcome.suite_seed,
+        candidate_sha=candidate_sha,
     )
 
 
@@ -1029,6 +1030,20 @@ def climb_once(
         raise ValueError("climb_once runs an editing role; the spec must allow execution")
     if not spec.scope:
         spec = dc_replace(spec, scope=tuple(contract.scope.allowed))
+
+    if resume_session_id:
+        # the resume-entry (cumulative depth) has a hard contract: an instruction
+        # to resume WITH, and a backend that can resume. Fail loudly here rather
+        # than burn a promptless turn or end the climb as `session-error` on a
+        # no-resume backend. The depth loop (caller) owns WHEN to resume; this
+        # validates that choice — it does not silently fall back to a fresh brief,
+        # which would turn a depth pass into a fresh attempt behind the caller's back.
+        if not improve_prompt:
+            raise ValueError("resume_session_id requires a non-empty improve_prompt")
+        if not getattr(
+            harness, "supports_resume", True
+        ):  # same optional-attr idiom as the panel policy
+            raise ValueError("resume_session_id given but the harness does not support resume")
 
     # deferred like measure_and_decide's import (measure -> dispatch ->
     # orchestrator for the eval primitives).

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -406,6 +406,10 @@ class ClimbResult:
     # the exact paths that were scope-checked and then measured — the caller
     # must refuse to commit anything beyond this set
     measured_paths: tuple[str, ...] = ()
+    # the sealed candidate snapshot this result was measured on (set on
+    # `improved`); the caller publishes THIS tree, and a depth loop selects the
+    # best across passes by it. "" on non-improved outcomes.
+    candidate_sha: str = ""
     session: SessionResult | None = None
     note: str = ""
     # the seed both measurements ran under (0 = benchmark has no seed_env):
@@ -988,6 +992,8 @@ def climb_once(
     panel_runner: Callable[[float, float, str], PanelVerdict] | None = None,
     panel_revisions: int = 1,
     brief_baseline: float | None = None,
+    resume_session_id: str = "",
+    improve_prompt: str = "",
 ) -> ClimbResult:
     """One implement→evaluate→verify cycle in an existing clean workspace.
 
@@ -1047,19 +1053,27 @@ def climb_once(
     # for orienting the brief only ("improve from ~13.8"); it is None on a
     # benchmark's first run, and the gate re-measures either way.
     baseline: float | None = brief_baseline
-    task = make_task(contract, config.benchmark, baseline, hypothesis=task_hypothesis)
-    brief = build_brief(
-        BriefInputs(
-            task=task,
-            contract_text=contract_text,
-            ruler=ruler,
-            lessons=lessons,
-            recent_reports=recent_reports,
-            budget=config.budget,
-        ),
-        created=created,
-    )
-    role_result = run_role(spec, harness, render(brief), workspace)
+    if resume_session_id:
+        # a cumulative depth pass (research-loop-buildout.md, Phase 2a): resume the
+        # prior session with the improve prompt instead of a fresh brief, so the
+        # author builds on — and sees the measured result of — its own last pass.
+        role_result = run_role(
+            spec, harness, improve_prompt, workspace, resume_session_id=resume_session_id
+        )
+    else:
+        task = make_task(contract, config.benchmark, baseline, hypothesis=task_hypothesis)
+        brief = build_brief(
+            BriefInputs(
+                task=task,
+                contract_text=contract_text,
+                ruler=ruler,
+                lessons=lessons,
+                recent_reports=recent_reports,
+                budget=config.budget,
+            ),
+            created=created,
+        )
+        role_result = run_role(spec, harness, render(brief), workspace)
     session = role_result.session
     if not role_result.ok:
         # the role-runner's verdict, not just the raw session flag (for a
@@ -1227,6 +1241,7 @@ def climb_once(
         session=session,
         branch=f"{config.branch_prefix}/{config.benchmark}",
         measured_paths=measured,
+        candidate_sha=candidate_sha,
         run_seed=run_seed,
         suite=suite,
         suite_seed=suite_seed_ran,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1044,6 +1044,16 @@ def climb_once(
     if resume_session_id and not getattr(harness, "supports_resume", True):
         # same optional-attr idiom as the panel policy
         raise ValueError("resume_session_id given but the harness does not support resume")
+    if resume_session_id and (task_hypothesis or lessons or recent_reports):
+        # a resume skips build_brief entirely (the session already carries this
+        # context from its first pass), so these brief-only inputs would be
+        # silently dropped — the same silent-discard hazard the coupling check
+        # above prevents. Reject them loudly; a resume pass is lean by design.
+        # (contract_text is NOT brief-only — the scope/gate use it either way.)
+        raise ValueError(
+            "resume_session_id resumes an existing session (no fresh brief); "
+            "task_hypothesis/lessons/recent_reports have no effect on a resume — omit them"
+        )
 
     # deferred like measure_and_decide's import (measure -> dispatch ->
     # orchestrator for the eval primitives).

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1044,15 +1044,18 @@ def climb_once(
     if resume_session_id and not getattr(harness, "supports_resume", True):
         # same optional-attr idiom as the panel policy
         raise ValueError("resume_session_id given but the harness does not support resume")
-    if resume_session_id and (task_hypothesis or lessons or recent_reports):
+    if resume_session_id and (
+        task_hypothesis or lessons or recent_reports or brief_baseline is not None
+    ):
         # a resume skips build_brief entirely (the session already carries this
         # context from its first pass), so these brief-only inputs would be
         # silently dropped — the same silent-discard hazard the coupling check
         # above prevents. Reject them loudly; a resume pass is lean by design.
         # (contract_text is NOT brief-only — the scope/gate use it either way.)
         raise ValueError(
-            "resume_session_id resumes an existing session (no fresh brief); "
-            "task_hypothesis/lessons/recent_reports have no effect on a resume — omit them"
+            "resume_session_id resumes an existing session (no fresh brief); the brief-only "
+            "inputs (task_hypothesis/lessons/recent_reports/brief_baseline) have no effect "
+            "on a resume — omit them"
         )
 
     # deferred like measure_and_decide's import (measure -> dispatch ->

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1031,19 +1031,19 @@ def climb_once(
     if not spec.scope:
         spec = dc_replace(spec, scope=tuple(contract.scope.allowed))
 
-    if resume_session_id:
-        # the resume-entry (cumulative depth) has a hard contract: an instruction
-        # to resume WITH, and a backend that can resume. Fail loudly here rather
-        # than burn a promptless turn or end the climb as `session-error` on a
-        # no-resume backend. The depth loop (caller) owns WHEN to resume; this
-        # validates that choice — it does not silently fall back to a fresh brief,
-        # which would turn a depth pass into a fresh attempt behind the caller's back.
-        if not improve_prompt:
-            raise ValueError("resume_session_id requires a non-empty improve_prompt")
-        if not getattr(
-            harness, "supports_resume", True
-        ):  # same optional-attr idiom as the panel policy
-            raise ValueError("resume_session_id given but the harness does not support resume")
+    # the resume-entry (cumulative depth) is a COUPLED pair: it needs both a
+    # session to resume and an instruction to resume with. Reject either alone
+    # loudly — a lone improve_prompt would be silently discarded by the fresh-brief
+    # branch (a depth pass turning into a fresh attempt behind the caller's back),
+    # a lone session id would burn a promptless turn. And reject a resume on a
+    # no-resume backend rather than let the climb end as `session-error`. The depth
+    # loop (caller) owns WHEN to resume; this validates that choice — it never
+    # silently falls back to a fresh brief.
+    if bool(resume_session_id) != bool(improve_prompt):
+        raise ValueError("resume_session_id and improve_prompt must be given together")
+    if resume_session_id and not getattr(harness, "supports_resume", True):
+        # same optional-attr idiom as the panel policy
+        raise ValueError("resume_session_id given but the harness does not support resume")
 
     # deferred like measure_and_decide's import (measure -> dispatch ->
     # orchestrator for the eval primitives).

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -170,6 +170,24 @@ roadmap: docs/roadmap.md
         load_contract(base % "-0.1", "org/pilot")
 
 
+def test_depth_k_defaults_to_one_and_validates_range() -> None:
+    # the per-benchmark depth dial: default 1 (single pass), bounded [1, 8].
+    from autoresearch.contract import load_contract
+
+    base = """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max%s}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    assert load_contract(base % "", "org/pilot").benchmarks[0].depth_k == 1
+    assert load_contract(base % ", depth_k: 4", "org/pilot").benchmarks[0].depth_k == 4
+    for bad in (", depth_k: 0", ", depth_k: 9"):
+        with pytest.raises(ValidationError):
+            load_contract(base % bad, "org/pilot")
+
+
 def test_seed_env_rejects_the_evaluators_managed_names() -> None:
     """seed_env: UV_PROJECT_ENVIRONMENT (or HOME) would defeat per-eval
     isolation; contracts are untrusted input, so the loader refuses."""

--- a/tests/test_measure_and_decide.py
+++ b/tests/test_measure_and_decide.py
@@ -301,6 +301,9 @@ def test_resume_improved_carries_the_saved_report():
     assert out.session.session_id == "s-woke"
     assert out.session.num_turns == 0  # a wake ran no turns
     assert out.measured_paths == ("src/model.py",) and out.run_seed == 7
+    # the wake path carries the sealed candidate sha too (so best-of-k can select
+    # and publish it), matching the in-job improved return
+    assert out.candidate_sha == CAND
 
 
 def test_resume_no_improvement_is_terminal_with_the_report():

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -84,8 +84,8 @@ def _wire(evaluator, workspace, base_ws=None):
     return measurer, snapshot
 
 
-def run_climb(tmp_path, values, session=None, config=CONFIG, changed=None, **kw):
-    harness = FakeHarness(result=session or ok_session())
+def run_climb(tmp_path, values, session=None, config=CONFIG, changed=None, harness=None, **kw):
+    harness = harness or FakeHarness(result=session or ok_session())
     evaluator = FakeEvaluator(values=list(values))
     measurer, snapshot = _wire(evaluator, tmp_path)
     result = climb_once(
@@ -140,9 +140,29 @@ def test_climb_once_resume_entry_skips_the_brief(tmp_path: Path) -> None:
     )
     assert result.outcome == "improved"
     brief_text, _ws, resumed = harness.calls[0]  # the FIRST call is the resume
+    # the exact-equality proves no fresh brief was rendered: a brief would carry
+    # the task/contract preamble, never equal the bare improve prompt.
     assert brief_text == "beat 13.876" and resumed == "prev-sess"
-    # no fresh brief was rendered (no task/contract preamble)
-    assert "mean_tour_length" not in brief_text
+
+
+def test_resume_entry_requires_an_improve_prompt(tmp_path: Path) -> None:
+    # the resume-entry contract: a session id with no instruction to resume with
+    # is a promptless turn -> reject loudly, never burn the turn.
+    with pytest.raises(ValueError, match="improve_prompt"):
+        run_climb(tmp_path, [13.876, 13.10], resume_session_id="prev-sess")
+
+
+def test_resume_entry_requires_a_resuming_backend(tmp_path: Path) -> None:
+    # resuming on a no-resume backend would end the climb as session-error; the
+    # primitive rejects it up front (the depth loop picks resume-capable backends).
+    with pytest.raises(ValueError, match="resume"):
+        run_climb(
+            tmp_path,
+            [13.876, 13.10],
+            resume_session_id="prev-sess",
+            improve_prompt="beat it",
+            harness=FakeHarness(result=ok_session(), supports_resume=False),
+        )
 
 
 def test_first_run_brief_has_no_baseline_number(tmp_path: Path) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -158,13 +158,28 @@ def test_resume_entry_couples_session_and_prompt(tmp_path: Path) -> None:
 def test_resume_entry_requires_a_resuming_backend(tmp_path: Path) -> None:
     # resuming on a no-resume backend would end the climb as session-error; the
     # primitive rejects it up front (the depth loop picks resume-capable backends).
-    with pytest.raises(ValueError, match="resume"):
+    # match the message unique to THIS check (not just "resume", which the coupling
+    # error also contains) so a mis-firing precondition can't false-pass.
+    with pytest.raises(ValueError, match="does not support resume"):
         run_climb(
             tmp_path,
             [13.876, 13.10],
             resume_session_id="prev-sess",
             improve_prompt="beat it",
             harness=FakeHarness(result=ok_session(), supports_resume=False),
+        )
+
+
+def test_resume_entry_rejects_brief_only_inputs(tmp_path: Path) -> None:
+    # a resume skips build_brief, so brief-only inputs would be silently dropped;
+    # the primitive rejects them loudly (the same anti-silent-discard stance).
+    with pytest.raises(ValueError, match="no effect on a resume"):
+        run_climb(
+            tmp_path,
+            [13.876, 13.10],
+            resume_session_id="prev-sess",
+            improve_prompt="beat it",
+            task_hypothesis="try 3-opt",
         )
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -124,6 +124,27 @@ def test_improvement_end_to_end(tmp_path: Path) -> None:
     )
 
 
+def test_improved_result_exposes_the_candidate_sha(tmp_path: Path) -> None:
+    # Phase 2a primitive: an improved result carries the sealed candidate sha the
+    # caller publishes (and a depth loop selects the best across passes by).
+    result, _, _ = run_climb(tmp_path, [13.876, 13.10])
+    assert result.outcome == "improved" and result.candidate_sha == "cand1"
+
+
+def test_climb_once_resume_entry_skips_the_brief(tmp_path: Path) -> None:
+    # Phase 2a primitive: a cumulative depth pass resumes the prior session with
+    # the improve prompt instead of a fresh brief (the depth loop, part 2, drives
+    # this; here we verify the entry point alone).
+    result, harness, _ = run_climb(
+        tmp_path, [13.876, 13.10], resume_session_id="prev-sess", improve_prompt="beat 13.876"
+    )
+    assert result.outcome == "improved"
+    brief_text, _ws, resumed = harness.calls[0]  # the FIRST call is the resume
+    assert brief_text == "beat 13.876" and resumed == "prev-sess"
+    # no fresh brief was rendered (no task/contract preamble)
+    assert "mean_tour_length" not in brief_text
+
+
 def test_first_run_brief_has_no_baseline_number(tmp_path: Path) -> None:
     # a benchmark's first climb has no ledger entry -> the brief drops the
     # reference number (never the gate, which still measures both sides).

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -88,6 +88,10 @@ def run_climb(tmp_path, values, session=None, config=CONFIG, changed=None, harne
     harness = harness or FakeHarness(result=session or ok_session())
     evaluator = FakeEvaluator(values=list(values))
     measurer, snapshot = _wire(evaluator, tmp_path)
+    # `created` is a brief-only input, so a resume rejects it; a fresh run gets the
+    # usual stamp. (Callers can still override via kw.)
+    if "created" not in kw and not kw.get("resume_session_id"):
+        kw["created"] = "2026-08-06T00:00:00Z"
     result = climb_once(
         config,
         CONTRACT,
@@ -98,7 +102,6 @@ def run_climb(tmp_path, values, session=None, config=CONFIG, changed=None, harne
         snapshot,
         ruler="mean tour length over the frozen pool",
         changed_paths=lambda: changed if changed is not None else ["src/pilot/solvers/tsp.py"],
-        created="2026-08-06T00:00:00Z",
         **kw,
     )
     return result, harness, evaluator
@@ -173,7 +176,11 @@ def test_resume_entry_requires_a_resuming_backend(tmp_path: Path) -> None:
 def test_resume_entry_rejects_brief_only_inputs(tmp_path: Path) -> None:
     # a resume skips build_brief, so brief-only inputs would be silently dropped;
     # the primitive rejects them loudly (the same anti-silent-discard stance).
-    for brief_only in ({"task_hypothesis": "try 3-opt"}, {"brief_baseline": 13.876}):
+    for brief_only in (
+        {"task_hypothesis": "try 3-opt"},
+        {"brief_baseline": 13.876},
+        {"created": "2026-08-06T00:00:00Z"},
+    ):
         with pytest.raises(ValueError, match="no effect on a resume"):
             run_climb(
                 tmp_path,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -178,9 +178,11 @@ def test_resume_entry_rejects_brief_only_inputs(tmp_path: Path) -> None:
     # the primitive rejects them loudly (the same anti-silent-discard stance).
     for brief_only in (
         {"task_hypothesis": "try 3-opt"},
-        {"brief_baseline": 13.876},
+        {"lessons": "prior climbs overfit the pool"},
+        {"recent_reports": ("last week's report",)},
         {"created": "2026-08-06T00:00:00Z"},
-    ):
+        {"brief_baseline": 13.876},
+    ):  # every one of the five guarded brief-only inputs, so dropping any regresses
         with pytest.raises(ValueError, match="no effect on a resume"):
             run_climb(
                 tmp_path,

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -173,14 +173,15 @@ def test_resume_entry_requires_a_resuming_backend(tmp_path: Path) -> None:
 def test_resume_entry_rejects_brief_only_inputs(tmp_path: Path) -> None:
     # a resume skips build_brief, so brief-only inputs would be silently dropped;
     # the primitive rejects them loudly (the same anti-silent-discard stance).
-    with pytest.raises(ValueError, match="no effect on a resume"):
-        run_climb(
-            tmp_path,
-            [13.876, 13.10],
-            resume_session_id="prev-sess",
-            improve_prompt="beat it",
-            task_hypothesis="try 3-opt",
-        )
+    for brief_only in ({"task_hypothesis": "try 3-opt"}, {"brief_baseline": 13.876}):
+        with pytest.raises(ValueError, match="no effect on a resume"):
+            run_climb(
+                tmp_path,
+                [13.876, 13.10],
+                resume_session_id="prev-sess",
+                improve_prompt="beat it",
+                **brief_only,
+            )
 
 
 def test_first_run_brief_has_no_baseline_number(tmp_path: Path) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -145,11 +145,14 @@ def test_climb_once_resume_entry_skips_the_brief(tmp_path: Path) -> None:
     assert brief_text == "beat 13.876" and resumed == "prev-sess"
 
 
-def test_resume_entry_requires_an_improve_prompt(tmp_path: Path) -> None:
-    # the resume-entry contract: a session id with no instruction to resume with
-    # is a promptless turn -> reject loudly, never burn the turn.
-    with pytest.raises(ValueError, match="improve_prompt"):
+def test_resume_entry_couples_session_and_prompt(tmp_path: Path) -> None:
+    # resume-entry is a coupled pair (both or neither): a lone session id burns a
+    # promptless turn; a lone improve_prompt would be silently discarded by the
+    # fresh-brief branch (a depth pass becoming a fresh attempt). Reject both.
+    with pytest.raises(ValueError, match="together"):
         run_climb(tmp_path, [13.876, 13.10], resume_session_id="prev-sess")
+    with pytest.raises(ValueError, match="together"):
+        run_climb(tmp_path, [13.876, 13.10], improve_prompt="beat it")
 
 
 def test_resume_entry_requires_a_resuming_backend(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

The primitives the cumulative-depth loop (Phase 2a, `research-loop-buildout.md`) needs — landed ahead of the `live_climb` surgery, all **additive + no behavior change** at today's defaults:

- **`Benchmark.depth_k`** dial (default 1 = today's single pass; bounded `[1, 8]`; per-benchmark, so "does depth pay here?" is answerable per benchmark). The declared knob — a contract can set it now; the depth loop that *reads* it lands in part 2.
- **climb_once resume-entry**: `resume_session_id` + `improve_prompt` resume the prior session with the improve prompt instead of a fresh brief — a depth pass builds on, and sees the measured result of, its own last pass (**cumulative** depth). The two are a **coupled pair** (both-or-neither, validated loudly); a resume also rejects the brief-only inputs it would silently drop (`task_hypothesis`/`lessons`/`recent_reports`/`created`/`brief_baseline`) and a no-resume backend. Default off → identical to today.
- **`ClimbResult.candidate_sha`**: the sealed (immutable) candidate commit an `improved` result was measured on — so the caller publishes *that* tree and a depth loop selects the best across passes by it. Set on both the in-job and wake improved returns.

## Why split from the loop

Part 2 is the `live_climb` fixed-`k` depth loop that drives these and publishes the best gate+panel-clean candidate. It touches the **live climb-publish path** (today it commits the live workspace; best-of-`k` must publish the best sealed `candidate_sha`, as the wake path already does — `climb.py:397`), so it gets its own reviewed PR.

**Part-2 constraints surfaced in review (captured, not part-1 bugs):**
- The depth loop must **retain the winning candidate's snapshot ref** until publish (the inline caller's `finally` drops snapshot refs — cf. the park path's `kept_ref`). In part 1 nothing dereferences `candidate_sha`, so it's latent until part 2.
- When part 2 *constructs* `improve_prompt` from measured result text, it must **data-fence** it like the panel wake path (`panel.py`). In part 1 `improve_prompt` is a dormant caller-supplied param.
- The depth loop must **thread one `run_seed` across passes** for a fair best-of-`k` (the resume-entry draws a fresh seed per call today; a shared seed belongs where it's consumed, not as an unused part-1 param).

## Test plan

- `depth_k`: default 1, accepts in-range, rejects out-of-range.
- `candidate_sha` on `improved` (in-job **and** wake path); resume-entry skips the brief and resumes with the improve prompt; the coupled-pair, no-resume-backend, and all five brief-only-input preconditions raise.
- Full suite green (703), no behavior change at the defaults. Gate (ruff + mypy) green.

## No secrets / no large files

Confirmed.
