### PR TITLE
Author syscalls part 2: the wake — Phase A complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Author syscalls, part 2 — the WAKE (research-loop-buildout.md Phase A is
+  complete; `AUTHOR_SLEEP_WAKE_READY` is flipped, so setting
+  `AUTORESEARCH_AUTHOR_SYSCALLS` now enables the whole loop end to end):
+  `resume_run` services `author-sleep` parks — each launch's job output (exit
+  code, stdout/stderr tails) and its declared artifacts are delivered into the
+  sandbox (`.autoresearch/results/<name>/`), and the SAME session is resumed
+  through the climb's resume-entry with the results data-fenced, the author's
+  own note echoed back, and the remaining budgets. The woken session may launch
+  again (a fresh author-sleep park, counts advanced) or finish — its gate
+  measures through the dispatched backend and parks the run as a CANDIDATE,
+  which the existing wake path (panel, sealed-sha publish) decides. A wake that
+  cannot resume (no author harness / no session id / a no-resume backend) ends
+  the run with a named `session-error`, never a stuck WAITING loop. The brief
+  now advertises the launch/sleep tool (with this run's budgets) exactly when
+  it is wired, and the wake CLI builds the author harness for author-sleep
+  parks even when no panel is configured.
+
 - Author syscalls, part 1 — the SLEEP side (docs/design/research-loop-buildout.md,
   Phase A; fully dark: enabling needs BOTH `AUTORESEARCH_AUTHOR_SYSCALLS` and the
   part-2 wake, which flips `AUTHOR_SLEEP_WAKE_READY` — arming the flag alone

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -69,6 +69,11 @@ class SessionBrief:
     recent_reports: tuple[str, ...]  # newest first, already bounded
     budget: BudgetState
     created: str  # ISO timestamp, supplied by the caller (builder stays pure)
+    # Author-syscall budgets (research-loop.md, "one syscall"): >0 advertises the
+    # launch/sleep tool to the author; 0 (the default) means the feature is off
+    # for this run and the brief never mentions it.
+    launch_budget: int = 0
+    sleep_budget: int = 0
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
@@ -84,6 +89,8 @@ class SessionBrief:
             recent_reports=tuple(data["recent_reports"]),
             budget=BudgetState(**data["budget"]),
             created=data["created"],
+            launch_budget=data.get("launch_budget", 0),
+            sleep_budget=data.get("sleep_budget", 0),
         )
 
 
@@ -97,6 +104,8 @@ class BriefInputs:
     lessons: str = ""
     recent_reports: tuple[str, ...] = field(default_factory=tuple)
     budget: BudgetState = field(default_factory=lambda: BudgetState(0.0, 0))
+    launch_budget: int = 0  # author-syscall budgets; 0 = feature off (no mention)
+    sleep_budget: int = 0
 
 
 def _cap(text: str, limit: int) -> str:
@@ -128,6 +137,8 @@ def build_brief(inputs: BriefInputs, created: str) -> SessionBrief:
         recent_reports=reports,
         budget=inputs.budget,
         created=created,
+        launch_budget=inputs.launch_budget,
+        sleep_budget=inputs.sleep_budget,
     )
 
 
@@ -207,6 +218,34 @@ def render(brief: SessionBrief) -> str:
         "# Budget",
         f"GPU-hours remaining: {brief.budget.gpu_hours_remaining}",
         f"Runs remaining this week: {brief.budget.runs_remaining_this_week}",
+    ]
+    if brief.launch_budget > 0:
+        # The launch/sleep tool is offered this run (research-loop.md): the
+        # author can run experiments OUTSIDE the sandbox and sleep for results.
+        parts += [
+            "",
+            "# Running experiments (the launch/sleep tool)",
+            "You are in a sandbox; heavier work (training, longer evals, "
+            "anything that will not finish inside this session) runs OUTSIDE "
+            "it. To run something and get its result, use the tool, then END "
+            "YOUR TURN — you will be woken in this same session with the "
+            "output and any artifacts delivered under .autoresearch/results/:",
+            "",
+            "    python .autoresearch/syscall launch --name <handle> "
+            "--minutes <N> --artifact <repo-relative file> -- <command>",
+            "    python .autoresearch/syscall sleep",
+            "",
+            "`status` shows staged launches and remaining budget; `note ...` "
+            "leaves a reminder echoed back to you on wake. Bad arguments fail "
+            "immediately — fix and retry before sleeping. You may launch "
+            "several jobs before one sleep, and after a wake you can launch "
+            "more, revise, or finish. Budgets this run: "
+            f"{brief.launch_budget} experiment launches, {brief.sleep_budget} "
+            "sleeps (a `sleep` with nothing staged is a checkpoint that "
+            "refreshes your session clock and costs one sleep). Spend them as "
+            "your judgment says; they are generous, not a target to exhaust.",
+        ]
+    parts += [
         "",
         "# Ground rules",
         "Work only within the contract's allowed paths. One hypothesis, one "

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -22,7 +22,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
-from autoresearch.contract import load_contract
+from autoresearch.contract import Benchmark, Contract, load_contract
 from autoresearch.dispatch import (
     Snapshot,
     afterany_ids,
@@ -41,6 +41,7 @@ from autoresearch.measure import DispatchSettings, LocalMeasurer
 from autoresearch.orchestrator import (
     ClimbConfig,
     ClimbParked,
+    ClimbResult,
     EvalError,
     Evaluator,
     Measurer,
@@ -294,7 +295,7 @@ PARK_QUEUE_SLACK_MIN = 12 * 60
 # part 2. Until part 2 flips this, arming AUTORESEARCH_AUTHOR_SYSCALLS alone
 # must not produce an unwakeable author-sleep park (terra, #132 r5) — the
 # feature stays off, loudly.
-AUTHOR_SLEEP_WAKE_READY = False
+AUTHOR_SLEEP_WAKE_READY = True  # Phase A part 2 shipped: the wake services author-sleep parks
 
 
 def _park_run(
@@ -403,6 +404,293 @@ def _park_run(
     save_record(run_root, waiting, now)
 
 
+def _make_launcher(dispatch: DispatchSettings, run_dir: Path, workspace: Path, run_id: str):
+    """The launch side of the author syscalls, shared by the first pass
+    (live_climb) and the author-sleep wake: each launch becomes a jailed job on
+    the sealed snapshot (write_eval_job's copy-out handles artifacts), and a
+    partially-submitted batch is reaped rather than orphaned."""
+
+    def launcher(sha: str, request: SyscallRequest) -> str:
+        from autoresearch.dispatch import eval_job_spec, write_eval_job
+
+        ids: list[str] = []
+        try:
+            for launch in request.launches:
+                script = write_eval_job(
+                    run_dir,
+                    f"launch-{launch.name}",
+                    repo_root=workspace,
+                    snapshot_sha=sha,
+                    command=launch.command,
+                    image=dispatch.image,
+                    artifacts=launch.artifacts,
+                    artifact_max_bytes=MAX_ARTIFACT_BYTES,
+                )
+                ids.append(
+                    dispatch.compute.submit(
+                        eval_job_spec(
+                            script,
+                            job_name=f"{run_id}-launch-{launch.name}",
+                            account=dispatch.account,
+                            partition=dispatch.partition,
+                            eval_minutes=launch.minutes,
+                        )
+                    )
+                )
+        except Exception:
+            # a partial batch must not orphan: no park record was written yet,
+            # so nothing would ever wake or cancel the jobs that DID submit —
+            # reap them here, then let the caller end the run as the error it
+            # is (same stance as the failed-_park_run cancel).
+            for job_id in ids:
+                with contextlib.suppress(Exception):
+                    dispatch.compute.cancel(job_id)
+            raise
+        # a checkpoint sleep (no launches) parks with no dependency and wakes
+        # on the sweep's deadline floor — slow but correct; a fast requeue wake
+        # is a follow-up.
+        return "afterany:" + ":".join(ids) if ids else ""
+
+    return launcher
+
+
+def _wake_author_sleep(
+    *,
+    run_root: Path,
+    run_id: str,
+    record: RunRecord,
+    ws: Workspace,
+    workspace: Path,
+    run_dir: Path,
+    dispatch: DispatchSettings,
+    github: GitHubClient,
+    now: float,
+    secrets: tuple[str, ...],
+    base_branch: str,
+    base_sha: str,
+    sleep_ref: str,
+    contract_text: str,
+    contract: Contract,
+    bench: Benchmark,
+    config: ClimbConfig,
+    measurer: Measurer,
+    harness: Harness | None,
+    spec: RoleSpec | None,
+    panel_lenses: tuple[PanelLens, ...],
+    panel_revisions: int,
+    issue_number: int,
+    eval_minutes: int | None,
+) -> LiveClimbOutcome:
+    """Wake an author-sleep park: deliver the launches' results into the
+    sandbox, resume the SAME session through the climb's resume-entry with them
+    (data-fenced), and let the climb run — it may sleep again (re-park), finish
+    into the gate (whose dispatched measures park it as a CANDIDATE the next
+    wake decides), or end on a terminal. The session's workspace persisted on
+    disk exactly as the author left it (the launches ran on node-local
+    checkouts of the sealed sha), so the resumed session continues its own tree
+    — cumulative depth.
+    """
+    from autoresearch.syscall import Launch as SyscallLaunch
+    from autoresearch.syscall import gather_results, render_wake, write_budget
+
+    def _end(result: ClimbResult, drop_refs: list[str]) -> LiveClimbOutcome:
+        # a terminal from the resumed climb: report, ending record, issue note —
+        # the same ending shape every other terminal takes.
+        for ref in drop_refs:
+            drop_snapshot(ws, Snapshot(commit="", tree="", ref=ref))
+        report_path = run_dir / "report.md"
+        _best_effort(
+            "run report",
+            lambda: report_path.write_text(result.report(config, redact_secrets=secrets)),
+            secrets,
+        )
+        ending = _ENDINGS_BY_OUTCOME.get(result.outcome, ABORTED)
+        final = _clear_stage(
+            RunRecord(
+                **{
+                    **record.__dict__,
+                    "state": ENDED,
+                    "ending": ending,
+                    "ending_note": redact(result.note, secrets),
+                }
+            )
+        )
+        _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
+        _post_issue_finished(
+            github,
+            config.target,
+            issue_number,
+            run_id,
+            result.outcome,
+            "",
+            redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
+            secrets,
+        )
+        return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
+
+    # The wake NEEDS the author harness (it resumes the session). Fail as a
+    # named ending, not a crash: the run cannot proceed and re-waking will not
+    # help without the harness, so leaving it WAITING would just hit the stuck
+    # cap slowly.
+    if (
+        harness is None
+        or spec is None
+        or not record.resume_session_id
+        or not getattr(harness, "supports_resume", True)
+    ):
+        return _end(
+            ClimbResult(
+                outcome="session-error",
+                note="author-sleep wake needs the author harness/spec and a resumable session",
+            ),
+            drop_refs=[sleep_ref],
+        )
+
+    # Deliver: read each launch's job output, copy declared artifacts into the
+    # excluded channel, and render the data-fenced wake text. The stage stores
+    # only what the wake needs (names + artifacts); command/minutes placeholders
+    # never reach the author.
+    launches = tuple(
+        SyscallLaunch(
+            name=str(item.get("name", "")),
+            command="(ran)",
+            minutes=1,
+            artifacts=tuple(str(a) for a in item.get("artifacts", [])),
+        )
+        for item in _stage_launches(record)
+    )
+    results = gather_results(run_dir, workspace, launches)
+    launches_used = int(record.stage.get("launches_used", 0))  # type: ignore[call-overload]
+    sleeps_used = int(record.stage.get("sleeps_used", 0))  # type: ignore[call-overload]
+    wake_text = render_wake(
+        results,
+        str(record.stage.get("syscall_note", "")),
+        launches_used=launches_used,
+        launch_budget=bench.depth_k,
+        sleeps_used=sleeps_used,
+        sleep_budget=bench.sleep_k,
+    )
+    _best_effort(
+        "budget refresh",
+        lambda: write_budget(
+            workspace,
+            launches_remaining=max(0, bench.depth_k - launches_used),
+            sleeps_remaining=max(0, bench.sleep_k - sleeps_used),
+        ),
+    )
+
+    # The wake's climb IO: measures go through the DISPATCHED measurer (this is
+    # a wake job with bounded walltime — the gate's evals run as their own jobs
+    # and park the run as a CANDIDATE), snapshots parent on base (same as the
+    # first pass: the clone was at base), and changed_paths carries no
+    # fingerprints (only the live inline publish needs them; every publish from
+    # here is the sealed-sha wake publish).
+    snapshots: list[Snapshot] = []
+
+    def snapshot() -> str:
+        snap = snapshot_tree(ws, base_sha)
+        if isinstance(measurer, LocalMeasurer):  # pragma: no cover - wake is dispatched
+            measurer.live[snap.commit] = workspace
+        snapshots.append(snap)
+        return snap.commit
+
+    def changed_paths() -> list[str]:
+        ws.git("add", "-A")
+        paths = ws.staged_paths()
+        ws.git("reset")
+        return paths
+
+    panel_runner = (
+        build_panel_runner(
+            ws,
+            run_dir,
+            base_sha,
+            panel_lenses,
+            contract_text,
+            config.target,
+            config.benchmark,
+            config.bot_login,
+            _utc_date(now),
+        )
+        if panel_lenses
+        else None
+    )
+
+    parked: ClimbParked | None = None
+    kept_ref = ""
+    try:
+        result = climb_once(
+            config,
+            contract_text,
+            workspace,
+            harness,
+            measurer,
+            base_sha,
+            snapshot,
+            ruler=RULER,
+            changed_paths=changed_paths,
+            spec=spec,
+            panel_runner=panel_runner,
+            panel_revisions=panel_revisions,
+            resume_session_id=record.resume_session_id,
+            improve_prompt=wake_text,
+            launcher=_make_launcher(dispatch, run_dir, workspace, run_id),
+            launches_used=launches_used,
+            sleeps_used=sleeps_used,
+        )
+    except ClimbParked as p:
+        # slept again, or the gate dispatched its measures (a candidate park the
+        # existing wake path decides). Keep the NEW park's snapshot ref; the OLD
+        # sleep ref is superseded once the new park persists.
+        kept_ref = next((s.ref for s in snapshots if s.commit == p.candidate_sha), "")
+        import time
+
+        try:
+            _park_run(
+                run_root,
+                record,
+                p,
+                kept_ref,
+                eval_minutes,
+                time.time(),
+                secrets,
+                base_branch=base_branch,
+            )
+        except Exception:
+            for job_id in afterany_ids(p.afterany):
+                dispatch.compute.cancel(job_id)
+            raise
+        parked = p
+        drop_snapshot(ws, Snapshot(commit="", tree="", ref=sleep_ref))
+        return LiveClimbOutcome(run_id=run_id, outcome="parked")
+    finally:
+        for snap in snapshots:
+            if parked and kept_ref and snap.ref == kept_ref:
+                continue
+            drop_snapshot(ws, snap)
+
+    # a terminal from the resumed session (session-error/-outage/-budget,
+    # scope-violation, eval-error; a dispatched gate never returns improved
+    # inline): end the run and release the sleep snapshot.
+    return _end(result, drop_refs=[sleep_ref])
+
+
+def _stage_launches(record: RunRecord) -> list[dict]:
+    """The persisted launch descriptors of an author-sleep stage (name +
+    artifacts), tolerating a malformed entry by skipping it (the job dirs are
+    keyed by name; a nameless entry has nothing to gather)."""
+    raw = record.stage.get("syscall_launches", [])
+    if not isinstance(raw, list):
+        return []
+    return [item for item in raw if isinstance(item, dict) and item.get("name")]
+
+
+def _utc_date(now: float) -> str:
+    from datetime import UTC, datetime
+
+    return datetime.fromtimestamp(now, UTC).strftime("%Y-%m-%d")
+
+
 def resume_run(
     run_root: Path,
     run_id: str,
@@ -446,16 +734,12 @@ def resume_run(
     # instead of reading `remote.origin.url`.
     ws = Workspace(root=workspace, auth=bot_auth, url=_target_clone_url(record.target))
 
-    # Every dispatched park is a CANDIDATE park (the baseline is measured by the
-    # gate after the session, not before it), so a candidate sha must be
-    # present. Guard rather than crash on `git diff base ""` if a stray
-    # baseline-shaped record ever reached here.
-    if stage.get("phase") != "candidate" or not stage.get("candidate_sha"):
-        # an "author-sleep" park lands here until the wake side (Phase A part 2:
-        # gather launch results, resume the session via the climb's resume-entry)
-        # exists — loud, so arming AUTORESEARCH_AUTHOR_SYSCALLS before part 2 is
-        # an operator error the record names rather than a silent hang.
-        raise EvalError(f"resume_run: run {run_id} is not a candidate park (stage={stage!r})")
+    # Two park kinds reach the wake: a CANDIDATE park (the gate's measures were
+    # dispatched) and an AUTHOR-SLEEP park (the author launched work and slept —
+    # research-loop-buildout.md Phase A). Both carry a sealed sha. Anything else
+    # is a stray record: guard rather than crash on `git diff base ""`.
+    if stage.get("phase") not in ("candidate", "author-sleep") or not stage.get("candidate_sha"):
+        raise EvalError(f"resume_run: run {run_id} is not a wakeable park (stage={stage!r})")
 
     base_sha = str(stage["base_sha"])
     candidate_sha = str(stage["candidate_sha"])
@@ -490,6 +774,39 @@ def resume_run(
     seed = int(stage["seed"])  # type: ignore[call-overload]
     suite_seed = int(stage["suite_seed"])  # type: ignore[call-overload]
     panel_reads = int(stage.get("panel_reads", 0))  # type: ignore[call-overload]
+
+    if stage.get("phase") == "author-sleep":
+        # The author slept on launches: deliver their results and RESUME the
+        # same session through the climb's resume-entry. Every exit is a park
+        # (slept again, or the gate dispatched its measures -> a candidate park
+        # the NEXT wake decides through the path below) or a terminal ending —
+        # never a publish, so the publish tail stays candidate-only.
+        return _wake_author_sleep(
+            run_root=run_root,
+            run_id=run_id,
+            record=record,
+            ws=ws,
+            workspace=workspace,
+            run_dir=run_dir,
+            dispatch=dispatch,
+            github=github,
+            now=now,
+            secrets=secrets,
+            base_branch=base_branch,
+            base_sha=base_sha,
+            sleep_ref=candidate_ref,
+            contract_text=contract_text,
+            contract=contract,
+            bench=bench,
+            config=config,
+            measurer=measurer,
+            harness=harness,
+            spec=spec,
+            panel_lenses=panel_lenses,
+            panel_revisions=panel_revisions,
+            issue_number=issue_number,
+            eval_minutes=eval_minutes,
+        )
 
     # rebuild the session from what the park saved: the (redacted) write-up and
     # its real spend, so the report shows true cost/turns. It is never re-run.
@@ -1461,54 +1778,12 @@ def live_climb(
         # offered only when the operator arms AUTORESEARCH_AUTHOR_SYSCALLS, the
         # dispatcher has cluster coordinates (the launches are Slurm jobs), and
         # the backend can resume (the wake resumes the SAME session).
-        launcher = None
         # `author_syscalls` already reflects the channel-ownership guard above
         # (a target-shipped `.autoresearch` — symlink, tracked request, or any
         # other pre-existing form — has disabled the feature for this run).
+        launcher = None
         if author_syscalls and dispatch is not None and getattr(harness, "supports_resume", True):
-
-            def launcher(sha: str, request: SyscallRequest) -> str:
-                from autoresearch.dispatch import eval_job_spec, write_eval_job
-
-                assert dispatch is not None
-                ids: list[str] = []
-                try:
-                    for launch in request.launches:
-                        script = write_eval_job(
-                            run_dir,
-                            f"launch-{launch.name}",
-                            repo_root=workspace,
-                            snapshot_sha=sha,
-                            command=launch.command,
-                            image=dispatch.image,
-                            artifacts=launch.artifacts,
-                            artifact_max_bytes=MAX_ARTIFACT_BYTES,
-                        )
-                        ids.append(
-                            dispatch.compute.submit(
-                                eval_job_spec(
-                                    script,
-                                    job_name=f"{run_id}-launch-{launch.name}",
-                                    account=dispatch.account,
-                                    partition=dispatch.partition,
-                                    eval_minutes=launch.minutes,
-                                )
-                            )
-                        )
-                except Exception:
-                    # a partial batch must not orphan: no park record was
-                    # written yet, so nothing would ever wake or cancel the
-                    # jobs that DID submit — reap them here, then let the
-                    # outer handler end the run as the error it is (same
-                    # stance as the failed-_park_run cancel below).
-                    for job_id in ids:
-                        with contextlib.suppress(Exception):
-                            dispatch.compute.cancel(job_id)
-                    raise
-                # a checkpoint sleep (no launches) parks with no dependency and
-                # wakes on the sweep's deadline floor — slow but correct; a
-                # fast requeue wake is a Phase A follow-up.
-                return "afterany:" + ":".join(ids) if ids else ""
+            launcher = _make_launcher(dispatch, run_dir, workspace, run_id)
 
         parked: ClimbParked | None = None
         kept_ref = ""  # the ONE candidate snapshot ref that must outlive a park
@@ -2275,11 +2550,13 @@ def main() -> int:
         wake_api_key = ""
         wake_harness = None
         wake_spec = None
-        # The editor harness for the depth-axis REVISION is built ONLY when a
-        # panel is configured — no panel means no blocking finding, so no
-        # revision and no author key to read. A panel-less wake stays a pure
+        # The editor harness is built when the wake may RESUME the session: a
+        # panel is configured (a blocking finding wakes the author to revise),
+        # or the park is an AUTHOR-SLEEP (that wake always resumes the session
+        # with its launches' results). A panel-less candidate wake stays a pure
         # read-decide-publish job and must not require the author key.
-        if wake_lenses:
+        _wake_stage = getattr(_wake_record, "stage", None) or {}
+        if wake_lenses or _wake_stage.get("phase") == "author-sleep":
             wake_panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
             wake_api_key = FileTokenProvider(Path(wake_key_file)).token()
             wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -2556,8 +2556,12 @@ def main() -> int:
         # with its launches' results). A panel-less candidate wake stays a pure
         # read-decide-publish job and must not require the author key.
         _wake_stage = getattr(_wake_record, "stage", None) or {}
-        if wake_lenses or _wake_stage.get("phase") == "author-sleep":
+        if wake_lenses:
+            # the panel's judges need the verifier key; an author-sleep wake
+            # alone does NOT — a panel-less deployment must not be forced to
+            # provision an unused credential (terra, #135 r1).
             wake_panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+        if wake_lenses or _wake_stage.get("phase") == "author-sleep":
             wake_api_key = FileTokenProvider(Path(wake_key_file)).token()
             wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
             wake_harness = build_editor_harness(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1128,6 +1128,10 @@ def climb_once(
                 lessons=lessons,
                 recent_reports=recent_reports,
                 budget=config.budget,
+                # the launch/sleep tool is advertised ONLY when it is wired
+                # (never a tool the author cannot actually call)
+                launch_budget=bench.depth_k if launcher is not None else 0,
+                sleep_budget=bench.sleep_k if launcher is not None else 0,
             ),
             created=created,
         )

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -275,8 +275,8 @@ def gather_results(
             exit_code: int | None = int((ev / "exit-code").read_text().strip())
         except (OSError, ValueError):
             exit_code = None
-        stdout = _read_text(ev / "stdout")
-        stderr = _read_text(ev / "stderr")
+        stdout = _read_tail(ev / "stdout", MAX_OUTPUT_CHARS)
+        stderr = _read_tail(ev / "stderr", MAX_OUTPUT_CHARS)
         skipped = tuple(ln for ln in _read_text(ev / "artifacts.log").splitlines() if ln.strip())
 
         dest = workspace / SYSCALL_DIR / RESULTS_SUBDIR / launch.name
@@ -294,8 +294,8 @@ def gather_results(
             LaunchResult(
                 name=launch.name,
                 exit_code=exit_code,
-                stdout_tail=_tail(stdout),
-                stderr_tail=_tail(stderr),
+                stdout_tail=stdout,
+                stderr_tail=stderr,
                 delivered=tuple(delivered),
                 skipped=skipped,
             )
@@ -303,11 +303,34 @@ def gather_results(
     return tuple(results)
 
 
-def _read_text(path: Path) -> str:
+def _read_text(path: Path, cap: int = 65_536) -> str:
+    """A bounded head-read for kernel-shaped files (artifacts.log lines are
+    written by our own job script, bounded by construction — the cap is a
+    backstop, never load-the-world)."""
     try:
-        return path.read_text(errors="replace")
+        with path.open("rb") as fh:
+            return fh.read(cap).decode("utf-8", "replace")
     except OSError:
         return ""
+
+
+def _read_tail(path: Path, max_chars: int) -> str:
+    """Read only the trailing bytes needed for `max_chars` — NEVER the whole
+    file. Launch stdout/stderr is agent-controlled and can be arbitrarily large;
+    loading it before truncating could exhaust the wake process
+    (terra, #135 r1). 4 bytes/char covers the UTF-8 worst case; a codepoint cut
+    at the window edge decodes as a replacement character, which is fine for a
+    tail."""
+    budget = max_chars * 4
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, 2)
+            size = fh.tell()
+            fh.seek(max(0, size - budget))
+            data = fh.read(budget)
+    except OSError:
+        return ""
+    return data.decode("utf-8", "replace")[-max_chars:]
 
 
 def _tail(text: str) -> str:

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -265,9 +265,7 @@ def gather_results(
     the author reads them there. A missing exit-code file means the job died
     before its wrapper ran (infra failure) — surfaced as `exit_code=None`, never
     a silent skip. The job-side copy-out already enforced containment (realpath,
-    size cap), so delivery here is a plain in-channel copy."""
-    import shutil
-
+    size cap); `_deliver_artifacts` guards the destination side."""
     results: list[LaunchResult] = []
     for launch in launches:
         ev = run_dir / f"eval-launch-{launch.name}"
@@ -279,28 +277,65 @@ def gather_results(
         stderr = _read_tail(ev / "stderr", MAX_OUTPUT_CHARS)
         skipped = tuple(ln for ln in _read_text(ev / "artifacts.log").splitlines() if ln.strip())
 
-        dest = workspace / SYSCALL_DIR / RESULTS_SUBDIR / launch.name
-        delivered: list[str] = []
-        src = ev / "artifacts"
-        if src.is_dir():
-            for f in sorted(p for p in src.rglob("*") if p.is_file()):
-                rel = f.relative_to(src)
-                out = dest / rel
-                out.parent.mkdir(parents=True, exist_ok=True)
-                with contextlib.suppress(OSError):
-                    shutil.copy(f, out)
-                    delivered.append(str(Path(SYSCALL_DIR) / RESULTS_SUBDIR / launch.name / rel))
+        delivered, skips = _deliver_artifacts(ev / "artifacts", workspace, launch.name)
         results.append(
             LaunchResult(
                 name=launch.name,
                 exit_code=exit_code,
                 stdout_tail=stdout,
                 stderr_tail=stderr,
-                delivered=tuple(delivered),
-                skipped=skipped,
+                delivered=delivered,
+                skipped=skipped + skips,
             )
         )
     return tuple(results)
+
+
+def _deliver_artifacts(
+    src: Path, workspace: Path, name: str
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Copy a launch's delivered artifacts into `.autoresearch/results/<name>/`.
+
+    The author controls `.autoresearch/` in its sandbox, so the DESTINATION is
+    hostile too (terra #135 r2): a symlinked channel dir or output path would
+    make `shutil.copy` write through it to an arbitrary host path with the wake
+    process's permissions. Defenses: refuse if any channel ANCESTOR is a symlink;
+    remove any pre-existing `results/<name>` (symlink → unlink, dir → rmtree) so
+    the delivery tree is entirely kernel-created; and skip any individual output
+    that still resolves to a symlink. The source side already validated the files
+    (realpath-contained, size-capped) when the job wrote them."""
+    import shutil
+
+    if not src.is_dir():
+        return (), ()
+    # a symlinked channel ancestor compromises every write under it — deliver
+    # nothing rather than follow it (the author still sees exit code + output).
+    channel = workspace / SYSCALL_DIR
+    results_root = channel / RESULTS_SUBDIR
+    if channel.is_symlink() or results_root.is_symlink():
+        return (), (f"artifacts not delivered: {SYSCALL_DIR} channel is a symlink (refused)",)
+
+    dest = results_root / name
+    if dest.is_symlink():
+        dest.unlink()
+    elif dest.exists():
+        shutil.rmtree(dest, ignore_errors=True)
+
+    delivered: list[str] = []
+    skips: list[str] = []
+    for f in sorted(p for p in src.rglob("*") if p.is_file()):
+        rel = f.relative_to(src)
+        out = dest / rel
+        out.parent.mkdir(parents=True, exist_ok=True)  # under the fresh, owned dest
+        if out.is_symlink():  # defence in depth: a parent we just made can't be one
+            skips.append(f"skipped (destination is a symlink): {rel}")
+            continue
+        try:
+            shutil.copy(f, out)
+            delivered.append(str(Path(SYSCALL_DIR) / RESULTS_SUBDIR / name / rel))
+        except OSError as exc:
+            skips.append(f"deliver failed: {rel} ({exc})")
+    return tuple(delivered), tuple(skips)
 
 
 def _read_text(path: Path, cap: int = 65_536) -> str:

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -250,6 +250,66 @@ def budget_error(
     return ""
 
 
+def gather_results(
+    run_dir: Path, workspace: Path, launches: tuple[Launch, ...]
+) -> tuple[LaunchResult, ...]:
+    """The wake side: read each launch's job output and deliver its declared
+    artifacts into the sandbox, one `LaunchResult` per launch (in request order,
+    so the author sees a stable list).
+
+    Reads `<run_dir>/eval-launch-<name>/` — exit-code, stdout/stderr (tails),
+    and the copy-out the job script already validated (`artifacts/` for
+    delivered files, `artifacts.log` for skips). The kernel COPIES those files
+    into `<workspace>/.autoresearch/results/<name>/` — inside the excluded
+    channel, so they never enter the candidate, scope, or drift fingerprints;
+    the author reads them there. A missing exit-code file means the job died
+    before its wrapper ran (infra failure) — surfaced as `exit_code=None`, never
+    a silent skip. The job-side copy-out already enforced containment (realpath,
+    size cap), so delivery here is a plain in-channel copy."""
+    import shutil
+
+    results: list[LaunchResult] = []
+    for launch in launches:
+        ev = run_dir / f"eval-launch-{launch.name}"
+        try:
+            exit_code: int | None = int((ev / "exit-code").read_text().strip())
+        except (OSError, ValueError):
+            exit_code = None
+        stdout = _read_text(ev / "stdout")
+        stderr = _read_text(ev / "stderr")
+        skipped = tuple(ln for ln in _read_text(ev / "artifacts.log").splitlines() if ln.strip())
+
+        dest = workspace / SYSCALL_DIR / RESULTS_SUBDIR / launch.name
+        delivered: list[str] = []
+        src = ev / "artifacts"
+        if src.is_dir():
+            for f in sorted(p for p in src.rglob("*") if p.is_file()):
+                rel = f.relative_to(src)
+                out = dest / rel
+                out.parent.mkdir(parents=True, exist_ok=True)
+                with contextlib.suppress(OSError):
+                    shutil.copy(f, out)
+                    delivered.append(str(Path(SYSCALL_DIR) / RESULTS_SUBDIR / launch.name / rel))
+        results.append(
+            LaunchResult(
+                name=launch.name,
+                exit_code=exit_code,
+                stdout_tail=_tail(stdout),
+                stderr_tail=_tail(stderr),
+                delivered=tuple(delivered),
+                skipped=skipped,
+            )
+        )
+    return tuple(results)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return ""
+
+
 def _tail(text: str) -> str:
     return text[-MAX_OUTPUT_CHARS:] if len(text) > MAX_OUTPUT_CHARS else text
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1796,6 +1796,22 @@ class JobWakeDispatcher:
             "--max-turns",
             str(self.spec.max_turns),
         ]
+        # An AUTHOR-SLEEP wake resumes a FULL author session (not the short
+        # read-decide a candidate wake runs), so the Slurm job must fit that
+        # session or walltime kills the resumed session mid-run and the run just
+        # waits for another wake (terra #135 r3). Size the job to the session
+        # budget + overhead and pass --session-minutes so the in-job
+        # self-deadline fires BEFORE Slurm's walltime. A candidate wake keeps
+        # the short budget (read results + panel).
+        from autoresearch.limits import CLIMB_OVERHEAD_MINUTES
+        from autoresearch.roles import author_spec
+
+        if record.stage.get("phase") == "author-sleep":
+            session_minutes = author_spec().budget.walltime_s // 60
+            argv += ["--session-minutes", str(session_minutes)]
+            job_minutes = min(session_minutes + CLIMB_OVERHEAD_MINUTES, self.spec.max_job_minutes)
+        else:
+            job_minutes = self.wake_minutes + _wake_panel_minutes(self.spec)
         if self.spec.pat_file:
             argv += ["--pat-file", self.spec.pat_file]
         # config-driven author: `climb --resume` resolves the author key from the
@@ -1808,7 +1824,7 @@ class JobWakeDispatcher:
                 job_name=name,
                 account=self.spec.account,
                 partition=self.spec.job_partition or self.spec.partition,
-                time_minutes=self.wake_minutes + _wake_panel_minutes(self.spec),
+                time_minutes=job_minutes,
                 command=_flight_command(self.spec.home, name, self.now, argv),
                 dependency=afterany,
                 cpus=2,

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1867,13 +1867,15 @@ def test_tracked_request_file_disables_syscalls_for_the_run(tmp_path, monkeypatc
 
 
 def test_armed_flag_without_wake_ready_stays_fully_off(tmp_path, target_repo, monkeypatch) -> None:
-    # arming the env flag before part 2 (the wake) exists must not produce an
-    # unwakeable author-sleep park: the feature stays off for the run — the
-    # request file is inert AND staged like any edit (terra #132 r5).
+    # the interlock mechanism: with the wake declared not-ready, arming the env
+    # flag must not produce an unwakeable author-sleep park — the feature stays
+    # off for the run and the request file is inert AND staged like any edit
+    # (terra #132 r5). The shipped default is now READY (part 2 landed), so the
+    # not-ready state is set explicitly here to pin the guard itself.
     import json as json_mod
 
     monkeypatch.setenv("AUTORESEARCH_AUTHOR_SYSCALLS", "1")
-    # AUTHOR_SLEEP_WAKE_READY stays False (the shipped default)
+    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", False)
     outcome, _ = run_live(
         tmp_path,
         target_repo,
@@ -2837,3 +2839,173 @@ def test_resume_improved_reconciles_to_an_existing_pr(tmp_path, monkeypatch) -> 
     # the snapshot is released (the candidate is already published)
     ws = state / "runs" / run_id / "ws"
     assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""
+
+
+# --- the author-sleep wake (research-loop-buildout.md Phase A, part 2) ---
+
+
+def _write_parked_author_sleep(tmp_path, monkeypatch, *, raise_exc=None, run_id="tsp-9"):
+    """An author-sleep-parked run on disk in the REAL park state: the session's
+    tree persisted as the author left it (uncommitted edits over base), the
+    sleep snapshot sealed under its ref, launch job outputs in the run dir, and
+    a WAITING record carrying the request + budget counts."""
+    import json as json_mod
+
+    from autoresearch.dispatch import snapshot_tree
+    from autoresearch.github import Workspace
+    from autoresearch.measure import DispatchSettings
+    from autoresearch.syscall import ensure_excluded
+
+    state = tmp_path / "state"
+    wsroot = state / "runs" / run_id / "ws"
+    (wsroot / "src" / "pilot" / "solvers").mkdir(parents=True)
+    (wsroot / ".autoresearch.yaml").write_text(CONTRACT_SYSCALLS)
+    (wsroot / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): ...\n")
+    _git(wsroot, "init", "-q", "-b", "main")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
+    base_sha = _git(wsroot, "rev-parse", "HEAD").strip()
+    ensure_excluded(wsroot)  # armed runs excluded the channel at first pass
+    (wsroot / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): return 'wip'\n")
+    ws = Workspace(root=wsroot)
+    snap = snapshot_tree(ws, base_sha)  # the sealed sleep tree
+    # the finished launch's job outputs, as the job script leaves them
+    ev = state / "runs" / run_id / "eval-launch-probe"
+    (ev / "artifacts").mkdir(parents=True)
+    (ev / "exit-code").write_text("0\n")
+    (ev / "stdout").write_text("tail improvement: 0.7\n")
+    (ev / "stderr").write_text("")
+    (ev / "artifacts" / "out.json").write_text('{"metric": 0.7}')
+
+    record = RunRecord(
+        run_id=run_id,
+        target="org/pilot",
+        task_title="improve tsp",
+        benchmark="tsp",
+        state="waiting",
+        resume_session_id="s1",
+        stage={
+            "phase": "author-sleep",
+            "base_sha": base_sha,
+            "candidate_sha": snap.commit,
+            "candidate_ref": snap.ref,
+            "seed": 7,
+            "suite_seed": 9,
+            "afterany": "afterany:501",
+            "report": "mid-flight",
+            "base_branch": "main",
+            "syscall_launches": [{"name": "probe", "artifacts": ["out.json"]}],
+            "syscall_note": "compare against the sweep",
+            "launches_used": 1,
+            "sleeps_used": 1,
+        },
+    )
+    save_record(state, record, 1_000_000.0)
+    fake = _FakeMeasurer(values={}, raise_exc=raise_exc)
+    monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: fake)
+    return state, run_id, wsroot, json_mod
+
+
+def test_author_sleep_wake_delivers_results_and_flows_to_a_candidate_park(
+    tmp_path, monkeypatch
+) -> None:
+    # the woken session continues, finishes, and the gate (dispatched) parks the
+    # run as a CANDIDATE — the existing wake path decides it next time.
+    from autoresearch.measure import MeasurementPending
+
+    state, run_id, wsroot, _ = _write_parked_author_sleep(
+        tmp_path, monkeypatch, raise_exc=MeasurementPending(("701", "702"))
+    )
+    from autoresearch.roles import author_spec
+
+    class RecordingHarness(ScriptedHarness):
+        def run(self, brief_text, workspace, resume_session_id=None):
+            calls.append((brief_text, str(workspace), resume_session_id))
+            return super().run(brief_text, workspace, resume_session_id)
+
+    calls: list = []
+    harness = RecordingHarness(
+        edits={"src/pilot/solvers/tsp.py": "def solve(): return 'polished'\n"}
+    )
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        harness=harness,
+        spec=author_spec(),
+    )
+    assert outcome.outcome == "parked"
+    record = load_record(state, run_id)
+    assert record.state == "waiting"
+    assert record.stage["phase"] == "candidate"  # flows into the existing wake
+    # the SAME session was resumed, with the launch results as its prompt
+    wake_text, _ws, resumed = calls[0]
+    assert resumed == "s1"
+    assert "tail improvement: 0.7" in wake_text  # the job's stdout, delivered
+    assert "compare against the sweep" in wake_text  # the author's note, echoed
+    assert "2 launches and 3 sleeps remaining" in wake_text  # budgets visible
+    assert ".autoresearch/results/probe/out.json" in wake_text
+    # the artifact really landed in the excluded channel
+    assert (wsroot / ".autoresearch" / "results" / "probe" / "out.json").read_text() == (
+        '{"metric": 0.7}'
+    )
+    # exactly ONE snapshot ref survives (the new candidate); the sleep ref is gone
+    refs = [r for r in _git(wsroot, "for-each-ref", "refs/dispatch/").splitlines() if r]
+    assert len(refs) == 1
+    assert str(record.stage["candidate_ref"]) in refs[0]
+
+
+def test_author_sleep_wake_can_sleep_again(tmp_path, monkeypatch) -> None:
+    # the woken author launches more work and sleeps again: a fresh author-sleep
+    # park with the counts advanced.
+    from autoresearch.roles import author_spec
+
+    state, run_id, _wsroot, json_mod = _write_parked_author_sleep(tmp_path, monkeypatch)
+
+    class SleepyHarness(ScriptedHarness):
+        def run(self, brief_text, workspace, resume_session_id=None):
+            (workspace / ".autoresearch").mkdir(exist_ok=True)
+            (workspace / ".autoresearch" / "syscall.json").write_text(
+                json_mod.dumps({"launches": [{"name": "second", "command": "run again"}]})
+            )
+            return super().run(brief_text, workspace, resume_session_id)
+
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        harness=SleepyHarness(edits={}),
+        spec=author_spec(),
+    )
+    assert outcome.outcome == "parked"
+    record = load_record(state, run_id)
+    assert record.stage["phase"] == "author-sleep"
+    assert record.stage["syscall_launches"] == [{"name": "second", "artifacts": []}]
+    assert record.stage["launches_used"] == 2 and record.stage["sleeps_used"] == 2
+    # the second launch's job script was written for the sealed NEW tree
+    assert (state / "runs" / run_id / "eval-launch-second" / "job.sh").exists()
+
+
+def test_author_sleep_wake_without_harness_ends_loudly(tmp_path, monkeypatch) -> None:
+    # the wake cannot resume without the author harness: a named ending, and the
+    # sleep snapshot is released (re-waking would never help).
+    state, run_id, wsroot, _ = _write_parked_author_sleep(tmp_path, monkeypatch)
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert outcome.outcome == "session-error"
+    record = load_record(state, run_id)
+    assert record.state == "ended"
+    assert "author harness" in record.ending_note
+    assert _git(wsroot, "for-each-ref", "refs/dispatch/").strip() == ""

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -187,6 +187,47 @@ def test_ensure_excluded_is_idempotent_and_hides_the_dir_from_git(tmp_path: Path
     assert SYSCALL_DIR not in staged
 
 
+def test_gather_results_reads_output_and_delivers_artifacts(tmp_path) -> None:
+    # the wake side: read each launch's exit/stdout/stderr + skips, and copy
+    # delivered artifacts into the excluded channel dir the author reads.
+    from autoresearch.syscall import Launch, gather_results
+
+    run_dir = tmp_path / "run"
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    # a normal launch with a delivered artifact + a skip log
+    ev = run_dir / "eval-launch-train"
+    (ev / "artifacts" / "sub").mkdir(parents=True)
+    (ev / "exit-code").write_text("0\n")
+    (ev / "stdout").write_text("loss: 0.4\n")
+    (ev / "stderr").write_text("")
+    (ev / "artifacts" / "curve.json").write_text("{}")
+    (ev / "artifacts" / "sub" / "extra.txt").write_text("x")
+    (ev / "artifacts.log").write_text("skipped (over 5000000 bytes): big.ckpt\n")
+    # a launch whose job died before the wrapper ran -> no exit-code file
+    dead = run_dir / "eval-launch-crashed"
+    dead.mkdir(parents=True)
+    (dead / "stderr").write_text("OOM\n")
+
+    results = gather_results(
+        run_dir,
+        ws,
+        (Launch("train", "c", 30, ("curve.json",)), Launch("crashed", "c", 30)),
+    )
+    assert [r.name for r in results] == ["train", "crashed"]  # request order
+    train, crashed = results
+    assert train.exit_code == 0 and "loss: 0.4" in train.stdout_tail
+    assert set(train.delivered) == {
+        ".autoresearch/results/train/curve.json",
+        ".autoresearch/results/train/sub/extra.txt",
+    }
+    assert train.skipped == ("skipped (over 5000000 bytes): big.ckpt",)
+    # the files really landed in the excluded channel
+    assert (ws / ".autoresearch" / "results" / "train" / "curve.json").read_text() == "{}"
+    # a job with no exit-code file surfaces as None (infra failure), not a skip
+    assert crashed.exit_code is None and "OOM" in crashed.stderr_tail
+
+
 def test_launch_job_script_copies_declared_artifacts(tmp_path: Path) -> None:
     """The job writer's copy-out, EXECUTED: declared file delivered; oversized
     and missing ones recorded in artifacts.log; a shell-metacharacter name is

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -228,6 +228,26 @@ def test_gather_results_reads_output_and_delivers_artifacts(tmp_path) -> None:
     assert crashed.exit_code is None and "OOM" in crashed.stderr_tail
 
 
+def test_gather_results_reads_only_the_tail_of_huge_output(tmp_path) -> None:
+    # launch output is agent-controlled and can be arbitrarily large: the wake
+    # must read only the trailing window, never load the whole file
+    # (terra #135 r1).
+    from autoresearch.syscall import MAX_OUTPUT_CHARS, Launch, gather_results
+
+    run_dir = tmp_path / "run"
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    ev = run_dir / "eval-launch-big"
+    ev.mkdir(parents=True)
+    (ev / "exit-code").write_text("0")
+    with (ev / "stdout").open("w") as fh:
+        fh.write("x" * (MAX_OUTPUT_CHARS * 50))  # far past the window
+        fh.write("\nFINAL: 0.42\n")
+    (results,) = gather_results(run_dir, ws, (Launch("big", "c", 30),))
+    assert len(results.stdout_tail) <= MAX_OUTPUT_CHARS
+    assert "FINAL: 0.42" in results.stdout_tail  # the tail, not the head
+
+
 def test_launch_job_script_copies_declared_artifacts(tmp_path: Path) -> None:
     """The job writer's copy-out, EXECUTED: declared file delivered; oversized
     and missing ones recorded in artifacts.log; a shell-metacharacter name is

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -228,6 +228,32 @@ def test_gather_results_reads_output_and_delivers_artifacts(tmp_path) -> None:
     assert crashed.exit_code is None and "OOM" in crashed.stderr_tail
 
 
+def test_gather_results_refuses_symlinked_destination_channel(tmp_path) -> None:
+    # the author controls .autoresearch in its sandbox: a symlinked results dir
+    # (or a planted output symlink) must not make delivery write through it to a
+    # host path (terra #135 r2).
+    from autoresearch.syscall import Launch, gather_results
+
+    run_dir = tmp_path / "run"
+    ws = tmp_path / "ws"
+    ev = run_dir / "eval-launch-probe"
+    (ev / "artifacts").mkdir(parents=True)
+    (ev / "exit-code").write_text("0")
+    (ev / "artifacts" / "out.json").write_text("safe")
+    # attacker target OUTSIDE the workspace
+    escape = tmp_path / "ESCAPE"
+    escape.mkdir()
+    (escape / "out.json").write_text("ORIGINAL")
+    # .autoresearch/results -> the escape dir
+    (ws / ".autoresearch").mkdir(parents=True)
+    (ws / ".autoresearch" / "results").symlink_to(escape, target_is_directory=True)
+
+    (r,) = gather_results(run_dir, ws, (Launch("probe", "c", 30, ("out.json",)),))
+    assert r.delivered == ()  # nothing delivered through the symlink
+    assert any("symlink" in s for s in r.skipped)
+    assert (escape / "out.json").read_text() == "ORIGINAL"  # host file untouched
+
+
 def test_gather_results_reads_only_the_tail_of_huge_output(tmp_path) -> None:
     # launch output is agent-controlled and can be arbitrarily large: the wake
     # must read only the trailing window, never load the whole file

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2156,3 +2156,45 @@ def test_job_wake_dispatcher_walltime_includes_the_panel(tmp_path, monkeypatch):
     assert _wake_panel_minutes(with_panel) > 0 and _wake_panel_minutes(no_panel) == 0
     assert times[0] == 20 + _wake_panel_minutes(with_panel)  # panel allowance added
     assert times[1] == 20  # no panel -> just the base
+
+
+def test_author_sleep_wake_gets_a_full_session_walltime(tmp_path, monkeypatch):
+    # an author-sleep wake resumes a FULL author session, so its Slurm job must
+    # fit the session (+ overhead) and pass --session-minutes, not the short
+    # candidate-wake budget (terra #135 r3).
+    from autoresearch.limits import CLIMB_OVERHEAD_MINUTES
+    from autoresearch.roles import author_spec
+    from autoresearch.runstate import RunRecord
+    from autoresearch.tick import FollowupSpec, JobWakeDispatcher
+
+    times: list[int] = []
+    joined_argv: list[str] = []
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            joined_argv.append(" ".join(argv))
+            for a in argv:
+                if a.startswith("--time="):
+                    times.append(int(a.split("=")[1]))
+            return CommandResult(0, "9001\n", "")
+        raise AssertionError(argv)
+
+    monkeypatch.setattr(
+        "autoresearch.tick._flight_command", lambda home, name, now, argv: " ".join(argv)
+    )
+    spec = FollowupSpec(
+        account="a", partition="p", run_root=tmp_path, image="/i.sif", home=tmp_path, panel=""
+    )
+    sleep_rec = RunRecord(
+        run_id="tsp-1",
+        target="o/r",
+        task_title="t",
+        benchmark="tsp",
+        state="waiting",
+        stage={"phase": "author-sleep", "afterany": "afterany:501"},
+    )
+    JobWakeDispatcher(SlurmCompute(runner=runner), spec, now=NOW).dispatch(sleep_rec, "x")
+    session_minutes = author_spec().budget.walltime_s // 60
+    assert times[0] == session_minutes + CLIMB_OVERHEAD_MINUTES  # fits the session
+    assert times[0] > 20  # far more than a candidate wake's base
+    assert f"--session-minutes {session_minutes}" in joined_argv[0]  # self-deadline set


### PR DESCRIPTION
## What

**Phase A part 2 — the wake.** `resume_run` now services `author-sleep` parks, completing the author-directed dispatch → sleep → wake loop end to end. `AUTHOR_SLEEP_WAKE_READY` is flipped: arming `AUTORESEARCH_AUTHOR_SYSCALLS` enables the whole feature.

## How it composes (the design's payoff)

- **Deliver**: `gather_results` reads each launch's job dir (exit code, output tails, `artifacts.log` skips) and copies delivered artifacts into `.autoresearch/results/<name>/` — inside the excluded channel, invisible to candidate/scope/drift. A job that died before its wrapper surfaces as `exit_code=None`, never a silent skip.
- **Resume**: the **same session** continues through the climb's resume-entry (#129), prompted with the data-fenced results, the author's own note echoed back, and the remaining budgets. Cumulative — the author picks up its own tree exactly as it left it.
- **Exits map onto existing machinery**: slept again → fresh author-sleep park (counts advanced; the old sleep ref is dropped only after the new park persists). Finished → the gate measures through the **dispatched** backend and parks the run as a **candidate**, which the existing wake path (panel, sealed-sha publish) decides — so the publish tail stays candidate-only and nothing is duplicated. Cannot resume (no harness / no session id / no-resume backend) → a named `session-error` ending, never a stuck WAITING loop.
- `_make_launcher` extracted and shared by `live_climb` and the wake (the partial-batch reap rides along).
- The wake CLI builds the author harness for author-sleep parks even without a panel (it always resumes the session).
- **The brief now advertises the tool** (usage + this run's budgets) exactly when the launcher is wired — never a tool the author can't call. `from_json` stays backward-compatible.

## Test plan

`gather_results` (delivery, request ordering, infra-failure). Three end-to-end wakes on a real parked-on-disk fixture (uncommitted author tree + sealed snapshot + real job outputs): resume-with-results → **candidate park** (the wake text carries stdout, note, budgets, artifact paths; the artifact lands in the channel; exactly one snapshot ref survives); **sleep-again** (counts advance, the second launch's job script is written for the new sealed tree); **no-harness** (named ending, all refs released). Interlock test now pins the not-ready guard explicitly. Full suite 750 green; ruff + mypy green.

## No secrets / no large files

Confirmed.
