### PR TITLE
docs: sweep remaining read-only-judge claims (judges run with a shell now)

### DIFF
--- a/docs/design/judge-placement.md
+++ b/docs/design/judge-placement.md
@@ -1,8 +1,8 @@
 # Where the judges live, and how their output flows
 
 **Status: living reference (v1, 2026-08-14).** Captures a design direction, not
-a today-change. It records why the reviewer and the verifier — which share a
-"read-only agent judge" implementation — belong in opposite homes, and what that
+a today-change. It records why the reviewer and the verifier — which share one
+agent-judge implementation — belong in opposite homes, and what that
 implies for their output, their identities, and how many of them we run. Pairs
 with `reviewer-infra.md` (the seams and the threat model), `roles.md` (RoleSpec
 and result-policy), and `consolidation.md` (the kernel as a multi-agent OS and
@@ -10,8 +10,8 @@ its syscalls).
 
 ## The thesis
 
-The reviewer and the verifier look like the same thing — a read-only agent that
-reads a diff and its surrounding code and returns findings. They are not the
+The reviewer and the verifier look like the same thing — an agent that
+reads a diff and its surrounding code and records findings. They are not the
 same thing. They are pointed at different authors, triggered by different
 events, and carry different stakes, and once you see that, their correct homes
 are opposite:

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -47,12 +47,16 @@ fork PR ever reaches the session. The workflow checks out the PR head
 (`persist-credentials: false`) and the judge runs with a shell over it — so a
 prompt-injected PR could get the judge to EXECUTE its checked-out code. That is
 not the boundary; the boundary is that the session is disposable and holds
-nothing worth taking: a scrubbed environment, no WRITE token (the tokenless
-split keeps that in a separate post job), and one in-session secret — the
-judge's own model API key, which is spend-capped and role-isolated. So the
-residual exposure of a shell judge on a bare runner is capped spend and
-whatever it can read/egress from that ephemeral runner, accepted for an
-advisory role (the container/cluster path is the tighter option). Fork-PR
+nothing worth taking for a WRITE: a scrubbed environment and no write token
+(the tokenless split keeps that in a separate post job). The credentials that
+ARE in the session — and a shell judge can `/proc`-read them — are its own
+spend-capped, role-isolated model API key and a READ-scoped `GITHUB_TOKEN`
+(and, while the reviewer repo is private, a read-only deploy key; see
+reviewer-infra.md). None of those can write to the repo. So the residual
+exposure of a shell judge on a bare runner is capped spend plus reading what a
+read-scoped token already reads, plus whatever it can egress from that
+ephemeral runner — accepted for an advisory role (the container/cluster path is
+the tighter option), and the read token drops to zero at the public flip. Fork-PR
 review remains out of scope until it gets its own design.
 
 **Audit checklist before any public flip** (each item verified on the live

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -56,7 +56,8 @@ reviewer-infra.md). None of those can write to the repo. So the residual
 exposure of a shell judge on a bare runner is capped spend plus reading what a
 read-scoped token already reads, plus whatever it can egress from that
 ephemeral runner — accepted for an advisory role (the container/cluster path is
-the tighter option), and the read token drops to zero at the public flip. Fork-PR
+the tighter option). Making the session carry NO token — not even the read
+one it exports today — is planned for the public flip, not yet in place. Fork-PR
 review remains out of scope until it gets its own design.
 
 **Audit checklist before any public flip** (each item verified on the live

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -45,9 +45,10 @@ Current mitigations already in the reusable workflow
 (`head.repo.full_name == github.repository`) sits before any step, and
 nothing from the PR is ever executed. Since the agent-reviewer swap the
 workflow DOES check out the PR head — read-only, `persist-credentials:
-false` — and the session that reads it has no execute or write tools and a
-scrubbed environment (no workflow token), so PR content can only inform the
-model as data, never run or exfiltrate. Fork-PR review remains out of scope
+false` — and the session runs with a scrubbed environment and no write token
+(the tokenless split holds the write token in a separate post job), so PR
+content can only inform the model as data; even a shell judge has no standing
+credential to exfiltrate. Fork-PR review remains out of scope
 until it gets its own design.
 
 **Audit checklist before any public flip** (each item verified on the live

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -42,15 +42,18 @@ shape: privileged context + attacker-influenced event.
 
 Current mitigations already in the reusable workflow
 (`advisory-review-agent.yml`): the fork gate
-(`head.repo.full_name == github.repository`) sits before any step, and
-nothing from the PR is ever executed. Since the agent-reviewer swap the
-workflow DOES check out the PR head — read-only, `persist-credentials:
-false` — and the session runs with a scrubbed environment and no WRITE token
-(the tokenless split holds the write token in a separate post job). PR content
-can only inform the model as data; the one secret a shell judge could exfiltrate
-is its own model API key, which is spend-capped and role-isolated (no workflow
-write token, no standing keys). Fork-PR review remains out of scope
-until it gets its own design.
+(`head.repo.full_name == github.repository`) sits before any step, so no
+fork PR ever reaches the session. The workflow checks out the PR head
+(`persist-credentials: false`) and the judge runs with a shell over it — so a
+prompt-injected PR could get the judge to EXECUTE its checked-out code. That is
+not the boundary; the boundary is that the session is disposable and holds
+nothing worth taking: a scrubbed environment, no WRITE token (the tokenless
+split keeps that in a separate post job), and one in-session secret — the
+judge's own model API key, which is spend-capped and role-isolated. So the
+residual exposure of a shell judge on a bare runner is capped spend and
+whatever it can read/egress from that ephemeral runner, accepted for an
+advisory role (the container/cluster path is the tighter option). Fork-PR
+review remains out of scope until it gets its own design.
 
 **Audit checklist before any public flip** (each item verified on the live
 workflow files of the repo being flipped, not on memory of them):

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -45,10 +45,11 @@ Current mitigations already in the reusable workflow
 (`head.repo.full_name == github.repository`) sits before any step, and
 nothing from the PR is ever executed. Since the agent-reviewer swap the
 workflow DOES check out the PR head — read-only, `persist-credentials:
-false` — and the session runs with a scrubbed environment and no write token
-(the tokenless split holds the write token in a separate post job), so PR
-content can only inform the model as data; even a shell judge has no standing
-credential to exfiltrate. Fork-PR review remains out of scope
+false` — and the session runs with a scrubbed environment and no WRITE token
+(the tokenless split holds the write token in a separate post job). PR content
+can only inform the model as data; the one secret a shell judge could exfiltrate
+is its own model API key, which is spend-capped and role-isolated (no workflow
+write token, no standing keys). Fork-PR review remains out of scope
 until it gets its own design.
 
 **Audit checklist before any public flip** (each item verified on the live

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -60,11 +60,18 @@ workflow files of the repo being flipped, not on memory of them):
 
 1. The fork gate is present, at the JOB level, on every caller workflow —
    and its polarity is "same repo only", not an allowlist that can drift.
-2. No step checks out, builds, installs, or executes anything from the PR
-   head (including transitively: no `uv sync` against the PR's lockfile, no
-   pre-commit on its config).
-3. `permissions:` blocks are minimal (`contents: read`,
-   `pull-requests: write`) on caller and reusable workflows alike.
+2. The judge session runs a shell over the PR-head checkout, so it CAN be
+   induced to execute PR-head code — that is acceptable ONLY because item 1
+   restricts the head to the SAME repo (fork code never reaches it) and the
+   session job is disposable and holds no write token (item 3). Verify those
+   hold; do NOT rely on "PR code is never executed" — it is, and the boundary
+   is the runner + the token split, not the tool set. (The post job, which
+   does hold the write token, runs NO session and touches nothing from the head.)
+3. The token split holds: the JOB that runs the session has at most
+   `pull-requests: read` (its shell judge can `/proc`-read whatever is in its
+   env, so no write token may be there); the separate post JOB holds
+   `pull-requests: write` and runs no session. Verify per-job `permissions:`,
+   not just top-level.
 4. Labels that trigger privileged runs (`autoresearch:review`): GitHub
    allows label application at TRIAGE, not write — so GitHub's own
    permission model is NOT sufficient gating on a public repo with triage

--- a/docs/design/review-placement.md
+++ b/docs/design/review-placement.md
@@ -99,8 +99,9 @@ the ephemeral hosted runner gives for free:
 > strips any `CLAUDE.md`/hooks the untrusted tree ships (the
 > instruction-smuggling class), a read-only tree, and a **per-session token
 > scoped to just the post** — never the daemon's standing keys. The reviewer
-> already has no execute or write tools; the added exposure is only the
-> standing keys the daemon holds, which the scoped token is what removes.
+> already runs with no write credential in its session (the tokenless split);
+> the added exposure is only the standing keys the daemon holds, which the
+> scoped token is what removes.
 
 This is the same jail the dispatcher already needs for eval jobs on untrusted
 trees, so B reuses containment we build anyway rather than inventing its own.

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -45,10 +45,11 @@ model or harness.
 
 For the local work, give the agent read-only access to the tree under
 review. As deployed, that tree is the PR HEAD — untrusted, same-repo code —
-so the safety argument is not "the tree is trusted"; it is that reading is
-not running: the agent has no execute or write tools, and everything it
-reads is data to judge, never instructions to follow (the prompt-injection
-boundary). The two dangerous acts are handled outside the read surface: the
+so the safety argument is not "the tree is trusted": the judge runs with a
+shell (it records its verdict through the syscall tool), so containment is the
+deployment's — an ephemeral runner or a container, plus the tokenless split
+(no write credential in the session). Everything the judge reads is data to
+judge, never instructions to follow (the prompt-injection boundary). The two dangerous acts are handled outside the read surface: the
 broker is the only outward path, and the PR's code is never run — that
 stays on the split-workflow path.
 
@@ -179,9 +180,9 @@ model.
 
 ## What's next
 
-The harness runs read-only agent sessions over the PR-head checkout — that part
-is done, and the least-token split now carries non-Claude second opinions on
-the auto path. Still to build: the `retrieve` tool contract and the broker,
+The harness runs agent sessions over the PR-head checkout — that part is done,
+and the tokenless split (read-only session job, separate write-token post job)
+now carries every backend on the auto path. Still to build: the `retrieve` tool contract and the broker,
 added without changing the harness. The meta-benchmark scores whether a change catches
 more seeded gaming per dollar before it ships.
 

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -145,13 +145,13 @@ the key.
 
 Two facts make this manageable.
 
-First, reading is not running. The deployed reviewer reads the PR head —
-untrusted code — and that is safe because reading it can only inform the
-model. File contents are treated as data, never as instructions. The judge
-holds a shell (it records its verdict by running the installed syscall tool);
-what contains the session is the deployment's boundary — the ephemeral runner
+First, the judge is NOT read-only. It holds a shell — it records its verdict
+by running the installed syscall tool — so a prompt-injected PR head could get
+it to execute PR-head code. "Reading is not running" is no longer the argument.
+What contains the session is the deployment's boundary — the ephemeral runner
 plus the tokenless split — not a per-role tool posture (see
-docs/design/role-cli.md, "the harness unification").
+docs/design/role-cli.md, "the harness unification"). File contents are still
+treated as data, never as instructions.
 
 Second, containment. Today the agent runs in a single GitHub-hosted step that
 holds the caller's workflow token (repo-scoped, short-lived) and a spend-capped
@@ -174,12 +174,14 @@ The residual read-scoped token drops to zero at the public flip.
 
 What is safe today, precisely. The agent workflows run only on same-repo PRs
 (the reviewer via `pull_request_target`'s same-repo gate; the verifier only on
-bot-authored branches), so no fork PR reaches them. That makes an agent that
-only reads safe to run now. It does not make running the PR's code safe.
-Bot-authored code is model-generated — the exact thing this note says not to run
-next to a secret — so even on internal PRs, executing the eval uses the guarded
-`run-candidate` path, never a direct run. Reading is what today's setup
-licenses; running is always guarded. The split workflow is what gates accepting
+bot-authored branches), so no fork PR reaches them. That is what makes the session safe to run now —
+the head is same-repo and the session is disposable and tokenless-for-write —
+NOT the tool set, since the judge can be induced to run PR-head code. Two kinds
+of execution, kept distinct: the DELIBERATE measurement of a candidate still
+goes through the guarded `run-candidate`/eval path, never a direct run next to
+a secret; INCIDENTAL execution by a prompt-injected judge is now possible, and
+its worst case is bounded by the disposable, tokenless session (capped-spend
+model key, no write credential). The split workflow is what gates accepting
 fork PRs after the repo goes public. See `public-surface.md` for that threat
 model.
 
@@ -266,8 +268,10 @@ but NONE closes the `/proc` read while the token sits in a parent process.
 Consequence for deployment: **every auto-path judge runs through the
 least-token split** (`advisory-review-agent.yml`), claude included — no
 session sits next to a write token, so backend choice is config, not a trust
-decision. Claude's write-safe/exec-safe/`/proc`-safe properties (probe above)
-remain as defense in depth, and the single-job manual bench
+decision. (Exec-safety is no longer assumed for ANY backend — every judge now
+holds a shell to run the syscall tool — which is exactly why the tokenless
+split, not the tool set, is the load-bearing defense; claude's `/proc`-safe
+Read is at most a mild backend-specific bonus.) The single-job manual bench
 (`review-agent.yml`) keeps the informed-caveat rule for one-off experiments.
 On private repos the split's session job still carries a read-scoped token
 (worst case: reading a repo the session already reads); at the public flip

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -53,7 +53,8 @@ in the session). Be honest about what that shell leaves exposed on a bare
 GitHub runner: the session's own model key (spend-capped, role-isolated) is
 reachable, and egress is not jailed there, so a prompt-injected judge could
 exfiltrate that key or read data out — accepted as generally-OK for an advisory
-role whose one in-session secret is spend-capped, with the container/cluster
+role whose in-session credentials are a spend-capped model key and a read-only
+token (no write credential), with the container/cluster
 path (where the broker becomes the only outward route, and `run-candidate`
 isolates PR code) as the tighter option. Everything the judge reads is still
 data to judge, never instructions to follow (the prompt-injection boundary).
@@ -170,7 +171,7 @@ buys read access to a repo the session is already reading, expiring with the
 job; the read-only deploy key for the private reviewer repo is present for
 the same reason and in the same blast-radius class), and the posting job
 holds the write token with no session next to it.
-The residual read-scoped token drops to zero at the public flip.
+The residual read-scoped token is INTENDED to drop to zero at the public flip (planned work — today the session job still exports the read token); the flip's checkout needs no token.
 
 What is safe today, precisely. The agent workflows run only on same-repo PRs
 (the reviewer via `pull_request_target`'s same-repo gate; the verifier only on

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -45,13 +45,18 @@ model or harness.
 
 For the local work, give the agent read-only access to the tree under
 review. As deployed, that tree is the PR HEAD — untrusted, same-repo code —
-so the safety argument is not "the tree is trusted": the judge runs with a
-shell (it records its verdict through the syscall tool), so containment is the
-deployment's — an ephemeral runner or a container, plus the tokenless split
-(no write credential in the session). Everything the judge reads is data to
-judge, never instructions to follow (the prompt-injection boundary). The two dangerous acts are handled outside the read surface: the
-broker is the only outward path, and the PR's code is never run — that
-stays on the split-workflow path.
+so the safety argument is not "the tree is trusted", and — since the judge now
+runs with a shell (it records its verdict through the syscall tool) — it is no
+longer "reading is not running" either. Containment is the deployment's: an
+ephemeral runner or a container, plus the tokenless split (no WRITE credential
+in the session). Be honest about what that shell leaves exposed on a bare
+GitHub runner: the session's own model key (spend-capped, role-isolated) is
+reachable, and egress is not jailed there, so a prompt-injected judge could
+exfiltrate that key or read data out — accepted as generally-OK for an advisory
+role whose one in-session secret is spend-capped, with the container/cluster
+path (where the broker becomes the only outward route, and `run-candidate`
+isolates PR code) as the tighter option. Everything the judge reads is still
+data to judge, never instructions to follow (the prompt-injection boundary).
 
 ## Retrieval is a tool, not context
 


### PR DESCRIPTION
Docs-only consistency follow-up to #140: several design docs still described judges as read-only-tool-set. Corrected to the current model — a judge runs with a shell (records its verdict via the syscall tool); containment is the deployment's (ephemeral runner / container + the tokenless split).

Doubles as the first live exercise of the verdict-tool review path (no parse fallback since #140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)