### PR TITLE
Interchangeable backends: one build_harness for every role

### DIFF
--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -9,9 +9,9 @@
 #     marker) as an artifact. The only secrets present are the session's own
 #     model key and read-scoped tokens (job token + the reviewer repo's
 #     read-only deploy key while private) — nothing worth stealing, so even
-#     backends that can read /proc (codex: shell; hermes: file tool) are safe
-#     here. Claude's native read-only tool set and /proc-safe Read remain
-#     defense in depth rather than load-bearing.
+#     backends that can read /proc are safe here: the ephemeral runner plus
+#     this tokenless split is the boundary (the judge holds a shell to run the
+#     verdict syscall tool; roles differ by prompt, not tool posture).
 #   post job — holds pull-requests:write, runs NO model session. Re-validates
 #     the envelope (right PR, bot/opt-out skip re-checked, sanitizing render)
 #     and posts through the normal advisory path with the reviewer named in
@@ -125,7 +125,6 @@ jobs:
     timeout-minutes: 70
     # Fork PRs must not reach any secret. `pull_request_target` runs in the
     # base repo's context, so this gate is what closes the pwn-request hole.
-    # The reviewer also never executes PR code, a second layer of defense.
     if: github.event.pull_request.head.repo.full_name == github.repository
     # READ-ONLY: the session runs here, so the job token must not be worth
     # stealing. pull-requests:read lets the CLI fetch the PR metadata/diff.
@@ -196,9 +195,6 @@ jobs:
           ANTHROPIC_REVIEWER_KEY: ${{ inputs.backend == 'claude' && secrets.anthropic_reviewer_key || '' }}
           OPENROUTER_API_KEY: ${{ inputs.backend == 'hermes' && inputs.hermes_provider != 'openai' && secrets.openrouter_api_key || '' }}
           OPENAI_REVIEWER_KEY: ${{ (inputs.backend == 'codex' || (inputs.backend == 'hermes' && inputs.hermes_provider == 'openai')) && secrets.openai_reviewer_key || '' }}
-          # codex's default bwrap can't init on GitHub-hosted; opt into
-          # Landlock (read-only, no egress). Harmless for other backends.
-          REVIEW_CODEX_LEGACY_LANDLOCK: ${{ inputs.backend == 'codex' && '1' || '' }}
           # hermes reads its pinned clone from here; provider seeds ~/.hermes.
           REVIEW_HERMES_REPO: ${{ github.workspace }}/hermes-agent
           REVIEW_HERMES_PROVIDER: ${{ inputs.hermes_provider }}

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -1,13 +1,9 @@
 name: advisory-review-agent-manual
-# Manual dispatch of the agent reviewer — the experimental bench for backends
-# that are not the PR-triggered default. Claude is the trusted default (native
-# read-only tool set). Codex and hermes are validated here first:
-#   codex reads by executing shell, so it runs in the Landlock read-only sandbox
-#     (its default bwrap can't init on GitHub-hosted). Even jailed it can read a
-#     parent's env via /proc, so this bench is an INFORMED one-off, never the
-#     auto default — see docs/design/reviewer-infra.md.
-#   hermes has no read-only tool set; its judge safety is environmental (inert
-#     writes on this throwaway runner, terminal disabled). Experimental only.
+# Manual dispatch of the agent reviewer — the bench for exercising any backend
+# on a chosen PR. Backends are interchangeable: every judge runs with a shell
+# (it records its verdict via the installed syscall tool), contained by the
+# ephemeral runner plus the tokenless split — roles differ by prompt, never by
+# a per-backend tool posture (docs/design/role-cli.md).
 # The PR-triggered production path is review.yml -> advisory-review-agent.yml.
 on:
   workflow_dispatch:
@@ -99,9 +95,6 @@ jobs:
           ANTHROPIC_REVIEWER_KEY: ${{ inputs.backend == 'claude' && secrets.ANTHROPIC_REVIEWER_KEY || '' }}
           OPENROUTER_API_KEY: ${{ inputs.backend == 'hermes' && inputs.hermes_provider != 'openai' && secrets.OPENROUTER_API_KEY || '' }}
           OPENAI_REVIEWER_KEY: ${{ (inputs.backend == 'codex' || (inputs.backend == 'hermes' && inputs.hermes_provider == 'openai')) && secrets.OPENAI_REVIEWER_KEY || '' }}
-          # codex's default bwrap can't init on GitHub-hosted; opt into Landlock
-          # (read-only, no egress). Harmless for the other backends.
-          REVIEW_CODEX_LEGACY_LANDLOCK: ${{ inputs.backend == 'codex' && '1' || '' }}
           # hermes reads its pinned clone from here; provider seeds ~/.hermes.
           REVIEW_HERMES_REPO: ${{ github.workspace }}/hermes-agent
           REVIEW_HERMES_PROVIDER: ${{ inputs.hermes_provider }}

--- a/.github/workflows/verify-agent.yml
+++ b/.github/workflows/verify-agent.yml
@@ -45,9 +45,12 @@ on:
           private; omit once public.
         required: false
 
+# Lowest by default; the post job (and only it) elevates to write. The session
+# job runs the model and holds only a read token — nothing worth lifting from a
+# shell judge via /proc (the tokenless split, mirroring the reviewer).
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 # One verification at a time per PR. Do NOT cancel in progress: a running
 # session is a paid model call, so queue a second dispatch behind it.
@@ -55,6 +58,10 @@ concurrency:
   group: verification-review-agent-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+# The gate below is duplicated verbatim on BOTH jobs (GitHub Actions has no
+# top-level place to share it): fork PRs must not reach the secret; the BOT's
+# PRs only (human PRs belong to the advisory reviewer); and a label event
+# counts only for the re-request label applied by someone other than the author.
 jobs:
   verify:
     runs-on: ubuntu-latest
@@ -62,17 +69,17 @@ jobs:
     continue-on-error: true
     # Backstop a hung session; the harness kills at its own walltime first.
     timeout-minutes: 70
-    # Fork PRs must not reach the secret; this role covers the BOT's PRs only
-    # (human PRs belong to the advisory reviewer); and label events count only
-    # for the SPECIFIC re-request label applied by someone other than the PR's
-    # author, so an unrelated triage label (or the bot relabeling its own PR)
-    # cannot bill another round.
     if: >-
       github.event.pull_request.head.repo.full_name == github.repository &&
       github.event.pull_request.user.login == inputs.bot_login &&
       (github.event.action != 'labeled' ||
        (github.event.label.name == 'autoresearch:review' &&
         github.event.sender.login != github.event.pull_request.user.login))
+    # Read-only: the session (and its shell judge) runs here, so its token must
+    # not be worth stealing — the write token lives in the post job.
+    permissions:
+      contents: read
+      pull-requests: read
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
@@ -112,15 +119,91 @@ jobs:
           set -euo pipefail
           curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.229
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-      - name: Run the agent verification
+      - name: Run the session (emit only — nothing posted from this job)
         working-directory: kernel
         env:
           ANTHROPIC_VERIFIER_KEY: ${{ secrets.anthropic_verifier_key }}
-          # The caller's own workflow token — the bot PAT is never used here.
+          # read-only job token: PR metadata/diff/thread fetch only.
           GITHUB_TOKEN: ${{ github.token }}
           PR_REPO: ${{ github.repository }}
           REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
           VERIFY_MODEL: ${{ inputs.model }}
           # The parent of the two checkouts (pr-head/ and base/).
           VERIFY_CHECKOUT: ${{ github.workspace }}
+          VERIFY_EMIT_FILE: ${{ runner.temp }}/verdict.json
         run: uv run python -m autoresearch.verify_agent_cli
+      - name: Backstop envelope
+        # Runs only when the CLI exited 0: a verifier_ref pinned before the
+        # tokenless split writes nothing on a clean skip, which would hard-fail
+        # the post job's required download. A crashed session exits nonzero,
+        # skips this step, and still fails loudly downstream. A skip-STUB, so
+        # the poster's own bot re-check silences it on a non-bot PR while a
+        # session that went silent surfaces a could-not-run round.
+        working-directory: kernel
+        env:
+          PR_REPO: ${{ github.repository }}
+          EMIT_FILE: ${{ runner.temp }}/verdict.json
+        run: |
+          if [ ! -f "$EMIT_FILE" ]; then
+            uv run python -c "import json, os, pathlib; pathlib.Path(os.environ['EMIT_FILE']).write_text(json.dumps({'repo': os.environ['PR_REPO'], 'number': int(os.environ['PR_NUMBER']), 'kind': 'skip-stub', 'detail': 'session wrote no envelope (verifier_ref predates the tokenless split, or the session went silent)'}))"
+          fi
+      - name: Upload the verdict
+        # not success(): a session that died AFTER emitting must still deliver
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: verify-verdict-${{ env.PR_NUMBER }}
+          path: ${{ runner.temp }}/verdict.json
+          if-no-files-found: ignore
+          retention-days: 3
+
+  post:
+    runs-on: ubuntu-latest
+    needs: verify
+    # Same gate as `verify` (duplicated: no shared top-level in Actions), so the
+    # two jobs run or skip together.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.user.login == inputs.bot_login &&
+      (github.event.action != 'labeled' ||
+       (github.event.label.name == 'autoresearch:review' &&
+        github.event.sender.login != github.event.pull_request.user.login))
+    continue-on-error: true
+    timeout-minutes: 15
+    # The write half: no model session runs in this job.
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Check out the verifier
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ inputs.verifier_repo }}
+          ref: ${{ inputs.verifier_ref }}
+          ssh-key: ${{ secrets.checkout_ssh_key }}
+          path: kernel
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: kernel/uv.lock
+      - name: Download the verdict
+        id: verdict
+        # NO continue-on-error: every session outcome uploads an envelope, so a
+        # missing artifact means the session died before emitting — fail this
+        # job visibly (the caller's PR stays green; job is continue-on-error).
+        uses: actions/download-artifact@v4
+        with:
+          name: verify-verdict-${{ env.PR_NUMBER }}
+          path: ${{ runner.temp }}
+      - name: Post the verdict
+        if: steps.verdict.outcome == 'success'
+        working-directory: kernel
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_REPO: ${{ github.repository }}
+          REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
+          VERIFY_EMIT_FILE: ${{ runner.temp }}/verdict.json
+        run: uv run python -m autoresearch.verify_post_cli

--- a/.github/workflows/verify-agent.yml
+++ b/.github/workflows/verify-agent.yml
@@ -1,8 +1,9 @@
 # Reusable agent-session verifier: integrity reads of BOT-authored PRs (the
-# agent reviewer's mirror). It checks out TWO trees read-only — the PR head
-# (the change under review) and the base branch (the trusted contract and
-# ruler) — and runs the verifier as an agent that reads them (no Bash/Write:
-# nothing from the PR is ever executed). Its constitution: never fails the
+# agent reviewer's mirror). It checks out TWO trees — the PR head (the change
+# under review) and the base branch (the trusted contract and ruler) — and
+# runs the verifier as an agent that investigates them and records its verdict
+# through the installed syscall tool. The ephemeral runner plus the tokenless
+# split contain the session. Its constitution: never fails the
 # caller's CI, never runs with secrets on a fork PR, silence is not
 # endorsement. Claude only on GitHub-hosted runners (codex's
 # sandbox cannot init there; codex verification runs via the cluster harness).
@@ -75,17 +76,19 @@ jobs:
     env:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      # Checks out the VERIFIER code; the PR's code is checked out below but
-      # never executed (the session has no execute or write tools).
+      # Checks out the VERIFIER code. NOT at `.autoresearch` — that name is
+      # the judge's syscall channel inside the workspace, which the kernel
+      # force-owns (recreates) before the session; a colliding checkout there
+      # would be destroyed.
       - name: Check out the verifier
         uses: actions/checkout@v4
         with:
           repository: ${{ inputs.verifier_repo }}
           ref: ${{ inputs.verifier_ref }}
           ssh-key: ${{ secrets.checkout_ssh_key }}
-          path: .autoresearch
+          path: kernel
           persist-credentials: false
-      - name: Check out the PR head (read-only; never executed)
+      - name: Check out the PR head (the change under review)
         uses: actions/checkout@v4
         with:
           ref: refs/pull/${{ env.PR_NUMBER }}/head
@@ -102,7 +105,7 @@ jobs:
       - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
-          cache-dependency-glob: .autoresearch/uv.lock
+          cache-dependency-glob: kernel/uv.lock
       # Native binary, pinned to the validated version — bump deliberately.
       - name: Install the Claude CLI
         run: |
@@ -110,7 +113,7 @@ jobs:
           curl -fsSL https://claude.ai/install.sh | bash -s -- 2.1.229
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Run the agent verification
-        working-directory: .autoresearch
+        working-directory: kernel
         env:
           ANTHROPIC_VERIFIER_KEY: ${{ secrets.anthropic_verifier_key }}
           # The caller's own workflow token — the bot PAT is never used here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Interchangeable backends — one harness construction for every role
+  (docs/design/role-cli.md, "the harness unification"). `build_harness`
+  (role_runner.py) replaces `build_editor_harness` and
+  `build_reviewer_harness`: claude maps `spec.tools` to native flags (judges
+  run `--bare` — an untrusted checkout must never load as instructions); codex
+  runs `--sandbox danger-full-access` uniformly (its own sandbox needs
+  bubblewrap — the boundary is the deployment's container or ephemeral runner,
+  plus the tokenless split); hermes derives its toolsets from the spec and is
+  a first-class backend (the manual-bench-only caveat is gone). Judges are
+  executing roles now: they hold `Bash` and record their verdict by RUNNING
+  the syscall tool (`finding` / `conclude`) — the reviewer/verifier briefs
+  instruct exactly that, and roles differ by prompt, verbs, and output
+  handling, never by a bespoke tool posture. A judge IS a role with an
+  `output_schema`, so the redundant `RoleSpec.verdict_tool` flag is removed
+  (`run_role` gates the verdict path on the schema), and the
+  parse-a-final-message-and-repair path is deleted — `read_verdict` on the
+  committed syscall channel is the one way a verdict reaches the kernel.
+
 - Hermes headless resume (`supports_resume = True`) — a headless CLI "resumes"
   by restarting with its prior context restored (all `claude --resume` /
   `codex exec resume` do), and hermes reads its brief from a file, so resume

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ Versions follow [SemVer](https://semver.org).
   parse-a-final-message-and-repair path is deleted — `read_verdict` on the
   committed syscall channel is the one way a verdict reaches the kernel.
 
+  Because judges now hold a shell, the verifier adopts the reviewer's existing
+  tokenless split: its session job runs read-only and emits the verdict to an
+  artifact (`VERIFY_EMIT_FILE`), and a separate write-token job
+  (`verify_post_cli`) posts it — so a prompt-injected judge has no write
+  credential to lift via /proc. The reviewer already worked this way.
+
 - Hermes headless resume (`supports_resume = True`) — a headless CLI "resumes"
   by restarting with its prior context restored (all `claude --resume` /
   `codex exec resume` do), and hermes reads its brief from a file, so resume

--- a/docs/design/agent-substrate.md
+++ b/docs/design/agent-substrate.md
@@ -218,8 +218,8 @@ role-runner and kernel.
 | Capability | Native | Synthesized fallback |
 | --- | --- | --- |
 | resume | wake a session with its context | replay distilled context into a fresh session |
-| structured output | schema-constrained final artifact | role-runner parses → validates → repairs `final_text` |
-| tool restriction | honor `allowed_tools` | if it can't restrict, it's ineligible for read-only judge roles |
+| structured output | the syscall tool's per-call validation + kernel `read_verdict` | none — a judge that commits no verdict fails its round |
+| tool restriction | honor `allowed_tools` | the deployment boundary contains the session either way |
 | cost / turn accounting | from backend output | session/token proxy |
 
 Editing-role **scope** (the write allowlist) is not a backend capability: the

--- a/docs/design/consolidation.md
+++ b/docs/design/consolidation.md
@@ -120,7 +120,7 @@ scope, key), and their spend counts against its budget.
 
 | Now | Fate |
 | --- | --- |
-| `climb`, `steward`, `followup` | Session dispatch collapsed: all five roles run through **one role-runner + a RoleSpec** (judges via their agent modules, `review_cli`/`verifier_cli` deleted; author via `climb_once`; follow-up via `respond_once` under the resuming role's key and scope; steward via `live_steward`) with the harness built from the spec (`build_editor_harness` for editing roles). What remains of these modules is each role's kernel half — measure/gate/PR/wake plumbing. The brief/skills halves becoming app config is the remaining consolidation. |
+| `climb`, `steward`, `followup` | Session dispatch collapsed: all five roles run through **one role-runner + a RoleSpec** (judges via their agent modules, `review_cli`/`verifier_cli` deleted; author via `climb_once`; follow-up via `respond_once` under the resuming role's key and scope; steward via `live_steward`) with the harness built from the spec (one `build_harness` for every role). What remains of these modules is each role's kernel half — measure/gate/PR/wake plumbing. The brief/skills halves becoming app config is the remaining consolidation. |
 | `review`, `verifier` (rendering, verdict/blocking machinery) | On the agent-session path; hold the shared vocabulary and rendering both judges use. |
 | `harness`, `brief` | The seam. Keep. Adapters live: claude, codex, hermes. |
 | `orchestrator`, `contract`, `github`, `compute`, `runstate`, `disk`, `limits`, `intake` | Kernel. Barely moves — the point. |
@@ -137,7 +137,7 @@ gap:
 
 - **resume** (wake a session with its working context)
 - **structured output** (schema-constrained verdict for judge roles)
-- **tool restriction** (read-only toolset for the reviewer boundary)
+- **tool restriction** (honor the spec's tool set)
 - **cost / turn accounting**
 
 Lineup: **Claude Code** (primary), **Codex** (second, confirmed), **Hermes
@@ -149,8 +149,9 @@ runs stay comparable.
 
 ## Reviewer and verifier are this consolidation
 
-They run on the agent-session path with a read-only checkout of the PR head
-(Read, Grep, Glob; no Bash, no Write; egress limited to the model API plus the
+They run on the agent-session path over a checkout of the PR head
+(investigating with the read tools, recording the verdict via the installed
+syscall tool; egress limited to the model API plus the
 curated
 retriever). The two seams collapse to one substrate; roles differ only by
 RoleSpec.
@@ -179,8 +180,9 @@ a bolt-on. Two levers:
 ## Staged plan
 
 1. **Reviewer/verifier onto the agent-session path, Codex as the proving
-   backend.** Lowest-stakes place to validate a second backend (a read-only judge
-   is far safer to run on an alternate stack than a file-editing author), and it
+   backend.** Lowest-stakes place to validate a second backend (a judge's
+   verdict is advisory, far safer on an alternate stack than a file-editing
+   author), and it
    ships the agentic-review upgrade at the same time.
 2. **Introduce `RoleSpec` + the role-runner**; move author, steward, follow-up
    onto it; fold prompt content into skills; wire the lesson-capture step.

--- a/docs/design/orchestrator-verify.md
+++ b/docs/design/orchestrator-verify.md
@@ -33,7 +33,7 @@ more things fall out of the same move:
 
 ```
 candidate measured improved (and suite-gated, when shared paths were touched)
-  → PANEL: parallel read-only sessions, one per lens
+  → PANEL: judge sessions, one per lens (run sequentially)
       verifier      — integrity lens (gaming, leakage, claim consistency);
                       strongest model
       code-reviewer — correctness/cleanliness lens; may run on a cheaper

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -141,15 +141,17 @@ Two facts make this manageable.
 
 First, reading is not running. The deployed reviewer reads the PR head —
 untrusted code — and that is safe because reading it can only inform the
-model, not execute anything: the session has no execute or write tools, and
-file contents are treated as data, never as instructions. Running code is
-the dangerous act, and the read-only reviewer never runs anything.
+model. File contents are treated as data, never as instructions. The judge
+holds a shell (it records its verdict by running the installed syscall tool);
+what contains the session is the deployment's boundary — the ephemeral runner
+plus the tokenless split — not a per-role tool posture (see
+docs/design/role-cli.md, "the harness unification").
 
 Second, containment. Today the agent runs in a single GitHub-hosted step that
 holds the caller's workflow token (repo-scoped, short-lived) and a spend-capped
 model key. What keeps that manageable is the same-repo gate (no fork PR reaches
-it) plus the read-only tool set — and, on the auto path, only Claude, whose
-`Read` refuses `/proc` so a prompt-injected session cannot lift the step token
+it) plus the tokenless split: the session job holds nothing worth stealing, so
+even a prompt-injected session with a shell cannot lift a posting credential
 (see "Which backend can judge"). Two residual risks have bounded worst cases: a
 leaked spend-capped key is capped spend until rotation, not open-ended
 credential loss; a prompt-injected agent's text reaches a repo comment through
@@ -196,9 +198,9 @@ more seeded gaming per dollar before it ships.
 ## Status (2026-08-13)
 
 The agent-session reviewer is live. It runs as a reusable workflow
-(`.github/workflows/advisory-review-agent.yml`): on a PR it checks out the head
-read-only, runs the reviewer as an agent that reads the code (no Bash/Write, so
-untrusted PR code is only read, never executed), and posts findings. Claude on
+(`.github/workflows/advisory-review-agent.yml`): on a PR it checks out the
+head, runs the reviewer as an agent that investigates the code and records its
+verdict through the installed syscall tool, and posts findings. Claude on
 GitHub-hosted runners is the default — its reads are native, so it needs no
 second sandbox; codex's default bwrap sandbox cannot init on GitHub-hosted
 runners (its Landlock fallback can, but on a deprecated flag with a `/proc` read
@@ -236,8 +238,9 @@ path-opening tool.
   the same reach as codex, via a file read (finding, 2026-08-14). Its *writes*
   are inert on an ephemeral runner, but that bounds the wrong thing; the token
   read is what matters. Not token-safe.
-- **Claude Code (2.1.229):** the strongest boundary — a native read-only tool
-  set (Read/Grep/Glob, no Write/Edit/Bash), so no writes and no shell. The new
+- **Claude Code (2.1.229):** historical note — judges then ran a native
+  read-only tool set (Read/Grep/Glob); since the harness unification they hold
+  a shell like every role, and the tokenless split is the boundary. The /proc
   axis raised the question: can `Read` open `/proc/<pid>/environ`? PROBED
   2026-08-14 (claude-proc-probe, opus-5, faithful harness mimic): `Read` REFUSES
   both `/proc/<parent-pid>/environ` and `/proc/self/environ` — a tool-level

--- a/docs/design/role-cli.md
+++ b/docs/design/role-cli.md
@@ -118,15 +118,22 @@ PAT in the session; findings are data, a separate step posts), an ephemeral
 jail, and the egress posture — which contains a shell-judge just as it contains
 an author.
 
-**Landed (the surface unification):** the one surface — `finding`/`conclude`
-verbs, the typed ABI, `read_verdict`, the force-owning `install_tool` — replaces
-the standalone `verdict` tool. `run_role` gates the verdict path on
-`spec.verdict_tool` alone (the deployment builds the harness to match the role).
-INERT until a spec sets `verdict_tool=True`. **Follow-up (harness unification):**
-route judges through the same executing-harness-in-a-jail setup authors use
-(differing only by system prompt + verbs + output handling), flip `verdict_tool`
-on, and delete `build_reviewer_harness`'s read-only branches and the judge
-parse-and-repair path.
+**Landed (the surface unification, PR #138):** the one surface —
+`finding`/`conclude` verbs, the typed ABI, `read_verdict`, the force-owning
+`install_tool` — replaced the standalone `verdict` tool.
+**Landed (the harness unification):** ONE `build_harness` constructs every
+role on every backend (`role_runner.py`), replacing `build_editor_harness` and
+`build_reviewer_harness`. Judges run like every other role — a shell for the
+syscall tool, contained by the deployment's boundary (a container where one
+exists, the ephemeral runner where one doesn't, plus the tokenless split) —
+and differ only by prompt, verbs, and output handling. A judge IS a role with
+an `output_schema`: `run_role` installs the tool and reads the verdict for
+exactly those specs (the separate `verdict_tool` flag was redundant and is
+gone), and the parse-a-final-message-and-repair path is deleted. Backends are
+interchangeable: claude (`spec.tools` → native flags, `--bare` for judges),
+codex (`danger-full-access` uniformly — the boundary is the deployment's, not
+codex's own sandbox), hermes (toolsets from the spec; first-class, no
+manual-bench caveat).
 
 **Acceptance:** a judge session produces a verdict with zero repair rounds;
 a malformed call is corrected in-session; the judge can run the tool and

--- a/docs/design/role-cli.md
+++ b/docs/design/role-cli.md
@@ -16,10 +16,10 @@ Two distinct wins, and each future application should name which one it buys:
   kernel holds the PAT/keys/cluster and performs the privileged act. A CLI verb
   is how the agent *directs* an act it must never *execute*. (The launch/sleep
   tool; GitHub writes; curated egress.)
-- **Win B — interactive validation replaces parse-and-repair.** Today a judge
-  emits a schema-constrained final message and the role-runner parses,
-  validates, and **repairs once** (`role_runner._repair_prompt`) — a lossy
-  retry that burns a turn and can still fail. A CLI validates each field **on
+- **Win B — interactive validation replaces parse-and-repair.** A judge used
+  to emit a schema-constrained final message that the role-runner parsed,
+  validated, and repaired once — a lossy retry that burned a turn and could
+  still fail (that path is deleted). A CLI validates each field **on
   the call**: bad input fails immediately, in-session, with a message the agent
   acts on. The artifact is well-formed **by construction**. (Judge verdicts;
   planner work-orders; the author tool's fast checks.)
@@ -48,8 +48,6 @@ The invariants, proven on #132/#133 and non-negotiable everywhere:
    containment mechanism (the jail contains them all).
 
 ## End-state
-
-One `research` CLI identity, instantiated per role with only that role's verbs:
 
 One `.autoresearch/syscall` tool, its live verbs gated per role by RoleSpec:
 

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -36,7 +36,7 @@ from autoresearch.github import (
     GitHubClient,
     Workspace,
 )
-from autoresearch.harness import ClaudeCodeHarness, CodexHarness, Harness, SessionResult, redact
+from autoresearch.harness import Harness, SessionResult, redact
 from autoresearch.measure import DispatchSettings, LocalMeasurer
 from autoresearch.orchestrator import (
     ClimbConfig,
@@ -63,7 +63,7 @@ from autoresearch.progress import (
     write_progress,
 )
 from autoresearch.review import PullRequest
-from autoresearch.role_runner import run_role
+from autoresearch.role_runner import build_harness, run_role
 from autoresearch.roles import author_spec
 from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
@@ -120,7 +120,7 @@ def codex_author_config_error(backend: str, model: str, image: str) -> str:
     if backend not in ("claude", "codex"):
         # a typo'd AUTORESEARCH_AUTHOR_BACKEND passes the env DEFAULT silently
         # (argparse validates the flag, not its default) and the climb rejects it
-        # at build_editor_harness — catch it on the tick host so a claimed intake
+        # at build_harness — catch it on the tick host so a claimed intake
         # issue never strands on it
         return f"unknown author backend {backend!r} (expected 'claude' or 'codex')"
     if backend == "claude":
@@ -1371,93 +1371,27 @@ def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
     if not args.panel.strip():
         return ()
     from autoresearch.panel import parse_lenses
-    from autoresearch.review_agent import build_reviewer_harness
+    from autoresearch.roles import reviewer_spec
 
     panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
     lenses = []
     for kind, backend, model in parse_lenses(args.panel):
         hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
         try:
-            judge = build_reviewer_harness(
+            judge = build_harness(
                 panel_key,
+                reviewer_spec(),
                 backend=backend,
                 binary=args.claude_bin if backend == "claude" else None,
                 model=model or None,
                 container_image=args.image if backend == "claude" else "",
                 hermes_repo=Path(hermes_repo_env) if hermes_repo_env else None,
-                provider=os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter"),
+                hermes_provider=os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter"),
             )
         except ValueError as exc:
             raise ValueError(f"panel entry {kind}:{backend}: {exc}") from exc
         lenses.append(PanelLens(kind=kind, harness=judge))
     return tuple(lenses)
-
-
-def build_editor_harness(
-    api_key: str,
-    spec: RoleSpec | None = None,
-    *,
-    backend: str = "claude",
-    binary: str | None = None,
-    model: str | None = None,
-    container_image: str = "",
-    codex_extra_args: tuple[str, ...] = (),
-) -> Harness:
-    """Construct an editing role's harness from its RoleSpec, for the chosen
-    backend — the same deployment wiring the judges use (`spec.budget` drives
-    turns and walltime). The session runs contained (apptainer) and KEEPS
-    instruction-file discovery — the target repo's CLAUDE.md is legitimate
-    guidance for an editing role, unlike a judge's untrusted checkout.
-
-    The seam (`run_role`, `climb_once`) takes any Harness, so a backend is one
-    branch here, zero kernel change (the reviewer's rollout):
-    - claude: native tool set, apptainer-contained; the trusted default.
-    - codex: apptainer-contained; codex runs `--sandbox danger-full-access`
-      (no inner OS sandbox) and relies on apptainer as the boundary, exactly as
-      the claude author does — codex's own sandbox needs bubblewrap, absent in
-      the image. An author MUST be contained (it writes+executes), so
-      container_image is REQUIRED — the read-only reviewer could skip it. Codex
-      resumes like claude (`codex exec resume`, validated on 0.130.0), so a
-      blocking panel finding WAKES it to revise. All three backends resume
-      (hermes via saved-transcript rehydration); the inline and wake revise
-      paths still gate on `supports_resume`, so any future backend that cannot
-      resume never blind-revises and never loses an improvement to a failed
-      resume."""
-    spec = spec or author_spec()
-    if not spec.execution.can_execute:
-        raise ValueError("build_editor_harness is for editing roles")
-    if backend == "codex":
-        if not container_image:
-            # an author writes+executes; it must not run uncontained
-            raise ValueError("codex editor backend requires a container_image (apptainer)")
-        return CodexHarness(
-            api_key=api_key,
-            binary=binary or "codex",
-            model=model or "",  # "" -> codex's configured default; pin a verified id
-            # apptainer IS the sandbox here (like the claude author, which has no
-            # inner OS sandbox). codex's own `workspace-write` needs bubblewrap,
-            # which isn't in the image and is unreliable nested inside apptainer;
-            # `danger-full-access` skips codex's sandbox and relies on apptainer's
-            # boundary (no host FS beyond the ws+home binds, scrubbed env), which
-            # already confines writes to the workspace.
-            sandbox="danger-full-access",
-            timeout_s=spec.budget.walltime_s,
-            container_image=container_image,
-            extra_args=codex_extra_args,
-        )
-    if backend != "claude":
-        raise ValueError(f"unknown editor backend: {backend!r}")
-    return ClaudeCodeHarness(
-        api_key=api_key,
-        binary=binary or "claude",
-        model=model or "claude-opus-5",
-        max_turns=spec.budget.max_turns,
-        timeout_s=spec.budget.walltime_s,
-        # the manifest drives the tool set, same as the budget (all author
-        # tools are native Claude tools; no MCP tools to filter out)
-        allowed_tools=spec.tools,
-        container_image=container_image,
-    )
 
 
 def build_panel_runner(
@@ -2565,7 +2499,7 @@ def main() -> int:
         if wake_lenses or _wake_stage.get("phase") == "author-sleep":
             wake_api_key = FileTokenProvider(Path(wake_key_file)).token()
             wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
-            wake_harness = build_editor_harness(
+            wake_harness = build_harness(
                 wake_api_key,
                 wake_spec,
                 backend=wake_backend,
@@ -2687,7 +2621,7 @@ def main() -> int:
                 base_branch=args.base_branch,
                 run_root=args.run_root,
                 run_id=run_id,
-                harness=build_editor_harness(
+                harness=build_harness(
                     api_key,
                     spec,
                     backend=args.author_backend,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1384,7 +1384,13 @@ def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
                 backend=backend,
                 binary=args.claude_bin if backend == "claude" else None,
                 model=model or None,
-                container_image=args.image if backend == "claude" else "",
+                # ALWAYS contained: the panel runs on the climb host next to key
+                # files, and a judge now holds a shell (codex `danger-full-access`),
+                # so it must run inside the image. `parse_lenses` gates panel
+                # backends to those containable here (claude today); passing the
+                # image unconditionally means codex is safe the moment it is
+                # enabled, never accidentally uncontained.
+                container_image=args.image,
                 hermes_repo=Path(hermes_repo_env) if hermes_repo_env else None,
                 hermes_provider=os.environ.get("REVIEW_HERMES_PROVIDER", "openrouter"),
             )

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -761,7 +761,8 @@ def main() -> int:
     # ending honest (cursors un-advanced on failure -> the next tick retries).
     import signal as _signal
 
-    from autoresearch.climb import arm_self_deadline, build_editor_harness
+    from autoresearch.climb import arm_self_deadline
+    from autoresearch.role_runner import build_harness
 
     armed = arm_self_deadline(args.job_minutes)
     if armed:
@@ -779,7 +780,7 @@ def main() -> int:
         outcome = respond_once(
             args.run_root,
             args.run_id,
-            harness=build_editor_harness(
+            harness=build_harness(
                 api_key,
                 spec,
                 backend=author_backend,

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -630,13 +630,12 @@ def _codex_command(
     Fresh and resume take DIFFERENT flags. `codex exec` has `--sandbox` and
     `--cd`; `codex exec resume <id>` has NEITHER (passing them is an argparse
     error) — it restores the recorded session, INCLUDING that session's sandbox
-    and cwd. Verified on codex-cli 0.130.0: resuming a `--sandbox read-only`
-    session with no sandbox flag still refuses writes, so a resumed read-only
-    reviewer stays jailed by inheritance, not by luck. The author adds
-    `--dangerously-bypass-approvals-and-sandbox` on resume anyway — its
-    danger-full-access is inherited, but the flag also skips approvals so a
-    headless write-heavy revise turn cannot stall. (Both authors and readers can
-    resume — readers via the structured-output repair turn.)
+    and cwd (verified on codex-cli 0.130.0). A `danger-full-access` session
+    (every role: the deployment's container or ephemeral runner is the
+    boundary, not codex's own sandbox) adds
+    `--dangerously-bypass-approvals-and-sandbox` on resume — the sandbox is
+    inherited anyway, but the flag also skips approvals so a headless
+    write-heavy turn cannot stall.
     """
     # --model is omitted when empty so codex uses its configured default; a
     # wrong model id is a 404 ("Model not found"), so only pin a verified one.
@@ -649,8 +648,8 @@ def _codex_command(
     ]
     if resume_session_id:
         # no --sandbox/--cd on resume: the recorded session's sandbox is
-        # inherited (read-only stays read-only). The author adds the bypass flag
-        # to also skip approvals headlessly; a reader inherits its read-only jail.
+        # inherited; the bypass flag also skips approvals so a headless turn
+        # cannot stall waiting for one.
         bypass = (
             ["--dangerously-bypass-approvals-and-sandbox"]
             if sandbox == "danger-full-access"
@@ -663,7 +662,7 @@ def _codex_command(
         "--json",  # JSONL events on stdout (session id, usage)
         *model_flag,
         "--sandbox",
-        sandbox,  # "read-only" for judge roles; "danger-full-access" for authors
+        sandbox,  # "danger-full-access": the deployment's boundary, not codex's
         "--cd",
         str(workspace),
         *tail,
@@ -737,27 +736,25 @@ def _parse_codex_result(
 class CodexHarness:
     """Headless OpenAI Codex CLI (`codex exec`) — a second Harness backend.
 
-    Stage 1's swappability proof, first used for the read-only reviewer
-    (docs/design/consolidation.md): Codex's own `--sandbox read-only` plus a
-    judge RoleSpec's tool set. CLI flags AND headless resume are verified against
-    codex-cli 0.130.0 (`session_id` = the `thread.started` `thread_id`; resume
-    recalls it); cost parsing stays best-effort (these backends are metered by a
-    session/token proxy in the budget layer).
+    Stage 1's swappability proof (docs/design/consolidation.md). CLI flags AND
+    headless resume are verified against codex-cli 0.130.0 (`session_id` = the
+    `thread.started` `thread_id`; resume recalls it); cost parsing stays
+    best-effort (these backends are metered by a session/token proxy in the
+    budget layer).
 
-    AUTHOR mode (`container_image` set): both `codex login` and `codex exec` run
-    inside `apptainer exec --containall --cleanenv`, sharing a bound `--home` so
-    the login's auth.json is visible to the exec. apptainer is the boundary — no
-    host FS beyond the two binds; `--cleanenv` scrubs the env down to the
-    author's own key, so the process tree carries no foreign token for a /proc
-    read to lift (the boundary is the scrubbed env, not PID isolation) — exactly
-    the posture of the Claude author. The AUTHOR passes `--sandbox
-    danger-full-access`: codex's own sandbox (`workspace-write`) needs bubblewrap,
-    absent in the image and unreliable nested in apptainer, and it is redundant
-    when apptainer already confines writes to the bound workspace+home. The host
-    codex binary is bind-mounted read-only into the container (like claude), so
-    the image stays codex-free and codex updates by swapping one host binary. The
-    reviewer path (no `container_image`) is unchanged: uncontained,
-    `--sandbox read-only`.
+    CONTAINED mode (`container_image` set): both `codex login` and `codex exec`
+    run inside `apptainer exec --containall --cleanenv`, sharing a bound
+    `--home` so the login's auth.json is visible to the exec. apptainer is the
+    boundary — no host FS beyond the two binds; `--cleanenv` scrubs the env
+    down to the role's own key, so the process tree carries no foreign token
+    for a /proc read to lift (the boundary is the scrubbed env, not PID
+    isolation) — the same posture as the Claude backend. `--sandbox
+    danger-full-access` uniformly: codex's own sandbox (`workspace-write`)
+    needs bubblewrap, absent in the image and unreliable nested in apptainer,
+    and the deployment's boundary (this container, or the ephemeral runner in
+    the uncontained case) already confines the session. The host codex binary
+    is bind-mounted read-only into the container (like claude), so the image
+    stays codex-free and codex updates by swapping one host binary.
 
     `run` never raises: every failure comes back as an error SessionResult.
     """
@@ -766,11 +763,13 @@ class CodexHarness:
     binary: str = "codex"
     # empty -> codex's configured default (a wrong id 404s); pin only a verified one
     model: str = ""
-    sandbox: str = "read-only"  # judge default; authors pass "workspace-write"
+    # the deployment's container or ephemeral runner is the boundary; codex's own
+    # sandbox stays off (it needs bubblewrap — absent/unreliable in apptainer)
+    sandbox: str = "danger-full-access"
     timeout_s: int = DEFAULT_TIMEOUT_S
     extra_args: tuple[str, ...] = field(default_factory=tuple)
-    # AUTHOR mode: when set, login+exec run inside this apptainer image. Empty =
-    # uncontained (the read-only reviewer path).
+    # when set, login+exec run inside this apptainer image; empty = uncontained
+    # (the deployment's runner is the boundary)
     container_image: str = ""
     apptainer_binary: str = "apptainer"
     # in-container path the host codex binary is bound to (bind-from-host, like
@@ -1065,21 +1064,13 @@ class HermesHarness:
     """Headless hermes-agent (Nous Research, MIT) — the OSS backend behind the
     Harness seam, driven via `uv run <repo>/run_agent.py` from a pinned clone.
 
-    ELIGIBILITY: author-side, or an EXPERIMENTAL judge — never a trusted judge,
-    and never on the auto path while a token is reachable. Hermes has no native
-    read-only toolset (its `file` toolset bundles write_file and patch, and
-    `approvals.deny` gates only shell), so it cannot enforce read-only at the tool
-    set the way Claude does. Critically, `file` READS ARBITRARY PATHS: even with
-    `terminal` disabled it can open /proc/<parent-pid>/environ and lift a
-    GITHUB_TOKEN held by the process that spawned it — the same /proc reach codex
-    has via shell, just via a file read. So "no shell" does NOT make it token-safe;
-    it must not judge next to a live token without the tokenless split (findings ->
-    artifact, a separate step posts). What IS bounded on an ephemeral runner is its
-    WRITES — inert (nothing to push, scrubbed env, container discarded), and only
-    where writes cannot persist. So: manual bench only (informed /proc caveat),
-    never the auto path, never the cluster/reused workspace, until an upstream
-    read/write toolset split or an OS jail that also hides /proc gives it a real
-    boundary. Claude stays the trusted default (native read-only tool set).
+    A first-class, interchangeable backend: like claude and codex, its boundary
+    is the deployment's (a container where one exists, the ephemeral runner
+    where one doesn't) plus the tokenless split — the session is spawned with a
+    scrubbed environment and no credential beyond its own key, so its `file`
+    toolset's arbitrary-path reads (including /proc) find nothing to lift, and
+    its writes are confined to the disposable workspace. Roles differ by
+    prompt, never by a hermes-specific posture.
     Instruction-file surface: hermes auto-loads AGENTS.md from the workspace,
     which sanitize_checkout already neutralizes in untrusted trees.
 
@@ -1107,10 +1098,7 @@ class HermesHarness:
     # approvals.deny: fnmatch globs hermes refuses before any yolo/mode-off
     # bypass (headless: a clean deny, never a hang). NOTE it matches SHELL
     # COMMANDS (the terminal tool), NOT the write_file/patch tool calls (source
-    # verified) — so it does NOT make a read-only judge. It is useful for the
-    # AUTHOR to hardline-forbid dangerous commands. A read-only hermes judge
-    # needs an OS-level jail (the checkout bind-mounted read-only) or an
-    # upstream split of the `file` toolset into read/write.
+    # verified). Useful to hardline-forbid specific dangerous commands.
     approvals_deny: tuple[str, ...] = ()
     model: str = ""  # OpenRouter format (provider/model); empty -> hermes default
     base_url: str = ""  # empty -> the seeded provider's own endpoint

--- a/src/autoresearch/panel.py
+++ b/src/autoresearch/panel.py
@@ -28,6 +28,7 @@ from autoresearch.roles import (
     verifier_spec,
     verify_result_from_role,
 )
+from autoresearch.syscall import tool_command
 from autoresearch.verifier import build_verify_agent_brief
 
 log = logging.getLogger(__name__)
@@ -128,14 +129,16 @@ def run_panel(
     for lens in lenses:
         who = lens.name()
         if lens.kind == "verify":
-            brief = build_verify_agent_brief(pr, contract_text, today=today)
+            brief = build_verify_agent_brief(
+                pr, contract_text, today=today, syscall_cmd=tool_command(panel_workspace)
+            )
             spec = verifier_spec()
             workspace = panel_workspace
             policy = verify_result_from_role
         elif lens.kind == "review":
-            brief = build_agent_brief(pr, today)
-            spec = reviewer_spec()
             workspace = panel_workspace / "pr-head"
+            brief = build_agent_brief(pr, today, syscall_cmd=tool_command(workspace))
+            spec = reviewer_spec()
             policy = review_result_from_role
         else:
             lines.append(f"- `{who}`: unknown lens kind {lens.kind!r} — NOT a clean read")

--- a/src/autoresearch/panel.py
+++ b/src/autoresearch/panel.py
@@ -1,7 +1,7 @@
 """The pre-PR verification panel: judges read the candidate before a PR exists.
 
 Implements the loop's judge half from docs/design/orchestrator-verify.md: a
-set of read-only lenses (integrity `verify`, code `review`) each runs as an
+set of judge lenses (integrity `verify`, code `review`) each runs as an
 agent session over the prepared checkouts, their verdicts are merged
 MECHANICALLY (any blocking finding wakes the author; the kernel never
 adjudicates judgment), and every lens's outcome — including "could not run" —

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -192,17 +192,25 @@ def _fence(text: str) -> str:
     return "`" * max(3, longest + 1)
 
 
-# Prepended to the shared rubric for the agent-session reviewer: it has a
-# read-only checkout and the read tools, so it can investigate beyond the diff.
+# Prepended to the shared rubric for the agent-session reviewer: it has the
+# checkout and the read tools to investigate beyond the diff, and it records its
+# verdict through the installed syscall tool (each call validated on the spot;
+# the kernel reads the committed verdict back — docs/design/role-cli.md).
 AGENT_INVESTIGATION = (
-    "The repository is checked out read-only in your working directory. Use Read, "
-    "Grep, and Glob to investigate beyond the diff: the surrounding code, callers, "
-    "and tests. The checked-out code is part of your evidence, so you may cite file "
-    "contents you read. You have no execute or write tools; do not run code.\n\n"
-    "When done, reply with ONLY a JSON object and nothing else: `findings` (a "
-    "list) and `notes` (a string). Each finding has `file`, `line` (or null), "
-    "`confidence` (low, medium, or high), `summary`, `detail`, `blocking` (true "
-    "or false), and `kind` (change, suggestion, question, or note)."
+    "The repository is checked out in your working directory. Use Read, Grep, "
+    "and Glob to investigate beyond the diff: the surrounding code, callers, "
+    "and tests. The checked-out code is part of your evidence, so you may cite "
+    "file contents you read. Do not modify the tree — your only product is the "
+    "verdict.\n\n"
+    "Record each finding as you confirm it, one command per finding:\n"
+    "  python .autoresearch/syscall finding --file <path> [--line N] "
+    "--confidence <low|medium|high> --summary <one line> --detail <the "
+    "evidence> [--blocking] --kind <change|suggestion|question|note>\n"
+    "When you are done, commit your verdict and end your turn:\n"
+    "  python .autoresearch/syscall conclude --notes <a short summary for the "
+    "reader>\n"
+    "A review with no defects is a bare `conclude`. The verdict you commit is "
+    "your final answer — do not also restate it in a message."
 )
 
 

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -192,33 +192,43 @@ def _fence(text: str) -> str:
     return "`" * max(3, longest + 1)
 
 
-# Prepended to the shared rubric for the agent-session reviewer: it has the
-# checkout and the read tools to investigate beyond the diff, and it records its
-# verdict through the installed syscall tool (each call validated on the spot;
-# the kernel reads the committed verdict back — docs/design/role-cli.md).
-AGENT_INVESTIGATION = (
-    "The repository is checked out in your working directory. Use Read, Grep, "
-    "and Glob to investigate beyond the diff: the surrounding code, callers, "
-    "and tests. The checked-out code is part of your evidence, so you may cite "
-    "file contents you read. Do not modify the tree — your only product is the "
-    "verdict.\n\n"
-    "Record each finding as you confirm it, one command per finding:\n"
-    "  python .autoresearch/syscall finding --file <path> [--line N] "
-    "--confidence <low|medium|high> --summary <one line> --detail <the "
-    "evidence> [--blocking] --kind <change|suggestion|question|note>\n"
-    "When you are done, commit your verdict and end your turn:\n"
-    "  python .autoresearch/syscall conclude --notes <a short summary for the "
-    "reader>\n"
-    "A review with no defects is a bare `conclude`. The verdict you commit is "
-    "your final answer — do not also restate it in a message."
-)
+# The tool invocation the caller passes when it knows the workspace; the default
+# (workspace-relative) is for callers/tests that don't. `syscall.tool_command`
+# renders the absolute form — needed because not every backend's cwd is the
+# workspace (hermes runs from its per-run home).
+DEFAULT_SYSCALL_CMD = "python .autoresearch/syscall"
 
 
-def build_agent_brief(pr: PullRequest, today: str | None = None) -> str:
+def _agent_investigation(syscall_cmd: str) -> str:
+    """The investigation instruction: read the tree for evidence, and record
+    the verdict through the installed syscall tool (each call validated on the
+    spot; the kernel reads the committed verdict back — docs/design/role-cli.md)."""
+    return (
+        "The repository is checked out in your working directory. Use Read, Grep, "
+        "and Glob to investigate beyond the diff: the surrounding code, callers, "
+        "and tests. The checked-out code is part of your evidence, so you may cite "
+        "file contents you read. Do not modify the tree — your only product is the "
+        "verdict.\n\n"
+        "Record each finding as you confirm it, one command per finding:\n"
+        f"  {syscall_cmd} finding --file <path> [--line N] "
+        "--confidence <low|medium|high> --summary <one line> --detail <the "
+        "evidence> [--blocking] --kind <change|suggestion|question|note>\n"
+        "When you are done, commit your verdict and end your turn:\n"
+        f"  {syscall_cmd} conclude --notes <a short summary for the reader>\n"
+        "A review with no defects is a bare `conclude`. The verdict you commit is "
+        "your final answer — do not also restate it in a message."
+    )
+
+
+def build_agent_brief(
+    pr: PullRequest, today: str | None = None, *, syscall_cmd: str = DEFAULT_SYSCALL_CMD
+) -> str:
     """The reviewer brief for an agent session: the shared rubric, the
     investigation instruction, and the PR itself, built on the shared
-    `build_prompt` so brief and rubric stay in one place."""
-    return f"{SYSTEM_PROMPT}\n\n{AGENT_INVESTIGATION}\n\n{build_prompt(pr, today)}"
+    `build_prompt` so brief and rubric stay in one place. `syscall_cmd` is the
+    command the judge runs to record its verdict (absolute when the caller knows
+    the workspace, so it resolves from any backend's cwd)."""
+    return f"{SYSTEM_PROMPT}\n\n{_agent_investigation(syscall_cmd)}\n\n{build_prompt(pr, today)}"
 
 
 def build_prompt(pr: PullRequest, today: str | None = None) -> str:

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -163,7 +163,10 @@ def run_agent_review(
                 _emit(emit_path, repo, number, kind="skip-clean", detail=skip)
             return None
 
-        role_result = run_role(spec, harness, build_agent_brief(pr, today), workspace)
+        from autoresearch.syscall import tool_command
+
+        brief = build_agent_brief(pr, today, syscall_cmd=tool_command(workspace))
+        role_result = run_role(spec, harness, brief, workspace)
         review = review_result_from_role(role_result)
         if review is None:
             # No verdict: an errored or refused session, not a clean read. An

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -1,5 +1,5 @@
-"""Agent-session reviewer: runs the reviewer as an agent over a read-only
-PR-head checkout.
+"""Agent-session reviewer: runs the reviewer as an agent over a PR-head
+checkout, recording its verdict through the installed syscall tool.
 
 `run_agent_review` is the orchestration core, testable with a fake harness and
 client. It builds on the shared vocabulary in `review`: the same skip rules,
@@ -134,7 +134,7 @@ def run_agent_review(
     today: str | None = None,
     emit_path: Path | None = None,
 ) -> str | None:
-    """Review PR #`number` as an agent session over `workspace` (a read-only
+    """Review PR #`number` as an agent session over `workspace` (a
     PR-head checkout the caller prepared). Post the findings inline via the
     Reviews API. Returns the round label, or None when it skipped or could not
     produce a verdict. Advisory: never raises the expected failures, so it can

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -19,10 +19,7 @@ from typing import Any
 
 from autoresearch.github import GitHubClient
 from autoresearch.harness import (
-    ClaudeCodeHarness,
-    CodexHarness,
     Harness,
-    HermesHarness,
     backend_id,
     budget_exhausted,
     outage,
@@ -45,101 +42,6 @@ from autoresearch.roles import review_result_from_role, reviewer_spec
 from autoresearch.rolespec import RoleSpec
 
 log = logging.getLogger(__name__)
-
-# Native Claude Code tools a judge session uses. The RoleSpec's other tools
-# (pr-context-read, retriever) are harness-provided MCP tools, wired separately;
-# they are not passed as native CLI tools here.
-_NATIVE_READ_TOOLS = ("Read", "Grep", "Glob")
-
-
-def build_reviewer_harness(
-    api_key: str,
-    spec: RoleSpec | None = None,
-    *,
-    backend: str = "claude",
-    binary: str | None = None,
-    model: str | None = None,
-    container_image: str = "",
-    hermes_repo: Path | None = None,
-    provider: str = "",
-    sandbox_extra: tuple[str, ...] = (),
-) -> Harness:
-    """Construct a read-only harness for the reviewer from its RoleSpec, for the
-    chosen backend — the deployment wiring the role-runner assumes (docs: "the
-    harness is assumed already constructed for the role").
-
-    How the read-only boundary is enforced differs by backend, and that
-    difference is a trust difference, not a detail:
-    - Claude: a native read-only tool set (no Write/Edit/Bash). A tool-set
-      boundary — the strongest, and the trusted default.
-    - Codex: reads by executing shell, so it needs an OS jail (`--sandbox
-      read-only`, plus `sandbox_extra` for host-specific config such as
-      `-c use_legacy_landlock=true` on GitHub-hosted runners). Even jailed it
-      can read a parent's env via /proc, so it is not run next to a token.
-    - Hermes: no read-only tool set at all — `file` bundles write, and
-      `approvals.deny` gates only shell. Its safety as a judge is ENVIRONMENTAL,
-      not tool-set: `terminal` is disabled (no shell, no /proc reach) and its
-      writes are inert on an ephemeral runner (nothing to push, scrubbed env).
-      Experimental only, and valid ONLY where writes cannot persist.
-
-    Budget: Claude gets max_turns and walltime; Codex is bounded by walltime
-    only (no per-turn cap yet) and does not use container_image."""
-    spec = spec or reviewer_spec()
-    if spec.execution.can_execute:
-        raise ValueError("build_reviewer_harness is for read-only judge roles")
-    if backend == "codex":
-        return CodexHarness(
-            api_key=api_key,
-            binary=binary or "codex",
-            model=model or "",  # codex's configured default
-            sandbox="read-only",
-            timeout_s=spec.budget.walltime_s,
-            extra_args=sandbox_extra,
-        )
-    if backend == "hermes":
-        if hermes_repo is None:
-            raise ValueError("hermes reviewer backend needs hermes_repo (the pinned clone)")
-        # "openai" maps to hermes's canonical openai-api provider (api-key
-        # auth against api.openai.com, key read from OPENAI_API_KEY; plain
-        # "openai" is a provider GROUP in hermes, not an id). openai-direct
-        # skips the OpenRouter platform fee at the same token rate, and the
-        # org's tax exemption applies. Model ids are provider-native:
-        # openai/gpt-5.6-terra on openrouter, gpt-5.6-terra on openai-api.
-        hermes_providers = {
-            "openrouter": ("openrouter", "OPENROUTER_API_KEY"),
-            "openai": ("openai-api", "OPENAI_API_KEY"),
-        }
-        if (provider or "openrouter") not in hermes_providers:
-            raise ValueError(f"unknown hermes provider: {provider!r}")
-        seed, key_env = hermes_providers[provider or "openrouter"]
-        # Defaults already encode the judge shape: file toolset only, terminal
-        # and every other executing/egress toolset disabled. Read-only rests on
-        # that config plus the ephemeral runner (see the docstring above).
-        return HermesHarness(
-            api_key=api_key,
-            key_env=key_env,
-            repo_dir=hermes_repo,
-            provider=seed,
-            model=model or "",
-            max_turns=spec.budget.max_turns,
-            timeout_s=spec.budget.walltime_s,
-        )
-    if backend != "claude":
-        raise ValueError(f"unknown reviewer backend: {backend!r}")
-    allowed = tuple(tool for tool in spec.tools if tool in _NATIVE_READ_TOOLS)
-    return ClaudeCodeHarness(
-        api_key=api_key,
-        binary=binary or "claude",
-        model=model or "claude-opus-5",
-        max_turns=spec.budget.max_turns,
-        timeout_s=spec.budget.walltime_s,
-        allowed_tools=allowed,
-        container_image=container_image,
-        # A judge's cwd contains an untrusted checkout: never load its
-        # CLAUDE.md / hooks / project settings as instructions.
-        bare=True,
-    )
-
 
 # Files an agent harness may auto-load as INSTRUCTIONS from a checkout. In an
 # untrusted tree they are attack surface (a PR-authored CLAUDE.md, or

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -1,7 +1,7 @@
 """Entry point for the agent-session advisory reviewer.
 
-Runs the reviewer as a read-only agent over a PR-head checkout the workflow
-prepared (REVIEW_CHECKOUT), and posts the findings inline. Exits 0 even on skip
+Runs the reviewer as an agent over a PR-head checkout the workflow prepared
+(REVIEW_CHECKOUT), and posts the findings inline. Exits 0 even on skip
 or failure — an advisory reviewer must never turn a target repo's CI red.
 """
 
@@ -119,14 +119,7 @@ def main() -> int:
         return 0
     # Backend-specific deployment config, resolved from env so the workflow
     # (which knows the host) supplies it, never the pure builder:
-    #   codex on GitHub-hosted needs the Landlock sandbox — the default bwrap
-    #     cannot init there (verified 2026-08-13), so the workflow opts in.
     #   hermes needs its pinned clone and a provider to seed ~/.hermes/config.
-    sandbox_extra: tuple[str, ...] = ()
-    if backend == "codex" and os.environ.get(
-        "REVIEW_CODEX_LEGACY_LANDLOCK", ""
-    ).strip().lower() in ("1", "true", "yes"):
-        sandbox_extra = ("-c", "use_legacy_landlock=true")
     hermes_repo: Path | None = None
     provider = ""
     if backend == "hermes":
@@ -173,8 +166,8 @@ def main() -> int:
                     reviewed_by=backend,
                 )
             return 0
-    # The workflow checks out the PR head read-only into REVIEW_CHECKOUT; the
-    # agent reads it but never executes it (read-only tool set). Fail closed:
+    # The workflow checks out the PR head into REVIEW_CHECKOUT for the agent
+    # to investigate (it records its verdict via the syscall tool). Fail closed:
     # defaulting to cwd would silently review the wrong tree (the reviewer's
     # own repo) if the checkout step were misconfigured.
     checkout = os.environ.get("REVIEW_CHECKOUT", "").strip()
@@ -213,7 +206,6 @@ def main() -> int:
         model=review_model or None,
         hermes_repo=hermes_repo,
         hermes_provider=provider,
-        codex_extra_args=sandbox_extra,
     )
     # Least-token split: with REVIEW_EMIT_FILE set, findings are written there
     # instead of posted — this job then needs only READ permissions, and a

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -15,10 +15,11 @@ from pathlib import Path
 from autoresearch.github import EnvTokenProvider, GitHubClient
 from autoresearch.review_agent import (
     _emit,
-    build_reviewer_harness,
     run_agent_review,
     sanitize_checkout,
 )
+from autoresearch.role_runner import build_harness
+from autoresearch.roles import reviewer_spec
 
 log = logging.getLogger(__name__)
 
@@ -204,14 +205,15 @@ def main() -> int:
         log.info("sanitized %d instruction file(s) in the checkout", renamed)
 
     client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
-    harness = build_reviewer_harness(
+    harness = build_harness(
         api_key,
+        reviewer_spec(),
         backend=backend,
         binary=os.environ.get("REVIEW_BINARY") or None,  # else the backend default on PATH
         model=review_model or None,
         hermes_repo=hermes_repo,
-        provider=provider,
-        sandbox_extra=sandbox_extra,
+        hermes_provider=provider,
+        codex_extra_args=sandbox_extra,
     )
     # Least-token split: with REVIEW_EMIT_FILE set, findings are written there
     # instead of posted — this job then needs only READ permissions, and a

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -112,7 +112,11 @@ def build_harness(
         if (hermes_provider or "openrouter") not in _HERMES_PROVIDERS:
             raise ValueError(f"unknown hermes provider: {hermes_provider!r}")
         seed, key_env = _HERMES_PROVIDERS[hermes_provider or "openrouter"]
-        enabled = ("file", "terminal") if spec.execution.can_execute else ("file",)
+        # `terminal` (the shell) is keyed on the SAME signal claude uses — the
+        # spec granting the Bash tool — not on can_execute, so every backend
+        # gives a role the same shell/no-shell whether or not those two ever
+        # diverge for a future spec.
+        enabled = ("file", "terminal") if "Bash" in spec.tools else ("file",)
         return HermesHarness(
             api_key=api_key,
             key_env=key_env,

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -1,33 +1,151 @@
-"""The role-runner: run one role session and validate its output.
+"""The role-runner: build a harness for a role, run one session, read its result.
 
-One loop replaces the per-role driver modules (docs/design/consolidation.md). It
-runs a RoleSpec on a Harness, and for a role that declares an `output_schema`
-(the judges) it parses and validates the session's final message into structured
-data, repairing once if the model returned malformed output. It does NOT judge,
-gate, measure, or post — the result-policy (kernel) acts on the RoleResult.
+One loop replaces the per-role driver modules (docs/design/consolidation.md),
+and ONE construction replaces the per-role harness builders: `build_harness`
+maps a RoleSpec to any backend uniformly — backends are interchangeable, and
+containment is the deployment's business (`container_image` where a jail
+exists, the ephemeral runner where one doesn't), never a per-role tool posture.
+Roles differ by prompt, verbs, and output handling.
+
+`run_role` runs a RoleSpec on a Harness. A role WITH an `output_schema` (a
+judge) records its verdict through the installed syscall tool (`finding` /
+`conclude`) and the kernel reads it back authoritatively (`read_verdict`) —
+each call was validated in-session, so the old parse-a-final-message-and-repair
+path is gone. It does NOT judge, gate, measure, or post — the result-policy
+(kernel) acts on the RoleResult.
 """
 
 from __future__ import annotations
 
-import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from autoresearch.harness import Harness, SessionResult
+from autoresearch.harness import (
+    ClaudeCodeHarness,
+    CodexHarness,
+    Harness,
+    HermesHarness,
+    SessionResult,
+)
 from autoresearch.rolespec import RoleSpec
 
 log = logging.getLogger(__name__)
 
-DEFAULT_MAX_REPAIRS = 1
+# Native Claude Code tool names a spec may grant. A spec's other tools
+# (pr-context-read, retriever) are harness-provided MCP tools, wired
+# separately — never passed as native CLI tools.
+_NATIVE_TOOLS = frozenset({"Read", "Grep", "Glob", "Write", "Edit", "Bash"})
+
+# hermes names capabilities as toolsets: `file` is the read/edit surface,
+# `terminal` the shell. Everything else stays disabled for parity with the
+# other backends — no spec grants web/browser/... tools there either.
+_HERMES_TOOLSETS = (
+    "file",
+    "terminal",
+    "web",
+    "search",
+    "browser",
+    "computer_use",
+    "code_execution",
+    "delegation",
+    "cronjob",
+    "skills",
+    "memory",
+)
+
+# hermes resolves credentials per provider (a registry); "openai" maps to its
+# canonical `openai-api` provider id (api-key auth against api.openai.com —
+# plain "openai" is a provider GROUP there, not an id).
+_HERMES_PROVIDERS = {
+    "openrouter": ("openrouter", "OPENROUTER_API_KEY"),
+    "openai": ("openai-api", "OPENAI_API_KEY"),
+}
+
+
+def build_harness(
+    api_key: str,
+    spec: RoleSpec,
+    *,
+    backend: str = "claude",
+    binary: str | None = None,
+    model: str | None = None,
+    container_image: str = "",
+    codex_extra_args: tuple[str, ...] = (),
+    hermes_repo: Path | None = None,
+    hermes_provider: str = "",
+) -> Harness:
+    """Construct the harness for any role on any backend — the ONE deployment
+    wiring (`spec.tools` → native flags, `spec.budget` → turns/walltime,
+    `spec.execution` → the backend's execution surface). Each branch below is
+    the backend's irreducible calling convention, nothing more:
+
+    - claude: `spec.tools` filtered to the native CLI tools; a judge's cwd is an
+      untrusted checkout, so judges (specs with an `output_schema`) run `--bare`
+      — never loading the tree's CLAUDE.md / hooks as instructions. Editors keep
+      instruction discovery (the target repo's guidance is legitimate for them).
+    - codex: `danger-full-access` uniformly — codex's own sandbox needs
+      bubblewrap (absent in the image, unreliable nested in apptainer), so the
+      boundary is the deployment's container or ephemeral runner, exactly as it
+      is for every other backend.
+    - hermes: toolsets from the spec's execution (`terminal` for a role that
+      executes); provider/key seeded per the registry above.
+
+    Containment is NOT decided here: pass `container_image` where the
+    deployment has a jail (the cluster), pass none where the runner itself is
+    the ephemeral boundary (CI). The tokenless split keeps credentials out of
+    the session either way."""
+    if backend == "codex":
+        return CodexHarness(
+            api_key=api_key,
+            binary=binary or "codex",
+            model=model or "",  # "" -> codex's configured default; pin a verified id
+            sandbox="danger-full-access",
+            timeout_s=spec.budget.walltime_s,
+            container_image=container_image,
+            extra_args=codex_extra_args,
+        )
+    if backend == "hermes":
+        if hermes_repo is None:
+            raise ValueError("hermes backend needs hermes_repo (the pinned clone)")
+        if (hermes_provider or "openrouter") not in _HERMES_PROVIDERS:
+            raise ValueError(f"unknown hermes provider: {hermes_provider!r}")
+        seed, key_env = _HERMES_PROVIDERS[hermes_provider or "openrouter"]
+        enabled = ("file", "terminal") if spec.execution.can_execute else ("file",)
+        return HermesHarness(
+            api_key=api_key,
+            key_env=key_env,
+            repo_dir=hermes_repo,
+            provider=seed,
+            model=model or "",
+            max_turns=spec.budget.max_turns,
+            timeout_s=spec.budget.walltime_s,
+            enabled_toolsets=enabled,
+            disabled_toolsets=tuple(t for t in _HERMES_TOOLSETS if t not in enabled),
+        )
+    if backend != "claude":
+        raise ValueError(f"unknown backend: {backend!r}")
+    return ClaudeCodeHarness(
+        api_key=api_key,
+        binary=binary or "claude",
+        model=model or "claude-opus-5",
+        max_turns=spec.budget.max_turns,
+        timeout_s=spec.budget.walltime_s,
+        allowed_tools=tuple(tool for tool in spec.tools if tool in _NATIVE_TOOLS),
+        container_image=container_image,
+        # a judge's cwd contains an untrusted checkout: never load its CLAUDE.md
+        # / hooks / project settings as instructions (defence in depth beside
+        # the caller's sanitize_checkout)
+        bare=spec.output_schema is not None,
+    )
 
 
 @dataclass(frozen=True)
 class RoleResult:
     """The outcome of one role run: the session plus, for judge roles, the
-    validated structured payload. `ok` is False when the session errored or the
-    output never validated; `data` is the validated object (None for an editing
+    validated verdict. `ok` is False when the session errored or no valid
+    verdict was committed; `data` is the validated object (None for an editing
     role, whose artifact is the workspace diff, or on failure)."""
 
     ok: bool
@@ -36,70 +154,28 @@ class RoleResult:
     error: str = ""
 
 
-def _extract_json(text: str) -> str:
-    """The JSON object inside a final message, tolerating code fences and prose
-    around it: the substring from the first `{` to the last `}`."""
-    stripped = text.strip()
-    start, end = stripped.find("{"), stripped.rfind("}")
-    if start != -1 and end > start:
-        return stripped[start : end + 1]
-    return stripped
-
-
-def _validate_output(text: str, schema: dict[str, Any]) -> tuple[dict[str, Any] | None, str]:
-    """Parse `text` as the schema's top-level object. Dep-free: a JSON object
-    with the schema's `required` keys present. Deeper validation is the
-    backend's native structured output or a later jsonschema pass."""
-    try:
-        data = json.loads(_extract_json(text))
-    except json.JSONDecodeError as exc:
-        return None, f"final message is not valid JSON: {exc}"
-    if not isinstance(data, dict):
-        return None, "final message is not a JSON object"
-    missing = [key for key in schema.get("required", []) if key not in data]
-    if missing:
-        return None, f"missing required keys: {missing}"
-    return data, ""
-
-
-def _repair_prompt(error: str) -> str:
-    return (
-        f"Your last message was not the structured output this task requires: {error}. "
-        "Reply with ONLY the JSON object — no prose, no code fences."
-    )
-
-
 def run_role(
     spec: RoleSpec,
     harness: Harness,
     brief_text: str,
     workspace: Path,
     resume_session_id: str | None = None,
-    max_repairs: int = DEFAULT_MAX_REPAIRS,
 ) -> RoleResult:
-    """Run one role session; validate structured output for judge roles.
+    """Run one role session; for a judge (a spec with an `output_schema`), read
+    the verdict it committed through the syscall tool.
 
-    A judge whose first message is malformed is asked once (per `max_repairs`)
-    to resend just the JSON, resuming the same session so it keeps its context.
-
-    The `harness` is assumed already constructed for this role — its tools,
-    execution sandbox, and budget set to match `spec`. That construction (map
-    spec.tools to the backend's native tool flags vs harness-provided MCP
-    tools, spec.execution to the sandbox, spec.budget to turns/walltime) is the
-    deployment wiring, done where the harness is built for the role — the same
-    way climb builds its harness from effective_limits. run_role does not
-    reconcile a mismatched harness; it runs what it is given.
+    The `harness` is assumed already constructed for this role
+    (`build_harness`). A judge records each finding as one validated tool call
+    and commits with `conclude`; `read_verdict` is the authoritative kernel-side
+    check, so there is no repair loop — a missing verdict (the judge never
+    concluded) or a malformed one is a failure the caller surfaces (a skip
+    stub), never a clean read (silence is never endorsement). Installing the
+    tool BEFORE the session force-owns the `.autoresearch/` channel, so a
+    pre-planted or stale ABI never survives into the read — a resumed (revise)
+    session likewise starts from a clean channel and commits a fresh verdict.
     """
-    # Verdict-tool mode (docs/design/role-cli.md): a judge commits its verdict
-    # via the syscall tool (`finding`/`conclude`) instead of a final JSON
-    # message. Install the tool BEFORE the session so it can call it; read the
-    # committed verdict AFTER (authoritatively) instead of parsing. Gated on the
-    # SPEC alone: like every other capability, the deployment builds the harness
-    # to match the role (a judge that emits via the tool runs a shell in the
-    # jail, same as an author) — run_role runs what it is given. A spec without
-    # verdict_tool uses the parse path below.
-    use_verdict_tool = spec.verdict_tool
-    if use_verdict_tool:
+    is_judge = spec.output_schema is not None
+    if is_judge:
         from autoresearch.syscall import install_tool
 
         install_tool(workspace)
@@ -108,41 +184,14 @@ def run_role(
         return RoleResult(
             ok=False, session=session, error=session.error_detail or session.stop_reason
         )
-    if spec.output_schema is None:
+    if not is_judge:
         return RoleResult(ok=True, session=session)  # editing role: artifact is the diff
-    if use_verdict_tool:
-        # No repair loop: the tool validated each finding in-session, and
-        # read_verdict is authoritative. A missing verdict (the judge never
-        # concluded) or a malformed one is a failure — the caller posts a skip
-        # stub, never a clean read (silence is never endorsement).
-        from autoresearch.syscall import VerdictError, read_verdict
+    from autoresearch.syscall import VerdictError, read_verdict
 
-        try:
-            data = read_verdict(workspace)
-        except VerdictError as exc:
-            return RoleResult(ok=False, session=session, error=f"invalid verdict: {exc}")
-        if data is None:
-            return RoleResult(ok=False, session=session, error="judge produced no verdict")
-        return RoleResult(ok=True, session=session, data=data)
-    data, error = _validate_output(session.final_text, spec.output_schema)
-    repairs = 0
-    while data is None and repairs < max_repairs:
-        # A repair prompt only works if it resumes the session that holds the
-        # investigation context. With no session to resume, a fresh session
-        # would see only "resend the JSON" and produce nothing useful — fail
-        # instead of burning a context-less turn.
-        resume_target = session.session_id or resume_session_id
-        if not resume_target:
-            log.info("role %s: cannot repair structured output without a session", spec.name)
-            break
-        repairs += 1
-        log.info("role %s: repairing structured output (%s)", spec.name, error)
-        session = harness.run(_repair_prompt(error), workspace, resume_session_id=resume_target)
-        if session.is_error:
-            return RoleResult(
-                ok=False, session=session, error=session.error_detail or session.stop_reason
-            )
-        data, error = _validate_output(session.final_text, spec.output_schema)
+    try:
+        data = read_verdict(workspace)
+    except VerdictError as exc:
+        return RoleResult(ok=False, session=session, error=f"invalid verdict: {exc}")
     if data is None:
-        return RoleResult(ok=False, session=session, error=f"invalid structured output: {error}")
+        return RoleResult(ok=False, session=session, error="judge produced no verdict")
     return RoleResult(ok=True, session=session, data=data)

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -17,9 +17,11 @@ from autoresearch.verifier import VERIFY_SCHEMA, verify_result_from_data
 
 # Investigation plus a shell: repo-read, Bash (a judge records its verdict by
 # running the syscall tool, and may run code to check a claim), and the
-# harness-provided pr-context and retriever. Judges run like every other role —
-# the deployment's boundary (container or ephemeral runner, plus the tokenless
-# split) contains them; roles differ by prompt, never by a bespoke tool posture.
+# harness-provided pr-context and retriever. Judges run like every other role;
+# the boundary is the deployment's (container or ephemeral runner) plus the
+# write-token split — the judge's session job holds at most a read-scoped token
+# (not worth lifting via /proc), and the write token lives in a separate post
+# job with no session next to it. Roles differ by prompt, not by tool posture.
 _JUDGE_TOOLS = ("Read", "Grep", "Glob", "Bash", "pr-context-read", "retriever")
 
 # The full editing set: the author implements, runs tests, and self-validates

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -15,9 +15,12 @@ from autoresearch.role_runner import RoleResult
 from autoresearch.rolespec import Environment, Execution, RoleSpec, SessionBudget
 from autoresearch.verifier import VERIFY_SCHEMA, verify_result_from_data
 
-# Read-only investigation: repo-read plus the harness-provided pr-context and
-# retriever. No Write/Edit/Bash — a judge never executes untrusted PR code.
-_JUDGE_TOOLS = ("Read", "Grep", "Glob", "pr-context-read", "retriever")
+# Investigation plus a shell: repo-read, Bash (a judge records its verdict by
+# running the syscall tool, and may run code to check a claim), and the
+# harness-provided pr-context and retriever. Judges run like every other role —
+# the deployment's boundary (container or ephemeral runner, plus the tokenless
+# split) contains them; roles differ by prompt, never by a bespoke tool posture.
+_JUDGE_TOOLS = ("Read", "Grep", "Glob", "Bash", "pr-context-read", "retriever")
 
 # The full editing set: the author implements, runs tests, and self-validates
 # inside its container. Execution is the role's job, not a leak.
@@ -66,24 +69,26 @@ def author_spec(
 def reviewer_spec(
     *, environment: Environment = "gh-runner", max_turns: int = 40, walltime_s: int = 1800
 ) -> RoleSpec:
-    """The advisory reviewer as a read-only agent session.
+    """The advisory reviewer as an agent session.
 
-    Investigates the PR head with the read tools and returns findings validated
-    against `review.FINDINGS_SCHEMA`. Read-only by construction — the RoleSpec
-    invariant rejects any mutating tool or write scope.
+    Investigates the PR head and records each finding through the installed
+    syscall tool (`finding` / `conclude`); the kernel validates the committed
+    verdict against `review.FINDINGS_SCHEMA` (`read_verdict`). It edits nothing
+    (scope None) — the deployment's boundary contains the session.
     """
     return RoleSpec(
         name="reviewer",
         instructions=(
             "Review the pull request for correctness and clarity. Investigate "
-            "beyond the diff with the read tools; do not execute code. Return the "
-            "findings as the required JSON object."
+            "beyond the diff with the read tools. Record each finding with the "
+            "installed syscall tool, then commit your verdict with its "
+            "`conclude` command and end your turn."
         ),
         key="reviewer",
         tools=_JUDGE_TOOLS,
-        execution=Execution(environment=environment, can_execute=False),
+        execution=Execution(environment=environment, can_execute=True),
         budget=SessionBudget(max_turns=max_turns, walltime_s=walltime_s),
-        skills=("kernel-primer", "plain-style", "review-rubric", "read-only-investigation"),
+        skills=("kernel-primer", "plain-style", "review-rubric", "investigation"),
         output_schema=FINDINGS_SCHEMA,
     )
 
@@ -91,25 +96,27 @@ def reviewer_spec(
 def verifier_spec(
     *, environment: Environment = "gh-runner", max_turns: int = 40, walltime_s: int = 1800
 ) -> RoleSpec:
-    """The verifier as a read-only agent session.
+    """The verifier as an agent session.
 
-    Investigates a bot PR's improvement claim with the read tools — the ruler
-    from the base checkout, the change from the head — and returns findings
-    validated against `verifier.VERIFY_SCHEMA` (the gaming taxonomy). Read-only
-    by construction, same as the reviewer."""
+    Investigates a bot PR's improvement claim — the ruler from the base
+    checkout, the change from the head — and records each finding through the
+    installed syscall tool; the kernel validates the committed verdict against
+    `verifier.VERIFY_SCHEMA` (the gaming taxonomy, `read_verdict`). It edits
+    nothing (scope None), same as the reviewer."""
     return RoleSpec(
         name="verifier",
         instructions=(
             "Verify the integrity of the benchmark improvement this bot PR "
             "claims. Read the ruler from the base checkout and follow the "
-            "change through the tree; do not execute code. Return the findings "
-            "as the required JSON object."
+            "change through the tree. Record each finding with the installed "
+            "syscall tool, then commit your verdict with its `conclude` "
+            "command and end your turn."
         ),
         key="verifier",
         tools=_JUDGE_TOOLS,
-        execution=Execution(environment=environment, can_execute=False),
+        execution=Execution(environment=environment, can_execute=True),
         budget=SessionBudget(max_turns=max_turns, walltime_s=walltime_s),
-        skills=("kernel-primer", "plain-style", "integrity-lens", "read-only-investigation"),
+        skills=("kernel-primer", "plain-style", "integrity-lens", "investigation"),
         output_schema=VERIFY_SCHEMA,
     )
 

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -72,9 +72,11 @@ def reviewer_spec(
     """The advisory reviewer as an agent session.
 
     Investigates the PR head and records each finding through the installed
-    syscall tool (`finding` / `conclude`); the kernel validates the committed
-    verdict against `review.FINDINGS_SCHEMA` (`read_verdict`). It edits nothing
-    (scope None) — the deployment's boundary contains the session.
+    syscall tool (`finding` / `conclude`); the kernel reads the committed
+    verdict back authoritatively (`syscall.read_verdict`, which owns the one
+    canonical verdict shape — `output_schema` marks the role as a judge and
+    documents the downstream shape). It edits nothing (scope None) — the
+    deployment's boundary contains the session.
     """
     return RoleSpec(
         name="reviewer",
@@ -100,8 +102,9 @@ def verifier_spec(
 
     Investigates a bot PR's improvement claim — the ruler from the base
     checkout, the change from the head — and records each finding through the
-    installed syscall tool; the kernel validates the committed verdict against
-    `verifier.VERIFY_SCHEMA` (the gaming taxonomy, `read_verdict`). It edits
+    installed syscall tool (`--category` carries the gaming taxonomy; the
+    kernel reads the verdict back via `syscall.read_verdict`, which owns the
+    one canonical verdict shape and clamps unknown categories). It edits
     nothing (scope None), same as the reviewer."""
     return RoleSpec(
         name="verifier",

--- a/src/autoresearch/rolespec.py
+++ b/src/autoresearch/rolespec.py
@@ -58,11 +58,12 @@ class RoleSpec:
     execution: Execution
     budget: SessionBudget
     skills: tuple[str, ...] = ()
-    # Judges only: the verdict must validate against this JSON schema. A role
-    # WITH a schema is a judge — it records findings through the installed
-    # syscall tool (`finding` / `conclude`, docs/design/role-cli.md) and the
-    # kernel reads the committed verdict authoritatively (`read_verdict`). None
-    # for editing roles, whose artifact is a workspace diff, not a verdict.
+    # A role WITH a schema is a judge: it records findings through the
+    # installed syscall tool (`finding` / `conclude`, docs/design/role-cli.md)
+    # and the kernel reads the committed verdict back authoritatively
+    # (`syscall.read_verdict`, which owns the one canonical verdict shape; the
+    # schema here marks the role and documents the downstream shape). None for
+    # editing roles, whose artifact is a workspace diff, not a verdict.
     output_schema: dict[str, Any] | None = None
     # Editing roles only: repo-relative write allowlist. None for judges —
     # they investigate and record a verdict; they do not edit the tree.
@@ -81,3 +82,7 @@ class RoleSpec:
                 raise RoleSpecError(
                     f"read-only role {self.name!r} edits nothing; scope must be None"
                 )
+        if self.output_schema is not None and self.scope is not None:
+            raise RoleSpecError(
+                f"judge {self.name!r} records a verdict, never edits; scope must be None"
+            )

--- a/src/autoresearch/rolespec.py
+++ b/src/autoresearch/rolespec.py
@@ -6,9 +6,12 @@ reads a RoleSpec to decide what a session sees (skills, tools), how it is
 constrained (key, scope, execution), and how its output is checked
 (`output_schema`).
 
-The one hard invariant here is the read-only judge boundary: a reviewer or
-verifier investigates a PR but never executes untrusted code, so it may not
-hold a mutating tool or a write scope (docs/design/reviewer-infra.md).
+Every role runs the same way — a session inside the deployment's boundary (a
+container where one exists, the ephemeral runner where one doesn't, plus the
+tokenless split) — and roles differ by prompt, verbs, and output handling,
+never by a bespoke containment posture. The invariant kept here is
+consistency: a spec that declares itself non-executing may not hold a
+mutating tool or a write scope.
 """
 
 from __future__ import annotations
@@ -20,8 +23,8 @@ RoleName = Literal["author", "reviewer", "verifier", "steward", "followup"]
 KeyFamily = Literal["author", "reviewer", "verifier", "steward"]
 Environment = Literal["apptainer", "gh-runner", "local"]
 
-# Tools that change files or run code. A read-only judge is granted none of
-# these: the security boundary is the tool set, not a prompt asking nicely.
+# Tools that change files or run code. A spec that declares can_execute=False
+# must not hold any of these — the declaration and the tool set must agree.
 MUTATING_TOOLS: frozenset[str] = frozenset({"Write", "Edit", "Bash"})
 
 
@@ -55,19 +58,15 @@ class RoleSpec:
     execution: Execution
     budget: SessionBudget
     skills: tuple[str, ...] = ()
-    # Judges only: the final artifact must validate against this JSON schema.
-    # None for editing roles, whose artifact is a workspace diff, not a verdict.
+    # Judges only: the verdict must validate against this JSON schema. A role
+    # WITH a schema is a judge — it records findings through the installed
+    # syscall tool (`finding` / `conclude`, docs/design/role-cli.md) and the
+    # kernel reads the committed verdict authoritatively (`read_verdict`). None
+    # for editing roles, whose artifact is a workspace diff, not a verdict.
     output_schema: dict[str, Any] | None = None
-    # Editing roles only: repo-relative write allowlist. None for read-only
-    # judges — declared here for legibility, enforced by the tool set too.
+    # Editing roles only: repo-relative write allowlist. None for judges —
+    # they investigate and record a verdict; they do not edit the tree.
     scope: tuple[str, ...] | None = None
-    # Judges only: emit the verdict through the installed syscall tool (the
-    # `finding` / `conclude` syscalls) instead of a final JSON message
-    # (docs/design/role-cli.md). Requires `output_schema` (a verdict IS that
-    # schema). The role runs the tool with a shell in the jail, same as an
-    # author — the deployment builds the harness to match (`run_role` gates on
-    # this flag alone). A spec without it uses the parse-and-repair path.
-    verdict_tool: bool = False
 
     def __post_init__(self) -> None:
         if not self.tools:
@@ -82,5 +81,3 @@ class RoleSpec:
                 raise RoleSpecError(
                     f"read-only role {self.name!r} edits nothing; scope must be None"
                 )
-        if self.verdict_tool and self.output_schema is None:
-            raise RoleSpecError(f"role {self.name!r}: verdict_tool needs an output_schema")

--- a/src/autoresearch/rolespec.py
+++ b/src/autoresearch/rolespec.py
@@ -7,11 +7,12 @@ constrained (key, scope, execution), and how its output is checked
 (`output_schema`).
 
 Every role runs the same way — a session inside the deployment's boundary (a
-container where one exists, the ephemeral runner where one doesn't, plus the
-tokenless split) — and roles differ by prompt, verbs, and output handling,
-never by a bespoke containment posture. The invariant kept here is
-consistency: a spec that declares itself non-executing may not hold a
-mutating tool or a write scope.
+container where one exists, the ephemeral runner where one doesn't) with no
+write credential in reach (a judge's session job holds at most a read-scoped
+token; writes happen in a separate post job) — and roles differ by prompt,
+verbs, and output handling, never by a bespoke containment posture. The
+invariant kept here is consistency: a spec that declares itself non-executing
+may not hold a mutating tool or a write scope.
 """
 
 from __future__ import annotations

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -33,7 +33,6 @@ from autoresearch.climb import (
     _best_effort,
     arm_self_deadline,
     arm_sigterm_containment,
-    build_editor_harness,
 )
 from autoresearch.contract import Contract, load_contract
 from autoresearch.github import FileTokenProvider, GitHubClient, Workspace
@@ -54,7 +53,7 @@ from autoresearch.progress import (
     load_leader,
     write_progress,
 )
-from autoresearch.role_runner import run_role
+from autoresearch.role_runner import build_harness, run_role
 from autoresearch.roles import steward_spec
 from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
@@ -805,7 +804,7 @@ def main() -> int:
             config=StewardConfig(target=args.target, benchmark=args.benchmark),
             run_root=args.run_root,
             run_id=run_id,
-            harness=build_editor_harness(
+            harness=build_harness(
                 api_key,
                 spec,
                 binary=args.claude_bin,

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -17,8 +17,8 @@ ABI the tool commits, and the readers here are its authoritative validators
   carrying its findings. `read_verdict` reads it — the same `{findings, notes}`
   shape `run_role` used to parse from a final message, minus the parse-and-repair
   loop (each finding was one validated call, so the verdict is well-formed BY
-  CONSTRUCTION). A backend whose judge cannot run the tool falls back to the
-  parse path in `run_role`.
+  CONSTRUCTION). A judge that commits no verdict fails its round loudly (the
+  caller posts a skip stub) — there is no parse fallback.
 
 The `.autoresearch/` directory is kernel-excluded from the diff via
 `.git/info/exclude` (repo-local, never a tracked edit), so requests and
@@ -344,6 +344,10 @@ def install_tool(workspace: Path) -> None:
 
     from autoresearch import syscall_cli
 
+    # read the tool source FIRST: if the channel path collides with the tree
+    # the source lives in (a deployment mistake), the rmtree below must not be
+    # able to destroy the source before it was read
+    source = Path(syscall_cli.__file__).read_text()
     channel = workspace / SYSCALL_DIR
     if channel.is_symlink() or (channel.exists() and not channel.is_dir()):
         channel.unlink()
@@ -351,7 +355,7 @@ def install_tool(workspace: Path) -> None:
         shutil.rmtree(channel)
     channel.mkdir(parents=True)
     tool = channel / "syscall"
-    tool.write_text(Path(syscall_cli.__file__).read_text())
+    tool.write_text(source)
     tool.chmod(0o755)
 
 

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -46,6 +46,17 @@ SYSCALL_DIR = ".autoresearch"
 SYSCALL_FILE = "syscall.json"
 RESULTS_SUBDIR = "results"
 
+
+def tool_command(workspace: Path) -> str:
+    """The command a role runs to invoke the installed tool, as an ABSOLUTE
+    path so it resolves from ANY working directory — not every backend's cwd is
+    the workspace (hermes runs from its per-run home, so a workspace-relative
+    `.autoresearch/syscall` would not be found). The tool itself roots its
+    channel at its own location, so an absolute invocation still writes into
+    this workspace's channel where `read_verdict` looks."""
+    return f"python {(workspace / SYSCALL_DIR / 'syscall').resolve()}"
+
+
 # Per-request bounds (the budget is separate: depth_k / sleep_k).
 # The whole file is read size-capped FIRST (agent-controlled input); the cap is
 # roomy for the field bounds below (8 launches x 2000-char commands + note).

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -311,7 +311,12 @@ def main(argv: list[str], root: Path | None = None) -> int:
     # argparse REMAINDER keeps a leading "--"; drop it for a clean command
     if getattr(args, "command", None) and args.command and args.command[0] == "--":
         args.command = args.command[1:]
-    root = root or Path.cwd()
+    # Root at the tool's own install location (<workspace>/.autoresearch/
+    # syscall -> the workspace), NEVER the caller's cwd: an agent may invoke
+    # the tool from a subdirectory or from another working directory entirely
+    # (hermes starts in its per-run home), and a cwd-rooted channel would
+    # silently commit the syscall where the kernel never looks.
+    root = root or Path(__file__).resolve().parent.parent
     try:
         print(_HANDLERS[args.cmd](root, args))
         return 0

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -288,19 +288,25 @@ def build_verify_prompt(
 # cannot have shaped it). Ruler reads must target base: the ruler comes from
 # the base branch, never the PR.
 AGENT_VERIFY_INVESTIGATION = (
-    "Two trees are checked out read-only in your working directory: `pr-head/` "
-    "is the pull request's code (the change under review, written by the agent "
-    "you are verifying), and `base/` is the PR's base branch (trusted: the "
+    "Two trees are checked out in your working directory: `pr-head/` is the "
+    "pull request's code (the change under review, written by the agent you "
+    "are verifying), and `base/` is the PR's base branch (trusted: the "
     "contract and the frozen ruler as they stood before this change). Read the "
     "ruler source — how the metric is "
     "ACTUALLY computed — from `base/`, never from `pr-head/`. Use Read, Grep, "
     "and Glob to follow the change through the tree: how the eval calls the "
-    "changed code, what it can see, what it could exploit. You have no execute "
-    "or write tools; do not run code.\n\n"
-    "When done, reply with ONLY a JSON object and nothing else: `findings` (a "
-    "list) and `notes` (a string). Each finding has `file`, `line` (or null), "
-    "`category` (one of: " + ", ".join(CATEGORIES) + "), `confidence` (low, "
-    "medium, or high), `summary`, `detail`, and `blocking` (true or false)."
+    "changed code, what it can see, what it could exploit. Do not modify "
+    "either tree — your only product is the verdict.\n\n"
+    "Record each finding as you confirm it, one command per finding:\n"
+    "  python .autoresearch/syscall finding --file <path> [--line N] "
+    "--category <one of: " + ", ".join(CATEGORIES) + "> "
+    "--confidence <low|medium|high> --summary <one line> --detail <the "
+    "evidence> [--blocking]\n"
+    "When you are done, commit your verdict and end your turn:\n"
+    "  python .autoresearch/syscall conclude --notes <a short summary for the "
+    "reader>\n"
+    "A clean verification is a bare `conclude`. The verdict you commit is your "
+    "final answer — do not also restate it in a message."
 )
 
 

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -283,7 +283,7 @@ def build_verify_prompt(
 
 
 # Prepended to the shared rubric for the agent-session verifier: it has TWO
-# read-only checkouts: the PR head (the change under
+# checkouts: the PR head (the change under
 # review) and the BASE branch (the trusted contract and ruler — the solver
 # cannot have shaped it). Ruler reads must target base: the ruler comes from
 # the base branch, never the PR.

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -287,27 +287,30 @@ def build_verify_prompt(
 # review) and the BASE branch (the trusted contract and ruler — the solver
 # cannot have shaped it). Ruler reads must target base: the ruler comes from
 # the base branch, never the PR.
-AGENT_VERIFY_INVESTIGATION = (
-    "Two trees are checked out in your working directory: `pr-head/` is the "
-    "pull request's code (the change under review, written by the agent you "
-    "are verifying), and `base/` is the PR's base branch (trusted: the "
-    "contract and the frozen ruler as they stood before this change). Read the "
-    "ruler source — how the metric is "
-    "ACTUALLY computed — from `base/`, never from `pr-head/`. Use Read, Grep, "
-    "and Glob to follow the change through the tree: how the eval calls the "
-    "changed code, what it can see, what it could exploit. Do not modify "
-    "either tree — your only product is the verdict.\n\n"
-    "Record each finding as you confirm it, one command per finding:\n"
-    "  python .autoresearch/syscall finding --file <path> [--line N] "
-    "--category <one of: " + ", ".join(CATEGORIES) + "> "
-    "--confidence <low|medium|high> --summary <one line> --detail <the "
-    "evidence> [--blocking]\n"
-    "When you are done, commit your verdict and end your turn:\n"
-    "  python .autoresearch/syscall conclude --notes <a short summary for the "
-    "reader>\n"
-    "A clean verification is a bare `conclude`. The verdict you commit is your "
-    "final answer — do not also restate it in a message."
-)
+DEFAULT_SYSCALL_CMD = "python .autoresearch/syscall"
+
+
+def _agent_verify_investigation(syscall_cmd: str) -> str:
+    return (
+        "Two trees are checked out in your working directory: `pr-head/` is the "
+        "pull request's code (the change under review, written by the agent you "
+        "are verifying), and `base/` is the PR's base branch (trusted: the "
+        "contract and the frozen ruler as they stood before this change). Read the "
+        "ruler source — how the metric is "
+        "ACTUALLY computed — from `base/`, never from `pr-head/`. Use Read, Grep, "
+        "and Glob to follow the change through the tree: how the eval calls the "
+        "changed code, what it can see, what it could exploit. Do not modify "
+        "either tree — your only product is the verdict.\n\n"
+        "Record each finding as you confirm it, one command per finding:\n"
+        f"  {syscall_cmd} finding --file <path> [--line N] "
+        "--category <one of: " + ", ".join(CATEGORIES) + "> "
+        "--confidence <low|medium|high> --summary <one line> --detail <the "
+        "evidence> [--blocking]\n"
+        "When you are done, commit your verdict and end your turn:\n"
+        f"  {syscall_cmd} conclude --notes <a short summary for the reader>\n"
+        "A clean verification is a bare `conclude`. The verdict you commit is your "
+        "final answer — do not also restate it in a message."
+    )
 
 
 def build_verify_agent_brief(
@@ -315,14 +318,18 @@ def build_verify_agent_brief(
     contract_text: str,
     today: str | None = None,
     thread: tuple[tuple[str, str], ...] = (),
+    *,
+    syscall_cmd: str = DEFAULT_SYSCALL_CMD,
 ) -> str:
     """The verifier brief for an agent session: the shared rubric, the
     two-tree investigation instruction, and the claim/diff/thread. The ruler
     and file contents are NOT fenced in — the agent reads them from the
     checkouts (ruler from base/); the contract is still fenced from the base
-    branch so the rules arrive orchestrator-vouched."""
+    branch so the rules arrive orchestrator-vouched. `syscall_cmd` is the
+    command the judge runs to record its verdict (absolute when the caller knows
+    the workspace, so it resolves from any backend's cwd)."""
     return (
-        f"{VERIFY_SYSTEM_PROMPT}\n\n{AGENT_VERIFY_INVESTIGATION}\n\n"
+        f"{VERIFY_SYSTEM_PROMPT}\n\n{_agent_verify_investigation(syscall_cmd)}\n\n"
         f"{build_verify_prompt(pr, contract_text, today=today, thread=thread)}"
     )
 

--- a/src/autoresearch/verify_agent.py
+++ b/src/autoresearch/verify_agent.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from autoresearch.github import GitHubClient
 from autoresearch.harness import Harness, backend_id, budget_exhausted, outage
 from autoresearch.posting import EXPECTED_FAILURES, post_round, post_skip_stub
-from autoresearch.review_agent import _pull_request
+from autoresearch.review_agent import _emit, _pull_request
 from autoresearch.role_runner import run_role
 from autoresearch.roles import verifier_spec, verify_result_from_role
 from autoresearch.rolespec import RoleSpec
@@ -57,6 +57,7 @@ def run_agent_verify(
     bot_login: str,
     spec: RoleSpec | None = None,
     today: str | None = None,
+    emit_path: Path | None = None,
 ) -> str | None:
     """Verify bot PR #`number` as an agent session over `workspace`, a
     directory holding the two checkouts the workflow prepared:
@@ -64,14 +65,33 @@ def run_agent_verify(
     findings as one issue comment per round. Returns the round label, or None
     when it skipped or could not produce a verdict. Advisory: never raises the
     expected failures.
+
+    With `emit_path` (the tokenless split, mirroring the reviewer): nothing is
+    posted — the raw verdict, or a skip-stub, is written there for a separate
+    write-token job (`verify_post_cli`). The session job then needs only a
+    read-scoped token, so a shell judge has no write credential to lift.
     """
     spec = spec or verifier_spec()
     today = today or datetime.now(UTC).date().isoformat()
+    reviewed_by = backend_id(harness)
+
+    def _skip_stub(detail: str) -> None:
+        # `detail` is already api-key-redacted by the harness (it owns its own
+        # secret), so no secret is passed here.
+        if emit_path is not None:
+            _emit(emit_path, repo, number, kind="skip-stub", detail=detail, reviewed_by=reviewed_by)
+        else:
+            post_skip_stub(client, repo, number, "verification", RuntimeError(detail))
+
     try:
         pr, pr_data = _pull_request(client, repo, number)
         skip = verify_skip_reason(pr, bot_login)
         if skip is not None:
             log.info("skipping verification of %s#%s: %s", repo, number, skip)
+            # a clean skip still leaves an envelope so the post job can REQUIRE
+            # an artifact — a missing one then always means a broken session
+            if emit_path is not None:
+                _emit(emit_path, repo, number, kind="skip-clean", detail=skip)
             return None
 
         contract_text = _base_contract(client, repo, pr_data)
@@ -92,17 +112,29 @@ def run_agent_verify(
             detail = role_result.error or role_result.session.stop_reason
             log.warning("verification produced no verdict on %s#%s: %s", repo, number, detail)
             if outage(role_result.session) or budget_exhausted(role_result.session):
-                # `detail` is already api-key-redacted by the harness (it owns
-                # its own secret), so no secrets are passed here.
-                post_skip_stub(client, repo, number, "verification", RuntimeError(detail))
+                _skip_stub(detail)
+            elif emit_path is not None:
+                # nothing worth posting, but the post job still needs an
+                # artifact so a MISSING one always means a broken session
+                _emit(emit_path, repo, number, kind="skip-clean", detail=detail)
             return None
 
+        if emit_path is not None:
+            _emit(
+                emit_path,
+                repo,
+                number,
+                kind="findings",
+                data=role_result.data,
+                reviewed_by=reviewed_by,
+            )
+            return "emitted"
         body = format_verify_comment(result)
         if body is None:
             log.info("nothing to post")
             return None
         round_label = post_round(
-            client, repo, number, VERIFY_MARKER, body, pr_data, reviewed_by=backend_id(harness)
+            client, repo, number, VERIFY_MARKER, body, pr_data, reviewed_by=reviewed_by
         )
         log.info("posted verification (%s) on %s#%s", round_label, repo, number)
         return round_label

--- a/src/autoresearch/verify_agent.py
+++ b/src/autoresearch/verify_agent.py
@@ -1,4 +1,4 @@
-"""Agent-session verifier: runs the verifier as an agent over TWO read-only
+"""Agent-session verifier: runs the verifier as an agent over TWO
 checkouts — the PR head (the change under review) and the base branch (the
 trusted contract and ruler).
 
@@ -59,7 +59,7 @@ def run_agent_verify(
     today: str | None = None,
 ) -> str | None:
     """Verify bot PR #`number` as an agent session over `workspace`, a
-    directory holding the two read-only checkouts the workflow prepared:
+    directory holding the two checkouts the workflow prepared:
     `pr-head/` (the change) and `base/` (trusted contract + ruler). Posts the
     findings as one issue comment per round. Returns the round label, or None
     when it skipped or could not produce a verdict. Advisory: never raises the

--- a/src/autoresearch/verify_agent.py
+++ b/src/autoresearch/verify_agent.py
@@ -101,7 +101,11 @@ def run_agent_verify(
         except EXPECTED_FAILURES as exc:
             log.warning("verifying without the discussion thread: %s", exc)
 
-        brief = build_verify_agent_brief(pr, contract_text, today=today, thread=thread)
+        from autoresearch.syscall import tool_command
+
+        brief = build_verify_agent_brief(
+            pr, contract_text, today=today, thread=thread, syscall_cmd=tool_command(workspace)
+        )
         role_result = run_role(spec, harness, brief, workspace)
         result = verify_result_from_role(role_result)
         if result is None:

--- a/src/autoresearch/verify_agent_cli.py
+++ b/src/autoresearch/verify_agent_cli.py
@@ -14,7 +14,8 @@ import sys
 from pathlib import Path
 
 from autoresearch.github import EnvTokenProvider, GitHubClient
-from autoresearch.review_agent import build_reviewer_harness, sanitize_checkout
+from autoresearch.review_agent import sanitize_checkout
+from autoresearch.role_runner import build_harness
 from autoresearch.roles import verifier_spec
 from autoresearch.verify_agent import run_agent_verify
 
@@ -63,7 +64,7 @@ def main() -> int:
 
     spec = verifier_spec()
     client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
-    harness = build_reviewer_harness(
+    harness = build_harness(
         api_key,
         spec,
         binary=os.environ.get("REVIEW_BINARY") or None,

--- a/src/autoresearch/verify_agent_cli.py
+++ b/src/autoresearch/verify_agent_cli.py
@@ -70,6 +70,10 @@ def main() -> int:
         binary=os.environ.get("REVIEW_BINARY") or None,
         model=os.environ.get("VERIFY_MODEL") or None,
     )
+    # Tokenless split: with VERIFY_EMIT_FILE set, the verdict is written there
+    # instead of posted — this job then needs only a read token, and a separate
+    # write-token job (verify_post_cli) posts with no session next to it.
+    emit_file = os.environ.get("VERIFY_EMIT_FILE", "").strip()
     run_agent_verify(
         client,
         repo,
@@ -78,6 +82,7 @@ def main() -> int:
         workspace,
         bot_login=bot_login,
         spec=spec,
+        emit_path=Path(emit_file).resolve() if emit_file else None,
     )
     return 0
 

--- a/src/autoresearch/verify_agent_cli.py
+++ b/src/autoresearch/verify_agent_cli.py
@@ -1,6 +1,6 @@
 """Entry point for the agent-session verifier.
 
-Runs the verifier as a read-only agent over the two checkouts the workflow
+Runs the verifier as an agent over the two checkouts the workflow
 prepared under VERIFY_CHECKOUT (`pr-head/` and `base/`), and posts the findings
 as an issue comment. Exits 0 even on skip or failure — the verifier is
 advisory and must never turn a target repo's CI red.
@@ -39,7 +39,7 @@ def main() -> int:
     if not api_key:
         log.warning("ANTHROPIC_VERIFIER_KEY is unset or empty; skipping verification")
         return 0
-    # The directory holding the workflow's two read-only checkouts: pr-head/
+    # The directory holding the workflow's two checkouts: pr-head/
     # (the change) and base/ (trusted contract + ruler). Fail closed: a cwd
     # default would let a misconfigured workflow verify the wrong trees.
     checkout = os.environ.get("VERIFY_CHECKOUT", "").strip()

--- a/src/autoresearch/verify_post_cli.py
+++ b/src/autoresearch/verify_post_cli.py
@@ -1,0 +1,116 @@
+"""Posting half of the verifier's tokenless split (mirrors review_post_cli).
+
+Reads the verdict envelope the session job emitted (`VERIFY_EMIT_FILE`),
+re-validates it, and posts through the normal verification path. This job holds
+the write token; NO model session runs next to it, so a shell judge in the
+session job has no write credential to lift. The artifact crosses a job
+boundary, so nothing in it is trusted: the envelope must name this PR, the
+bot-only skip rule is re-checked here, and every string passes the same
+sanitizing render as the single-job path. Exits 0 on every failure — the
+verifier never fails the target repo's CI.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+
+from autoresearch.github import EnvTokenProvider, GitHubClient
+from autoresearch.posting import EXPECTED_FAILURES, post_round, post_skip_stub
+from autoresearch.review_agent import _pull_request
+from autoresearch.verifier import (
+    VERIFY_MARKER,
+    format_verify_comment,
+    verify_result_from_data,
+    verify_skip_reason,
+)
+
+log = logging.getLogger(__name__)
+
+
+def post_from_file(
+    client: GitHubClient, repo: str, number: int, bot_login: str, path: Path
+) -> str | None:
+    """Post the emitted verdict (or skip stub). Returns the round label, or
+    None when there was nothing to post or the envelope was refused."""
+    try:
+        envelope = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning("verdict file unreadable (%s); nothing posted", exc)
+        return None
+    if not isinstance(envelope, dict):
+        log.warning("verdict file is not an object; nothing posted")
+        return None
+    if envelope.get("repo") != repo or envelope.get("number") != number:
+        log.warning("verdict envelope names a different PR; refused")
+        return None
+    kind = envelope.get("kind")
+    if kind == "skip-clean":
+        log.info("session skipped cleanly (%s); nothing to post", envelope.get("detail", ""))
+        return None
+    if kind not in ("skip-stub", "findings"):
+        log.warning("unknown envelope kind %r; nothing posted", kind)
+        return None
+    try:
+        # the write authority re-checks the bot-only rule for EVERY kind: this
+        # side of the artifact boundary is the one that must never post on a
+        # non-bot PR — a forged envelope is still a post
+        pr, pr_data = _pull_request(client, repo, number)
+        skip = verify_skip_reason(pr, bot_login)
+        if skip is not None:
+            log.info("skipping post on %s#%s: %s", repo, number, skip)
+            return None
+        if kind == "skip-stub":
+            post_skip_stub(client, repo, number, "verification", RuntimeError("no verdict"))
+            return "skip-stub"
+        data = envelope.get("data")
+        result = verify_result_from_data(data if isinstance(data, dict) else {})
+        body = format_verify_comment(result)
+        if body is None:
+            log.info("nothing to post")
+            return None
+        round_label = post_round(
+            client,
+            repo,
+            number,
+            VERIFY_MARKER,
+            body,
+            pr_data,
+            reviewed_by=str(envelope.get("reviewed_by", "")),
+        )
+        log.info("posted verification (%s) on %s#%s", round_label, repo, number)
+        return round_label
+    except EXPECTED_FAILURES as exc:  # advisory: never fail the target repo's CI
+        log.warning("posting did not complete: %s: %s", type(exc).__name__, exc)
+        return None
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    repo = os.environ.get("PR_REPO", "").strip()
+    number_raw = os.environ.get("PR_NUMBER", "").strip()
+    if not repo or not number_raw.isdigit():
+        log.warning("PR_REPO/PR_NUMBER unset or invalid; skipping")
+        return 0
+    bot_login = os.environ.get("REVIEW_BOT_LOGIN", "").strip()
+    if not bot_login:
+        log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot re-check the bot rule)")
+        return 0
+    emit_file = os.environ.get("VERIFY_EMIT_FILE", "").strip()
+    if not emit_file:
+        log.warning("VERIFY_EMIT_FILE is unset; skipping")
+        return 0
+    path = Path(emit_file).resolve()
+    if not path.is_file():
+        log.info("no verdict file at %s (clean skip upstream); nothing to post", path)
+        return 0
+    client = GitHubClient(auth=EnvTokenProvider("GITHUB_TOKEN"))
+    post_from_file(client, repo, int(number_raw), bot_login, path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1496,31 +1496,30 @@ def test_moved_base_regates_the_suite_on_the_merged_tree(tmp_path, target_repo) 
 
 def test_author_harness_is_built_from_the_spec() -> None:
     """The spec is the single source for the session budget: manifest and
-    harness cannot disagree (the judges' build_reviewer_harness pattern)."""
-    from autoresearch.climb import build_editor_harness
+    harness cannot disagree (one build_harness for every role)."""
     from autoresearch.harness import ClaudeCodeHarness
-    from autoresearch.roles import author_spec, reviewer_spec
+    from autoresearch.role_runner import build_harness
+    from autoresearch.roles import author_spec
 
     spec = author_spec(max_turns=7, walltime_s=120)
-    harness = build_editor_harness("sk-key", spec, container_image="img.sif")
+    harness = build_harness("sk-key", spec, container_image="img.sif")
     assert isinstance(harness, ClaudeCodeHarness)  # default backend; narrows the type
     assert harness.max_turns == 7
     assert harness.timeout_s == 120
     assert harness.container_image == "img.sif"
-    with pytest.raises(ValueError, match="editing roles"):
-        build_editor_harness("sk-key", reviewer_spec())
+    assert harness.bare is False  # an editor keeps the target repo's guidance
 
 
 def test_editor_harness_codex_backend_is_contained() -> None:
-    """The codex author backend is one branch, zero kernel change: contained
-    (apptainer) with --sandbox danger-full-access (apptainer is the boundary; no
-    bwrap), and container_image is REQUIRED (an author writes+executes)."""
-    from autoresearch.climb import build_editor_harness
+    """The codex author backend is one branch of the ONE builder: apptainer is
+    the boundary (--sandbox danger-full-access; no bwrap), containment passed
+    through from the deployment."""
     from autoresearch.harness import CodexHarness
+    from autoresearch.role_runner import build_harness
     from autoresearch.roles import author_spec
 
     spec = author_spec(max_turns=9, walltime_s=300)
-    harness = build_editor_harness(
+    harness = build_harness(
         "sk-o",
         spec,
         backend="codex",
@@ -1535,15 +1534,14 @@ def test_editor_harness_codex_backend_is_contained() -> None:
     assert harness.timeout_s == 300
     assert harness.extra_args == ("-c", "use_legacy_landlock=true")  # host codex config
     assert harness.supports_resume is True  # codex exec resume, validated on 0.130.0
-    # an author MUST be contained
-    with pytest.raises(ValueError, match="container_image"):
-        build_editor_harness("sk-o", spec, backend="codex", container_image="")
-    with pytest.raises(ValueError, match="unknown editor backend"):
-        build_editor_harness("sk-o", spec, backend="bogus", container_image="img.sif")
+    with pytest.raises(ValueError, match="unknown backend"):
+        build_harness("sk-o", spec, backend="bogus", container_image="img.sif")
 
 
 def _panel_judge(texts):
-    """A scripted read-only judge for the real run_panel path."""
+    """A scripted judge for the real run_panel path: commits its verdict
+    through the syscall channel, exactly as the tool does."""
+    import json as json_mod
     from dataclasses import dataclass, field
 
     @dataclass
@@ -1553,13 +1551,27 @@ def _panel_judge(texts):
 
         def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
             self.seen_ws.append(Path(workspace))
+            text = self.queue.pop(0)
+            # commit the verdict through the syscall channel, as the tool would
+            payload = None
+            try:
+                payload = json_mod.loads(text)
+            except (json_mod.JSONDecodeError, TypeError):
+                payload = None  # a judge that never concluded: no verdict written
+            if isinstance(payload, dict):
+                for f in payload.get("findings", []):
+                    if isinstance(f, dict):
+                        f.setdefault("kind", "note")  # the tool's own default
+                d = Path(workspace) / ".autoresearch"
+                d.mkdir(exist_ok=True)
+                (d / "syscall.json").write_text(json_mod.dumps({"type": "verdict", **payload}))
             return SessionResult(
                 stop_reason="end_turn",
                 is_error=False,
                 cost_usd=0.0,
                 num_turns=1,
                 session_id="judge",
-                final_text=self.queue.pop(0),
+                final_text=text,
                 transcript_path="",
             )
 

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -786,10 +786,19 @@ def test_context_excludes_drive_by_and_forged_marker_comments(review_run) -> Non
 
 
 def test_read_only_spec_is_refused(review_run) -> None:
-    # the responder edits and replies; a judge spec here is a deployment bug —
-    # contained per-lane like any responder failure (cursor un-advanced), so
-    # one bad deployment cannot crash the tick's other lanes
-    from autoresearch.roles import reviewer_spec
+    # the responder edits and replies; a non-executing spec here is a
+    # deployment bug — contained per-lane like any responder failure (cursor
+    # un-advanced), so one bad deployment cannot crash the tick's other lanes
+    from autoresearch.rolespec import Execution, RoleSpec, SessionBudget
+
+    read_only = RoleSpec(
+        name="reviewer",
+        instructions="x",
+        key="reviewer",
+        tools=("Read",),
+        execution=Execution(environment="gh-runner", can_execute=False),
+        budget=SessionBudget(max_turns=1, walltime_s=1),
+    )
 
     root, _ = review_run
     harness = ResumingHarness()
@@ -803,7 +812,7 @@ def test_read_only_spec_is_refused(review_run) -> None:
         bot_login=BOT,
         now=NOW,
         secrets=(),
-        spec=reviewer_spec(),
+        spec=read_only,
     )
     assert outcome.action == "error"
     assert "must allow execution" in outcome.note

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1023,11 +1023,20 @@ def test_task_names_the_suite_gate_only_when_it_exists(tmp_path: Path) -> None:
 
 
 def test_climb_once_refuses_a_read_only_spec(tmp_path: Path) -> None:
-    # the author is an editing role; a judge spec here is a deployment bug
-    from autoresearch.roles import reviewer_spec
+    # the author is an editing role; a non-executing spec here is a deployment bug
+    from autoresearch.rolespec import Execution, RoleSpec, SessionBudget
+
+    read_only = RoleSpec(
+        name="reviewer",
+        instructions="x",
+        key="reviewer",
+        tools=("Read",),
+        execution=Execution(environment="gh-runner", can_execute=False),
+        budget=SessionBudget(max_turns=1, walltime_s=1),
+    )
 
     with pytest.raises(ValueError, match="must allow execution"):
-        run_climb(tmp_path, [13.876], spec=reviewer_spec())
+        run_climb(tmp_path, [13.876], spec=read_only)
 
 
 def test_shared_match_is_case_folded_like_the_other_path_checks(tmp_path: Path) -> None:

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -45,6 +45,19 @@ class _Judge:
 
     def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
         self.workspaces.append(Path(workspace))
+        if not self.is_error:
+            # commit the verdict through the syscall channel, as the tool would
+            try:
+                payload = json.loads(self.text)
+            except (json.JSONDecodeError, TypeError):
+                payload = None  # never concluded: no verdict written
+            if isinstance(payload, dict):
+                for f in payload.get("findings", []):
+                    if isinstance(f, dict):
+                        f.setdefault("kind", "note")  # the tool's own default
+                d = Path(workspace) / ".autoresearch"
+                d.mkdir(exist_ok=True)
+                (d / "syscall.json").write_text(json.dumps({"type": "verdict", **payload}))
         return SessionResult(
             stop_reason="error" if self.is_error else "completed",
             is_error=self.is_error,

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -4,6 +4,10 @@ GitHub client — no real session, no network."""
 from __future__ import annotations
 
 import json
+
+# judge runs write the syscall channel into the workspace now, so give the
+# module its own throwaway dir rather than a fixed global path
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -11,7 +15,7 @@ from autoresearch.harness import SessionResult
 from autoresearch.review import build_agent_brief
 from autoresearch.review_agent import run_agent_review
 
-_WORKSPACE = Path("/tmp/checkout")
+_WORKSPACE = Path(tempfile.mkdtemp(prefix="review-agent-tests-"))
 
 _FINDINGS = json.dumps(
     {
@@ -49,6 +53,19 @@ class _Harness:
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
     ) -> SessionResult:
         self.briefs.append(brief_text)
+        if not self._err:
+            # commit the verdict through the syscall channel, as the tool would
+            try:
+                payload = json.loads(self._text)
+            except (json.JSONDecodeError, TypeError):
+                payload = None  # never concluded: no verdict written
+            if isinstance(payload, dict):
+                for f in payload.get("findings", []):
+                    if isinstance(f, dict):
+                        f.setdefault("kind", "note")  # the tool's own default
+                d = Path(workspace) / ".autoresearch"
+                d.mkdir(exist_ok=True)
+                (d / "syscall.json").write_text(json.dumps({"type": "verdict", **payload}))
         return SessionResult(
             stop_reason="error" if self._err else "completed",
             is_error=self._err,
@@ -112,8 +129,9 @@ def test_clean_review_posts_inline() -> None:
     assert len(client.reviews) == 1
     _body, inline = client.reviews[0]
     assert any(c.get("path") == "models/encoder.py" for c in inline)
-    # the brief carried the read-only investigation instruction
-    assert "checked out read-only" in harness.briefs[0]
+    # the brief carries the investigation + syscall emit instructions
+    assert "checked out in your working directory" in harness.briefs[0]
+    assert "python .autoresearch/syscall finding" in harness.briefs[0]
 
 
 def test_null_labels_do_not_crash() -> None:
@@ -176,90 +194,6 @@ def test_malformed_output_posts_nothing() -> None:
     assert client.reviews == [] and client.comments == []
 
 
-def test_build_reviewer_harness_is_read_only() -> None:
-    from autoresearch.harness import ClaudeCodeHarness
-    from autoresearch.review_agent import build_reviewer_harness
-
-    harness = build_reviewer_harness("k")
-    assert isinstance(harness, ClaudeCodeHarness)  # default backend
-    # the read-only boundary binds the session: no execute/write tools
-    assert "Bash" not in harness.allowed_tools
-    assert "Write" not in harness.allowed_tools and "Edit" not in harness.allowed_tools
-    assert set(harness.allowed_tools) == {"Read", "Grep", "Glob"}
-    # budget comes from the RoleSpec
-    assert harness.max_turns == 40 and harness.timeout_s == 1800
-
-
-def test_build_reviewer_harness_codex_backend() -> None:
-    from autoresearch.harness import CodexHarness
-    from autoresearch.review_agent import build_reviewer_harness
-
-    h = build_reviewer_harness("k", backend="codex")
-    assert isinstance(h, CodexHarness)
-    assert h.sandbox == "read-only"  # read-only judge boundary via the sandbox
-    assert h.extra_args == ()  # no host-specific sandbox config by default
-
-
-def test_build_reviewer_harness_codex_sandbox_extra_passthrough() -> None:
-    from autoresearch.harness import CodexHarness
-    from autoresearch.review_agent import build_reviewer_harness
-
-    # The deployment (workflow) opts into the Landlock sandbox on GitHub-hosted;
-    # the builder threads it verbatim to codex's argv.
-    extra = ("-c", "use_legacy_landlock=true")
-    h = build_reviewer_harness("k", backend="codex", sandbox_extra=extra)
-    assert isinstance(h, CodexHarness)
-    assert h.extra_args == extra
-
-
-def test_build_reviewer_harness_hermes_backend(tmp_path: Path) -> None:
-    from autoresearch.harness import HermesHarness
-    from autoresearch.review_agent import build_reviewer_harness
-
-    h = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="openrouter")
-    assert isinstance(h, HermesHarness)
-    assert h.repo_dir == tmp_path and h.provider == "openrouter"
-    # Read-only-ish judge shape: file toolset only, terminal (shell) disabled.
-    assert h.enabled_toolsets == ("file",)
-    assert "terminal" in h.disabled_toolsets
-
-
-def test_build_reviewer_harness_hermes_requires_repo() -> None:
-    import pytest
-
-    from autoresearch.review_agent import build_reviewer_harness
-
-    with pytest.raises(ValueError, match="hermes_repo"):
-        build_reviewer_harness("k", backend="hermes")
-
-
-def test_build_reviewer_harness_rejects_unknown_backend() -> None:
-    import pytest
-
-    from autoresearch.review_agent import build_reviewer_harness
-
-    with pytest.raises(ValueError, match="unknown reviewer backend"):
-        build_reviewer_harness("k", backend="gemini-cli")
-
-
-def test_build_reviewer_harness_rejects_execute_role() -> None:
-    import pytest
-
-    from autoresearch.review_agent import build_reviewer_harness
-    from autoresearch.rolespec import Execution, RoleSpec, SessionBudget
-
-    author = RoleSpec(
-        name="author",
-        instructions="x",
-        key="author",
-        tools=("Read", "Edit", "Bash"),
-        execution=Execution(environment="apptainer", can_execute=True),
-        budget=SessionBudget(max_turns=10, walltime_s=60),
-    )
-    with pytest.raises(ValueError, match="read-only"):
-        build_reviewer_harness("k", author)
-
-
 def test_build_agent_brief_reuses_rubric_and_diff() -> None:
     from autoresearch.review import PullRequest
 
@@ -268,13 +202,18 @@ def test_build_agent_brief_reuses_rubric_and_diff() -> None:
     assert "reviewing a pull request" in brief.lower()
     assert "input_gain" in brief  # the diff is embedded
     assert "2026-08-13" in brief
+    # the emit path is the syscall tool, not a JSON reply
+    assert "python .autoresearch/syscall finding" in brief
+    assert "conclude" in brief
 
 
-def test_reviewer_harness_uses_read_only_permission_mode(monkeypatch: Any, tmp_path: Path) -> None:
-    # defense in depth: a read-only harness passes --permission-mode default
-    # (edits denied), not acceptEdits. Inspect the actual spawned argv.
+def test_judge_harness_grants_the_shell_and_runs_bare(monkeypatch: Any, tmp_path: Path) -> None:
+    # the judge runs like any other role: Bash granted (it records its verdict
+    # by running the syscall tool) and --bare (an untrusted checkout must never
+    # load as instructions). Inspect the actual spawned argv.
     import autoresearch.harness as harness_mod
-    from autoresearch.review_agent import build_reviewer_harness
+    from autoresearch.role_runner import build_harness
+    from autoresearch.roles import reviewer_spec
 
     seen: dict[str, Any] = {}
 
@@ -290,34 +229,10 @@ def test_reviewer_harness_uses_read_only_permission_mode(monkeypatch: Any, tmp_p
             return json.dumps({"result": "{}", "session_id": "s"}), ""
 
     monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
-    build_reviewer_harness("k").run("brief", tmp_path)
+    build_harness("k", reviewer_spec()).run("brief", tmp_path)
     argv = seen["argv"]
-    assert argv[argv.index("--permission-mode") + 1] == "default"
-    assert "Bash" not in argv[argv.index("--allowedTools") + 1]
-
-
-def test_reviewer_harness_runs_bare(monkeypatch: Any, tmp_path: Path) -> None:
-    # --bare: no hooks, no CLAUDE.md auto-discovery — a PR-authored
-    # instruction file must never load as instructions
-    import autoresearch.harness as harness_mod
-    from autoresearch.review_agent import build_reviewer_harness
-
-    seen: dict[str, Any] = {}
-
-    class FakePopen:
-        returncode = 0
-
-        def __init__(self, command: list[str], **_: Any) -> None:
-            seen["argv"] = command
-
-        def communicate(
-            self, input: str | None = None, timeout: float | None = None
-        ) -> tuple[str, str]:
-            return json.dumps({"result": "{}", "session_id": "s"}), ""
-
-    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
-    build_reviewer_harness("k").run("brief", tmp_path)
-    assert "--bare" in seen["argv"]
+    assert "Bash" in argv[argv.index("--allowedTools") + 1]
+    assert "--bare" in argv
 
 
 def test_sanitize_checkout_renames_nested_instruction_files(tmp_path: Path) -> None:
@@ -579,23 +494,3 @@ def test_skip_stub_names_its_opinion(tmp_path: Path) -> None:
     )
     (comment,) = client.comments
     assert "advisory review (second opinion — terra)" in comment
-
-
-def test_hermes_openai_direct_exports_the_openai_key_env(tmp_path: Path) -> None:
-    # openai-direct: same token rate, no OpenRouter platform fee; hermes reads
-    # the key from the env var its provider registry names
-    from autoresearch.harness import HermesHarness
-    from autoresearch.review_agent import build_reviewer_harness
-
-    h = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="openai")
-    assert isinstance(h, HermesHarness)
-    assert h.provider == "openai-api"  # hermes's canonical id; "openai" is a group
-    assert h.key_env == "OPENAI_API_KEY"
-    default = build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="")
-    assert isinstance(default, HermesHarness)
-    assert default.provider == "openrouter"
-    assert default.key_env == "OPENROUTER_API_KEY"
-    import pytest
-
-    with pytest.raises(ValueError, match="unknown hermes provider"):
-        build_reviewer_harness("k", backend="hermes", hermes_repo=tmp_path, provider="mystery")

--- a/tests/test_review_agent.py
+++ b/tests/test_review_agent.py
@@ -129,9 +129,11 @@ def test_clean_review_posts_inline() -> None:
     assert len(client.reviews) == 1
     _body, inline = client.reviews[0]
     assert any(c.get("path") == "models/encoder.py" for c in inline)
-    # the brief carries the investigation + syscall emit instructions
+    # the brief carries the investigation + syscall emit instructions (the tool
+    # path is absolute here — run_agent_review passes the workspace so it
+    # resolves from any backend's cwd)
     assert "checked out in your working directory" in harness.briefs[0]
-    assert "python .autoresearch/syscall finding" in harness.briefs[0]
+    assert ".autoresearch/syscall finding" in harness.briefs[0]
 
 
 def test_null_labels_do_not_crash() -> None:

--- a/tests/test_review_agent_cli.py
+++ b/tests/test_review_agent_cli.py
@@ -26,8 +26,8 @@ def _patch(monkeypatch: Any, env: dict[str, str]) -> dict[str, Any]:
     # test can assert the backend is actually forwarded
     monkeypatch.setattr(
         cli,
-        "build_reviewer_harness",
-        lambda api_key, **k: calls.update(build_key=api_key, build_kwargs=k) or "harness",
+        "build_harness",
+        lambda api_key, spec, **k: calls.update(build_key=api_key, build_kwargs=k) or "harness",
     )
     monkeypatch.setattr(
         cli,
@@ -86,7 +86,7 @@ def test_hermes_backend_reads_openrouter_key(monkeypatch: Any, tmp_path: Path) -
     assert calls["build_kwargs"]["backend"] == "hermes"
     assert calls["build_key"] == "sk-or-test"
     assert calls["build_kwargs"]["hermes_repo"] == tmp_path.resolve()
-    assert calls["build_kwargs"]["provider"] == "openrouter"
+    assert calls["build_kwargs"]["hermes_provider"] == "openrouter"
 
 
 def test_hermes_backend_without_repo_skips(monkeypatch: Any) -> None:
@@ -160,7 +160,7 @@ def test_hermes_openai_provider_reads_the_openai_key(monkeypatch: Any, tmp_path:
     calls = _patch(monkeypatch, env)
     assert cli.main() == 0
     assert calls["build_key"] == "sk-openai-test"
-    assert calls["build_kwargs"]["provider"] == "openai"
+    assert calls["build_kwargs"]["hermes_provider"] == "openai"
 
 
 def test_unknown_hermes_provider_in_emit_mode_writes_a_stub(
@@ -301,4 +301,4 @@ def test_explicitly_empty_hermes_provider_means_the_default(
     calls = _patch(monkeypatch, env)
     assert cli.main() == 0
     assert calls["build_key"] == "sk-or-test"
-    assert calls["build_kwargs"]["provider"] == "openrouter"
+    assert calls["build_kwargs"]["hermes_provider"] == "openrouter"

--- a/tests/test_review_policy.py
+++ b/tests/test_review_policy.py
@@ -13,8 +13,6 @@ from autoresearch.review import format_review
 from autoresearch.role_runner import RoleResult, run_role
 from autoresearch.roles import review_result_from_role, reviewer_spec
 
-_WORKSPACE = Path("/tmp/does-not-matter")
-
 # a diff whose new side has an anchorable line in models/encoder.py
 _DIFF = (
     "diff --git a/models/encoder.py b/models/encoder.py\n"
@@ -26,43 +24,49 @@ _DIFF = (
     "     pass\n"
 )
 
-_AGENT_FINDINGS = json.dumps(
-    {
-        "findings": [
-            {
-                "file": "models/encoder.py",
-                "line": 2,
-                "confidence": "high",
-                "summary": "input_gain is a per-layer LR in disguise",
-                "detail": "This belongs in the initializer/LR seam, not forward().",
-                "blocking": True,
-            }
-        ],
-        "notes": "one blocking finding",
-    }
-)
+_AGENT_FINDINGS = {
+    "findings": [
+        {
+            "file": "models/encoder.py",
+            "line": 2,
+            "confidence": "high",
+            "summary": "input_gain is a per-layer LR in disguise",
+            "detail": "This belongs in the initializer/LR seam, not forward().",
+            "blocking": True,
+            "kind": "change",
+        }
+    ],
+    "notes": "one blocking finding",
+}
 
 
 class _Harness:
-    def __init__(self, final_text: str) -> None:
-        self._final_text = final_text
+    """A judge session: commits a verdict through the syscall channel (as the
+    tool would), or commits nothing when given None."""
+
+    def __init__(self, verdict: dict | None) -> None:
+        self._verdict = verdict
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
     ) -> SessionResult:
+        if self._verdict is not None:
+            d = Path(workspace) / ".autoresearch"
+            d.mkdir(exist_ok=True)
+            (d / "syscall.json").write_text(json.dumps({"type": "verdict", **self._verdict}))
         return SessionResult(
             stop_reason="completed",
             is_error=False,
             cost_usd=0.0,
             num_turns=1,
             session_id="s",
-            final_text=self._final_text,
+            final_text="(verdict via tool)",
             transcript_path="",
         )
 
 
-def test_agent_findings_flow_to_inline_review_payload() -> None:
-    role_result = run_role(reviewer_spec(), _Harness(_AGENT_FINDINGS), "brief", _WORKSPACE)
+def test_agent_findings_flow_to_inline_review_payload(tmp_path: Path) -> None:
+    role_result = run_role(reviewer_spec(), _Harness(_AGENT_FINDINGS), "brief", tmp_path)
     review = review_result_from_role(role_result)
     assert review is not None
     assert len(review.findings) == 1
@@ -85,9 +89,8 @@ def test_failed_role_yields_no_review() -> None:
     assert review_result_from_role(failed) is None
 
 
-def test_malformed_agent_output_yields_no_review() -> None:
-    # never validates -> run_role fails -> policy returns None (post a skip stub)
-    role_result = run_role(
-        reviewer_spec(), _Harness("not json"), "brief", _WORKSPACE, max_repairs=0
-    )
+def test_no_verdict_yields_no_review(tmp_path: Path) -> None:
+    # the judge never concluded -> run_role fails -> policy returns None
+    # (post a skip stub)
+    role_result = run_role(reviewer_spec(), _Harness(None), "brief", tmp_path)
     assert review_result_from_role(role_result) is None

--- a/tests/test_role_runner.py
+++ b/tests/test_role_runner.py
@@ -1,5 +1,5 @@
-"""Role-runner: structured-output validation, the repair loop, and the role
-specs. The harness is faked; no session is actually run."""
+"""Role-runner: the unified harness builder, the verdict-tool read, and the
+role specs. The harness is faked; no session is actually run."""
 
 from __future__ import annotations
 
@@ -45,9 +45,12 @@ class _SeqHarness:
         return self.results.pop(0)
 
 
-def test_reviewer_spec_is_read_only_and_uses_findings_schema() -> None:
+def test_reviewer_spec_is_an_executing_judge_with_findings_schema() -> None:
+    # a judge runs like every other role (shell for the syscall tool; the
+    # deployment's boundary contains it) and edits nothing
     spec = reviewer_spec()
-    assert spec.execution.can_execute is False
+    assert spec.execution.can_execute is True
+    assert "Bash" in spec.tools
     assert spec.scope is None
     assert spec.output_schema is FINDINGS_SCHEMA
 
@@ -61,47 +64,9 @@ def test_author_spec_is_an_executing_editor_with_no_schema() -> None:
     assert author_spec(scope=("src/x/",)).scope == ("src/x/",)
 
 
-def test_happy_path_returns_validated_data() -> None:
-    harness = _SeqHarness([_session(_FINDINGS)])
-    result = run_role(reviewer_spec(), harness, "brief", _WORKSPACE)
-    assert result.ok is True
-    assert result.data == {"findings": [], "notes": "looks fine"}
-
-
-def test_tolerates_code_fenced_json() -> None:
-    fenced = f"Here are my findings:\n```json\n{_FINDINGS}\n```\n"
-    result = run_role(reviewer_spec(), _SeqHarness([_session(fenced)]), "brief", _WORKSPACE)
-    assert result.ok is True
-    assert result.data is not None
-
-
-def test_repairs_once_then_succeeds() -> None:
-    harness = _SeqHarness([_session("not json at all"), _session(_FINDINGS)])
-    result = run_role(reviewer_spec(), harness, "brief", _WORKSPACE)
-    assert result.ok is True
-    # the repair call resumed the first session
-    assert harness.calls == [None, "sess-1"]
-
-
-def test_exhausts_repairs_and_fails() -> None:
-    harness = _SeqHarness([_session("nope"), _session("still nope")])
-    result = run_role(reviewer_spec(), harness, "brief", _WORKSPACE, max_repairs=1)
-    assert result.ok is False
-    assert "invalid structured output" in result.error
-
-
-def test_missing_required_key_is_invalid() -> None:
-    partial = json.dumps({"findings": []})  # no "notes"
-    result = run_role(
-        reviewer_spec(), _SeqHarness([_session(partial)]), "brief", _WORKSPACE, max_repairs=0
-    )
-    assert result.ok is False
-    assert "notes" in result.error
-
-
-def test_session_error_propagates() -> None:
+def test_session_error_propagates(tmp_path: Path) -> None:
     harness = _SeqHarness([_session(is_error=True, error_detail="boom")])
-    result = run_role(reviewer_spec(), harness, "brief", _WORKSPACE)
+    result = run_role(reviewer_spec(), harness, "brief", tmp_path)
     assert result.ok is False
     assert result.error == "boom"
 
@@ -158,9 +123,7 @@ class _VerdictHarness:
 
 
 def _verdict_spec():
-    from dataclasses import replace
-
-    return replace(reviewer_spec(), verdict_tool=True)
+    return reviewer_spec()
 
 
 def test_verdict_tool_mode_reads_the_committed_verdict(tmp_path: Path) -> None:
@@ -211,14 +174,67 @@ def test_verdict_tool_mode_malformed_verdict_is_a_failure(tmp_path: Path) -> Non
     assert not result.ok and "invalid verdict" in result.error
 
 
-def test_judge_without_verdict_tool_parses_the_final_message(tmp_path: Path) -> None:
-    # a judge spec that does NOT set verdict_tool uses the parse path — no tool
-    # installed, findings validated from the final message. run_role gates the
-    # tool on the spec alone (the deployment builds the harness to match).
-    from dataclasses import replace
+# --- build_harness: the ONE construction for every role and backend ---
 
-    spec = replace(reviewer_spec(), verdict_tool=False)
-    harness = _SeqHarness(results=[_session(_FINDINGS)])
-    result = run_role(spec, harness, "x", tmp_path)
-    assert result.ok and result.data == {"findings": [], "notes": "looks fine"}
-    assert not (tmp_path / ".autoresearch").exists()  # tool NOT installed
+
+def test_build_harness_claude_judge_gets_tools_and_bare() -> None:
+    from autoresearch.harness import ClaudeCodeHarness
+    from autoresearch.role_runner import build_harness
+
+    h = build_harness("k", reviewer_spec())
+    assert isinstance(h, ClaudeCodeHarness)
+    # native tools from the spec: the read set plus the shell that runs the
+    # syscall tool (MCP names like pr-context-read are wired separately)
+    assert set(h.allowed_tools) == {"Read", "Grep", "Glob", "Bash"}
+    assert h.bare is True  # untrusted checkout: never load its instructions
+    assert h.max_turns == 40 and h.timeout_s == 1800  # budget from the spec
+
+
+def test_build_harness_codex_is_uniform_for_all_roles() -> None:
+    # one execution surface: codex's own sandbox stays off; the deployment's
+    # container or ephemeral runner is the boundary, for judges and editors alike
+    from autoresearch.harness import CodexHarness
+    from autoresearch.role_runner import build_harness
+
+    judge = build_harness("k", reviewer_spec(), backend="codex")
+    editor = build_harness("k", author_spec(), backend="codex", container_image="img.sif")
+    assert isinstance(judge, CodexHarness) and isinstance(editor, CodexHarness)
+    assert judge.sandbox == editor.sandbox == "danger-full-access"
+    assert judge.container_image == "" and editor.container_image == "img.sif"
+
+
+def test_build_harness_hermes_toolsets_follow_the_spec(tmp_path: Path) -> None:
+    from autoresearch.harness import HermesHarness
+    from autoresearch.role_runner import build_harness
+
+    h = build_harness(
+        "k", reviewer_spec(), backend="hermes", hermes_repo=tmp_path, hermes_provider="openai"
+    )
+    assert isinstance(h, HermesHarness)
+    assert h.repo_dir == tmp_path
+    assert h.provider == "openai-api" and h.key_env == "OPENAI_API_KEY"
+    # an executing role has the shell; everything else stays off for parity
+    assert set(h.enabled_toolsets) == {"file", "terminal"}
+    assert "terminal" not in h.disabled_toolsets and "web" in h.disabled_toolsets
+
+
+def test_build_harness_hermes_requires_repo_and_known_provider(tmp_path: Path) -> None:
+    import pytest
+
+    from autoresearch.role_runner import build_harness
+
+    with pytest.raises(ValueError, match="hermes_repo"):
+        build_harness("k", reviewer_spec(), backend="hermes")
+    with pytest.raises(ValueError, match="unknown hermes provider"):
+        build_harness(
+            "k", reviewer_spec(), backend="hermes", hermes_repo=tmp_path, hermes_provider="wat"
+        )
+
+
+def test_build_harness_rejects_unknown_backend() -> None:
+    import pytest
+
+    from autoresearch.role_runner import build_harness
+
+    with pytest.raises(ValueError, match="unknown backend"):
+        build_harness("k", reviewer_spec(), backend="gemini-cli")

--- a/tests/test_role_runner.py
+++ b/tests/test_role_runner.py
@@ -218,6 +218,22 @@ def test_build_harness_hermes_toolsets_follow_the_spec(tmp_path: Path) -> None:
     assert "terminal" not in h.disabled_toolsets and "web" in h.disabled_toolsets
 
 
+def test_build_harness_hermes_terminal_keys_on_the_bash_tool(tmp_path: Path) -> None:
+    # the shell is granted from the SAME signal claude uses (the Bash tool),
+    # not can_execute — so a role without Bash gets no terminal even if it
+    # executes (terra #140 r5).
+    from dataclasses import replace
+
+    from autoresearch.harness import HermesHarness
+    from autoresearch.role_runner import build_harness
+
+    spec = replace(reviewer_spec(), tools=("Read", "Grep", "Glob"))  # no Bash
+    h = build_harness("k", spec, backend="hermes", hermes_repo=tmp_path)
+    assert isinstance(h, HermesHarness)
+    assert h.enabled_toolsets == ("file",)  # no terminal without Bash
+    assert "terminal" in h.disabled_toolsets
+
+
 def test_build_harness_hermes_requires_repo_and_known_provider(tmp_path: Path) -> None:
     import pytest
 

--- a/tests/test_rolespec.py
+++ b/tests/test_rolespec.py
@@ -75,3 +75,21 @@ def test_empty_tools_rejected() -> None:
             execution=Execution(environment="apptainer", can_execute=True),
             budget=SessionBudget(max_turns=10, walltime_s=60),
         )
+
+
+def test_judge_may_not_hold_a_write_scope() -> None:
+    import pytest
+
+    from autoresearch.rolespec import Execution, RoleSpec, RoleSpecError, SessionBudget
+
+    with pytest.raises(RoleSpecError, match="never edits"):
+        RoleSpec(
+            name="reviewer",
+            instructions="x",
+            key="reviewer",
+            tools=("Read", "Bash"),
+            execution=Execution(environment="gh-runner", can_execute=True),
+            budget=SessionBudget(max_turns=1, walltime_s=1),
+            output_schema={"required": []},
+            scope=("src/",),  # a judge records a verdict; it edits nothing
+        )

--- a/tests/test_rolespec.py
+++ b/tests/test_rolespec.py
@@ -75,20 +75,3 @@ def test_empty_tools_rejected() -> None:
             execution=Execution(environment="apptainer", can_execute=True),
             budget=SessionBudget(max_turns=10, walltime_s=60),
         )
-
-
-def test_verdict_tool_requires_an_output_schema() -> None:
-    import pytest
-
-    from autoresearch.rolespec import Execution, RoleSpec, RoleSpecError, SessionBudget
-
-    with pytest.raises(RoleSpecError, match="output_schema"):
-        RoleSpec(
-            name="reviewer",
-            instructions="x",
-            key="reviewer",
-            tools=("Read",),
-            execution=Execution(environment="gh-runner", can_execute=False),
-            budget=SessionBudget(max_turns=1, walltime_s=1),
-            verdict_tool=True,  # no output_schema -> invariant violation
-        )

--- a/tests/test_steward.py
+++ b/tests/test_steward.py
@@ -728,10 +728,19 @@ def test_rebase_row_records_the_measurement_seed(tmp_path) -> None:
 
 
 def test_read_only_spec_is_refused_before_any_work(tmp_path, steward_repo) -> None:
-    # the steward edits env code; a judge spec here is a deployment bug — loud
-    # and immediate, before the record or any network work
-    from autoresearch.roles import reviewer_spec
+    # the steward edits env code; a non-executing spec here is a deployment
+    # bug — loud and immediate, before the record or any network work
+    from autoresearch.rolespec import Execution, RoleSpec, SessionBudget
     from autoresearch.steward import StewardConfig, live_steward
+
+    read_only = RoleSpec(
+        name="reviewer",
+        instructions="x",
+        key="reviewer",
+        tools=("Read",),
+        execution=Execution(environment="gh-runner", can_execute=False),
+        budget=SessionBudget(max_turns=1, walltime_s=1),
+    )
 
     with pytest.raises(ValueError, match="must allow execution"):
         live_steward(
@@ -744,7 +753,7 @@ def test_read_only_spec_is_refused_before_any_work(tmp_path, steward_repo) -> No
             bot_auth=None,  # type: ignore[arg-type]
             now=1_000_000.0,
             created="t",
-            spec=reviewer_spec(),
+            spec=read_only,
         )
     # "before any work" made checkable: no run dir, no record, nothing on disk
     assert not (tmp_path / "state").exists()

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -341,3 +341,13 @@ def test_installed_tool_roots_at_its_install_location_not_cwd(tmp_path: Path) ->
     assert r.returncode == 0, r.stderr
     assert not (elsewhere / ".autoresearch").exists()  # nothing lands at cwd
     assert read_verdict(ws) == {"findings": [], "notes": "clean"}  # kernel finds it
+
+
+def test_tool_command_is_absolute(tmp_path: Path) -> None:
+    # a judge whose cwd is not the workspace (hermes) must still find the tool:
+    # the brief command is absolute (adversarial/terra review of #140).
+    from autoresearch.syscall import tool_command
+
+    cmd = tool_command(tmp_path / "ws")
+    assert cmd.startswith("python /")  # absolute, resolves from any cwd
+    assert cmd.endswith("/ws/.autoresearch/syscall")

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -317,3 +317,27 @@ def test_status_shows_staged_findings(tmp_path: Path, capsys) -> None:
     run(tmp_path, "status")
     out = capsys.readouterr().out
     assert "1 finding(s) staged" in out and "BLOCKING" in out and "a.py:3" in out
+
+
+def test_installed_tool_roots_at_its_install_location_not_cwd(tmp_path: Path) -> None:
+    """An agent may invoke the tool from a subdirectory or another working dir
+    entirely (hermes starts in its per-run home): the syscall must land in the
+    tool's OWN workspace channel, never a cwd-relative one the kernel never
+    reads (adversarial review of the interchangeable-backend refactor)."""
+    from autoresearch.syscall import install_tool, read_verdict
+
+    ws = tmp_path / "ws"
+    ws.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    install_tool(ws)
+    tool = ws / ".autoresearch" / "syscall"
+    r = subprocess.run(
+        [sys.executable, "-I", str(tool), "conclude", "--notes", "clean"],
+        cwd=elsewhere,  # NOT the workspace
+        capture_output=True,
+        text=True,
+    )
+    assert r.returncode == 0, r.stderr
+    assert not (elsewhere / ".autoresearch").exists()  # nothing lands at cwd
+    assert read_verdict(ws) == {"findings": [], "notes": "clean"}  # kernel finds it

--- a/tests/test_verify_agent.py
+++ b/tests/test_verify_agent.py
@@ -193,3 +193,50 @@ def test_bogus_category_clamps_to_other() -> None:
         "notes": "",
     }
     assert verify_result_from_data(data).findings[0].category == "other"
+
+
+def test_tokenless_split_emits_then_posts(tmp_path: Path) -> None:
+    # The write-token split: run_agent_verify(emit_path=...) writes the verdict
+    # to a file and posts NOTHING (the session job holds no write token); a
+    # separate post step (verify_post_cli) reads it and posts.
+    import json as _json
+
+    from autoresearch.verify_post_cli import post_from_file
+
+    ws = tmp_path / "two-trees"
+    ws.mkdir()
+    emit = tmp_path / "verdict.json"
+    session_client = _Client()
+    label = run_agent_verify(
+        session_client,  # type: ignore[arg-type]
+        "org/repo",
+        9,
+        _Harness(_FINDINGS),
+        ws,
+        bot_login=BOT,
+        emit_path=emit,
+    )
+    assert label == "emitted"
+    assert session_client.comments == []  # the session job posts nothing
+    envelope = _json.loads(emit.read_text())
+    assert envelope["repo"] == "org/repo" and envelope["number"] == 9
+    assert envelope["kind"] == "findings"
+
+    post_client = _Client()  # the write-token job, no session
+    round_label = post_from_file(post_client, "org/repo", 9, BOT, emit)  # type: ignore[arg-type]
+    assert round_label is not None
+    assert len(post_client.comments) == 1
+    assert "autoresearch:verification-review" in post_client.comments[0]
+
+
+def test_post_from_file_refuses_a_mismatched_pr(tmp_path: Path) -> None:
+    import json as _json
+
+    from autoresearch.verify_post_cli import post_from_file
+
+    emit = tmp_path / "verdict.json"
+    emit.write_text(_json.dumps({"repo": "org/repo", "number": 9, "kind": "findings", "data": {}}))
+    client = _Client()
+    # the artifact crosses a job boundary: an envelope naming another PR is refused
+    assert post_from_file(client, "org/repo", 10, BOT, emit) is None  # type: ignore[arg-type]
+    assert client.comments == []

--- a/tests/test_verify_agent.py
+++ b/tests/test_verify_agent.py
@@ -40,6 +40,19 @@ class _Harness:
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
     ) -> SessionResult:
         self.briefs.append(brief_text)
+        if not self._err:
+            # commit the verdict through the syscall channel, as the tool would
+            try:
+                payload = json.loads(self._text)
+            except (json.JSONDecodeError, TypeError):
+                payload = None  # never concluded: no verdict written
+            if isinstance(payload, dict):
+                for f in payload.get("findings", []):
+                    if isinstance(f, dict):
+                        f.setdefault("kind", "note")  # the tool's own default
+                d = Path(workspace) / ".autoresearch"
+                d.mkdir(exist_ok=True)
+                (d / "syscall.json").write_text(json.dumps({"type": "verdict", **payload}))
         return SessionResult(
             stop_reason="error" if self._err else "completed",
             is_error=self._err,
@@ -158,7 +171,8 @@ def test_brief_directs_ruler_reads_at_base() -> None:
     assert "Read the ruler source" in brief
     assert "`base/`" in brief and "`pr-head/`" in brief
     assert "contract: yes" in brief  # fenced from base, orchestrator-vouched
-    assert "do not run code" in brief.lower()
+    assert "python .autoresearch/syscall finding" in brief  # the emit path
+    assert "do not modify" in brief.lower()
 
 
 def test_bogus_category_clamps_to_other() -> None:

--- a/tests/test_verify_agent_cli.py
+++ b/tests/test_verify_agent_cli.py
@@ -26,7 +26,7 @@ def _patch(monkeypatch: Any, env: dict[str, str]) -> dict[str, Any]:
     calls: dict[str, Any] = {}
     monkeypatch.setattr(
         cli,
-        "build_reviewer_harness",
+        "build_harness",
         lambda api_key, spec, **k: calls.update(key=api_key, spec=spec) or "harness",
     )
     monkeypatch.setattr(


### PR DESCRIPTION
## What

**Interchangeable backends: one harness construction for every role.** Realizes
"nothing different between harnesses — as long as there is a boundary, they are
interchangeable; roles differ by system prompt" (docs/design/role-cli.md, "the
harness unification").

## Changes

- **One `build_harness`** (`role_runner.py`) replaces `build_editor_harness` +
  `build_reviewer_harness`:
  - claude — `spec.tools` → native flags; judges run `--bare` (an untrusted
    checkout must never load as instructions);
  - codex — `--sandbox danger-full-access` uniformly (its own sandbox needs
    bubblewrap; the boundary is the deployment's container or ephemeral
    runner, plus the tokenless split);
  - hermes — toolsets derived from the spec; **first-class** (the
    manual-bench-only caveat is deleted).
- **Judges are executing roles**: `Bash` in `_JUDGE_TOOLS`; the
  reviewer/verifier briefs instruct `python .autoresearch/syscall finding …` /
  `conclude` instead of "reply with ONLY a JSON object".
- **Two deletions fell out**: `RoleSpec.verdict_tool` (redundant — a judge IS
  a role with an `output_schema`; `run_role` gates on that) and the entire
  parse-a-final-message-and-repair path. `read_verdict` on the committed
  channel is the one way a verdict reaches the kernel.
- New invariant: a judge may not hold a write scope.
- Containment is the deployment's knob (`container_image` passthrough): the
  cluster passes apptainer; CI relies on the ephemeral runner + tokenless
  split. No per-role security posture anywhere.

## Adversarial review (independent agent) — all findings fixed

- **CRITICAL**: `verify-agent.yml` checked the kernel out at `.autoresearch` —
  the judge's syscall channel — so `install_tool` would have rmtree'd the
  verifier's own source and every round silently skipped. Checkout moved to
  `kernel/`; `install_tool` reads the tool source before owning the channel.
- **HIGH**: the syscall CLI rooted its channel at **cwd**, so a judge not
  sitting in the workspace (hermes by construction) committed its verdict
  where the kernel never looks. It now roots at its own install location —
  correct from any cwd, every backend (test included).
- Plus: honest validation docstrings (read_verdict owns the canonical shape),
  the deleted-fallback promise removed, the inert Landlock knob deleted, and a
  full sweep of stale "read-only judge / never executes" claims across
  workflows, src, and docs/design.

## Net

+699/−771 across the two commits — the "clean backend" is a net deletion.
772 tests green; ruff + format + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
