### PR TITLE
Judge verdict tool part 1: the mechanism (tool + authoritative reader)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Judge verdict tool, part 1 — the mechanism (docs/design/role-cli.md, Phase 2;
+  not yet wired into role_runner, so inert until part 2). `verdict_cli.py` is a
+  standalone (stdlib-only) tool the kernel installs at `.verdict/verdict`: a
+  judge records each finding as one validated call (`verdict finding --file
+  --line --confidence --summary --detail [--blocking] [--kind] [--category]`)
+  and commits with `verdict conclude`, replacing the "emit one JSON message,
+  kernel parses-and-repairs" path — the verdict is well-formed by construction.
+  `verdict.py` is the kernel side: `read_verdict` authoritatively validates the
+  committed `.verdict/verdict.json` (size-capped, every field checked; the tool
+  is convenience, never the trust boundary) into the same `{findings, notes}`
+  shape role_runner used to parse. Part 2 adds the RoleSpec allow-listed
+  single-command capability and rewires the judges onto it.
+
 - Author syscalls, part 2 — the WAKE (research-loop-buildout.md Phase A is
   complete; `AUTHOR_SLEEP_WAKE_READY` is flipped, so setting
   `AUTORESEARCH_AUTHOR_SYSCALLS` now enables the whole loop end to end):

--- a/src/autoresearch/verdict.py
+++ b/src/autoresearch/verdict.py
@@ -53,7 +53,9 @@ def read_verdict(workspace: Path) -> dict[str, Any] | None:
         raise VerdictError(f"verdict is not valid JSON: {exc}") from exc
     if not isinstance(data, dict):
         raise VerdictError("verdict must be a JSON object")
-    notes = data.get("notes", "")
+    if "notes" not in data:
+        raise VerdictError("verdict is missing required key: notes")
+    notes = data["notes"]
     if not isinstance(notes, str):
         raise VerdictError("notes must be a string")
     raw = data.get("findings")
@@ -63,25 +65,36 @@ def read_verdict(workspace: Path) -> dict[str, Any] | None:
     return {"findings": findings, "notes": notes}
 
 
+_REQUIRED_FINDING_KEYS = ("file", "line", "confidence", "summary", "detail", "blocking", "kind")
+
+
 def _validate_finding(i: int, item: Any) -> dict[str, Any]:
     if not isinstance(item, dict):
         raise VerdictError(f"finding #{i} must be an object")
     file = item.get("file")
     if not isinstance(file, str) or not file:
         raise VerdictError(f"finding #{i}: file must be a non-empty string")
-    line = item.get("line", None)
+    # ENFORCE the schema's required keys — do not default them. Defaulting
+    # `blocking` to False in particular is a fail-open: a finding that omits it
+    # would silently not gate ("silence is never endorsement"). The tool always
+    # emits every key, so this only rejects a malformed hand-written verdict
+    # (the tool is not the trust boundary — terra #136 r3).
+    missing = [k for k in _REQUIRED_FINDING_KEYS if k not in item]
+    if missing:
+        raise VerdictError(f"finding {file}: missing required keys {missing}")
+    line = item["line"]
     if line is not None and (not isinstance(line, int) or isinstance(line, bool) or line < 1):
         raise VerdictError(f"finding {file}: line must be a positive (1-indexed) integer or null")
-    confidence = item.get("confidence")
+    confidence = item["confidence"]
     if confidence not in CONFIDENCES:
         raise VerdictError(f"finding {file}: confidence must be one of {sorted(CONFIDENCES)}")
-    kind = item.get("kind", "note")
+    kind = item["kind"]
     if kind not in KINDS:
         raise VerdictError(f"finding {file}: kind must be one of {sorted(KINDS)}")
     for key in ("summary", "detail"):
-        if not isinstance(item.get(key), str) or not item[key]:
+        if not isinstance(item[key], str) or not item[key]:
             raise VerdictError(f"finding {file}: {key} must be a non-empty string")
-    blocking = item.get("blocking", False)
+    blocking = item["blocking"]
     if not isinstance(blocking, bool):
         raise VerdictError(f"finding {file}: blocking must be a boolean")
     out = {

--- a/src/autoresearch/verdict.py
+++ b/src/autoresearch/verdict.py
@@ -86,10 +86,13 @@ def _validate_finding(i: int, item: Any) -> dict[str, Any]:
     if line is not None and (not isinstance(line, int) or isinstance(line, bool) or line < 1):
         raise VerdictError(f"finding {file}: line must be a positive (1-indexed) integer or null")
     confidence = item["confidence"]
-    if confidence not in CONFIDENCES:
+    # check TYPE before membership: `in frozenset` raises TypeError on an
+    # unhashable agent value (e.g. confidence: []) — that must surface as a
+    # VerdictError, not a crash (terra #136 r4).
+    if not isinstance(confidence, str) or confidence not in CONFIDENCES:
         raise VerdictError(f"finding {file}: confidence must be one of {sorted(CONFIDENCES)}")
     kind = item["kind"]
-    if kind not in KINDS:
+    if not isinstance(kind, str) or kind not in KINDS:
         raise VerdictError(f"finding {file}: kind must be one of {sorted(KINDS)}")
     for key in ("summary", "detail"):
         if not isinstance(item[key], str) or not item[key]:
@@ -110,6 +113,7 @@ def _validate_finding(i: int, item: Any) -> dict[str, Any]:
     if category:  # verifier-only; keep only when the judge set it
         if not isinstance(category, str):
             raise VerdictError(f"finding {file}: category must be a string")
+        # (category is str here, so `in CATEGORIES` cannot raise on unhashables)
         # CLAMP an unknown category to "other" rather than reject — same stance
         # as the existing verifier path (verifier.py: "a free-string category
         # must not leak through"), so a taxonomy typo normalizes instead of

--- a/src/autoresearch/verdict.py
+++ b/src/autoresearch/verdict.py
@@ -110,14 +110,16 @@ def _validate_finding(i: int, item: Any) -> dict[str, Any]:
         "kind": kind,
     }
     category = item.get("category", "")
-    if category:  # verifier-only; keep only when the judge set it
-        if not isinstance(category, str):
-            raise VerdictError(f"finding {file}: category must be a string")
-        # (category is str here, so `in CATEGORIES` cannot raise on unhashables)
-        # CLAMP an unknown category to "other" rather than reject — same stance
-        # as the existing verifier path (verifier.py: "a free-string category
-        # must not leak through"), so a taxonomy typo normalizes instead of
-        # nuking a whole verdict. (terra #136 r1)
+    # TYPE first, then truthiness: a falsy non-string (category: 0 or []) must
+    # be a VerdictError, not silently dropped by the `if category:` guard
+    # (terra #136 r5). Absent or "" is legitimately "no category".
+    if not isinstance(category, str):
+        raise VerdictError(f"finding {file}: category must be a string")
+    if category:  # verifier-only; a non-empty string
+        # (str here, so `in CATEGORIES` cannot raise on unhashables) — CLAMP an
+        # unknown category to "other" rather than reject, the existing verifier
+        # stance (verifier.py: "a free-string category must not leak through"),
+        # so a taxonomy typo normalizes instead of nuking a verdict (terra r1).
         from autoresearch.verifier import CATEGORIES
 
         out["category"] = category if category in CATEGORIES else "other"

--- a/src/autoresearch/verdict.py
+++ b/src/autoresearch/verdict.py
@@ -1,0 +1,113 @@
+"""Judge verdicts: the kernel side of the verdict tool (docs/design/role-cli.md
+Phase 2).
+
+The judge's interface is `verdict_cli.py` (installed at `.verdict/verdict`); it
+commits a verdict to `.verdict/verdict.json` on `conclude`. This module is the
+KERNEL side — `read_verdict` is the authoritative validator (the tool is
+agent-controlled once dropped, so it is never trusted), returning the SAME
+`{findings, notes}` shape `run_role` used to parse from the final message, minus
+the parse-and-repair loop. `install_tool` drops the standalone tool into the
+judge's workspace.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+VERDICT_DIR = ".verdict"
+VERDICT_FILE = "verdict.json"
+MAX_VERDICT_BYTES = 1_000_000  # generous; agent-controlled, so size-capped first
+CONFIDENCES = frozenset({"low", "medium", "high"})
+KINDS = frozenset({"change", "suggestion", "question", "note"})
+
+
+class VerdictError(ValueError):
+    """The committed verdict is missing or malformed. Loud: a judge that ran
+    the tool meant a verdict, so a broken file is an error, never a silent
+    empty pass (silence is never endorsement)."""
+
+
+def read_verdict(workspace: Path) -> dict[str, Any] | None:
+    """Read and validate the committed verdict. None = the judge never
+    concluded (no file) — the caller treats that as no-verdict, exactly like an
+    errored session. A present-but-malformed verdict raises VerdictError.
+
+    Validates every field the schema requires (the tool's checks are advisory);
+    an unknown enum, a wrong type, or a missing key fails here — the verdict is
+    well-formed after this returns."""
+    path = workspace / VERDICT_DIR / VERDICT_FILE
+    try:
+        with path.open("rb") as fh:
+            head = fh.read(MAX_VERDICT_BYTES + 1)
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        raise VerdictError(f"verdict unreadable: {exc}") from exc
+    if len(head) > MAX_VERDICT_BYTES:
+        raise VerdictError(f"verdict exceeds {MAX_VERDICT_BYTES} bytes")
+    try:
+        data = json.loads(head.decode("utf-8", "replace"))
+    except json.JSONDecodeError as exc:
+        raise VerdictError(f"verdict is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise VerdictError("verdict must be a JSON object")
+    notes = data.get("notes", "")
+    if not isinstance(notes, str):
+        raise VerdictError("notes must be a string")
+    raw = data.get("findings")
+    if not isinstance(raw, list):
+        raise VerdictError("findings must be a list")
+    findings = [_validate_finding(i, item) for i, item in enumerate(raw)]
+    return {"findings": findings, "notes": notes}
+
+
+def _validate_finding(i: int, item: Any) -> dict[str, Any]:
+    if not isinstance(item, dict):
+        raise VerdictError(f"finding #{i} must be an object")
+    file = item.get("file")
+    if not isinstance(file, str) or not file:
+        raise VerdictError(f"finding #{i}: file must be a non-empty string")
+    line = item.get("line", None)
+    if line is not None and (not isinstance(line, int) or isinstance(line, bool)):
+        raise VerdictError(f"finding {file}: line must be an integer or null")
+    confidence = item.get("confidence")
+    if confidence not in CONFIDENCES:
+        raise VerdictError(f"finding {file}: confidence must be one of {sorted(CONFIDENCES)}")
+    kind = item.get("kind", "note")
+    if kind not in KINDS:
+        raise VerdictError(f"finding {file}: kind must be one of {sorted(KINDS)}")
+    for key in ("summary", "detail"):
+        if not isinstance(item.get(key), str) or not item[key]:
+            raise VerdictError(f"finding {file}: {key} must be a non-empty string")
+    blocking = item.get("blocking", False)
+    if not isinstance(blocking, bool):
+        raise VerdictError(f"finding {file}: blocking must be a boolean")
+    out = {
+        "file": file,
+        "line": line,
+        "confidence": confidence,
+        "summary": item["summary"],
+        "detail": item["detail"],
+        "blocking": blocking,
+        "kind": kind,
+    }
+    category = item.get("category", "")
+    if category:  # verifier-only; keep only when the judge set it
+        if not isinstance(category, str):
+            raise VerdictError(f"finding {file}: category must be a string")
+        out["category"] = category
+    return out
+
+
+def install_tool(workspace: Path) -> None:
+    """Drop the standalone verdict tool into the judge's workspace at
+    `.verdict/verdict`. Verbatim copy of `verdict_cli.py` (stdlib-only, since a
+    judge runs in a prepared checkout without autoresearch installed)."""
+    from autoresearch import verdict_cli
+
+    tool = workspace / VERDICT_DIR / "verdict"
+    tool.parent.mkdir(exist_ok=True)
+    tool.write_text(Path(verdict_cli.__file__).read_text())
+    tool.chmod(0o755)

--- a/src/autoresearch/verdict.py
+++ b/src/autoresearch/verdict.py
@@ -70,8 +70,8 @@ def _validate_finding(i: int, item: Any) -> dict[str, Any]:
     if not isinstance(file, str) or not file:
         raise VerdictError(f"finding #{i}: file must be a non-empty string")
     line = item.get("line", None)
-    if line is not None and (not isinstance(line, int) or isinstance(line, bool)):
-        raise VerdictError(f"finding {file}: line must be an integer or null")
+    if line is not None and (not isinstance(line, int) or isinstance(line, bool) or line < 1):
+        raise VerdictError(f"finding {file}: line must be a positive (1-indexed) integer or null")
     confidence = item.get("confidence")
     if confidence not in CONFIDENCES:
         raise VerdictError(f"finding {file}: confidence must be one of {sorted(CONFIDENCES)}")
@@ -97,7 +97,13 @@ def _validate_finding(i: int, item: Any) -> dict[str, Any]:
     if category:  # verifier-only; keep only when the judge set it
         if not isinstance(category, str):
             raise VerdictError(f"finding {file}: category must be a string")
-        out["category"] = category
+        # CLAMP an unknown category to "other" rather than reject — same stance
+        # as the existing verifier path (verifier.py: "a free-string category
+        # must not leak through"), so a taxonomy typo normalizes instead of
+        # nuking a whole verdict. (terra #136 r1)
+        from autoresearch.verifier import CATEGORIES
+
+        out["category"] = category if category in CATEGORIES else "other"
     return out
 
 

--- a/src/autoresearch/verdict.py
+++ b/src/autoresearch/verdict.py
@@ -110,10 +110,24 @@ def _validate_finding(i: int, item: Any) -> dict[str, Any]:
 def install_tool(workspace: Path) -> None:
     """Drop the standalone verdict tool into the judge's workspace at
     `.verdict/verdict`. Verbatim copy of `verdict_cli.py` (stdlib-only, since a
-    judge runs in a prepared checkout without autoresearch installed)."""
+    judge runs in a prepared checkout without autoresearch installed).
+
+    The `.verdict` channel must be KERNEL-OWNED: the judge's checkout is the
+    author's tree, which could ship `.verdict` as a symlink to a host path so
+    `write_text` writes through it (terra #136 r2, same class as the syscall
+    channel). Remove any pre-existing `.verdict` (symlink → unlink, dir →
+    rmtree, file → unlink) and recreate it as a dir we own, so nothing is
+    followed."""
+    import shutil
+
     from autoresearch import verdict_cli
 
-    tool = workspace / VERDICT_DIR / "verdict"
-    tool.parent.mkdir(exist_ok=True)
+    channel = workspace / VERDICT_DIR
+    if channel.is_symlink() or (channel.exists() and not channel.is_dir()):
+        channel.unlink()
+    elif channel.is_dir():
+        shutil.rmtree(channel)
+    channel.mkdir(parents=True)
+    tool = channel / "verdict"
     tool.write_text(Path(verdict_cli.__file__).read_text())
     tool.chmod(0o755)

--- a/src/autoresearch/verdict_cli.py
+++ b/src/autoresearch/verdict_cli.py
@@ -62,6 +62,8 @@ def cmd_finding(root: Path, args: argparse.Namespace) -> str:
         raise ToolError(f"--confidence must be one of {CONFIDENCES}")
     if args.kind not in KINDS:
         raise ToolError(f"--kind must be one of {KINDS}")
+    if args.line is not None and args.line < 1:
+        raise ToolError("--line is 1-indexed; omit it for a non-local finding")
     for label, text in (("--summary", args.summary), ("--detail", args.detail)):
         if not text.strip():
             raise ToolError(f"{label} must not be empty")

--- a/src/autoresearch/verdict_cli.py
+++ b/src/autoresearch/verdict_cli.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""The judge's verdict tool — the agent-facing surface for reviewer/verifier
+verdicts (docs/design/role-cli.md, Phase 2).
+
+Standalone by contract: the kernel installs its source at `.verdict/verdict`
+and a judge runs it as a single allow-listed command (judges have no general
+Bash — a distinct RoleSpec capability, not `can_execute`). It replaces the
+"emit one big JSON message, kernel parses-and-repairs" path (role_runner): each
+finding is one validated call, so the verdict is well-formed BY CONSTRUCTION and
+the repair loop disappears.
+
+    python .verdict/verdict finding --file solver.py --line 42 --confidence high \\
+        --summary "off-by-one" --detail "the loop skips the last index" --blocking
+    python .verdict/verdict conclude --notes "one blocking defect; rest is clean"
+
+`finding` stages into `.verdict/findings.json`; `conclude` commits the whole
+verdict to `.verdict/verdict.json` (the ABI the kernel reads). Validation here is
+for FAST in-session feedback — the kernel re-validates authoritatively
+(`verdict.py`), so this tool is convenience, never a trust boundary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import sys
+from pathlib import Path
+
+DIR = ".verdict"
+STAGING = "findings.json"
+ABI = "verdict.json"
+CONFIDENCES = ("low", "medium", "high")
+KINDS = ("change", "suggestion", "question", "note")
+MAX_TEXT = 6_000  # per summary/detail/notes/category
+MAX_FINDINGS = 200
+
+
+class ToolError(Exception):
+    """A bad invocation: printed to stderr, exit 2, nothing staged."""
+
+
+def _load(root: Path) -> dict:
+    try:
+        return json.loads((root / DIR / STAGING).read_text())
+    except FileNotFoundError:
+        return {"findings": [], "notes": ""}
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ToolError(f"staged verdict unreadable ({exc}); run `cancel` to reset") from exc
+
+
+def _save(root: Path, data: dict) -> None:
+    d = root / DIR
+    d.mkdir(exist_ok=True)
+    (d / STAGING).write_text(json.dumps(data, indent=2))
+
+
+def cmd_finding(root: Path, args: argparse.Namespace) -> str:
+    if not args.file.strip():
+        raise ToolError("--file must not be empty")
+    if args.confidence not in CONFIDENCES:
+        raise ToolError(f"--confidence must be one of {CONFIDENCES}")
+    if args.kind not in KINDS:
+        raise ToolError(f"--kind must be one of {KINDS}")
+    for label, text in (("--summary", args.summary), ("--detail", args.detail)):
+        if not text.strip():
+            raise ToolError(f"{label} must not be empty")
+        if len(text) > MAX_TEXT:
+            raise ToolError(f"{label} exceeds {MAX_TEXT} chars")
+    if args.category and len(args.category) > MAX_TEXT:
+        raise ToolError(f"--category exceeds {MAX_TEXT} chars")
+    staged = _load(root)
+    if len(staged["findings"]) >= MAX_FINDINGS:
+        raise ToolError(f"at most {MAX_FINDINGS} findings")
+    finding = {
+        "file": args.file,
+        "line": args.line,  # None when --line omitted: a non-local finding
+        "confidence": args.confidence,
+        "summary": args.summary,
+        "detail": args.detail,
+        "blocking": bool(args.blocking),
+        "kind": args.kind,
+    }
+    if args.category:
+        finding["category"] = args.category  # verifier gaming-taxonomy; omitted otherwise
+    staged["findings"].append(finding)
+    _save(root, staged)
+    tag = "BLOCKING" if args.blocking else args.kind
+    where = f"{args.file}:{args.line or '?'}"
+    return f"recorded {tag} finding on {where} ({len(staged['findings'])} so far)."
+
+
+def cmd_conclude(root: Path, args: argparse.Namespace) -> str:
+    if len(args.notes) > MAX_TEXT:
+        raise ToolError(f"--notes exceeds {MAX_TEXT} chars")
+    staged = _load(root)
+    staged["notes"] = args.notes
+    d = root / DIR
+    d.mkdir(exist_ok=True)
+    (d / ABI).write_text(json.dumps(staged))
+    (d / STAGING).unlink(missing_ok=True)
+    n = len(staged["findings"])
+    blocking = sum(1 for f in staged["findings"] if f.get("blocking"))
+    return (
+        f"verdict recorded: {n} finding(s), {blocking} blocking. This is your "
+        "final answer — end your turn."
+    )
+
+
+def cmd_status(root: Path, _args: argparse.Namespace) -> str:
+    staged = _load(root)
+    lines = [f"{len(staged['findings'])} finding(s) staged:"]
+    for f in staged["findings"]:
+        tag = "BLOCKING" if f.get("blocking") else f.get("kind", "note")
+        lines.append(f"  - [{tag}] {f['file']}:{f.get('line') or '?'} — {f['summary']}")
+    if staged.get("notes"):
+        lines.append(f"  notes: {staged['notes']}")
+    return "\n".join(lines)
+
+
+def cmd_cancel(root: Path, _args: argparse.Namespace) -> str:
+    (root / DIR / STAGING).unlink(missing_ok=True)
+    return "staged findings discarded."
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(prog="verdict", description="judge verdict tool")
+    sub = p.add_subparsers(dest="cmd", required=True)
+    fi = sub.add_parser("finding", help="record one finding")
+    fi.add_argument("--file", required=True)
+    fi.add_argument(
+        "--line", type=int, default=None, help="1-indexed; omit for a non-local finding"
+    )
+    fi.add_argument("--confidence", required=True, help=f"one of {CONFIDENCES}")
+    fi.add_argument("--summary", required=True, help="one-line claim")
+    fi.add_argument("--detail", required=True, help="the evidence")
+    fi.add_argument("--blocking", action="store_true", help="a confirmed defect that gates merge")
+    fi.add_argument("--kind", default="note", help=f"one of {KINDS}")
+    fi.add_argument("--category", default="", help="verifier gaming taxonomy; omit for review")
+    co = sub.add_parser("conclude", help="commit the verdict; then end your turn")
+    co.add_argument("--notes", default="", help="summary the reader sees")
+    sub.add_parser("status", help="show staged findings")
+    sub.add_parser("cancel", help="discard staged findings")
+    return p
+
+
+_HANDLERS = {
+    "finding": cmd_finding,
+    "conclude": cmd_conclude,
+    "status": cmd_status,
+    "cancel": cmd_cancel,
+}
+
+
+def main(argv: list[str], root: Path | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    root = root or Path.cwd()
+    try:
+        print(_HANDLERS[args.cmd](root, args))
+        return 0
+    except ToolError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via main(argv) in tests
+    with contextlib.suppress(BrokenPipeError):
+        sys.exit(main(sys.argv[1:]))

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -1,0 +1,202 @@
+"""The judge verdict tool + its kernel-side reader (docs/design/role-cli.md
+Phase 2). The tool is the agent surface; verdict.json is the ABI; read_verdict
+is the authoritative validator that replaces role_runner's parse-and-repair."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from autoresearch.verdict import VerdictError, install_tool, read_verdict
+from autoresearch.verdict_cli import main
+
+
+def run(tmp: Path, *argv: str) -> int:
+    return main(list(argv), root=tmp)
+
+
+def test_findings_then_conclude_round_trip_through_the_reader(tmp_path: Path, capsys) -> None:
+    assert (
+        run(
+            tmp_path,
+            "finding",
+            "--file",
+            "src/solver.py",
+            "--line",
+            "42",
+            "--confidence",
+            "high",
+            "--summary",
+            "off-by-one",
+            "--detail",
+            "the loop skips the last index",
+            "--blocking",
+            "--kind",
+            "change",
+        )
+        == 0
+    )
+    assert "BLOCKING" in capsys.readouterr().out
+    # a second, non-local, non-blocking finding
+    run(
+        tmp_path,
+        "finding",
+        "--file",
+        "README.md",
+        "--confidence",
+        "low",
+        "--summary",
+        "typo",
+        "--detail",
+        "spelling",
+        "--kind",
+        "note",
+    )
+    assert run(tmp_path, "conclude", "--notes", "one real defect") == 0
+    assert "final answer" in capsys.readouterr().out
+
+    verdict = read_verdict(tmp_path)  # the KERNEL's authoritative parse
+    assert verdict is not None
+    assert verdict["notes"] == "one real defect"
+    assert len(verdict["findings"]) == 2
+    f0 = verdict["findings"][0]
+    assert f0 == {
+        "file": "src/solver.py",
+        "line": 42,
+        "confidence": "high",
+        "summary": "off-by-one",
+        "detail": "the loop skips the last index",
+        "blocking": True,
+        "kind": "change",
+    }
+    assert verdict["findings"][1]["line"] is None  # --line omitted -> null
+    assert not (tmp_path / ".verdict" / "findings.json").exists()  # staging cleared
+
+
+def test_no_verdict_file_is_none(tmp_path: Path) -> None:
+    assert read_verdict(tmp_path) is None  # judge never concluded
+
+
+def test_conclude_with_no_findings_is_a_clean_verdict(tmp_path: Path) -> None:
+    run(tmp_path, "conclude", "--notes", "materially sound")
+    verdict = read_verdict(tmp_path)
+    assert verdict == {"findings": [], "notes": "materially sound"}
+
+
+def test_verifier_category_is_carried(tmp_path: Path) -> None:
+    run(
+        tmp_path,
+        "finding",
+        "--file",
+        "x.py",
+        "--confidence",
+        "high",
+        "--summary",
+        "s",
+        "--detail",
+        "d",
+        "--blocking",
+        "--category",
+        "benchmark-gaming",
+    )
+    run(tmp_path, "conclude")
+    verdict = read_verdict(tmp_path)
+    assert verdict is not None
+    assert verdict["findings"][0]["category"] == "benchmark-gaming"
+
+
+def test_tool_validation_fails_fast(tmp_path: Path, capsys) -> None:
+    cases = [
+        (
+            ["finding", "--file", "", "--confidence", "high", "--summary", "s", "--detail", "d"],
+            "file",
+        ),
+        (
+            ["finding", "--file", "x", "--confidence", "wat", "--summary", "s", "--detail", "d"],
+            "confidence",
+        ),
+        (
+            ["finding", "--file", "x", "--confidence", "high", "--summary", "", "--detail", "d"],
+            "summary",
+        ),
+        (["conclude", "--notes", "x" * 6001], "exceeds"),
+    ]
+    for argv, needle in cases:
+        rc = run(tmp_path, *argv)
+        assert rc == 2
+        assert needle in (capsys.readouterr().err)
+
+
+def test_reader_rejects_malformed_verdict_loudly(tmp_path: Path) -> None:
+    d = tmp_path / ".verdict"
+    d.mkdir()
+    # a bad confidence the tool would have blocked, but a hand-written ABI must
+    # still be caught by the kernel (the tool is not the trust boundary)
+    (d / "verdict.json").write_text(
+        json.dumps(
+            {
+                "findings": [
+                    {
+                        "file": "x",
+                        "line": 1,
+                        "confidence": "SURE",
+                        "summary": "s",
+                        "detail": "d",
+                        "blocking": True,
+                        "kind": "note",
+                    }
+                ],
+                "notes": "",
+            }
+        )
+    )
+    with pytest.raises(VerdictError, match="confidence"):
+        read_verdict(tmp_path)
+
+
+def test_reader_size_caps_a_giant_verdict(tmp_path: Path) -> None:
+    from autoresearch.verdict import MAX_VERDICT_BYTES
+
+    d = tmp_path / ".verdict"
+    d.mkdir()
+    (d / "verdict.json").write_text("x" * (MAX_VERDICT_BYTES + 1))
+    with pytest.raises(VerdictError, match="exceeds"):
+        read_verdict(tmp_path)
+
+
+def test_installed_tool_is_standalone(tmp_path: Path) -> None:
+    # the kernel installs the tool into a prepared checkout without autoresearch;
+    # prove the copy runs under a bare interpreter (isolated mode)
+    install_tool(tmp_path)
+    tool = tmp_path / ".verdict" / "verdict"
+    assert tool.exists()
+    r = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            str(tool),
+            "finding",
+            "--file",
+            "a.py",
+            "--confidence",
+            "low",
+            "--summary",
+            "s",
+            "--detail",
+            "d",
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    r = subprocess.run(
+        [sys.executable, "-I", str(tool), "conclude"], cwd=tmp_path, capture_output=True, text=True
+    )
+    assert r.returncode == 0
+    verdict = read_verdict(tmp_path)
+    assert verdict is not None and verdict["findings"][0]["file"] == "a.py"

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -257,6 +257,27 @@ def test_reader_rejects_a_finding_missing_blocking(tmp_path: Path) -> None:
         read_verdict(tmp_path)
 
 
+def test_reader_handles_unhashable_enum_values(tmp_path: Path) -> None:
+    # a hand-written finding with a list where a string enum belongs must raise
+    # VerdictError, not crash the reader with TypeError (terra #136 r4).
+    d = tmp_path / ".verdict"
+    d.mkdir(exist_ok=True)
+    for bad in ("confidence", "kind"):
+        f = {
+            "file": "x",
+            "line": 1,
+            "confidence": "high",
+            "summary": "s",
+            "detail": "d",
+            "blocking": True,
+            "kind": "note",
+        }
+        f[bad] = []  # unhashable
+        (d / "verdict.json").write_text(json.dumps({"findings": [f], "notes": ""}))
+        with pytest.raises(VerdictError, match=bad):
+            read_verdict(tmp_path)
+
+
 def test_reader_size_caps_a_giant_verdict(tmp_path: Path) -> None:
     from autoresearch.verdict import MAX_VERDICT_BYTES
 

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -241,6 +241,22 @@ def test_reader_size_caps_a_giant_verdict(tmp_path: Path) -> None:
         read_verdict(tmp_path)
 
 
+def test_install_tool_refuses_a_symlinked_channel(tmp_path: Path) -> None:
+    # the judge's checkout is author-authored: a .verdict symlink to a host dir
+    # must not let install write through it (terra #136 r2).
+    escape = tmp_path / "ESCAPE"
+    escape.mkdir()
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    (ws / ".verdict").symlink_to(escape, target_is_directory=True)
+    install_tool(ws)
+    # .verdict is now a real kernel-owned dir, not the symlink; nothing written
+    # through to the escape target
+    assert not (ws / ".verdict").is_symlink()
+    assert (ws / ".verdict" / "verdict").exists()
+    assert list(escape.iterdir()) == []
+
+
 def test_installed_tool_is_standalone(tmp_path: Path) -> None:
     # the kernel installs the tool into a prepared checkout without autoresearch;
     # prove the copy runs under a bare interpreter (isolated mode)

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -231,6 +231,32 @@ def test_reader_rejects_malformed_verdict_loudly(tmp_path: Path) -> None:
         read_verdict(tmp_path)
 
 
+def test_reader_rejects_a_finding_missing_blocking(tmp_path: Path) -> None:
+    # fail-open guard: a finding that omits blocking must be REJECTED, never
+    # defaulted to non-gating ("silence is never endorsement" — terra #136 r3).
+    d = tmp_path / ".verdict"
+    d.mkdir(exist_ok=True)
+    (d / "verdict.json").write_text(
+        json.dumps(
+            {
+                "findings": [
+                    {
+                        "file": "x",
+                        "line": 1,
+                        "confidence": "high",
+                        "summary": "s",
+                        "detail": "d",
+                        "kind": "note",
+                    }
+                ],
+                "notes": "",
+            }
+        )
+    )
+    with pytest.raises(VerdictError, match="missing required keys"):
+        read_verdict(tmp_path)
+
+
 def test_reader_size_caps_a_giant_verdict(tmp_path: Path) -> None:
     from autoresearch.verdict import MAX_VERDICT_BYTES
 

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -176,6 +176,36 @@ def test_line_must_be_positive_tool_and_reader(tmp_path: Path, capsys) -> None:
         read_verdict(tmp_path)
 
 
+def test_reader_rejects_a_falsy_non_string_category(tmp_path: Path) -> None:
+    # a falsy non-string category (0, []) must raise, not be silently dropped
+    # by a truthiness guard (terra #136 r5).
+    d = tmp_path / ".verdict"
+    d.mkdir(exist_ok=True)
+    bad_values: list[object] = [0, []]
+    for bad in bad_values:
+        (d / "verdict.json").write_text(
+            json.dumps(
+                {
+                    "findings": [
+                        {
+                            "file": "x",
+                            "line": 1,
+                            "confidence": "high",
+                            "summary": "s",
+                            "detail": "d",
+                            "blocking": True,
+                            "kind": "note",
+                            "category": bad,
+                        }
+                    ],
+                    "notes": "",
+                }
+            )
+        )
+        with pytest.raises(VerdictError, match="category must be a string"):
+            read_verdict(tmp_path)
+
+
 def test_reader_clamps_unknown_category_to_other(tmp_path: Path) -> None:
     # a taxonomy typo normalizes to "other" rather than nuking the verdict —
     # same stance as verifier.py's clamp (terra #136 r1).

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -101,12 +101,12 @@ def test_verifier_category_is_carried(tmp_path: Path) -> None:
         "d",
         "--blocking",
         "--category",
-        "benchmark-gaming",
+        "ruler-fishing",
     )
     run(tmp_path, "conclude")
     verdict = read_verdict(tmp_path)
     assert verdict is not None
-    assert verdict["findings"][0]["category"] == "benchmark-gaming"
+    assert verdict["findings"][0]["category"] == "ruler-fishing"  # a real taxonomy value
 
 
 def test_tool_validation_fails_fast(tmp_path: Path, capsys) -> None:
@@ -129,6 +129,79 @@ def test_tool_validation_fails_fast(tmp_path: Path, capsys) -> None:
         rc = run(tmp_path, *argv)
         assert rc == 2
         assert needle in (capsys.readouterr().err)
+
+
+def test_line_must_be_positive_tool_and_reader(tmp_path: Path, capsys) -> None:
+    # 1-indexed: 0/negative are meaningless -> rejected both in-session and by
+    # the authoritative reader (terra #136 r1).
+    assert (
+        run(
+            tmp_path,
+            "finding",
+            "--file",
+            "x",
+            "--line",
+            "0",
+            "--confidence",
+            "high",
+            "--summary",
+            "s",
+            "--detail",
+            "d",
+        )
+        == 2
+    )
+    assert "1-indexed" in capsys.readouterr().err
+    d = tmp_path / ".verdict"
+    d.mkdir(exist_ok=True)
+    (d / "verdict.json").write_text(
+        json.dumps(
+            {
+                "findings": [
+                    {
+                        "file": "x",
+                        "line": -3,
+                        "confidence": "high",
+                        "summary": "s",
+                        "detail": "d",
+                        "blocking": False,
+                        "kind": "note",
+                    }
+                ],
+                "notes": "",
+            }
+        )
+    )
+    with pytest.raises(VerdictError, match="positive"):
+        read_verdict(tmp_path)
+
+
+def test_reader_clamps_unknown_category_to_other(tmp_path: Path) -> None:
+    # a taxonomy typo normalizes to "other" rather than nuking the verdict —
+    # same stance as verifier.py's clamp (terra #136 r1).
+    d = tmp_path / ".verdict"
+    d.mkdir(exist_ok=True)
+    (d / "verdict.json").write_text(
+        json.dumps(
+            {
+                "findings": [
+                    {
+                        "file": "x",
+                        "line": 1,
+                        "confidence": "high",
+                        "summary": "s",
+                        "detail": "d",
+                        "blocking": True,
+                        "kind": "note",
+                        "category": "made-up-thing",
+                    }
+                ],
+                "notes": "",
+            }
+        )
+    )
+    verdict = read_verdict(tmp_path)
+    assert verdict is not None and verdict["findings"][0]["category"] == "other"
 
 
 def test_reader_rejects_malformed_verdict_loudly(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

**Phase 2 of the role-CLI plan (#134), part 1 — the mechanism.** Inert until part 2 wires it into `role_runner` (mirrors how the syscall arc landed its mechanism before its consumer).

Replaces the judges' "emit one big JSON message → `role_runner` parses-and-**repairs**" path with a **verdict tool**: each finding is one validated call, so the verdict is well-formed *by construction* and the repair loop disappears.

- **`verdict_cli.py`** — standalone (stdlib-only) tool the kernel installs at `.verdict/verdict`. `verdict finding --file --line --confidence --summary --detail [--blocking] [--kind] [--category]` records one finding; `verdict conclude --notes` commits `{findings, notes}` to `.verdict/verdict.json`. Validation is **in-session**: a bad `--confidence`, empty `--summary`, etc. fail on the call, not as a post-session repair round.
- **`verdict.py`** — the kernel side. `read_verdict` **authoritatively** re-validates the committed ABI (size-capped; every field + enum checked; the verifier `category` carried when present) into the exact `{findings, notes}` shape `role_runner` used to parse. The tool is convenience, **never** the trust boundary — a hand-written malformed verdict is still rejected.

## Test plan

Round-trip tool→ABI→reader; clean/empty verdict; verifier category; validation-fails-fast (4 cases); reader rejects a hand-written bad ABI; size cap; and a `python -I` run of the *installed* copy proving it's standalone (no site-packages), like the judge's prepared checkout. Full suite 761 green; ruff + mypy green.

## Next (part 2)

The RoleSpec **allow-listed single-command** capability (judges have no general Bash — the capability terra flagged in the #134 plan) + rewire `reviewer`/`verifier` onto the tool and delete the `output_schema` parse-and-repair path for migrated roles.

## No secrets / no large files

Confirmed.
