### PR TITLE
Judge verdict tool part 2: wire role_runner (inert until a backend hosts it)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Judge verdict tool, part 2 — the wiring (docs/design/role-cli.md, Phase 2;
+  inert until a backend hosts the tool). `RoleSpec.verdict_tool` declares a judge
+  emits its verdict through the installed tool (one allow-listed command, not
+  general Bash — the read-only invariant still holds; requires an
+  `output_schema`). `run_role` now branches: when the role sets `verdict_tool`
+  and the harness reports `supports_verdict_tool`, it installs the tool before
+  the session and reads the committed verdict authoritatively AFTER — no
+  parse-and-repair loop; a missing or malformed verdict is a failure (silence is
+  never endorsement). A backend without the capability falls back to the
+  existing parse-and-repair path, unchanged. No backend sets the capability yet
+  (part 3 grants claude the scoped command after the restriction is validated),
+  so this changes no live behavior.
+
 - Judge verdict tool, part 1 — the mechanism (docs/design/role-cli.md, Phase 2;
   not yet wired into role_runner, so inert until part 2). `verdict_cli.py` is a
   standalone (stdlib-only) tool the kernel installs at `.verdict/verdict`: a

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -1158,6 +1158,7 @@ class FakeHarness:
     script: Any = None  # optional callable(brief_text, workspace) for side effects
     calls: list[tuple[str, str, str | None]] = field(default_factory=list)
     supports_resume: bool = True  # a field so tests can exercise the no-resume path
+    supports_verdict_tool: bool = False  # a field so tests can exercise verdict-tool mode
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -90,6 +90,17 @@ def run_role(
     way climb builds its harness from effective_limits. run_role does not
     reconcile a mismatched harness; it runs what it is given.
     """
+    # Verdict-tool mode (docs/design/role-cli.md Phase 2): a judge whose backend
+    # can host the tool commits its verdict via one allow-listed command instead
+    # of a final JSON message. Install the tool BEFORE the session so it can call
+    # it; read the committed verdict AFTER (authoritatively) instead of parsing.
+    # A backend that cannot host it (`supports_verdict_tool` False) falls back to
+    # the parse-and-repair path below.
+    use_verdict_tool = spec.verdict_tool and getattr(harness, "supports_verdict_tool", False)
+    if use_verdict_tool:
+        from autoresearch.verdict import install_tool
+
+        install_tool(workspace)
     session = harness.run(brief_text, workspace, resume_session_id)
     if session.is_error:
         return RoleResult(
@@ -97,6 +108,20 @@ def run_role(
         )
     if spec.output_schema is None:
         return RoleResult(ok=True, session=session)  # editing role: artifact is the diff
+    if use_verdict_tool:
+        # No repair loop: the tool validated each finding in-session, and
+        # read_verdict is authoritative. A missing verdict (the judge never
+        # concluded) or a malformed one is a failure — the caller posts a skip
+        # stub, never a clean read (silence is never endorsement).
+        from autoresearch.verdict import VerdictError, read_verdict
+
+        try:
+            data = read_verdict(workspace)
+        except VerdictError as exc:
+            return RoleResult(ok=False, session=session, error=f"invalid verdict: {exc}")
+        if data is None:
+            return RoleResult(ok=False, session=session, error="judge produced no verdict")
+        return RoleResult(ok=True, session=session, data=data)
     data, error = _validate_output(session.final_text, spec.output_schema)
     repairs = 0
     while data is None and repairs < max_repairs:

--- a/src/autoresearch/rolespec.py
+++ b/src/autoresearch/rolespec.py
@@ -61,6 +61,14 @@ class RoleSpec:
     # Editing roles only: repo-relative write allowlist. None for read-only
     # judges — declared here for legibility, enforced by the tool set too.
     scope: tuple[str, ...] | None = None
+    # Judges only: emit the verdict through the installed verdict tool (one
+    # allow-listed command) instead of a final JSON message (docs/design/
+    # role-cli.md Phase 2). Requires `output_schema` (a verdict IS that schema);
+    # distinct from `can_execute` — a single scoped command, never general Bash,
+    # so the read-only invariant still holds. A backend that cannot host the
+    # tool falls back to parsing the final message (harness
+    # `supports_verdict_tool`), so this is a preference, not a hard requirement.
+    verdict_tool: bool = False
 
     def __post_init__(self) -> None:
         if not self.tools:
@@ -75,3 +83,5 @@ class RoleSpec:
                 raise RoleSpecError(
                     f"read-only role {self.name!r} edits nothing; scope must be None"
                 )
+        if self.verdict_tool and self.output_schema is None:
+            raise RoleSpecError(f"role {self.name!r}: verdict_tool needs an output_schema")

--- a/tests/test_role_runner.py
+++ b/tests/test_role_runner.py
@@ -132,3 +132,88 @@ def test_steward_spec_is_an_executing_editor_in_its_own_territory() -> None:
     assert {"Write", "Edit", "Bash"} <= set(spec.tools)
     assert spec.output_schema is None  # the artifact is the env-work diff + report
     assert spec.scope == ()  # filled from contract.steward.allowed by the kernel
+
+
+# --- verdict-tool mode (docs/design/role-cli.md Phase 2) ---
+
+
+@dataclass
+class _VerdictHarness:
+    """A harness that hosts the verdict tool: on run it writes a committed
+    verdict (as the judge would via the tool), and declares the capability."""
+
+    verdict: dict | None
+    supports_verdict_tool: bool = True
+    installed: bool = False
+
+    def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+        # the tool was installed before run (we assert the dir exists); simulate
+        # the judge committing a verdict
+        self.installed = (Path(workspace) / ".verdict" / "verdict").exists()
+        if self.verdict is not None:
+            (Path(workspace) / ".verdict").mkdir(exist_ok=True)
+            (Path(workspace) / ".verdict" / "verdict.json").write_text(json.dumps(self.verdict))
+        return _session("(verdict via tool)")
+
+
+def _verdict_spec():
+    from dataclasses import replace
+
+    return replace(reviewer_spec(), verdict_tool=True)
+
+
+def test_verdict_tool_mode_reads_the_committed_verdict(tmp_path: Path) -> None:
+    v = {
+        "findings": [
+            {
+                "file": "x.py",
+                "line": 3,
+                "confidence": "high",
+                "summary": "s",
+                "detail": "d",
+                "blocking": True,
+                "kind": "change",
+            }
+        ],
+        "notes": "one defect",
+    }
+    harness = _VerdictHarness(verdict=v)
+    result = run_role(_verdict_spec(), harness, "review it", tmp_path)
+    assert harness.installed  # tool installed BEFORE the session
+    assert result.ok and result.data is not None
+    assert result.data["findings"][0]["blocking"] is True
+    assert result.data["notes"] == "one defect"
+
+
+def test_verdict_tool_mode_no_verdict_is_a_failure(tmp_path: Path) -> None:
+    # the judge never concluded -> no clean read (silence is never endorsement)
+    result = run_role(_verdict_spec(), _VerdictHarness(verdict=None), "x", tmp_path)
+    assert not result.ok and "no verdict" in result.error
+
+
+def test_verdict_tool_mode_malformed_verdict_is_a_failure(tmp_path: Path) -> None:
+    bad = {
+        "findings": [
+            {
+                "file": "x",
+                "line": 1,
+                "confidence": "SURE",
+                "summary": "s",
+                "detail": "d",
+                "blocking": True,
+                "kind": "note",
+            }
+        ],
+        "notes": "",
+    }
+    result = run_role(_verdict_spec(), _VerdictHarness(verdict=bad), "x", tmp_path)
+    assert not result.ok and "invalid verdict" in result.error
+
+
+def test_verdict_spec_falls_back_to_parsing_when_backend_lacks_support(tmp_path: Path) -> None:
+    # a verdict_tool spec on a backend WITHOUT the capability parses the final
+    # message (the message-based fallback) — no tool installed.
+    harness = _SeqHarness(results=[_session(_FINDINGS)])  # supports_verdict_tool absent -> False
+    result = run_role(_verdict_spec(), harness, "x", tmp_path)
+    assert result.ok and result.data == {"findings": [], "notes": "looks fine"}
+    assert not (tmp_path / ".verdict").exists()  # tool NOT installed

--- a/tests/test_rolespec.py
+++ b/tests/test_rolespec.py
@@ -75,3 +75,20 @@ def test_empty_tools_rejected() -> None:
             execution=Execution(environment="apptainer", can_execute=True),
             budget=SessionBudget(max_turns=10, walltime_s=60),
         )
+
+
+def test_verdict_tool_requires_an_output_schema() -> None:
+    import pytest
+
+    from autoresearch.rolespec import Execution, RoleSpec, RoleSpecError, SessionBudget
+
+    with pytest.raises(RoleSpecError, match="output_schema"):
+        RoleSpec(
+            name="reviewer",
+            instructions="x",
+            key="reviewer",
+            tools=("Read",),
+            execution=Execution(environment="gh-runner", can_execute=False),
+            budget=SessionBudget(max_turns=1, walltime_s=1),
+            verdict_tool=True,  # no output_schema -> invariant violation
+        )


### PR DESCRIPTION
## What

**Phase 2 of the role-CLI plan, part 2 — the wiring.** Connects the verdict tool (#136) to the role-runner. **Inert until a backend hosts the tool** (part 3 grants claude the scoped command after the restriction is validated), so this changes no live behavior.

- **`RoleSpec.verdict_tool`** — declares a judge emits its verdict through the installed tool: one allow-listed command, **not** general Bash (the read-only invariant still holds), and it requires an `output_schema` (a verdict *is* that schema; enforced by a new invariant).
- **`supports_verdict_tool`** — a harness capability (`getattr`, default `False`, same idiom as `supports_resume`): the backend can host the tool.
- **`run_role` branches**: when the role sets `verdict_tool` *and* the harness supports it → install the tool before the session, read the committed verdict **authoritatively** after — **no parse-and-repair loop**; a missing or malformed verdict is a failure (silence is never endorsement). Otherwise → the existing parse-and-repair path, unchanged (the fallback for backends that can't restrict execution to one command).

## Why inert now

Claude's scoped-Bash grant (`Bash(python .verdict/verdict:*)`) needs its actual restriction behavior validated before we trust it as the judge's only execution — same posture as Phase A's enablement. So this lands the wiring; part 3 flips claude on.

## Test plan

verdict-tool mode reads the committed verdict (tool installed *before* the session); no-verdict → failure; malformed verdict → failure; a `verdict_tool` spec on a backend *without* support falls back to parsing with **no tool installed**; RoleSpec invariant rejects `verdict_tool` without an `output_schema`. Full suite 772 green; ruff + mypy green.

## No secrets / no large files

Confirmed.
