### PR TITLE
fix: sweep polls all afterany jobs — multi-job parks are no longer blind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Multi-job parks are no longer blind: the tick's backup sweep now polls every
+  job id in the stage's `afterany` string when a park records no single
+  `experiment_job_id` (a candidate with sibling evals, or several author
+  launches) and wakes when ALL are done. Previously such a park's only wake
+  was the deadline floor — observed live as ~12 h of dead time after evals
+  that finished in minutes. The park-time afterany wake job (zero-latency
+  primary) remains planned; the sweep stays the backup.
+
 ### Added
 
 - `climb --author-syscalls` — a one-off switch to arm the author launch/sleep

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -236,7 +236,9 @@ def render(brief: SessionBrief) -> str:
             "    python .autoresearch/syscall sleep",
             "",
             "`status` shows staged launches and remaining budget; `note ...` "
-            "leaves a reminder echoed back to you on wake. Bad arguments fail "
+            "leaves a reminder echoed back to you on wake. `--artifact` must "
+            "name a file your command actually writes (stdout/stderr are "
+            "captured regardless). Bad arguments fail "
             "immediately — fix and retry before sleeping. You may launch "
             "several jobs before one sleep, and after a wake you can launch "
             "more, revise, or finish. Budgets this run: "

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -362,12 +362,11 @@ def _park_run(
         # resume_session_id, set below for every park — no stage duplicate)
         stage["launches_used"] = parked.launches_used
         stage["sleeps_used"] = parked.sleeps_used
-    # The sweep polls ONE experiment_job_id and wakes on its terminal+grace. That
-    # is right for a single-job park (baseline, or a candidate with no siblings):
-    # poll it. But a MULTI-job park (candidate + siblings) must not wake when the
-    # FIRST job finishes while the rest run — so it records no single job and
-    # rides the DEADLINE floor instead (which sits past every eval's walltime).
-    # The precise "all jobs done" fast wake is the afterany wake job (a later PR).
+    # A single-job park records its one pollable id; a MULTI-job park records
+    # none — the sweep falls back to polling every id in the stage's `afterany`
+    # string and wakes only when ALL are done (tick._poll_targets). The park-time
+    # afterany wake job (zero-latency primary; the sweep stays backup) is still
+    # a later PR.
     experiment_job_id = job_ids[0] if len(job_ids) == 1 else ""
     # The deadline is a FLOOR: park time (`now` here is the park moment, passed
     # by the caller) + the eval walltime + a generous queue/grace slack, so a

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -809,12 +809,12 @@ def _sweep_implementing(root: Path, compute: SlurmCompute, now: float, grace_s: 
             fresh = load_record(root, record.run_id)
             if fresh.state != IMPLEMENTING:
                 continue  # the climb landed its own ending meanwhile
-            if fresh.experiment_job_id:
+            for jid in _poll_targets(fresh):
                 # defensive: no current path records an experiment while
                 # still implementing, but an orphan GPU job burning budget
                 # after its run is declared dead must never survive one
                 with contextlib.suppress(Exception):
-                    compute.cancel(fresh.experiment_job_id)
+                    compute.cancel(jid)
             save_record(
                 root,
                 replace(
@@ -845,6 +845,20 @@ def _sweep_implementing(root: Path, compute: SlurmCompute, now: float, grace_s: 
         except Exception as exc:  # per-record isolation, like the waiting sweep
             log.warning("implementing-sweep failed on %s: %s", record.run_id, exc)
     return ended
+
+
+def _poll_targets(record: RunRecord) -> list[str]:
+    """Every Slurm job this run waits on. The single `experiment_job_id` is
+    the common case; a MULTI-job park (candidate + siblings, or several author
+    launches) records no single id — its jobs live in the stage's `afterany`
+    dependency string, the one source that always names them all. Without
+    this fallback a multi-job park was a BLIND park riding the deadline floor
+    (~hours of dead time after evals that finished in minutes — observed live
+    2026-08-25)."""
+    if record.experiment_job_id:
+        return [record.experiment_job_id]
+    afterany = str((record.stage or {}).get("afterany", ""))
+    return [t for t in afterany.split(":")[1:] if t]
 
 
 def _sweep_one(
@@ -892,8 +906,9 @@ def _sweep_one(
             stuck.append(record.run_id)
             return
 
-        if not record.experiment_job_id:
-            # No job id to poll. A BLIND PARK (the measurer could not read Slurm,
+        job_ids = _poll_targets(record)
+        if not job_ids:
+            # No job ids to poll. A BLIND PARK (the measurer could not read Slurm,
             # so `MeasurementPending` carried no ids) still hibernated with a
             # deadline — the deadline floor is its ONLY wake, so fire on it. A
             # genuinely mid-write record has no deadline and is left alone.
@@ -902,7 +917,7 @@ def _sweep_one(
             return
 
         try:
-            state = compute.status(record.experiment_job_id)
+            states = [compute.status(jid) for jid in job_ids]
         except SlurmQueryError:
             # Layer 4's rule: query failure is "Slurm unknown", never "gone".
             deferred.append(record.run_id)
@@ -914,9 +929,10 @@ def _sweep_one(
         # PENDING, where the consequence would be cancelling a healthy job.
         past_deadline = record.deadline <= 0 or now > record.deadline
 
-        if is_terminal(state):
+        if all(is_terminal(s) for s in states):
+            state = ",".join(sorted(set(states)))
             # Layer 3, with real grace: time runs from when the sweep FIRST
-            # saw the experiment terminal, not from submission — the afterany
+            # saw every job terminal, not from submission — the afterany
             # job gets the full window to deliver before the backup steps in.
             if record.terminal_seen <= 0:
                 if dry_run:
@@ -937,20 +953,25 @@ def _sweep_one(
                 return
             if now - record.terminal_seen >= grace_s:
                 wake(record, f"experiment {state}", state)
-        elif state == GONE:
+        elif any(is_pending(s) for s in states) and record.deadline > 0 and now > record.deadline:
+            # Unschedulable in practice: cancel every non-terminal job
+            # (best-effort — scancel trouble must not abort the sweep), then
+            # wake with that fact.
+            if not dry_run:
+                for jid, s in zip(job_ids, states, strict=True):
+                    if is_terminal(s) or s == GONE:
+                        continue
+                    try:
+                        compute.cancel(jid)
+                    except Exception as exc:  # scancel trouble is never fatal here
+                        log.warning("cancel %s failed: %s", jid, exc)
+            wake(record, "experiment unschedulable (pending past deadline)", "unschedulable")
+        elif all(is_terminal(s) or s == GONE for s in states):
+            # done-or-vanished, at least one GONE (all-terminal handled above)
             if past_deadline:
                 wake(record, "experiment vanished from Slurm", "vanished")
             # else: sacct lag right after submission is normal; wait.
-        elif is_pending(state) and record.deadline > 0 and now > record.deadline:
-            # Unschedulable in practice: cancel (best-effort — scancel
-            # trouble must not abort the sweep), then wake with that fact.
-            if not dry_run:
-                try:
-                    compute.cancel(record.experiment_job_id)
-                except Exception as exc:  # scancel trouble is never fatal here
-                    log.warning("cancel %s failed: %s", record.experiment_job_id, exc)
-            wake(record, "experiment unschedulable (pending past deadline)", "unschedulable")
-        # RUNNING (or recently pending): nothing to do; the afterany job has it.
+        # something RUNNING (or recently pending): nothing to do yet.
 
 
 def tick(

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -245,6 +245,33 @@ def test_blind_park_before_its_deadline_is_left_alone(tmp_path: Path) -> None:
     assert dispatcher.dispatched == []
 
 
+def test_multi_job_park_wakes_when_all_afterany_jobs_finish(tmp_path: Path) -> None:
+    """A multi-job park (candidate + siblings, several author launches)
+    records no single experiment_job_id — the sweep polls every id in the
+    stage's afterany string instead of riding the deadline floor for hours
+    (observed live 2026-08-25)."""
+    waiting_run(
+        tmp_path,
+        experiment_job_id="",
+        stage={"afterany": "afterany:200:201", "phase": "candidate"},
+    )
+    report, _ = run_tick(tmp_path, FakeSlurm(states={"200": "COMPLETED", "201": "COMPLETED"}))
+    assert report.woken == (("r1", "COMPLETED"),)
+
+
+def test_multi_job_park_waits_while_any_afterany_job_runs(tmp_path: Path) -> None:
+    waiting_run(
+        tmp_path,
+        experiment_job_id="",
+        terminal_seen=0.0,
+        stage={"afterany": "afterany:200:201", "phase": "candidate"},
+    )
+    _, dispatcher = run_tick(tmp_path, FakeSlurm(states={"200": "COMPLETED", "201": "RUNNING"}))
+    assert dispatcher.dispatched == []
+    # not all done: the grace clock must NOT start on a partial finish
+    assert load_record(tmp_path, "r1").terminal_seen == 0.0
+
+
 def test_terminal_within_grace_leaves_it_to_the_afterany_job(tmp_path: Path) -> None:
     waiting_run(tmp_path, terminal_seen=NOW - 10)  # first seen moments ago
     report, dispatcher = run_tick(tmp_path, FakeSlurm(states={"100": "COMPLETED"}))


### PR DESCRIPTION
## What

The tick's backup sweep now polls **every** job id in a waiting run's `stage.afterany` string when the park records no single `experiment_job_id`, waking only when ALL are done. Previously such a park was a *blind park* whose only wake was the deadline floor.

## Why (observed live, 2026-08-25)

During the author-syscall live validation (run `tsp-20260825-141345`), the candidate re-park recorded `afterany:16340206:16340207` (paired evals, done in 2 min) but no pollable id — the sweep rode the deadline floor ~12 h away. Same class hits `depth_k>1` author parks (several launches). This is the deferred #106 blind-repark finding, confirmed live.

## How

- `_poll_targets(record)`: `experiment_job_id` if set (common case, unchanged), else the ids parsed from `stage.afterany`.
- Sweep aggregates: all terminal → the existing stamp/grace/wake path; any pending past deadline → cancel every non-terminal sibling + unschedulable wake; terminal+vanished mix past deadline → vanished wake; anything running → wait (the grace clock must not start on a partial finish — test pins this).
- Single-job behavior is branch-for-branch identical to before.
- The implementing-sweep's defensive orphan-cancel uses the same targets.
- Park writer unchanged (no schema movement; old records wake under the new sweep, new records degrade to the deadline floor under an old sweep — safe both ways across a deploy).
- Brief nudge: `--artifact` must name a file the command actually writes (the live author declared one its command never wrote; the copy-out skip-logged it correctly).

The park-time afterany wake job (zero-latency primary; sweep stays backup) remains a later PR — this fixes correctness at cadence granularity.

## Test plan

- New: multi-job park wakes when all afterany jobs finish; waits (and does not start the grace clock) while any runs.
- Full suite: 779 passed; ruff check/format + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
