### PR TITLE
climb --author-syscalls: one-off switch to validate the author sleep/wake substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `climb --author-syscalls` — a one-off switch to arm the author launch/sleep
+  syscalls for a SINGLE climb (equivalent to `AUTORESEARCH_AUTHOR_SYSCALLS=1`,
+  ORed with it, but scoped to the run so a live validation need not arm the
+  whole tick). The benchmark must also declare `depth_k>1`. This is the
+  enablement seam for validating the (still-dark) author sleep/wake substrate
+  end-to-end on a real cluster before it goes live.
+
 - Interchangeable backends — one harness construction for every role
   (docs/design/role-cli.md, "the harness unification"). `build_harness`
   (role_runner.py) replaces `build_editor_harness` and

--- a/docs/validation/author-syscalls.md
+++ b/docs/validation/author-syscalls.md
@@ -12,14 +12,10 @@ whole loop.
 `AUTORESEARCH_AUTHOR_SYSCALLS` env flag), so you do **not** arm the whole tick.
 Two conditions must both hold:
 
-1. **Dispatch coords exist:** the run needs `--image` and the cluster
-   account/partition — launch jobs are jailed Slurm jobs on a sealed snapshot.
-   Without them the flag warns and stays OFF (there is no launcher, so an armed
-   author would strand).
-2. **A launch budget:** the benchmark's `depth_k` caps how many launches the
-   author may make. The default (1) is enough to validate one launch → sleep →
-   wake; raise `depth_k` in the target's `.autoresearch.yaml` to try multiple.
-   `sleep_k` defaults to 4.
+- **Dispatch coords** (`--image` + account/partition): launches are jailed
+  Slurm jobs, so without them nothing launches.
+- **A launch budget**: `depth_k` (default 1 = one launch) caps launches; raise
+  it in the target's `.autoresearch.yaml` to test more.
 
 Then run one climb by hand (not via the tick):
 

--- a/docs/validation/author-syscalls.md
+++ b/docs/validation/author-syscalls.md
@@ -1,0 +1,83 @@
+# Validating the author sleep/wake substrate (live)
+
+The author launch/sleep syscalls (`.autoresearch/syscall`, park→wake, artifact
+copy-out) are **fake-tested only** — never run on a real cluster. Before the
+substrate goes live (and before the `submit` verb, the env-flag decommission, or
+the `climb → attempt` rename build on it), run this once on Torch and watch the
+whole loop.
+
+## Arm it (one climb only)
+
+`--author-syscalls` arms the feature for a SINGLE climb (ORed with the
+`AUTORESEARCH_AUTHOR_SYSCALLS` env flag), so you do **not** arm the whole tick.
+Two conditions must both hold:
+
+1. **The benchmark opts in:** its `.autoresearch.yaml` declares `depth_k > 1`
+   (how many external experiment jobs the author may launch) on the benchmark
+   you target. `sleep_k` defaults to 4.
+2. **Dispatch coords exist:** the run needs `--image` and the cluster
+   account/partition (launch jobs are jailed Slurm jobs on a sealed snapshot).
+
+Then run one climb by hand (not via the tick):
+
+```bash
+source env.sh
+uv run python -m autoresearch.climb \
+  --target <org/repo> --benchmark <cheap-benchmark-with-depth_k> \
+  --run-root <run-root> --image <image.sif> \
+  --author-syscalls \
+  <the account/partition/limit args the tick normally passes>
+```
+
+Pick a **cheap** benchmark and a task where running an experiment is natural, so
+the author actually calls `syscall launch` + `sleep` (the tool is advertised in
+the brief only when armed).
+
+## Watch the whole loop
+
+The lifecycle to confirm, in order:
+
+1. **Tool installed:** `<run_dir>/ws/.autoresearch/syscall` exists, and
+   `.autoresearch/budget.json` shows `depth_k` / `sleep_k`.
+2. **Author sleeps:** the session ends having written
+   `.autoresearch/syscall.json` (`type: "sleep"`, one+ launches).
+3. **Park:** the run record is `waiting`, `stage.phase == "author-sleep"`, with
+   `stage.afterany` naming the submitted launch job(s), `syscall_launches`, and
+   `launches_used` / `sleeps_used` counts.
+4. **Launch job runs:** `<run_dir>/eval-launch-<name>/` fills with `exit-code`,
+   `stdout`, `stderr`, and `artifacts/` (the declared files, copied out).
+5. **Wake:** the tick wakes the parked run; `gather_results` delivers artifacts
+   into `<ws>/.autoresearch/results/<name>/`, and the SAME session resumes
+   (`resume_session_id` unchanged) with the results data-fenced + the author's
+   note echoed back.
+6. **Terminate:** the woken author either sleeps again (a fresh author-sleep
+   park, counts advanced) or finishes → gate measures → candidate → publish.
+
+## Success criteria
+
+- The run parks `author-sleep` and the launch job actually runs on Slurm.
+- The wake **resumes the same session** and the author sees the delivered
+  results (context survived a REAL hibernation — the thing fakes cannot test).
+- Artifacts copied out under apptainer and landed in `results/<name>/`.
+- The run reaches a normal terminal (candidate/publish or an honest negative),
+  not a stuck `waiting` loop or a `session-error`.
+
+## The three things fakes cannot exercise (verify each)
+
+- **Session recall across real hibernation** — step 5's `resume_session_id`.
+- **Artifact copy-out under apptainer** — step 4's `artifacts/`, step 5's
+  `results/<name>/`.
+- **Walltime / self-deadline interplay on a live node** — the park deadline
+  rides the longest launch; confirm the wake fires and does not race the job.
+
+## Kill switch
+
+The flag is per-run: to disable, just don't pass `--author-syscalls` (and keep
+`AUTORESEARCH_AUTHOR_SYSCALLS` unset so the tick stays off). A parked run with no
+wake ends with a named `session-error`, never a silent stuck loop.
+
+## After green
+
+Report back and the follow-ups unblock: build `submit` on the proven substrate
+(retiring the panel-revision loop), remove the dead `AUTHOR_SLEEP_WAKE_READY`
+constant, and migrate the env flag into contract-driven enablement.

--- a/docs/validation/author-syscalls.md
+++ b/docs/validation/author-syscalls.md
@@ -12,18 +12,21 @@ whole loop.
 `AUTORESEARCH_AUTHOR_SYSCALLS` env flag), so you do **not** arm the whole tick.
 Two conditions must both hold:
 
-1. **The benchmark opts in:** its `.autoresearch.yaml` declares `depth_k > 1`
-   (how many external experiment jobs the author may launch) on the benchmark
-   you target. `sleep_k` defaults to 4.
-2. **Dispatch coords exist:** the run needs `--image` and the cluster
-   account/partition (launch jobs are jailed Slurm jobs on a sealed snapshot).
+1. **Dispatch coords exist:** the run needs `--image` and the cluster
+   account/partition — launch jobs are jailed Slurm jobs on a sealed snapshot.
+   Without them the flag warns and stays OFF (there is no launcher, so an armed
+   author would strand).
+2. **A launch budget:** the benchmark's `depth_k` caps how many launches the
+   author may make. The default (1) is enough to validate one launch → sleep →
+   wake; raise `depth_k` in the target's `.autoresearch.yaml` to try multiple.
+   `sleep_k` defaults to 4.
 
 Then run one climb by hand (not via the tick):
 
 ```bash
 source env.sh
 uv run python -m autoresearch.climb \
-  --target <org/repo> --benchmark <cheap-benchmark-with-depth_k> \
+  --target <org/repo> --benchmark <a-cheap-benchmark> \
   --run-root <run-root> --image <image.sif> \
   --author-syscalls \
   <the account/partition/limit args the tick normally passes>

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1587,6 +1587,17 @@ def live_climb(
                 "built yet (Phase A part 2); author syscalls stay OFF this run"
             )
             author_syscalls = False
+        if author_syscalls and dispatch is None:
+            # launches are jailed Slurm jobs; with no dispatch coords there is
+            # no launcher, so an armed author would sleep on a launch that can
+            # never run and the park would strand. Refuse the feature loudly
+            # rather than produce a stuck run (terra #142).
+            log.warning(
+                "author syscalls armed but no dispatch coords (image/account/"
+                "partition); launches cannot run, so author syscalls stay OFF "
+                "this run"
+            )
+            author_syscalls = False
         # The `.autoresearch/` channel must be KERNEL-OWNED. In a fresh clone,
         # anything already at that path was committed by the TARGET — a symlink
         # (install would write through it to a host path with our permissions —
@@ -2413,8 +2424,10 @@ def main() -> int:
         action="store_true",
         help="arm the author launch/sleep syscalls for THIS climb (a one-off "
         "validation switch; equivalent to AUTORESEARCH_AUTHOR_SYSCALLS=1 but "
-        "scoped to this run, so it need not arm the whole tick). The benchmark "
-        "must also declare depth_k>1 in its contract.",
+        "scoped to this run, so it need not arm the whole tick). Requires "
+        "dispatch coords (--image + account/partition) — launches are jailed "
+        "Slurm jobs. The benchmark's depth_k caps how many launches the author "
+        "may make (default 1, enough to validate one launch).",
     )
     parser.add_argument(
         "--job-minutes",

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1509,6 +1509,7 @@ def live_climb(
     panel_lenses: tuple[PanelLens, ...] = (),
     panel_revisions: int = 1,
     dispatch: DispatchSettings | None = None,
+    author_syscalls: bool = False,
 ) -> LiveClimbOutcome:
     """Run one climb against the real target repo. With `panel_lenses`, the
     pre-PR verification panel gates the claim before any PR exists
@@ -1573,11 +1574,13 @@ def live_climb(
         contract = load_contract(contract_text, config.target)
         # With author syscalls armed, the channel (`.autoresearch/`) never
         # enters diffs, scope, or drift fingerprints — repo-local exclude.
-        # Gated on the SAME flag as the launcher: with the feature off, an
-        # untracked `.autoresearch/` file must be staged and judged like any
-        # other agent edit, not silently hidden by a magic dir name (terra,
-        # #132 r2 — the off state stays byte-identical to today).
-        author_syscalls = bool(os.environ.get("AUTORESEARCH_AUTHOR_SYSCALLS"))
+        # Enabled by the `author_syscalls` arg OR the env flag (the tick inherits
+        # env; a one-off validation climb passes `--author-syscalls` so it need
+        # not arm the whole tick). With the feature off, an untracked
+        # `.autoresearch/` file must be staged and judged like any other agent
+        # edit, not silently hidden by a magic dir name (terra, #132 r2 — the off
+        # state stays byte-identical to today).
+        author_syscalls = author_syscalls or bool(os.environ.get("AUTORESEARCH_AUTHOR_SYSCALLS"))
         if author_syscalls and not AUTHOR_SLEEP_WAKE_READY:
             log.warning(
                 "AUTORESEARCH_AUTHOR_SYSCALLS is set but the wake side is not "
@@ -2406,6 +2409,14 @@ def main() -> int:
     )
     parser.add_argument("--panel-revisions", type=int, default=1)
     parser.add_argument(
+        "--author-syscalls",
+        action="store_true",
+        help="arm the author launch/sleep syscalls for THIS climb (a one-off "
+        "validation switch; equivalent to AUTORESEARCH_AUTHOR_SYSCALLS=1 but "
+        "scoped to this run, so it need not arm the whole tick). The benchmark "
+        "must also declare depth_k>1 in its contract.",
+    )
+    parser.add_argument(
         "--job-minutes",
         type=int,
         default=0,
@@ -2640,6 +2651,7 @@ def main() -> int:
                 panel_lenses=panel_lenses,
                 panel_revisions=args.panel_revisions,
                 dispatch=dispatch,
+                author_syscalls=args.author_syscalls,
                 evaluator=SubprocessEvaluator(container_image=args.image),
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1587,17 +1587,6 @@ def live_climb(
                 "built yet (Phase A part 2); author syscalls stay OFF this run"
             )
             author_syscalls = False
-        if author_syscalls and dispatch is None:
-            # launches are jailed Slurm jobs; with no dispatch coords there is
-            # no launcher, so an armed author would sleep on a launch that can
-            # never run and the park would strand. Refuse the feature loudly
-            # rather than produce a stuck run (terra #142).
-            log.warning(
-                "author syscalls armed but no dispatch coords (image/account/"
-                "partition); launches cannot run, so author syscalls stay OFF "
-                "this run"
-            )
-            author_syscalls = False
         # The `.autoresearch/` channel must be KERNEL-OWNED. In a fresh clone,
         # anything already at that path was committed by the TARGET — a symlink
         # (install would write through it to a host path with our permissions —
@@ -2424,10 +2413,10 @@ def main() -> int:
         action="store_true",
         help="arm the author launch/sleep syscalls for THIS climb (a one-off "
         "validation switch; equivalent to AUTORESEARCH_AUTHOR_SYSCALLS=1 but "
-        "scoped to this run, so it need not arm the whole tick). Requires "
-        "dispatch coords (--image + account/partition) — launches are jailed "
-        "Slurm jobs. The benchmark's depth_k caps how many launches the author "
-        "may make (default 1, enough to validate one launch).",
+        "scoped to this run, so it need not arm the whole tick). Launches need "
+        "dispatch coords (--image + account/partition) — without a launcher the "
+        "tool is simply not offered. The benchmark's depth_k caps how many "
+        "launches the author may make (default 1, enough to validate one).",
     )
     parser.add_argument(
         "--job-minutes",

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1751,6 +1751,30 @@ def target_repo_syscalls(tmp_path: Path, monkeypatch) -> Path:
     return _seed_target(tmp_path, monkeypatch, CONTRACT_SYSCALLS)
 
 
+def test_author_syscalls_without_dispatch_stays_off(
+    tmp_path, target_repo_syscalls, monkeypatch
+) -> None:
+    # arming the flag with no dispatch coords must NOT strand: launches can't
+    # run without a launcher, so the feature disables (terra #142).
+    import json as json_mod
+
+    monkeypatch.delenv("AUTORESEARCH_AUTHOR_SYSCALLS", raising=False)
+    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
+    outcome, _ = run_live(
+        tmp_path,
+        target_repo_syscalls,
+        edits={
+            ".autoresearch/syscall.json": json_mod.dumps(
+                {"type": "sleep", "launches": [{"name": "probe", "command": "x"}]}
+            ),
+        },
+        values=[13.876, 13.1],  # feature off -> measures + climbs normally
+        dispatch=None,  # no launcher
+        author_syscalls=True,
+    )
+    assert outcome.outcome != "parked"  # did not strand on an unlaunchable sleep
+
+
 def test_author_syscalls_flag_arms_the_feature_without_the_env(
     tmp_path, target_repo_syscalls, monkeypatch
 ) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1751,30 +1751,6 @@ def target_repo_syscalls(tmp_path: Path, monkeypatch) -> Path:
     return _seed_target(tmp_path, monkeypatch, CONTRACT_SYSCALLS)
 
 
-def test_author_syscalls_without_dispatch_stays_off(
-    tmp_path, target_repo_syscalls, monkeypatch
-) -> None:
-    # arming the flag with no dispatch coords must NOT strand: launches can't
-    # run without a launcher, so the feature disables (terra #142).
-    import json as json_mod
-
-    monkeypatch.delenv("AUTORESEARCH_AUTHOR_SYSCALLS", raising=False)
-    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
-    outcome, _ = run_live(
-        tmp_path,
-        target_repo_syscalls,
-        edits={
-            ".autoresearch/syscall.json": json_mod.dumps(
-                {"type": "sleep", "launches": [{"name": "probe", "command": "x"}]}
-            ),
-        },
-        values=[13.876, 13.1],  # feature off -> measures + climbs normally
-        dispatch=None,  # no launcher
-        author_syscalls=True,
-    )
-    assert outcome.outcome != "parked"  # did not strand on an unlaunchable sleep
-
-
 def test_author_syscalls_flag_arms_the_feature_without_the_env(
     tmp_path, target_repo_syscalls, monkeypatch
 ) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -331,6 +331,7 @@ def run_live(
     author_backend="claude",
     author_model="claude-opus-5",
     author_key_file="",
+    author_syscalls=False,
 ) -> tuple:
     github = FakeGitHub()
     outcome = live_climb(
@@ -348,6 +349,7 @@ def run_live(
         author_backend=author_backend,
         author_model=author_model,
         author_key_file=author_key_file,
+        author_syscalls=author_syscalls,
     )
     return outcome, github
 
@@ -1747,6 +1749,34 @@ CONTRACT_SYSCALLS = CONTRACT.replace("    direction: min\n", "    direction: min
 @pytest.fixture
 def target_repo_syscalls(tmp_path: Path, monkeypatch) -> Path:
     return _seed_target(tmp_path, monkeypatch, CONTRACT_SYSCALLS)
+
+
+def test_author_syscalls_flag_arms_the_feature_without_the_env(
+    tmp_path, target_repo_syscalls, monkeypatch
+) -> None:
+    # the one-off validation switch: `--author-syscalls` (run_live's
+    # author_syscalls=True) arms the launch/sleep feature with the env flag
+    # UNSET, so a validation climb need not arm the whole tick.
+    import json as json_mod
+
+    monkeypatch.delenv("AUTORESEARCH_AUTHOR_SYSCALLS", raising=False)
+    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
+    outcome, _ = run_live(
+        tmp_path,
+        target_repo_syscalls,
+        edits={
+            "src/pilot/solvers/tsp.py": "def solve(): return 'probe'\n",
+            ".autoresearch/syscall.json": json_mod.dumps(
+                {"type": "sleep", "launches": [{"name": "probe", "command": "uv run probe.py"}]}
+            ),
+        },
+        values=[],  # parked before any measurement
+        dispatch=_fake_dispatch(),
+        author_syscalls=True,  # armed by the flag, not the env
+    )
+    assert outcome.outcome == "parked"
+    record = load_record(tmp_path / "state", "tsp-1")
+    assert record.state == "waiting" and record.stage["phase"] == "author-sleep"
 
 
 def test_author_sleep_live_parks_and_submits_launch_jobs(


### PR DESCRIPTION
The author launch/sleep syscall substrate is fake-tested only and has never run live. Validating it end-to-end (real hibernation, apptainer artifact copy-out, live walltime interplay) needs a real cluster run with the feature armed.

Today the only switch is the `AUTORESEARCH_AUTHOR_SYSCALLS` env flag, inherited by the whole tick — too broad for a single validation climb. This adds `climb --author-syscalls` to arm it for **one climb only** (ORed with the env flag). `live_climb` gains an `author_syscalls` param; the CLI flag and `run_live` thread it. Off by default — no behavior change.

The enablement seam for the validate-substrate-first step (Mengye 2026-08-25). The benchmark must also declare `depth_k>1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)