### PR TITLE
ci: dismantle the opus-5 advisory reviewer, keep terra

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,20 +9,11 @@ permissions:
   contents: read
   pull-requests: write
 jobs:
-  advisory:
+  # Single advisory reviewer: terra (hermes, openai-direct). The claude-opus-5
+  # reviewer was removed (2026-08-23) — it did not converge (unbounded nitpick
+  # rounds, re-raising resolved items); terra catches the real issues and settles.
+  review:
     # a labeled event only runs for the autoresearch:review label (manual re-review)
-    if: github.event.action != 'labeled' || github.event.label.name == 'autoresearch:review'
-
-    uses: agentic-learning-ai-lab/autoresearch/.github/workflows/advisory-review-agent.yml@main
-    with:
-      bot_login: agentic-learning-bot
-    secrets:
-      anthropic_reviewer_key: ${{ secrets.ANTHROPIC_REVIEWER_KEY }}
-
-  # Independent second opinion (terra via hermes, openai-direct) — same reusable,
-  # different backend and opinion label. Independence is the point: no coordination with
-  # the primary round.
-  second-opinion:
     if: github.event.action != 'labeled' || github.event.label.name == 'autoresearch:review'
 
     uses: agentic-learning-ai-lab/autoresearch/.github/workflows/advisory-review-agent.yml@main
@@ -33,6 +24,6 @@ jobs:
       # OpenAI account is tax-exempt); model id is provider-native
       hermes_provider: openai
       model: gpt-5.6-terra
-      opinion_label: second opinion — terra
+      opinion_label: terra
     secrets:
       openai_reviewer_key: ${{ secrets.OPENAI_REVIEWER_KEY }}


### PR DESCRIPTION
Removes the `claude-opus-5` advisory reviewer job from `review.yml`; **terra** (hermes/openai-direct, `gpt-5.6-terra`) becomes the sole CI reviewer.

**Why:** on #129 the opus-5 reviewer never converged — unbounded nitpick rounds, re-raising already-resolved items — while terra caught the real bugs early and settled after a couple of rounds. Chasing opus-5 to "quiet" was a token sink and a disservice.

The `advisory-review-agent` reusable still supports the `claude` backend for other callers; only this repo's use of it is removed. No required checks reference the review jobs (only `ci` is required), so the job rename (`advisory`/`second-opinion` → `review`) breaks no gate.

Self-reviewed: YAML valid, no dangling refs, docs are generic examples (not stale mirrors).