### PR TITLE
Author syscalls: agent-facing launch/sleep tool (JSON becomes internal ABI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,12 @@ Versions follow [SemVer](https://semver.org).
   (new per-benchmark `sleep_k`, default 4, bounded `[1, 16]`), submits later
   (Phase B). An over-budget ask wakes the same session once with a refusal;
   a malformed request errs loudly; the `.autoresearch/` channel is excluded
-  from diffs/scope/drift via `.git/info/exclude`. The wake side (deliver
-  results, resume the session through the climb's resume-entry) is part 2.
+  from diffs/scope/drift via `.git/info/exclude`. The author's INTERFACE is a
+  tool (`python .autoresearch/syscall launch ... -- <cmd>`; `... sleep`),
+  installed into the sandbox — the JSON is an internal ABI it commits, with
+  in-session validation so bad args fail immediately, not as a burned sleep.
+  The wake side (deliver results, resume the session through the climb's
+  resume-entry) is part 2.
 
 - Per-benchmark depth budget `depth_k` on the contract's benchmark
   (docs/design/research-loop.md, "one syscall, author-directed"): how many

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -80,6 +80,8 @@ from autoresearch.runstate import (
 )
 from autoresearch.syscall import MAX_ARTIFACT_BYTES, SYSCALL_DIR, SYSCALL_FILE, SyscallRequest
 from autoresearch.syscall import ensure_excluded as syscall_excluded
+from autoresearch.syscall import install_tool as syscall_install_tool
+from autoresearch.syscall import write_budget as syscall_write_budget
 from autoresearch.verifier import MAX_CLAIM_CHARS
 
 log = logging.getLogger(__name__)
@@ -1326,6 +1328,17 @@ def live_climb(
             author_syscalls = False
         if author_syscalls:
             syscall_excluded(workspace)
+            # the author's interface is the TOOL (`python .autoresearch/syscall
+            # launch ... -- <cmd>`; `... sleep`), never the raw ABI file —
+            # install it plus the informational budget its `status` shows.
+            syscall_install_tool(workspace)
+            _bench = next((b for b in contract.benchmarks if b.name == config.benchmark), None)
+            if _bench is not None:
+                syscall_write_budget(
+                    workspace,
+                    launches_remaining=_bench.depth_k,
+                    sleeps_remaining=_bench.sleep_k,
+                )
 
         def changed_paths() -> list[str]:
             ws.git("add", "-A")

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -78,7 +78,7 @@ from autoresearch.runstate import (
     save_record,
     stamp_outage,
 )
-from autoresearch.syscall import MAX_ARTIFACT_BYTES, SYSCALL_DIR, SYSCALL_FILE, SyscallRequest
+from autoresearch.syscall import MAX_ARTIFACT_BYTES, SYSCALL_DIR, SyscallRequest
 from autoresearch.syscall import ensure_excluded as syscall_excluded
 from autoresearch.syscall import install_tool as syscall_install_tool
 from autoresearch.syscall import write_budget as syscall_write_budget
@@ -1326,6 +1326,20 @@ def live_climb(
                 "built yet (Phase A part 2); author syscalls stay OFF this run"
             )
             author_syscalls = False
+        # The `.autoresearch/` channel must be KERNEL-OWNED. In a fresh clone,
+        # anything already at that path was committed by the TARGET — a symlink
+        # (install would write through it to a host path with our permissions —
+        # terra #133 r1), a tracked request (free cluster compute — #132 r3), or
+        # any other booby trap. If the path pre-exists in ANY form, disable the
+        # feature for the run, loudly; otherwise we create a dir we own.
+        channel = workspace / SYSCALL_DIR
+        if author_syscalls and (channel.is_symlink() or channel.exists()):
+            log.warning(
+                "target ships a %s path (symlink=%s); author syscalls disabled for this run",
+                SYSCALL_DIR,
+                channel.is_symlink(),
+            )
+            author_syscalls = False
         if author_syscalls:
             syscall_excluded(workspace)
             # the author's interface is the TOOL (`python .autoresearch/syscall
@@ -1448,24 +1462,10 @@ def live_climb(
         # dispatcher has cluster coordinates (the launches are Slurm jobs), and
         # the backend can resume (the wake resumes the SAME session).
         launcher = None
-        # A request is only valid if the SESSION wrote it. The workspace is a
-        # fresh clone, so a request file that exists BEFORE the session is
-        # tracked in the target's base tree — a repo could otherwise consume
-        # cluster compute by committing one (terra, #132 r3). Booby-trapped
-        # channel -> the feature stays off for this run, loudly.
-        preexisting_request = (workspace / SYSCALL_DIR / SYSCALL_FILE).exists()
-        if author_syscalls and preexisting_request:
-            log.warning(
-                "target ships a tracked %s/%s; author syscalls disabled for this run",
-                SYSCALL_DIR,
-                SYSCALL_FILE,
-            )
-        if (
-            author_syscalls
-            and not preexisting_request
-            and dispatch is not None
-            and getattr(harness, "supports_resume", True)
-        ):
+        # `author_syscalls` already reflects the channel-ownership guard above
+        # (a target-shipped `.autoresearch` — symlink, tracked request, or any
+        # other pre-existing form — has disabled the feature for this run).
+        if author_syscalls and dispatch is not None and getattr(harness, "supports_resume", True):
 
             def launcher(sha: str, request: SyscallRequest) -> str:
                 from autoresearch.dispatch import eval_job_spec, write_eval_job

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -1,12 +1,17 @@
-"""Author-facing syscalls: launch / sleep (research-loop.md, "one syscall").
+"""Author syscalls: the kernel side of launch / sleep (research-loop.md, "one
+syscall").
 
-The author lives in the sandbox; real experiments run outside it. The channel
-is a file: the author writes `.autoresearch/syscall.json` in its workspace and
-ends its session — that IS the sleep. The kernel reads the request, submits
-each launch as a jailed job on a sealed snapshot of the author's tree, parks
-the run, and later wakes the SAME session with every job's results delivered
-as data (`render_wake`). A session that ends with no request follows today's
-path (implicit submit; the explicit submit payload is Phase B).
+The author lives in the sandbox; real experiments run outside it. The AUTHOR's
+interface is a TOOL (`syscall_cli.py`, installed at `.autoresearch/syscall`):
+`python .autoresearch/syscall launch ... -- <cmd>` then `... sleep`. This module
+is the KERNEL side — `.autoresearch/syscall.json` is the internal ABI the tool
+commits on `sleep`, and `read_request` here is its authoritative validator
+(never trusting the tool, which is agent-controlled once dropped). The author
+writes the ABI and ends its session — that IS the sleep. The kernel reads the
+request, submits each launch as a jailed job on a sealed snapshot of the
+author's tree, parks the run, and later wakes the SAME session with every job's
+results delivered as data (`render_wake`). A session that ends with no request
+follows today's path (implicit submit; the explicit submit payload is Phase B).
 
 The `.autoresearch/` directory is kernel-excluded from the diff via
 `.git/info/exclude` (repo-local, never a tracked edit), so requests and
@@ -192,6 +197,33 @@ def ensure_excluded(workspace: Path) -> None:
         exclude.write_text(
             existing + ("" if existing.endswith("\n") or not existing else "\n") + line + "\n"
         )
+
+
+def install_tool(workspace: Path) -> None:
+    """Drop the agent-facing launch/sleep tool into the sandbox.
+
+    The AUTHOR's interface is the tool (`python .autoresearch/syscall launch
+    ... -- <cmd>`; `... sleep`), not the JSON — the file this module reads is
+    the internal ABI the tool commits on `sleep`. The tool is a verbatim copy
+    of `syscall_cli.py` (standalone by contract: stdlib-only, since the target
+    repo does not have autoresearch installed), living inside the excluded
+    channel dir so it never enters diffs, scope, or fingerprints."""
+    from autoresearch import syscall_cli
+
+    tool = workspace / SYSCALL_DIR / "syscall"
+    tool.parent.mkdir(exist_ok=True)
+    tool.write_text(Path(syscall_cli.__file__).read_text())
+    tool.chmod(0o755)
+
+
+def write_budget(workspace: Path, *, launches_remaining: int, sleeps_remaining: int) -> None:
+    """Kernel-written budget the tool's `status` shows. Informational for the
+    author's planning only — enforcement stays in `budget_error`."""
+    d = workspace / SYSCALL_DIR
+    d.mkdir(exist_ok=True)
+    (d / "budget.json").write_text(
+        json.dumps({"launches_remaining": launches_remaining, "sleeps_remaining": sleeps_remaining})
+    )
 
 
 def budget_error(

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import shlex
 import sys
 from pathlib import Path
 
@@ -85,7 +86,11 @@ def _budget_line(root: Path) -> str:
 
 
 def cmd_launch(root: Path, args: argparse.Namespace) -> str:
-    command = " ".join(args.command).strip()
+    # shlex.join, NOT " ".join: the shell that invoked this CLI already split
+    # `-- python train.py --label "a b"` into tokens, so re-quote them so the
+    # eventual `sh -c "$(cat command.txt)"` re-parses the SAME tokens (a plain
+    # join would collapse `a b` into two args — terra #133 r1).
+    command = shlex.join(args.command).strip()
     if not command:
         raise ToolError("launch needs a command after `--`")
     if len(command) > MAX_COMMAND_CHARS:

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""The author's launch/sleep tool — the agent-facing surface for author
+syscalls (research-loop.md, "one syscall, author-directed").
+
+This file is STANDALONE by contract: the kernel copies its source into the
+sandbox at `.autoresearch/syscall` (the target repo does not have autoresearch
+installed), so it imports only the stdlib. The author calls it like a CLI and
+never hand-writes JSON:
+
+    python .autoresearch/syscall launch --name train --minutes 90 \\
+        --artifact results/curve.json -- uv run python train.py --lr 3e-4
+    python .autoresearch/syscall note "compare with the lr sweep"
+    python .autoresearch/syscall status
+    python .autoresearch/syscall sleep       # then END YOUR TURN to hibernate
+
+`launch`/`note` stage into `.autoresearch/request.json`; `sleep` commits the
+staged request to `.autoresearch/syscall.json` (the kernel ABI it reads after
+the session ends) — so building a request and committing to hibernate are
+separate acts, and an in-progress request never triggers a sleep. `sleep` with
+nothing staged is a checkpoint sleep (re-schedule me, fresh clock).
+
+The validation here is for FAST, IN-SESSION feedback only. The kernel
+re-validates every field authoritatively when it reads the ABI (syscall.py) —
+this tool is a convenience layer, never a trust boundary, so an author that
+writes the ABI directly is still fully checked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# Mirror of syscall.py's bounds for local feedback. syscall.py is authoritative;
+# keep these in sync (a drift only makes the tool's warning stale, never unsafe —
+# the kernel still enforces the real limits).
+DIR = ".autoresearch"
+REQUEST = "request.json"  # staging (tool-owned)
+ABI = "syscall.json"  # committed request the kernel reads
+BUDGET = "budget.json"  # kernel-written: remaining counts, for `status`
+MAX_LAUNCHES = 8
+MAX_COMMAND_CHARS = 2_000
+MAX_ARTIFACTS = 8
+MAX_NOTE_CHARS = 2_000
+MAX_LAUNCH_MINUTES = 240
+_NAME = re.compile(r"^[a-z0-9][a-z0-9-]{0,31}$")
+
+
+class ToolError(Exception):
+    """A bad invocation: printed to stderr, exit 2, nothing staged."""
+
+
+def _dir(root: Path) -> Path:
+    d = root / DIR
+    d.mkdir(exist_ok=True)
+    return d
+
+
+def _load_staged(root: Path) -> dict:
+    f = root / DIR / REQUEST
+    try:
+        data = json.loads(f.read_text())
+    except FileNotFoundError:
+        return {"launches": [], "note": ""}
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ToolError(f"staged request is unreadable ({exc}); run `cancel` to reset") from exc
+    return data
+
+
+def _save_staged(root: Path, data: dict) -> None:
+    (_dir(root) / REQUEST).write_text(json.dumps(data, indent=2))
+
+
+def _budget_line(root: Path) -> str:
+    try:
+        b = json.loads((root / DIR / BUDGET).read_text())
+        return (
+            f"budget: {b.get('launches_remaining', '?')} launches, "
+            f"{b.get('sleeps_remaining', '?')} sleeps remaining"
+        )
+    except (OSError, json.JSONDecodeError):
+        return "budget: (unknown)"
+
+
+def cmd_launch(root: Path, args: argparse.Namespace) -> str:
+    command = " ".join(args.command).strip()
+    if not command:
+        raise ToolError("launch needs a command after `--`")
+    if len(command) > MAX_COMMAND_CHARS:
+        raise ToolError(f"command exceeds {MAX_COMMAND_CHARS} chars")
+    if not _NAME.match(args.name):
+        raise ToolError(f"--name must match {_NAME.pattern}")
+    if args.minutes < 1:
+        raise ToolError("--minutes must be a positive integer")
+    minutes = min(args.minutes, MAX_LAUNCH_MINUTES)
+    if len(args.artifact) > MAX_ARTIFACTS:
+        raise ToolError(f"at most {MAX_ARTIFACTS} --artifact paths")
+    for a in args.artifact:
+        if a.startswith(("/", "~")) or ".." in a.split("/") or "\\" in a:
+            raise ToolError(f"--artifact {a!r} must be a repo-relative path, no traversal")
+    staged = _load_staged(root)
+    if any(la["name"] == args.name for la in staged["launches"]):
+        raise ToolError(f"a launch named {args.name!r} is already staged")
+    if len(staged["launches"]) >= MAX_LAUNCHES:
+        raise ToolError(f"at most {MAX_LAUNCHES} launches per sleep")
+    staged["launches"].append(
+        {"name": args.name, "command": command, "minutes": minutes, "artifacts": args.artifact}
+    )
+    _save_staged(root, staged)
+    return (
+        f"staged launch {args.name!r} ({minutes} min); {len(staged['launches'])} staged. "
+        f"Add more, or `sleep` to run them. {_budget_line(root)}."
+    )
+
+
+def cmd_note(root: Path, args: argparse.Namespace) -> str:
+    note = args.text
+    if len(note) > MAX_NOTE_CHARS:
+        raise ToolError(f"note exceeds {MAX_NOTE_CHARS} chars")
+    staged = _load_staged(root)
+    staged["note"] = note
+    _save_staged(root, staged)
+    return "note saved (delivered back to you on wake)."
+
+
+def cmd_status(root: Path, _args: argparse.Namespace) -> str:
+    staged = _load_staged(root)
+    lines = [f"{len(staged['launches'])} launch(es) staged; {_budget_line(root)}."]
+    for la in staged["launches"]:
+        arts = (" -> " + ", ".join(la["artifacts"])) if la.get("artifacts") else ""
+        lines.append(f"  - {la['name']} ({la['minutes']} min): {la['command']}{arts}")
+    if staged.get("note"):
+        lines.append(f"  note: {staged['note']}")
+    return "\n".join(lines)
+
+
+def cmd_cancel(root: Path, _args: argparse.Namespace) -> str:
+    (root / DIR / REQUEST).unlink(missing_ok=True)
+    return "staged request discarded."
+
+
+def cmd_sleep(root: Path, _args: argparse.Namespace) -> str:
+    staged = _load_staged(root)
+    # commit staging -> the ABI file the kernel reads; then END THE TURN.
+    (_dir(root) / ABI).write_text(json.dumps(staged))
+    (root / DIR / REQUEST).unlink(missing_ok=True)
+    n = len(staged["launches"])
+    what = f"{n} launch(es)" if n else "a checkpoint (no launches)"
+    return (
+        f"committed {what}. END YOUR TURN NOW to hibernate — you will be woken "
+        "with the results. (If you keep working, the sleep still triggers when "
+        "the session ends.)"
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="syscall", description="author launch/sleep tool")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    la = sub.add_parser("launch", help="stage a job to run outside the sandbox")
+    la.add_argument("--name", required=True, help="your handle for this job (a-z0-9-)")
+    la.add_argument("--minutes", type=int, default=30, help="walltime ask (clamped to 240)")
+    la.add_argument(
+        "--artifact",
+        action="append",
+        default=[],
+        help="repo-relative file to bring back (repeatable)",
+    )
+    la.add_argument("command", nargs=argparse.REMAINDER, help="-- then the command to run")
+    no = sub.add_parser("note", help="save a note to yourself, echoed back on wake")
+    no.add_argument("text")
+    sub.add_parser("status", help="show staged launches and remaining budget")
+    sub.add_parser("cancel", help="discard the staged request")
+    sub.add_parser("sleep", help="commit the staged request; then end your turn")
+    return p
+
+
+_HANDLERS = {
+    "launch": cmd_launch,
+    "note": cmd_note,
+    "status": cmd_status,
+    "cancel": cmd_cancel,
+    "sleep": cmd_sleep,
+}
+
+
+def main(argv: list[str], root: Path | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    # argparse REMAINDER keeps a leading "--"; drop it for a clean command
+    if getattr(args, "command", None) and args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    root = root or Path.cwd()
+    try:
+        print(_HANDLERS[args.cmd](root, args))
+        return 0
+    except ToolError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via main(argv) in tests
+    sys.exit(main(sys.argv[1:]))

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -53,6 +53,17 @@ class ToolError(Exception):
     """A bad invocation: printed to stderr, exit 2, nothing staged."""
 
 
+def _rel_path_ok(path: str) -> bool:
+    """MUST match syscall._rel_path_ok exactly — the CLI's fast check has to
+    accept precisely what the kernel accepts, or the author burns a sleep on a
+    post-session validation error (the very thing the tool exists to prevent).
+    Rejects absolute/`~`, backslashes, over-long, and any empty/`.`/`..`
+    component (so ``, `.`, `out/./x`, `out//x` all fail here as they do there)."""
+    if not path or len(path) > 500 or path.startswith(("/", "~")) or "\\" in path:
+        return False
+    return all(p not in ("", ".", "..") for p in path.split("/"))
+
+
 def _dir(root: Path) -> Path:
     d = root / DIR
     d.mkdir(exist_ok=True)
@@ -103,8 +114,8 @@ def cmd_launch(root: Path, args: argparse.Namespace) -> str:
     if len(args.artifact) > MAX_ARTIFACTS:
         raise ToolError(f"at most {MAX_ARTIFACTS} --artifact paths")
     for a in args.artifact:
-        if a.startswith(("/", "~")) or ".." in a.split("/") or "\\" in a:
-            raise ToolError(f"--artifact {a!r} must be a repo-relative path, no traversal")
+        if not _rel_path_ok(a):
+            raise ToolError(f"--artifact {a!r} must be a repo-relative file path, no traversal")
     staged = _load_staged(root)
     if any(la["name"] == args.name for la in staged["launches"]):
         raise ToolError(f"a launch named {args.name!r} is already staged")

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1781,6 +1781,13 @@ def test_author_sleep_live_parks_and_submits_launch_jobs(
     assert record.stage["syscall_note"] == "look at the tails"
     assert record.stage["launches_used"] == 1 and record.stage["sleeps_used"] == 1
     assert record.resume_session_id == "s1"  # the wake resumes the SAME session
+    # the agent-facing TOOL + its budget were installed into the channel dir
+    import json as _json
+
+    ws = tmp_path / "state" / "runs" / "tsp-1" / "ws"
+    assert (ws / ".autoresearch" / "syscall").exists()
+    budget = _json.loads((ws / ".autoresearch" / "budget.json").read_text())
+    assert budget == {"launches_remaining": 3, "sleeps_remaining": 4}
     # the job is the eval jail on the sealed tree; the author's command travels
     # via command.txt (never shell-interpolated into the script)
     ev = tmp_path / "state" / "runs" / "tsp-1" / "eval-launch-probe"

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1795,6 +1795,35 @@ def test_author_sleep_live_parks_and_submits_launch_jobs(
     assert "out/tails.json" in (ev / "job.sh").read_text()
 
 
+def test_symlinked_channel_disables_syscalls_and_never_writes_through_it(
+    tmp_path, monkeypatch
+) -> None:
+    # a target that commits `.autoresearch` as a SYMLINK to a host path must not
+    # get the tool/exclude/budget written THROUGH it (terra #133 r1): a
+    # pre-existing channel in any form disables the feature for the run.
+    monkeypatch.setenv("AUTORESEARCH_AUTHOR_SYSCALLS", "1")
+    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
+    target = _seed_target(tmp_path, monkeypatch, CONTRACT_SYSCALLS)
+    seed = tmp_path / "seed"
+    escape = tmp_path / "ESCAPE"
+    escape.mkdir()
+    (seed / ".autoresearch").symlink_to(escape, target_is_directory=True)
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "trap")
+    _git(seed, "push", "-q", str(tmp_path / "origin.git"), "main")
+
+    outcome, _ = run_live(
+        tmp_path,
+        target,
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'better'\n"},
+        values=[13.876, 13.1],
+        dispatch=_fake_dispatch(),
+    )
+    assert outcome.outcome == "improved"  # ran normally, feature off
+    # nothing was written through the symlink to the escape dir
+    assert list(escape.iterdir()) == []
+
+
 def test_tracked_request_file_disables_syscalls_for_the_run(tmp_path, monkeypatch) -> None:
     # a target repo that COMMITS a valid syscall.json must not consume cluster
     # compute: a request is only honored if the session wrote it, so a

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -1,0 +1,126 @@
+"""The author's launch/sleep TOOL — the agent-facing surface. The JSON file is
+the internal ABI; the author drives everything through this CLI, so these tests
+call `main(argv, root)` exactly as a Bash invocation would."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from autoresearch.syscall import read_request
+from autoresearch.syscall_cli import main
+
+
+def run(tmp: Path, *argv: str, capsys=None) -> int:
+    return main(list(argv), root=tmp)
+
+
+def test_launch_then_sleep_commits_the_abi(tmp_path: Path, capsys) -> None:
+    assert (
+        run(
+            tmp_path,
+            "launch",
+            "--name",
+            "train-lr3",
+            "--minutes",
+            "90",
+            "--artifact",
+            "results/curve.json",
+            "--",
+            "uv",
+            "run",
+            "python",
+            "train.py",
+            "--lr",
+            "3e-4",
+        )
+        == 0
+    )
+    out = capsys.readouterr().out
+    assert "staged launch 'train-lr3'" in out and "1 staged" in out
+    assert run(tmp_path, "sleep") == 0
+    assert "END YOUR TURN" in capsys.readouterr().out
+    # the committed ABI parses through the KERNEL's authoritative reader
+    req = read_request(tmp_path)
+    assert req is not None
+    assert req.launches[0].name == "train-lr3"
+    assert req.launches[0].command == "uv run python train.py --lr 3e-4"
+    assert req.launches[0].minutes == 90
+    assert req.launches[0].artifacts == ("results/curve.json",)
+    # staging is cleared by the commit
+    assert not (tmp_path / ".autoresearch" / "request.json").exists()
+
+
+def test_note_and_status_and_cancel(tmp_path: Path, capsys) -> None:
+    run(tmp_path, "launch", "--name", "probe", "--", "echo", "hi")
+    run(tmp_path, "note", "check the tails first")
+    capsys.readouterr()
+    assert run(tmp_path, "status") == 0
+    out = capsys.readouterr().out
+    assert "1 launch(es) staged" in out and "probe" in out and "check the tails" in out
+    assert run(tmp_path, "cancel") == 0
+    capsys.readouterr()
+    run(tmp_path, "status")
+    assert "0 launch(es) staged" in capsys.readouterr().out
+
+
+def test_validation_fails_fast_in_session(tmp_path: Path, capsys) -> None:
+    # the whole point of the tool: bad input fails IMMEDIATELY with a message,
+    # instead of becoming a burned post-sleep session-error.
+    cases = [
+        (["launch", "--name", "UPPER", "--", "x"], "--name"),
+        (["launch", "--name", "ok"], "needs a command"),
+        (["launch", "--name", "ok", "--artifact", "../pw", "--", "x"], "repo-relative"),
+        (["launch", "--name", "ok", "--minutes", "0", "--", "x"], "positive"),
+        (["note", "x" * 2001], "exceeds"),
+    ]
+    for argv, needle in cases:
+        assert run(tmp_path, *argv) == 2
+        err = capsys.readouterr().err
+        assert needle in err, (argv, err)
+    # duplicate staged name
+    assert run(tmp_path, "launch", "--name", "a", "--", "x") == 0
+    assert run(tmp_path, "launch", "--name", "a", "--", "y") == 2
+    assert "already staged" in capsys.readouterr().err
+
+
+def test_sleep_with_nothing_staged_is_a_checkpoint(tmp_path: Path, capsys) -> None:
+    assert run(tmp_path, "sleep") == 0
+    assert "checkpoint" in capsys.readouterr().out
+    req = read_request(tmp_path)
+    assert req is not None and req.launches == ()
+
+
+def test_status_shows_the_kernel_written_budget(tmp_path: Path, capsys) -> None:
+    from autoresearch.syscall import write_budget
+
+    write_budget(tmp_path, launches_remaining=3, sleeps_remaining=4)
+    run(tmp_path, "status")
+    assert "3 launches, 4 sleeps remaining" in capsys.readouterr().out
+
+
+def test_installed_tool_is_standalone(tmp_path: Path) -> None:
+    """The kernel copies the tool into a sandbox WITHOUT autoresearch
+    installed — prove the copy runs under a bare interpreter (isolated mode:
+    no site-packages, no cwd on sys.path)."""
+    from autoresearch.syscall import install_tool
+
+    install_tool(tmp_path)
+    tool = tmp_path / ".autoresearch" / "syscall"
+    assert tool.exists()
+    r = subprocess.run(
+        [sys.executable, "-I", str(tool), "launch", "--name", "solo", "--", "echo", "ok"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert "staged launch 'solo'" in r.stdout
+    r = subprocess.run(
+        [sys.executable, "-I", str(tool), "sleep"], cwd=tmp_path, capture_output=True, text=True
+    )
+    assert r.returncode == 0 and "END YOUR TURN" in r.stdout
+    abi = json.loads((tmp_path / ".autoresearch" / "syscall.json").read_text())
+    assert abi["launches"][0]["name"] == "solo"

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -53,6 +53,37 @@ def test_launch_then_sleep_commits_the_abi(tmp_path: Path, capsys) -> None:
     assert not (tmp_path / ".autoresearch" / "request.json").exists()
 
 
+def test_quoted_command_args_survive_to_the_abi(tmp_path: Path, capsys) -> None:
+    # a shell that invoked the CLI split `--label "a b"` into tokens; the tool
+    # must re-quote so the eventual sh -c re-parses the SAME tokens, not two
+    # (terra #133 r1). Round-trips through the kernel's authoritative reader.
+    run(
+        tmp_path,
+        "launch",
+        "--name",
+        "q",
+        "--",
+        "python",
+        "t.py",
+        "--label",
+        "a b",
+        "--flag=x y",
+    )
+    run(tmp_path, "sleep")
+    req = read_request(tmp_path)
+    assert req is not None
+    # shlex round-trip: the command re-splits into exactly the original tokens
+    import shlex as _shlex
+
+    assert _shlex.split(req.launches[0].command) == [
+        "python",
+        "t.py",
+        "--label",
+        "a b",
+        "--flag=x y",
+    ]
+
+
 def test_note_and_status_and_cancel(tmp_path: Path, capsys) -> None:
     run(tmp_path, "launch", "--name", "probe", "--", "echo", "hi")
     run(tmp_path, "note", "check the tails first")

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -117,6 +117,21 @@ def test_validation_fails_fast_in_session(tmp_path: Path, capsys) -> None:
     assert "already staged" in capsys.readouterr().err
 
 
+def test_artifact_path_check_matches_the_kernel(tmp_path: Path, capsys) -> None:
+    # the tool's fast check must accept EXACTLY what the kernel accepts, or the
+    # author burns a sleep on a post-session error (terra #133 r2). Cross-check
+    # each tricky path against both validators.
+    from autoresearch.syscall import _rel_path_ok as kernel_ok
+
+    cases = ["out/x.json", "", ".", "out/./x", "out//x", "../x", "/abs", "~/x", "a\\b"]
+    for path in cases:
+        rc = run(tmp_path, "launch", "--name", "a", "--artifact", path, "--", "echo", "hi")
+        run(tmp_path, "cancel")
+        capsys.readouterr()
+        tool_ok = rc == 0
+        assert tool_ok == kernel_ok(path), (path, tool_ok, kernel_ok(path))
+
+
 def test_sleep_with_nothing_staged_is_a_checkpoint(tmp_path: Path, capsys) -> None:
     assert run(tmp_path, "sleep") == 0
     assert "checkpoint" in capsys.readouterr().out


### PR DESCRIPTION
## What

The author's interface for launch/sleep is now a **tool**, not hand-written JSON (your 2026-08-24 redirect). `.autoresearch/syscall.json` becomes an **internal ABI**; the agent drives everything through a CLI:

```
python .autoresearch/syscall launch --name train --minutes 90 \
    --artifact results/curve.json -- uv run python train.py --lr 3e-4
python .autoresearch/syscall note "compare with the lr sweep"
python .autoresearch/syscall status        # staged launches + remaining budget
python .autoresearch/syscall sleep         # commit, then end the turn
```

- **`syscall_cli.py`** — standalone by contract (stdlib-only; the kernel copies its source into the sandbox, since the target repo has no autoresearch). `launch`/`note` stage into `request.json`; `sleep` commits to `syscall.json` (the ABI). Building a request and committing to hibernate are separate acts — an in-progress request never triggers a sleep; `sleep` with nothing staged is a checkpoint.
- **The win over raw JSON: interactive validation.** Bad `--name`/`--minutes`/`--artifact`/command fail *in-session* immediately, instead of becoming a burned post-sleep `session-error`.
- **Not a trust boundary.** `syscall.py`'s `read_request` stays the authoritative validator — an author that writes the ABI directly is still fully checked. The tool is pure UX.
- Kernel side: `install_tool()` + `write_budget()` run in `live_climb`'s armed block. Still fully dark behind the `AUTHOR_SLEEP_WAKE_READY` interlock (the wake is the next PR).

## Test plan

- Full CLI surface via `main(argv)`: stage → commit → ABI parses through the *kernel* reader; note/status/cancel; checkpoint sleep; validation-fails-fast (5 cases) + duplicate-name.
- A `python -I` run of the **installed** copy — proves it's standalone under a bare interpreter (no site-packages), exactly like the sandbox.
- The armed live climb test now asserts the tool + budget land in the channel dir.
- Full suite 743 green; ruff + mypy green.

## No secrets / no large files

Confirmed.
