### PR TITLE
feat: the submit verb — author-driven review, retiring the panel-revision loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- The `submit` verb (research-loop-buildout.md Phase B; role-cli.md Phase 1):
+  the author declares its candidate ready with `syscall submit` + `sleep` —
+  the tree is SEALED, the gate's paired evals (and any sibling launches) run
+  as jobs, and the review panel reads the credited claim. A clean pass
+  publishes the sealed candidate as a PR directly; a failed gate or blocking
+  findings wake the SAME session with the feedback and the author decides —
+  revise and resubmit, run more experiments, or finish with an honest
+  negative. A submit costs only the sleep it rides on (`sleep_k` bounds the
+  rounds; no new dial).
+
+### Removed
+
+- The orchestrator-driven panel-revision loop, retired in favor of
+  author-driven revision via `submit` (buildout Phase B invariant: the swap
+  lands in one PR). `panel_revisions` / `--panel-revisions`, the
+  `_panel_revise_policy` composition seam, and the candidate wake's
+  `_do_revise` re-entry are deleted. A plain finish (no submit) still runs
+  the same gate and panel, but blocking findings now always open a DRAFT PR
+  for a human — they no longer re-enter the author by kernel policy.
+
 - `climb --author-syscalls` — a one-off switch to arm the author launch/sleep
   syscalls for a SINGLE climb (equivalent to `AUTORESEARCH_AUTHOR_SYSCALLS=1`,
   ORed with it, but scoped to the run so a live validation need not arm the

--- a/docs/design/research-loop-buildout.md
+++ b/docs/design/research-loop-buildout.md
@@ -104,7 +104,7 @@ real Slurm job, resumes with the output, and continues — observed end-to-end;
 exhaustion surfaces as a refused launch, not a killed session; an author that
 never launches is byte-identical to today.
 
-## Phase B — submit as a payload
+## Phase B — submit as a payload — LANDED
 
 Surfaced to the author as the `submit` verb on the role CLI (`role-cli.md`,
 Phase 1 — the tool from #133 grows the verb; the JSON stays internal ABI).
@@ -159,6 +159,6 @@ against fakes before that.)
    the existing park/wake plumbing + #129 resume primitives; tested on fakes.
 2. **Light up the dispatcher** on a real long-eval benchmark; observe Phase A
    end-to-end.
-3. **Phase B — submit-for-review as a payload**, retiring the orchestrator
-   panel-revision loop; suite gate + metric taxonomy land alongside.
+3. **Phase B — submit-for-review as a payload** — LANDED (the orchestrator
+   panel-revision loop is retired); suite gate + metric taxonomy still to come.
 4. Parallel/coordination helpers only if recurring author patterns earn them.

--- a/docs/design/role-cli.md
+++ b/docs/design/role-cli.md
@@ -78,17 +78,17 @@ can wake). **Acceptance:** an armed author launches, hibernates through a real
 (faked-Slurm in tests) job, wakes with output + artifacts, continues, and the
 whole loop is byte-identical when unarmed.
 
-### Phase 1 — `submit`: review as a verb (buildout Phase B)
+### Phase 1 — `submit`: review as a verb (buildout Phase B) — LANDED
 
-**Prerequisite: #133 merged** (the author launch/sleep CLI — in review as this
-plan is written; the tool this phase grows a verb on).
 `syscall submit` on the author tool: the agent declares its candidate ready;
-the kernel seals, runs the gate (private seed) + panel as jobs, and wakes the
-author with verdict + comments; the author revises / experiments more /
-resubmits / concludes. Retires the orchestrator-driven panel-revision loop
-(`panel_revisions` policy re-entry) **in the same PR** (invariant 3).
-**Acceptance:** submit → sleep → wake-with-findings → further experiment →
-resubmit → PR, on one session thread; a clean first submit still opens a PR.
+the kernel seals the tree, runs the gate (paired evals, and any sibling
+launches, as jobs) and the panel on the credited claim. A clean pass
+publishes the sealed candidate as a PR directly; a failed gate or blocking
+findings wake the SAME session with the feedback and the author decides —
+revise/resubmit, more experiments, or an honest negative finish. The
+orchestrator-driven panel-revision loop (`panel_revisions` policy re-entry)
+was retired in the same PR (invariant 3); a plain finish with blocking
+findings drafts the PR for a human. A submit costs the sleep it rides on.
 
 ### Phase 2 — judge verdicts as a syscall type (highest reliability leverage)
 

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -233,6 +233,7 @@ def render(brief: SessionBrief) -> str:
             "",
             "    python .autoresearch/syscall launch --name <handle> "
             "--minutes <N> --artifact <repo-relative file> -- <command>",
+            "    python .autoresearch/syscall submit",
             "    python .autoresearch/syscall sleep",
             "",
             "`status` shows staged launches and remaining budget; `note ...` "
@@ -244,6 +245,16 @@ def render(brief: SessionBrief) -> str:
             "sleeps (a `sleep` with nothing staged is a checkpoint that "
             "refreshes your session clock and costs one sleep). Spend them as "
             "your judgment says; they are generous, not a target to exhaust.",
+            "",
+            "When your candidate is READY, stage `submit` and then `sleep`: "
+            "your tree is sealed, measured against the baseline, and read by "
+            "the review panel. A clean pass is published as a PR directly; "
+            "otherwise you wake with the gate result or the panel's findings "
+            "and decide — revise and submit again, run more experiments, or "
+            "finish with an honest negative report. A submit costs only the "
+            "sleep it rides on. Finishing WITHOUT a submit still runs the "
+            "same gate and panel, but blocking findings then open a draft PR "
+            "for a human instead of coming back to you.",
         ]
     parts += [
         "",

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -849,6 +849,33 @@ def resume_run(
         # resolved and the suite pairs fanned out); a blind re-park (empty
         # afterany) or the same jobs still pending is NO progress, so the stuck
         # cap must keep counting.
+        if stage.get("submitted"):
+            # No author was woken yet, so a SUBMITTED park's re-park (the suite
+            # fanned out) still owes the author the gate+panel results and its
+            # sibling launches' results — carry the submit context forward, or
+            # the next wake drafts instead of waking the author and the launch
+            # descriptors are lost (terra #144 r3). Commands/minutes are spent
+            # history; the wake needs only names + artifacts (as persisted).
+            from autoresearch.syscall import Launch as _Launch
+            from autoresearch.syscall import SyscallRequest as _SyscallRequest
+
+            parked.submitted = True
+            parked.launches_used = int(stage.get("launches_used", 0))  # type: ignore[call-overload]
+            parked.sleeps_used = int(stage.get("sleeps_used", 0))  # type: ignore[call-overload]
+            if parked.syscall is None:
+                parked.syscall = _SyscallRequest(
+                    launches=tuple(
+                        _Launch(
+                            name=str(item.get("name", "")),
+                            command="(ran)",
+                            minutes=1,
+                            artifacts=tuple(str(a) for a in item.get("artifacts", [])),
+                        )
+                        for item in _stage_launches(record)
+                    ),
+                    note=str(stage.get("syscall_note", "")),
+                    submit=True,
+                )
         old_afterany = str(record.stage.get("afterany", ""))
         made_progress = bool(parked.afterany) and parked.afterany != old_afterany
         _park_run(

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -63,7 +63,7 @@ from autoresearch.progress import (
     write_progress,
 )
 from autoresearch.review import PullRequest
-from autoresearch.role_runner import build_harness, run_role
+from autoresearch.role_runner import build_harness
 from autoresearch.roles import author_spec
 from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
@@ -346,13 +346,17 @@ def _park_run(
         "session_cost_usd": parked.session.cost_usd if parked.session else 0.0,
         "session_turns": parked.session.num_turns if parked.session else 0,
     }
-    if parked.phase == "author-sleep":
-        # An author-directed sleep (research-loop-buildout.md Phase A): the wake
+    if parked.submitted:
+        # a SUBMITTED candidate park (buildout Phase B): the wake delivers the
+        # gate + panel results back to the author instead of deciding by policy
+        stage["submitted"] = True
+    if parked.syscall is not None:
+        # A syscall park — an author-directed sleep (research-loop-buildout.md
+        # Phase A) or a submitted candidate carrying sibling launches: the wake
         # gathers each launch's results by NAME from the run dir, delivers the
         # declared artifacts, and resumes the SAME session — so the stage must
         # carry the launch names/artifacts, the author's note, and the budget
         # counts as of this park.
-        assert parked.syscall is not None
         stage["syscall_launches"] = [
             {"name": launch.name, "artifacts": list(launch.artifacts)}
             for launch in parked.syscall.launches
@@ -380,6 +384,10 @@ def _park_run(
         # eval_minutes=None, while its author trains for hours). A checkpoint
         # sleep has no jobs: floor 0 wakes it at the first deadline pass.
         floor_minutes = max((la.minutes for la in parked.syscall.launches), default=0)
+    elif parked.syscall is not None:
+        # a submitted candidate with sibling launches waits on gate evals AND
+        # launches — the floor must sit past the longest of either
+        floor_minutes = max(floor_minutes, *(la.minutes for la in parked.syscall.launches), 0)
     deadline = now + (floor_minutes + PARK_QUEUE_SLACK_MIN) * 60
     waiting = RunRecord(
         **{
@@ -477,19 +485,21 @@ def _wake_author_sleep(
     harness: Harness | None,
     spec: RoleSpec | None,
     panel_lenses: tuple[PanelLens, ...],
-    panel_revisions: int,
     issue_number: int,
     eval_minutes: int | None,
+    extra_update: str = "",
 ) -> LiveClimbOutcome:
-    """Wake an author-sleep park: deliver the launches' results into the
-    sandbox, resume the SAME session through the climb's resume-entry with them
-    (data-fenced), and let the climb run — it may sleep again (re-park), finish
-    into the gate (whose dispatched measures park it as a CANDIDATE the next
-    wake decides), or end on a terminal. The session's workspace persisted on
+    """Wake a syscall park and resume the AUTHOR: deliver the launches' results
+    into the sandbox, resume the SAME session through the climb's resume-entry
+    with them (data-fenced), and let the climb run — it may sleep again
+    (re-park), submit, finish into the gate (whose dispatched measures park it
+    as a CANDIDATE), or end on a terminal. The session's workspace persisted on
     disk exactly as the author left it (the launches ran on node-local
     checkouts of the sealed sha), so the resumed session continues its own tree
-    — cumulative depth.
-    """
+    — cumulative depth. `extra_update` leads the wake text — a SUBMITTED park's
+    gate result or panel verdict (buildout Phase B), delivered back to the
+    author to act on; `sleep_ref` is whichever snapshot ref this park holds
+    (the sleep seal, or the submitted candidate)."""
     from autoresearch.syscall import Launch as SyscallLaunch
     from autoresearch.syscall import gather_results, render_wake, write_budget
 
@@ -570,6 +580,9 @@ def _wake_author_sleep(
         sleeps_used=sleeps_used,
         sleep_budget=bench.sleep_k,
     )
+    if extra_update:
+        # a submitted park's gate/panel feedback leads; launch results follow
+        wake_text = f"{extra_update}\n\n{wake_text}"
     _best_effort(
         "budget refresh",
         lambda: write_budget(
@@ -631,7 +644,6 @@ def _wake_author_sleep(
             changed_paths=changed_paths,
             spec=spec,
             panel_runner=panel_runner,
-            panel_revisions=panel_revisions,
             resume_session_id=record.resume_session_id,
             improve_prompt=wake_text,
             launcher=_make_launcher(dispatch, run_dir, workspace, run_id),
@@ -704,7 +716,6 @@ def resume_run(
     panel_lenses: tuple[PanelLens, ...] = (),
     harness: Harness | None = None,
     spec: RoleSpec | None = None,
-    panel_revisions: int = 1,
 ) -> LiveClimbOutcome:
     """Wake a parked dispatched climb and re-enter its decision WITHOUT the
     session (`orchestrator.resume_climb`), from the record `_park_run` wrote.
@@ -803,7 +814,6 @@ def resume_run(
             harness=harness,
             spec=spec,
             panel_lenses=panel_lenses,
-            panel_revisions=panel_revisions,
             issue_number=issue_number,
             eval_minutes=eval_minutes,
         )
@@ -855,124 +865,62 @@ def resume_run(
         )
         return LiveClimbOutcome(run_id=run_id, outcome="parked")
 
-    def _do_revise(verdict: PanelVerdict, reads: int) -> LiveClimbOutcome | None:
-        """A blocking panel finding -> wake the agent to revise (the depth
-        axis). Re-run the session with the findings, re-snapshot the revised
-        tree, and re-measure — which re-parks (dispatched) so the NEXT wake
-        runs the panel again. Returns the parked/terminal outcome, or None when
-        the revision session could not run (the caller then DRAFTs the original
-        candidate — the improvement is real, it just could not be revised)."""
-        assert harness is not None and spec is not None
-        wake_result = run_role(
-            spec, harness, verdict.wake_text, workspace, resume_session_id=record.resume_session_id
+    # A SUBMITTED park (the author's `submit` syscall, buildout Phase B): gate
+    # and panel results go back to the AUTHOR — it revises and resubmits, runs
+    # more experiments, or concludes — instead of being decided by policy here.
+    # Falls back to the plain-finish behavior (negative terminal / draft PR)
+    # when the session cannot be resumed.
+    submitted_park = bool(stage.get("submitted"))
+    author_resumable = (
+        harness is not None
+        and spec is not None
+        and bool(record.resume_session_id)
+        and getattr(harness, "supports_resume", True)
+    )
+
+    def _wake_author(extra_update: str) -> LiveClimbOutcome:
+        # resume the submitted park's author with the gate/panel feedback
+        # leading its wake text; the candidate ref is this park's held snapshot
+        return _wake_author_sleep(
+            run_root=run_root,
+            run_id=run_id,
+            record=record,
+            ws=ws,
+            workspace=workspace,
+            run_dir=run_dir,
+            dispatch=dispatch,
+            github=github,
+            now=now,
+            secrets=secrets,
+            base_branch=base_branch,
+            base_sha=base_sha,
+            sleep_ref=candidate_ref,
+            contract_text=contract_text,
+            contract=contract,
+            bench=bench,
+            config=config,
+            measurer=measurer,
+            harness=harness,
+            spec=spec,
+            panel_lenses=panel_lenses,
+            issue_number=issue_number,
+            eval_minutes=eval_minutes,
+            extra_update=extra_update,
         )
-        if not wake_result.ok:
-            log.warning("wake revision session failed for %s; drafting the original", run_id)
-            return None
-        # the revised tree is a NEW candidate; snapshot it (parented on base).
-        # A snapshot failure (git write-tree, disk) must NOT escape and leave the
-        # run WAITING to retry — that would re-spend a revision session on the
-        # same finding. Fall back to DRAFTING the original (its improvement is
-        # real and measured); the caller commits candidate_sha, not the revision.
-        try:
-            new_snap = snapshot_tree(ws, base_sha)
-        except Exception as exc:
-            log.warning(
-                "wake revision snapshot failed for %s (%s); drafting the original",
-                run_id,
-                redact(f"{type(exc).__name__}: {exc}", secrets),
-            )
-            return None
-        new_measured = tuple(
-            p
-            for p in ws.git("diff", "--name-only", "-z", base_sha, new_snap.commit).split("\0")
-            if p
-        )
-        old_snap = Snapshot(commit=candidate_sha, tree="", ref=candidate_ref)
-        try:
-            revised = resume_climb(
-                contract,
-                bench,
-                base_sha=base_sha,
-                candidate_sha=new_snap.commit,
-                seed=seed,
-                suite_seed=suite_seed,
-                measured_paths=new_measured,
-                session=wake_result.session,
-                measurer=measurer,
-                min_relative_improvement=config.min_relative_improvement,
-            )
-        except ClimbParked as p:
-            # re-park on the NEW candidate; carry the revision count so the next
-            # wake honors the cap. Keep the new snapshot, drop the superseded old.
-            _park_run(
-                run_root,
-                record,
-                p,
-                new_snap.ref,
-                eval_minutes,
-                now,
-                secrets,
-                base_branch=base_branch,
-                panel_reads=reads,
-            )
-            drop_snapshot(ws, old_snap)
-            return LiveClimbOutcome(run_id=run_id, outcome="parked")
-        except Exception as exc:
-            # the re-measure could not even dispatch (e.g. Slurm submit) — do NOT
-            # discard the ORIGINAL's real, measured improvement; drop the new
-            # snapshot and DRAFT the original (the caller keeps candidate_sha).
-            log.warning(
-                "wake revision re-measure failed for %s (%s); drafting the original",
-                run_id,
-                redact(f"{type(exc).__name__}: {exc}", secrets),
-            )
-            drop_snapshot(ws, new_snap)
-            return None
-        if revised.outcome == "improved":
-            # the dispatched re-measure should have PARKED; an inline 'improved'
-            # here (a cached result) is unexpected and unverified — draft the
-            # original rather than ABORT with no PR.
-            log.warning(
-                "wake revision re-measure returned improved without parking for %s; drafting",
-                run_id,
-            )
-            drop_snapshot(ws, new_snap)
-            return None
-        # the re-measure returned a NEGATIVE terminal (the revision went out of
-        # scope, regressed, or eval-errored): end the run, drop BOTH snapshots.
-        drop_snapshot(ws, old_snap)
-        drop_snapshot(ws, new_snap)
-        report_path = run_dir / "report.md"
-        _best_effort(
-            "run report",
-            lambda: report_path.write_text(revised.report(config, redact_secrets=secrets)),
-            secrets,
-        )
-        ending = _ENDINGS_BY_OUTCOME.get(revised.outcome, ABORTED)
-        final = _clear_stage(
-            RunRecord(
-                **{
-                    **record.__dict__,
-                    "state": ENDED,
-                    "ending": ending,
-                    "ending_note": redact(revised.note, secrets),
-                }
-            )
-        )
-        _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
-        _post_issue_finished(
-            github,
-            config.target,
-            issue_number,
-            run_id,
-            revised.outcome,
-            "",
-            redact(revised.report(config, redact_secrets=secrets), secrets)[:8000],
-            secrets,
-        )
-        return LiveClimbOutcome(
-            run_id=run_id, outcome=revised.outcome, report_path=str(report_path)
+
+    if (
+        submitted_park
+        and author_resumable
+        and result.outcome in ("no-improvement", "suite-regression")
+    ):
+        # the submitted candidate failed the gate: feedback, never a silent
+        # terminal — the author decides what happens next
+        return _wake_author(
+            "Your `submit` did NOT clear the gate: "
+            f"{result.note or result.outcome} "
+            f"(baseline {result.baseline}, candidate {result.candidate}). "
+            "Revise and submit again, run more experiments, or finish with an "
+            "honest negative report."
         )
 
     if result.outcome == "improved":
@@ -1122,40 +1070,20 @@ def resume_run(
                         degraded=True,
                     )
                 reads = panel_reads + 1
-                # DEPTH AXIS (docs/design/research-loop.md): a blocking finding
-                # WAKES THE AGENT to revise — re-run the session with the
-                # findings, re-snapshot, re-measure (-> re-park) — instead of
-                # drafting, bounded by panel_revisions. Fall through to a DRAFT
-                # when we cannot resume (no harness/session) or the cap is hit.
-                can_revise = (
-                    bool(verdict.blocking)
-                    and harness is not None
-                    # a no-resume backend (hermes) declares supports_resume=False
-                    # -> draft, don't resume (claude and codex both resume)
-                    and getattr(harness, "supports_resume", True)
-                    and spec is not None
-                    and bool(record.resume_session_id)
-                    and reads <= panel_revisions
+                # DEPTH AXIS (docs/design/research-loop.md): blocking findings
+                # on a SUBMITTED claim go back to the AUTHOR (buildout Phase B)
+                # — it revises and resubmits (a fresh seal + gate + panel), or
+                # concludes. A plain finish (or an unresumable session) DRAFTs
+                # the PR with the findings open for a human to triage.
+                if bool(verdict.blocking) and submitted_park and author_resumable:
+                    return _wake_author(verdict.wake_text)
+                result = dc_replace(
+                    result,
+                    panel_transcript=verdict.transcript,
+                    panel_rounds=reads,
+                    panel_blocking_open=bool(verdict.blocking),
+                    panel_degraded=verdict.degraded,
                 )
-                if can_revise:
-                    revised = _do_revise(verdict, reads)
-                    if revised is not None:
-                        return revised
-                    # the revision session could not run — DRAFT the original
-                    result = dc_replace(
-                        result,
-                        panel_transcript=verdict.transcript,
-                        panel_rounds=reads,
-                        panel_blocking_open=True,
-                    )
-                else:
-                    result = dc_replace(
-                        result,
-                        panel_transcript=verdict.transcript,
-                        panel_rounds=reads,
-                        panel_blocking_open=bool(verdict.blocking),
-                        panel_degraded=verdict.degraded,
-                    )
 
             entries = update_leader(
                 load_leader(workspace),
@@ -1507,7 +1435,6 @@ def live_climb(
     task_hypothesis: str = "",
     spec: RoleSpec | None = None,
     panel_lenses: tuple[PanelLens, ...] = (),
-    panel_revisions: int = 1,
     dispatch: DispatchSettings | None = None,
     author_syscalls: bool = False,
 ) -> LiveClimbOutcome:
@@ -1749,7 +1676,6 @@ def live_climb(
                 task_hypothesis=task_hypothesis,
                 spec=spec,
                 panel_runner=panel_runner,
-                panel_revisions=panel_revisions,
                 brief_baseline=prior_best.best if prior_best else None,
                 launcher=launcher,
             )
@@ -2407,7 +2333,6 @@ def main() -> int:
         default=PANEL_KEY_DEFAULT,
         help="key file for panel judge sessions (the verifier's own key, never the author's)",
     )
-    parser.add_argument("--panel-revisions", type=int, default=1)
     parser.add_argument(
         "--author-syscalls",
         action="store_true",
@@ -2515,7 +2440,11 @@ def main() -> int:
             # alone does NOT — a panel-less deployment must not be forced to
             # provision an unused credential (terra, #135 r1).
             wake_panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
-        if wake_lenses or _wake_stage.get("phase") == "author-sleep":
+        if (
+            wake_lenses
+            or _wake_stage.get("phase") == "author-sleep"
+            or _wake_stage.get("submitted")
+        ):
             wake_api_key = FileTokenProvider(Path(wake_key_file)).token()
             wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
             wake_harness = build_harness(
@@ -2545,7 +2474,6 @@ def main() -> int:
                 panel_lenses=wake_lenses,
                 harness=wake_harness,
                 spec=wake_spec,
-                panel_revisions=args.panel_revisions,
             )
         finally:
             # This wake job HOLDS the run's lease (the sweep transferred it on
@@ -2651,7 +2579,6 @@ def main() -> int:
                 ),
                 spec=spec,
                 panel_lenses=panel_lenses,
-                panel_revisions=args.panel_revisions,
                 dispatch=dispatch,
                 author_syscalls=args.author_syscalls,
                 evaluator=SubprocessEvaluator(container_image=args.image),

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -911,10 +911,11 @@ def resume_run(
     if (
         submitted_park
         and author_resumable
-        and result.outcome in ("no-improvement", "suite-regression")
+        and result.outcome in ("no-improvement", "suite-regression", "eval-error")
     ):
-        # the submitted candidate failed the gate: feedback, never a silent
-        # terminal — the author decides what happens next
+        # the submitted candidate failed the gate — including an eval that
+        # errored (terra #144 r1): feedback, never a silent terminal — the
+        # author decides what happens next (rounds stay bounded by sleep_k)
         return _wake_author(
             "Your `submit` did NOT clear the gate: "
             f"{result.note or result.outcome} "

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -358,7 +358,11 @@ def _park_run(
         # carry the launch names/artifacts, the author's note, and the budget
         # counts as of this park.
         stage["syscall_launches"] = [
-            {"name": launch.name, "artifacts": list(launch.artifacts)}
+            # minutes ride along so a RE-PARK's deadline floor still covers the
+            # longest launch (terra #144 r4) — without them a rebuilt descriptor
+            # would undershoot the floor and the sweep could cancel a healthy
+            # queued sibling as "pending past deadline"
+            {"name": launch.name, "minutes": launch.minutes, "artifacts": list(launch.artifacts)}
             for launch in parked.syscall.launches
         ]
         stage["syscall_note"] = redact(parked.syscall.note, secrets)
@@ -564,7 +568,7 @@ def _wake_author_sleep(
         SyscallLaunch(
             name=str(item.get("name", "")),
             command="(ran)",
-            minutes=1,
+            minutes=int(item.get("minutes") or 1),
             artifacts=tuple(str(a) for a in item.get("artifacts", [])),
         )
         for item in _stage_launches(record)
@@ -868,7 +872,9 @@ def resume_run(
                         _Launch(
                             name=str(item.get("name", "")),
                             command="(ran)",
-                            minutes=1,
+                            # the persisted walltime, so the re-park's deadline
+                            # floor still covers the longest launch
+                            minutes=int(item.get("minutes") or 1),
                             artifacts=tuple(str(a) for a in item.get("artifacts", [])),
                         )
                         for item in _stage_launches(record)

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -115,6 +115,7 @@ class ClimbParked(Exception):
         syscall: SyscallRequest | None = None,
         launches_used: int = 0,
         sleeps_used: int = 0,
+        submitted: bool = False,
     ):
         self.phase = phase
         self.afterany = afterany
@@ -123,11 +124,15 @@ class ClimbParked(Exception):
         self.suite_seed = suite_seed
         self.candidate_sha = candidate_sha
         self.session = session
-        # author-sleep parks only (phase "author-sleep"): the request the wake
-        # gathers results for, and the budget counts AFTER this park.
+        # Syscall parks (an author-sleep, or a SUBMITTED candidate — Phase B):
+        # the request the wake gathers results for, and the budget counts AFTER
+        # this park. `submitted` marks a candidate park raised by `submit`: the
+        # wake delivers gate + panel results back to the AUTHOR instead of
+        # deciding by policy.
         self.syscall = syscall
         self.launches_used = launches_used
         self.sleeps_used = sleeps_used
+        self.submitted = submitted
         super().__init__(f"climb parked at {phase} on {afterany or '(no dep)'}")
 
 
@@ -939,54 +944,12 @@ def resume_climb(
     )
 
 
-# --- the composition seam (docs/design/research-loop-buildout.md) ---
-# climb_once's inner loop is run -> measure -> decide. `run` (run_role) and
-# `measure` (measure_and_decide) are already factored; this is the "decide the
-# next invocation" half, pulled out of the loop as a pluggable policy so the loop
-# is agnostic to WHY it iterates. One policy exists (panel-driven revision) and
-# no more are planned: the author-directed model (research-loop.md, "one
-# syscall") moves next-move decisions into the author; this seam is retained as
-# structure and retires with the orchestrator-driven revision loop (Phase B).
-
-
-@dataclass(frozen=True)
-class _Revise:
-    """Iterate: re-run the editing role with this prompt, then re-measure."""
-
-    prompt: str
-
-
-@dataclass(frozen=True)
-class _Halt:
-    """Stop the loop and publish. `blocking_open` -> the caller drafts the PR
-    with the open findings rather than arming it."""
-
-    blocking_open: bool = False
-
-
-def _panel_revise_policy(
-    verdict: PanelVerdict,
-    session: SessionResult,
-    harness: Harness,
-    reads: int,
-    revisions: int,
-) -> _Revise | _Halt:
-    """The one decision policy today: a blocking panel finding wakes the author to
-    revise, bounded by `revisions`, unless the backend cannot resume (then draft).
-    A pure function of the read + the session's resumability — the loop owns the
-    stateful bits (running the panel, executing the wake). A future results-driven
-    (depth) policy will also take the gate result; this one needs only the verdict."""
-    if not verdict.blocking:
-        # clean (or degraded-but-clean) read: nothing to fix -> publish
-        return _Halt()
-    if not session.session_id or not getattr(harness, "supports_resume", True):
-        # cannot resume: a fresh session would revise blind, and a resume the
-        # backend can't do would lose the verified improvement -> draft instead
-        return _Halt(blocking_open=True)
-    if reads > revisions:
-        # capped with findings still open: the human must see the unconverged loop
-        return _Halt(blocking_open=True)
-    return _Revise(verdict.wake_text)
+def _merge_afterany(*parts: str) -> str:
+    """Join afterany dependency strings ("afterany:1:2") into one; "" parts
+    drop out. A submit's park waits on the gate's evals AND its sibling
+    launches together."""
+    ids = [t for part in parts for t in part.split(":")[1:] if t]
+    return "afterany:" + ":".join(ids) if ids else ""
 
 
 def climb_once(
@@ -1005,7 +968,6 @@ def climb_once(
     task_hypothesis: str = "",
     spec: RoleSpec | None = None,
     panel_runner: Callable[[float, float, str], PanelVerdict] | None = None,
-    panel_revisions: int = 1,
     brief_baseline: float | None = None,
     resume_session_id: str = "",
     improve_prompt: str = "",
@@ -1032,19 +994,22 @@ def climb_once(
     contract.
 
     With `panel_runner` (docs/design/orchestrator-verify.md), a credited
-    claim is read by the verification panel BEFORE it can become a PR:
-    blocking findings wake the same session (data-fenced), the revision is
-    re-snapshotted, fully re-measured and re-gated, and the panel re-reads —
-    up to `panel_revisions` revisions after the initial read. Blocking findings
-    still open at the cap set `panel_blocking_open` (the caller posts a
-    DRAFT PR carrying them). The caller supplies the runner because the
-    panel's checkouts are git work (this function owns no git).
+    claim is read by the verification panel BEFORE it can become a PR. On a
+    SUBMITTED claim (the author's `submit` syscall), blocking findings and the
+    gate result go back to the AUTHOR — it revises and resubmits, or concludes
+    (research-loop-buildout.md Phase B); on a plain finish, blocking findings
+    set `panel_blocking_open` (the caller posts a DRAFT PR carrying them).
+    The caller supplies the runner because the panel's checkouts are git work
+    (this function owns no git).
 
     With `launcher` (author syscalls, research-loop-buildout.md Phase A), a
     session that ends having asked to launch-and-sleep parks this climb as
     `author-sleep` instead of measuring: the tree is sealed via `snapshot()`,
     the launcher submits the jobs (caller-owned — it is compute work), and the
-    ClimbParked carries the request plus the budget counts. `launches_used` /
+    ClimbParked carries the request plus the budget counts. A `submit` rides
+    the same request: the gate (and any sibling launches) run on the sealed
+    tree — a dispatched gate parks as a `candidate` with the `submitted`
+    marker, an inline gate feeds back in-session. `launches_used` /
     `sleeps_used` are the counts so far (a wake passes them from the stage);
     the budgets come from the benchmark's `depth_k` / `sleep_k`.
     """
@@ -1156,20 +1121,72 @@ def climb_once(
             note=role_result.error or session.error_detail or session.stop_reason,
         )
 
-    # --- author syscalls (research-loop.md, "one syscall"; buildout Phase A) ---
-    # An enabled author (the caller wired a `launcher`) may end its session
-    # having asked to LAUNCH work outside the sandbox and SLEEP on it. Within
-    # budget: seal the tree, submit through the launcher, and park — the wake
-    # re-enters THIS function through the resume-entry with the results as the
-    # improve prompt, so the whole tail (scope, gate, panel, sleeping again)
-    # composes unchanged. Over budget: wake the author ONCE with a refusal so
-    # it can conclude honestly; a session that over-asks again proceeds to
-    # measurement with the tree as it stands (bounded, never an endless
-    # refuse/re-ask loop). With no launcher the feature is off and a stray
-    # request file is just an untracked file (excluded from the diff either way).
-    if launcher is not None:
-        refused_once = False
-        while True:
+    # --- the decision loop (research-loop.md, "one syscall"; buildout A+B) ---
+    # Each pass: honor the session's syscall request, then measure the tree.
+    # An enabled author (the caller wired a `launcher`) may end its session —
+    # or a resumed leg of it — having asked to LAUNCH work outside the sandbox
+    # and SLEEP on it (seal the tree, submit through the launcher, park; the
+    # wake re-enters THIS function through the resume-entry so the whole tail
+    # composes unchanged), and/or to SUBMIT its candidate: the gate and any
+    # sibling launches run on the sealed tree — a dispatched gate parks as a
+    # `candidate` with the `submitted` marker (the wake delivers gate + panel
+    # back to the author), an inline gate feeds back in-session and the loop
+    # re-reads the author's next move. Over budget: wake the author ONCE with
+    # a refusal so it can conclude honestly; a session that over-asks again
+    # proceeds to measurement with the tree as it stands (bounded, never an
+    # endless refuse/re-ask loop). With no launcher the feature is off and a
+    # stray request file is just an untracked file (excluded from the diff
+    # either way).
+    panel_reads = 0
+    panel_sections: list[str] = []
+    panel_blocking_open = False
+    panel_degraded = False
+    candidate: float | None = baseline
+    suite: tuple[SuiteMeasurement, ...] = ()
+    suite_seed_ran = 0
+    measured: tuple[str, ...] = ()
+    refused_once = False
+
+    def _resume(prompt: str) -> ClimbResult | None:
+        """Resume the author session with `prompt`: None on success (session
+        advanced), else the terminal ClimbResult for the failed resume."""
+        nonlocal session
+        wake_result = run_role(
+            spec, harness, prompt, workspace, resume_session_id=session.session_id
+        )
+        session = wake_result.session
+        if wake_result.ok:
+            return None
+        if outage(session):
+            kind = "session-outage"
+        elif budget_exhausted(session):
+            kind = "session-budget"
+        else:
+            kind = "session-error"
+        return ClimbResult(
+            outcome=kind,
+            baseline=baseline,
+            candidate=candidate,
+            session=session,
+            note=wake_result.error or session.error_detail or session.stop_reason,
+            run_seed=run_seed,
+            panel_transcript="\n\n".join(panel_sections),
+            panel_rounds=panel_reads,
+        )
+
+    def _can_resume() -> bool:
+        return bool(session.session_id) and getattr(harness, "supports_resume", True)
+
+    def _budgets_line() -> str:
+        return (
+            f"Budgets: {max(0, bench.depth_k - launches_used)} launches and "
+            f"{max(0, bench.sleep_k - sleeps_used)} sleeps remaining."
+        )
+
+    while True:
+        # the syscall request the session's last leg left, if any
+        submitted: SyscallRequest | None = None
+        while launcher is not None:
             try:
                 request = read_syscall_request(workspace)
             except SyscallError as exc:
@@ -1190,6 +1207,15 @@ def climb_once(
                 sleep_budget=bench.sleep_k,
             )
             if not problem:
+                if request.submit:
+                    # a submit rides the measurement below on the SEALED tree —
+                    # "a launch whose job is the gate" (buildout Phase B). Its
+                    # sibling launches are submitted after the scope check +
+                    # snapshot; the sleep it rides on is counted now.
+                    submitted = request
+                    launches_used += len(request.launches)
+                    sleeps_used += 1
+                    break
                 # Scope BEFORE the snapshot, same invariant as the candidate
                 # path below: an out-of-scope tree is never snapshotted OR
                 # executed — the out-of-scope edit could be to the ruler
@@ -1219,45 +1245,21 @@ def climb_once(
                     launches_used=launches_used + len(request.launches),
                     sleeps_used=sleeps_used + 1,
                 )
-            if (
-                refused_once
-                or not session.session_id
-                or not getattr(harness, "supports_resume", True)
-            ):
+            if refused_once or not _can_resume():
                 log.warning("syscall request dropped after refusal (%s); measuring as-is", problem)
                 break
             # the refusal burns no count (nothing was launched, nothing woke a
             # job); the refused_once bound is what stops a refuse/re-ask loop.
             refused_once = True
-            role_result = run_role(
-                spec,
-                harness,
+            failed = _resume(
                 render_syscall_refusal(
                     problem,
                     launches_remaining=max(0, bench.depth_k - launches_used),
                     sleeps_remaining=max(0, bench.sleep_k - sleeps_used),
-                ),
-                workspace,
-                resume_session_id=session.session_id,
-            )
-            session = role_result.session
-            if not role_result.ok:
-                return ClimbResult(
-                    outcome="session-outage" if outage(session) else "session-error",
-                    baseline=baseline,
-                    session=session,
-                    note=role_result.error or session.error_detail or session.stop_reason,
                 )
-
-    panel_reads = 0
-    panel_sections: list[str] = []
-    panel_blocking_open = False
-    panel_degraded = False
-    candidate: float | None = baseline
-    suite: tuple[SuiteMeasurement, ...] = ()
-    suite_seed_ran = 0
-    measured: tuple[str, ...] = ()
-    while True:
+            )
+            if failed is not None:
+                return failed
         measured = tuple(changed_paths())
         # Scope BEFORE the snapshot: an out-of-scope tree is never snapshotted
         # OR measured — the out-of-scope edit could be to the ruler itself. This
@@ -1293,6 +1295,13 @@ def climb_once(
                 panel_transcript="\n\n".join(panel_sections),
                 panel_rounds=panel_reads,
             )
+        # a submit's sibling launches ride the same park, submitted on the
+        # sealed sha AFTER the scope check so a launch never runs
+        # out-of-scope code (same invariant as the launch-only path above)
+        launch_afterany = ""
+        if submitted is not None and submitted.launches:
+            assert launcher is not None  # a submit only arrives through it
+            launch_afterany = launcher(candidate_sha, submitted)
         try:
             outcome = measure_and_decide(
                 contract,
@@ -1307,19 +1316,42 @@ def climb_once(
             )
         except MeasurementPending as pending:
             # PARK 2 (dispatched candidate/suite, after the session): the wake
-            # reads the cached results and decides. Carries the candidate sha
+            # reads the cached results and decides — or, on a SUBMITTED park,
+            # delivers them back to the author. Carries the candidate sha
             # and the session so the caller persists the snapshot ref (drop at
             # the terminal state) and the resume session id.
             raise ClimbParked(
                 phase="candidate",
-                afterany=pending.afterany(),
+                afterany=_merge_afterany(pending.afterany(), launch_afterany),
                 base_sha=base_sha,
                 seed=run_seed,
                 suite_seed=suite_seed,
                 candidate_sha=candidate_sha,
                 session=session,
+                syscall=submitted,
+                launches_used=launches_used,
+                sleeps_used=sleeps_used,
+                submitted=submitted is not None,
             ) from None
         if isinstance(outcome, ClimbResult):
+            if (
+                submitted is not None
+                and outcome.outcome in ("no-improvement", "suite-regression")
+                and _can_resume()
+            ):
+                # a submitted candidate that failed the gate is FEEDBACK to the
+                # author — it revises and resubmits, or concludes honestly
+                # (buildout Phase B) — never a silent terminal.
+                failed = _resume(
+                    "Your `submit` did NOT clear the gate: "
+                    f"{outcome.note or outcome.outcome} "
+                    f"(baseline {outcome.baseline}, candidate {outcome.candidate}). "
+                    f"{_budgets_line()} Revise and submit again, run more "
+                    "experiments, or finish with an honest negative report."
+                )
+                if failed is not None:
+                    return failed
+                continue
             # a terminal measurement outcome (scope-violation / eval-error /
             # no-improvement / suite-regression): add the session + panel
             # context this function owns. The baseline stays whatever the GATE
@@ -1354,40 +1386,20 @@ def climb_once(
         # only the FINAL read's degradation matters: an earlier outage that a
         # later clean read supersedes is history, not state
         panel_degraded = verdict.degraded
-        # decide the next invocation (the composition seam): today the panel-revise
-        # policy. A _Halt ends the loop (drafting if findings stay open); a _Revise
-        # wakes the author with the policy's prompt and re-enters run -> measure.
-        decision = _panel_revise_policy(verdict, session, harness, panel_reads, panel_revisions)
-        if isinstance(decision, _Halt):
-            panel_blocking_open = decision.blocking_open
-            break
-        wake_result = run_role(
-            spec,
-            harness,
-            decision.prompt,
-            workspace,
-            resume_session_id=session.session_id or None,
-        )
-        session = wake_result.session
-        if not wake_result.ok:
-            if outage(session):
-                kind = "session-outage"
-            elif budget_exhausted(session):
-                kind = "session-budget"
-            else:
-                kind = "session-error"
-            return ClimbResult(
-                outcome=kind,
-                baseline=baseline,
-                candidate=candidate,
-                session=session,
-                note=wake_result.error or session.error_detail or session.stop_reason,
-                run_seed=run_seed,
-                panel_transcript="\n\n".join(panel_sections),
-                panel_rounds=panel_reads,
-            )
-        # loop: the revision is a NEW candidate — re-snapshot, then scope,
-        # paired eval, improvement threshold, and the suite gate all re-apply
+        if verdict.blocking and submitted is not None and _can_resume():
+            # blocking findings on a SUBMITTED claim go back to the AUTHOR —
+            # it revises and resubmits, runs more experiments, or concludes
+            # (buildout Phase B: the author drives the depth axis; the
+            # orchestrator-driven revision policy is retired). The loop then
+            # re-reads its next syscall; the revision re-measures from scratch.
+            failed = _resume(f"{verdict.wake_text}\n\n{_budgets_line()}")
+            if failed is not None:
+                return failed
+            continue
+        # a plain finish (or an unresumable session): blocking findings stay
+        # open — the caller drafts the PR for a human to triage.
+        panel_blocking_open = bool(verdict.blocking)
+        break
 
     return ClimbResult(
         outcome="improved",

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1336,12 +1336,13 @@ def climb_once(
         if isinstance(outcome, ClimbResult):
             if (
                 submitted is not None
-                and outcome.outcome in ("no-improvement", "suite-regression")
+                and outcome.outcome in ("no-improvement", "suite-regression", "eval-error")
                 and _can_resume()
             ):
-                # a submitted candidate that failed the gate is FEEDBACK to the
-                # author — it revises and resubmits, or concludes honestly
-                # (buildout Phase B) — never a silent terminal.
+                # a submitted candidate that failed the gate — including an
+                # eval that errored — is FEEDBACK to the author: it revises and
+                # resubmits, or concludes honestly (buildout Phase B) — never a
+                # silent terminal. Rounds stay bounded by sleep_k.
                 failed = _resume(
                     "Your `submit` did NOT clear the gate: "
                     f"{outcome.note or outcome.outcome} "

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1183,6 +1183,16 @@ def climb_once(
             f"{max(0, bench.sleep_k - sleeps_used)} sleeps remaining."
         )
 
+    def _not_run_note(request: SyscallRequest | None) -> str:
+        # inline gates never dispatch a submit's sibling launches (nothing
+        # would gather them) — tell the author; their budget was not spent
+        if request is None or not request.launches:
+            return ""
+        return (
+            "Your sibling launches did NOT run (the gate completed inline); "
+            "stage them again if still needed. "
+        )
+
     while True:
         # the syscall request the session's last leg left, if any
         submitted: SyscallRequest | None = None
@@ -1209,11 +1219,12 @@ def climb_once(
             if not problem:
                 if request.submit:
                     # a submit rides the measurement below on the SEALED tree —
-                    # "a launch whose job is the gate" (buildout Phase B). Its
-                    # sibling launches are submitted after the scope check +
-                    # snapshot; the sleep it rides on is counted now.
+                    # "a launch whose job is the gate" (buildout Phase B). The
+                    # sleep it rides on is counted now; sibling launches are
+                    # dispatched (and counted) only if the gate parks — an
+                    # inline gate must never orphan launch jobs no wake would
+                    # gather (terra #144 r2).
                     submitted = request
-                    launches_used += len(request.launches)
                     sleeps_used += 1
                     break
                 # Scope BEFORE the snapshot, same invariant as the candidate
@@ -1295,13 +1306,6 @@ def climb_once(
                 panel_transcript="\n\n".join(panel_sections),
                 panel_rounds=panel_reads,
             )
-        # a submit's sibling launches ride the same park, submitted on the
-        # sealed sha AFTER the scope check so a launch never runs
-        # out-of-scope code (same invariant as the launch-only path above)
-        launch_afterany = ""
-        if submitted is not None and submitted.launches:
-            assert launcher is not None  # a submit only arrives through it
-            launch_afterany = launcher(candidate_sha, submitted)
         try:
             outcome = measure_and_decide(
                 contract,
@@ -1319,7 +1323,15 @@ def climb_once(
             # reads the cached results and decides — or, on a SUBMITTED park,
             # delivers them back to the author. Carries the candidate sha
             # and the session so the caller persists the snapshot ref (drop at
-            # the terminal state) and the resume session id.
+            # the terminal state) and the resume session id. A submit's sibling
+            # launches ride the SAME park, dispatched only HERE — once the gate
+            # has proven dispatched — on the sealed sha (scope was checked
+            # above, so a launch never runs out-of-scope code).
+            launch_afterany = ""
+            if submitted is not None and submitted.launches:
+                assert launcher is not None  # a submit only arrives through it
+                launch_afterany = launcher(candidate_sha, submitted)
+                launches_used += len(submitted.launches)
             raise ClimbParked(
                 phase="candidate",
                 afterany=_merge_afterany(pending.afterany(), launch_afterany),
@@ -1347,7 +1359,8 @@ def climb_once(
                     "Your `submit` did NOT clear the gate: "
                     f"{outcome.note or outcome.outcome} "
                     f"(baseline {outcome.baseline}, candidate {outcome.candidate}). "
-                    f"{_budgets_line()} Revise and submit again, run more "
+                    f"{_not_run_note(submitted)}{_budgets_line()} "
+                    "Revise and submit again, run more "
                     "experiments, or finish with an honest negative report."
                 )
                 if failed is not None:
@@ -1393,7 +1406,7 @@ def climb_once(
             # (buildout Phase B: the author drives the depth axis; the
             # orchestrator-driven revision policy is retired). The loop then
             # re-reads its next syscall; the revision re-measures from scratch.
-            failed = _resume(f"{verdict.wake_text}\n\n{_budgets_line()}")
+            failed = _resume(f"{verdict.wake_text}\n\n{_not_run_note(submitted)}{_budgets_line()}")
             if failed is not None:
                 return failed
             continue

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -107,6 +107,11 @@ class SyscallRequest:
 
     launches: tuple[Launch, ...]
     note: str = ""  # the author's reminder-to-self, echoed back on wake
+    # research-loop-buildout.md Phase B: a submit is a launch whose job is the
+    # GATE (paired baseline/candidate on the sealed tree) plus the panel; the
+    # wake returns verdict + gate result to the author (published directly when
+    # it clears cleanly). Costs the sleep it rides on, nothing else.
+    submit: bool = False
 
 
 @dataclass(frozen=True)
@@ -163,12 +168,15 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     # so anything else here (e.g. a verdict) is a wrong-type request, not a sleep.
     if data.get("type") != "sleep":
         raise SyscallError(f"expected a sleep syscall, got type {data.get('type')!r}")
-    unknown = set(data) - {"type", "launches", "note"}
+    unknown = set(data) - {"type", "launches", "note", "submit"}
     if unknown:
         raise SyscallError(f"unknown syscall keys: {sorted(unknown)}")
     note = data.get("note", "")
     if not isinstance(note, str) or len(note) > MAX_NOTE_CHARS:
         raise SyscallError(f"note must be a string of at most {MAX_NOTE_CHARS} chars")
+    submit = data.get("submit", False)
+    if not isinstance(submit, bool):
+        raise SyscallError("submit must be a boolean")
     raw_launches = data.get("launches", [])
     if not isinstance(raw_launches, list):
         raise SyscallError("launches must be a list")
@@ -212,7 +220,7 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     # a sleep with no launches is legitimate: checkpoint-and-reschedule
     # (research-loop.md, "the session clock is visible") — it still burns a
     # sleep count, which is what bounds living forever.
-    return SyscallRequest(launches=tuple(launches), note=note)
+    return SyscallRequest(launches=tuple(launches), note=note, submit=submit)
 
 
 def read_verdict(workspace: Path) -> dict[str, Any] | None:

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -9,6 +9,7 @@ experiments and hibernate:
     python .autoresearch/syscall launch --name train --minutes 90 \\
         --artifact results/curve.json -- uv run python train.py --lr 3e-4
     python .autoresearch/syscall note "compare with the lr sweep"
+    python .autoresearch/syscall submit      # seal + gate + panel on this tree
     python .autoresearch/syscall sleep       # then END YOUR TURN to hibernate
 
 The JUDGE's syscalls record a verdict and exit — `conclude` is the judge's
@@ -89,11 +90,17 @@ def _load_staged(root: Path) -> dict:
     try:
         data = json.loads(f.read_text())
     except FileNotFoundError:
-        return {"launches": [], "note": "", "findings": [], "notes": ""}
+        return {"launches": [], "note": "", "submit": False, "findings": [], "notes": ""}
     except (OSError, json.JSONDecodeError) as exc:
         raise ToolError(f"staged request is unreadable ({exc}); run `cancel` to reset") from exc
     # tolerate a partial file: default any missing family so either role's verbs work
-    for key, empty in (("launches", []), ("note", ""), ("findings", []), ("notes", "")):
+    for key, empty in (
+        ("launches", []),
+        ("note", ""),
+        ("submit", False),
+        ("findings", []),
+        ("notes", ""),
+    ):
         data.setdefault(key, empty)
     return data
 
@@ -161,14 +168,33 @@ def cmd_note(root: Path, args: argparse.Namespace) -> str:
     return "note saved (delivered back to you on wake)."
 
 
+def cmd_submit(root: Path, _args: argparse.Namespace) -> str:
+    staged = _load_staged(root)
+    staged["submit"] = True
+    _save_staged(root, staged)
+    return (
+        "staged submit: on `sleep` your current tree is SEALED and measured "
+        "against the baseline, and the review panel reads the claim; you will "
+        "be woken with the result (published if it clears cleanly). "
+        f"{_budget_line(root)}."
+    )
+
+
 def cmd_sleep(root: Path, _args: argparse.Namespace) -> str:
     staged = _load_staged(root)
     # commit the SLEEP syscall -> the ABI the kernel reads; then END THE TURN.
-    payload = {"type": "sleep", "launches": staged["launches"], "note": staged["note"]}
+    payload = {
+        "type": "sleep",
+        "launches": staged["launches"],
+        "note": staged["note"],
+        "submit": bool(staged["submit"]),
+    }
     (_dir(root) / ABI).write_text(json.dumps(payload))
     (root / DIR / REQUEST).unlink(missing_ok=True)
     n = len(staged["launches"])
     what = f"{n} launch(es)" if n else "a checkpoint (no launches)"
+    if staged["submit"]:
+        what += " + a submit (seal, gate, panel)"
     return (
         f"committed {what}. END YOUR TURN NOW to hibernate — you will be woken "
         "with the results. (If you keep working, the sleep still triggers when "
@@ -238,11 +264,13 @@ def cmd_conclude(root: Path, args: argparse.Namespace) -> str:
 def cmd_status(root: Path, _args: argparse.Namespace) -> str:
     staged = _load_staged(root)
     lines: list[str] = []
-    if staged["launches"] or (root / DIR / BUDGET).exists():
+    if staged["launches"] or staged["submit"] or (root / DIR / BUDGET).exists():
         lines.append(f"{len(staged['launches'])} launch(es) staged; {_budget_line(root)}.")
         for la in staged["launches"]:
             arts = (" -> " + ", ".join(la["artifacts"])) if la.get("artifacts") else ""
             lines.append(f"  - {la['name']} ({la['minutes']} min): {la['command']}{arts}")
+        if staged["submit"]:
+            lines.append("  submit staged: `sleep` seals this tree for the gate + panel")
         if staged.get("note"):
             lines.append(f"  note: {staged['note']}")
     if staged["findings"]:
@@ -274,7 +302,11 @@ def build_parser() -> argparse.ArgumentParser:
     la.add_argument("command", nargs=argparse.REMAINDER, help="-- then the command to run")
     no = sub.add_parser("note", help="save a note to yourself, echoed back on wake")
     no.add_argument("text")
-    sub.add_parser("sleep", help="commit staged launches; then end your turn")
+    sub.add_parser(
+        "submit",
+        help="stage a submit: on sleep, seal this tree for the gate + review panel",
+    )
+    sub.add_parser("sleep", help="commit staged launches/submit; then end your turn")
     # judge verbs
     fi = sub.add_parser("finding", help="record one finding")
     fi.add_argument("--file", required=True)
@@ -298,6 +330,7 @@ def build_parser() -> argparse.ArgumentParser:
 _HANDLERS = {
     "launch": cmd_launch,
     "note": cmd_note,
+    "submit": cmd_submit,
     "sleep": cmd_sleep,
     "finding": cmd_finding,
     "conclude": cmd_conclude,

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2204,6 +2204,39 @@ def test_resume_reparks_when_a_measure_is_pending(tmp_path, monkeypatch) -> None
     assert _git(ws, "for-each-ref", "refs/dispatch/").strip() != ""  # snapshot kept
 
 
+def test_resume_repark_of_a_submitted_park_keeps_the_submit_context(tmp_path, monkeypatch):
+    # terra #144 r3: a submitted candidate whose wake dispatches MORE measures
+    # (the suite fans out) re-parks BEFORE any author wake — the new stage must
+    # keep the submitted marker, the budget counts, and the sibling-launch
+    # descriptors, or the next wake drafts instead of waking the author and
+    # the launches' results are never gathered.
+    from autoresearch.measure import MeasurementPending
+
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, raise_exc=MeasurementPending(("601", "602"))
+    )
+    rec = load_record(state, run_id)
+    rec.stage["submitted"] = True
+    rec.stage["syscall_launches"] = [{"name": "probe", "artifacts": ["out.txt"]}]
+    rec.stage["launches_used"] = 1
+    rec.stage["sleeps_used"] = 1
+    save_record(state, rec, 1_000_050.0)
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert outcome.outcome == "parked"
+    record = load_record(state, run_id)
+    assert record.state == "waiting"
+    assert record.stage.get("submitted") is True
+    assert record.stage["syscall_launches"] == [{"name": "probe", "artifacts": ["out.txt"]}]
+    assert record.stage["launches_used"] == 1 and record.stage["sleeps_used"] == 1
+
+
 def test_resume_improved_pushes_and_opens_pr(tmp_path, monkeypatch) -> None:
     # candidate beats baseline -> branch the sealed sha, fold in the ledger,
     # push, open the PR against main; the record goes in-review.

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2593,10 +2593,10 @@ def test_resume_panel_error_drafts_and_keeps_candidate(tmp_path, monkeypatch) ->
     assert github.prs[0]["draft"] is True and github.armed == []  # degraded -> draft, no arm
 
 
-def test_resume_blocking_panel_wakes_the_agent_to_revise_and_reparks(tmp_path, monkeypatch) -> None:
-    # THE DEPTH-AXIS CORE: a blocking panel finding wakes the agent to revise —
-    # re-run the session with the findings, re-snapshot, re-measure -> re-park
-    # (panel_reads incremented), instead of drafting.
+def test_resume_blocking_panel_on_a_submitted_park_wakes_the_author(tmp_path, monkeypatch) -> None:
+    # THE DEPTH-AXIS CORE (buildout Phase B): on a SUBMITTED park, a blocking
+    # panel finding goes back to the AUTHOR — the same session is resumed with
+    # the findings, revises, and its re-measure re-parks — instead of drafting.
     import json as _json
     from dataclasses import dataclass
 
@@ -2638,8 +2638,18 @@ def test_resume_blocking_panel_wakes_the_agent_to_revise_and_reparks(tmp_path, m
     state, run_id = _write_parked_candidate(
         tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
     )
-    # the INITIAL measure returns improved (-> panel -> revise); the re-measure
-    # of the revised candidate PARKS, exactly as the dispatched backend does.
+    # mark the park SUBMITTED: the author sealed this candidate via `submit`
+    rec = load_record(state, run_id)
+    rec.stage["submitted"] = True
+    save_record(state, rec, 1_000_050.0)
+    # the real flow excluded the channel at climb start (.git/info/exclude
+    # persists in the run's ws); the hand-built test ws needs it too, or the
+    # wake's budget refresh pollutes changed_paths
+    from autoresearch.syscall import ensure_excluded
+
+    ensure_excluded(state / "runs" / run_id / "ws")
+    # the INITIAL measure returns improved (-> panel -> author wake); the
+    # re-measure of the revised candidate PARKS, as the dispatched backend does.
     from autoresearch.measure import DispatchSettings, MeasurementPending
 
     class _TwoPhase:
@@ -2665,13 +2675,13 @@ def test_resume_blocking_panel_wakes_the_agent_to_revise_and_reparks(tmp_path, m
         panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
         harness=RevisingHarness(),
         spec=author_spec(),
-        panel_revisions=1,
     )
     assert outcome.outcome == "parked"  # re-parked to measure the REVISED candidate
     assert github.prs == []  # no PR — the revision must be verified first
     rec = load_record(state, run_id)
     assert rec.state == "waiting"
-    assert rec.stage["panel_reads"] == 1  # one revision taken; the cap advances
+    # the new park is a plain finish (the author did not resubmit)
+    assert not rec.stage.get("submitted")
     assert rec.stage["candidate_sha"] != old  # a NEW candidate (the revision)
     # the revised edit landed in the new candidate; the old snapshot was dropped
     ws = state / "runs" / run_id / "ws"
@@ -2679,9 +2689,10 @@ def test_resume_blocking_panel_wakes_the_agent_to_revise_and_reparks(tmp_path, m
     assert str(rec.stage["candidate_sha"]) in kept and str(old) not in kept
 
 
-def test_resume_blocking_panel_at_the_cap_drafts_without_revising(tmp_path, monkeypatch) -> None:
-    # once panel_reads has hit panel_revisions, a further blocking finding stops
-    # revising and DRAFTs (the human sees the unconverged findings).
+def test_resume_blocking_panel_on_a_plain_finish_drafts(tmp_path, monkeypatch) -> None:
+    # a candidate park WITHOUT a submit gets no author loop: blocking findings
+    # DRAFT the PR for a human (the policy-driven revision loop is retired —
+    # the author drives depth via `submit`).
     import json as _json
 
     from autoresearch.orchestrator import author_spec
@@ -2705,10 +2716,6 @@ def test_resume_blocking_panel_at_the_cap_drafts_without_revising(tmp_path, monk
     state, run_id = _write_parked_candidate(
         tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
     )
-    # simulate a run that already used its one revision
-    rec = load_record(state, run_id)
-    rec.stage["panel_reads"] = 1
-    save_record(state, rec, 1_000_050.0)
     github = FakeGitHub()
     outcome = resume_run(
         state,
@@ -2720,143 +2727,9 @@ def test_resume_blocking_panel_at_the_cap_drafts_without_revising(tmp_path, monk
         panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
         harness=object(),  # type: ignore[arg-type]
         spec=author_spec(),
-        panel_revisions=1,
     )
     assert outcome.outcome == "improved"  # publishes...
     assert github.prs[0]["draft"] is True and github.armed == []  # ...as a DRAFT, no revise
-
-
-def test_resume_revision_snapshot_failure_drafts_the_original(tmp_path, monkeypatch) -> None:
-    # if the revised tree cannot be snapshotted (git/disk), the wake must NOT
-    # leave the run parked to retry (re-spending a session) — it DRAFTs the
-    # original, whose improvement is real and measured.
-    import json as _json
-    from dataclasses import dataclass
-
-    from autoresearch import climb as climb_mod
-    from autoresearch.orchestrator import EvalError, author_spec
-    from autoresearch.panel import PanelLens
-
-    @dataclass
-    class RevisingHarness:
-        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
-            return SessionResult(
-                stop_reason="end_turn",
-                is_error=False,
-                cost_usd=0.5,
-                num_turns=3,
-                session_id="s1",
-                final_text="revised",
-                transcript_path="",
-            )
-
-    def boom(ws, base_sha):
-        raise EvalError("git write-tree failed")
-
-    monkeypatch.setattr(climb_mod, "snapshot_tree", boom)
-    blocking = _json.dumps(
-        {
-            "findings": [
-                {
-                    "file": "src/pilot/solvers/tsp.py",
-                    "line": 1,
-                    "confidence": "high",
-                    "summary": "s",
-                    "detail": "d",
-                    "blocking": True,
-                }
-            ],
-            "notes": "",
-        }
-    )
-    state, run_id = _write_parked_candidate(
-        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
-    )
-    github = FakeGitHub()
-    outcome = resume_run(
-        state,
-        run_id,
-        dispatch=_fake_dispatch(),
-        github=github,  # type: ignore[arg-type]
-        bot_auth=NoAuth(),  # type: ignore[arg-type]
-        now=1_000_100.0,
-        panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
-        harness=RevisingHarness(),
-        spec=author_spec(),
-        panel_revisions=1,
-    )
-    assert outcome.outcome == "improved"  # drafted, not parked/aborted
-    assert github.prs[0]["draft"] is True and github.armed == []
-    assert load_record(state, run_id).state == "in-review"  # ended, not left waiting
-
-
-def test_resume_revision_remeasure_failure_drafts_the_original(tmp_path, monkeypatch) -> None:
-    # if the revision's re-measure cannot even dispatch (e.g. Slurm submit), the
-    # ORIGINAL's real improvement must NOT be discarded — draft it.
-    import json as _json
-    from dataclasses import dataclass
-
-    from autoresearch.measure import DispatchSettings
-    from autoresearch.orchestrator import author_spec
-    from autoresearch.panel import PanelLens
-
-    @dataclass
-    class RevisingHarness:
-        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
-            return SessionResult(
-                stop_reason="end_turn",
-                is_error=False,
-                cost_usd=0.5,
-                num_turns=3,
-                session_id="s1",
-                final_text="revised",
-                transcript_path="",
-            )
-
-    class _RaiseOnRemeasure:
-        def __init__(self):
-            self.calls = 0
-
-        def results(self, measures):
-            self.calls += 1
-            if self.calls == 1:
-                return {"baseline": 13.0, "candidate": 12.0}
-            raise RuntimeError("sbatch failed")  # not EvalError/MeasurementPending
-
-    blocking = _json.dumps(
-        {
-            "findings": [
-                {
-                    "file": "src/pilot/solvers/tsp.py",
-                    "line": 1,
-                    "confidence": "high",
-                    "summary": "s",
-                    "detail": "d",
-                    "blocking": True,
-                }
-            ],
-            "notes": "",
-        }
-    )
-    state, run_id = _write_parked_candidate(
-        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
-    )
-    monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: _RaiseOnRemeasure())
-    github = FakeGitHub()
-    outcome = resume_run(
-        state,
-        run_id,
-        dispatch=_fake_dispatch(),
-        github=github,  # type: ignore[arg-type]
-        bot_auth=NoAuth(),  # type: ignore[arg-type]
-        now=1_000_100.0,
-        panel_lenses=(PanelLens("review", _panel_judge([blocking])),),
-        harness=RevisingHarness(),
-        spec=author_spec(),
-        panel_revisions=1,
-    )
-    assert outcome.outcome == "improved"  # the original is drafted, not aborted
-    assert github.prs[0]["draft"] is True and load_record(state, run_id).state == "in-review"
 
 
 def test_resume_improved_reconciles_to_an_existing_pr(tmp_path, monkeypatch) -> None:

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -123,7 +123,9 @@ def test_author_sleep_park_persists_the_request_and_floors_on_the_launch(tmp_pat
     # floor rides the launch, so a healthy queued job never gets swept
     assert r.deadline == 1000.0 + (180 + 12 * 60) * 60
     assert r.stage["phase"] == "author-sleep"
-    assert r.stage["syscall_launches"] == [{"name": "train", "artifacts": ["out/curve.json"]}]
+    assert r.stage["syscall_launches"] == [
+        {"name": "train", "minutes": 180, "artifacts": ["out/curve.json"]}
+    ]
     assert r.stage["syscall_note"] == "compare to the lr sweep"
     assert r.resume_session_id == "s9"  # the record's own field; no stage duplicate
     assert r.stage["launches_used"] == 1 and r.stage["sleeps_used"] == 1
@@ -1820,7 +1822,9 @@ def test_author_sleep_live_parks_and_submits_launch_jobs(
     assert record.state == "waiting"
     assert record.stage["phase"] == "author-sleep"
     assert record.stage["afterany"] == "afterany:1000"
-    assert record.stage["syscall_launches"] == [{"name": "probe", "artifacts": ["out/tails.json"]}]
+    assert record.stage["syscall_launches"] == [
+        {"name": "probe", "minutes": 45, "artifacts": ["out/tails.json"]}
+    ]
     assert record.stage["syscall_note"] == "look at the tails"
     assert record.stage["launches_used"] == 1 and record.stage["sleeps_used"] == 1
     assert record.resume_session_id == "s1"  # the wake resumes the SAME session
@@ -2217,7 +2221,7 @@ def test_resume_repark_of_a_submitted_park_keeps_the_submit_context(tmp_path, mo
     )
     rec = load_record(state, run_id)
     rec.stage["submitted"] = True
-    rec.stage["syscall_launches"] = [{"name": "probe", "artifacts": ["out.txt"]}]
+    rec.stage["syscall_launches"] = [{"name": "probe", "minutes": 240, "artifacts": ["out.txt"]}]
     rec.stage["launches_used"] = 1
     rec.stage["sleeps_used"] = 1
     save_record(state, rec, 1_000_050.0)
@@ -2233,8 +2237,13 @@ def test_resume_repark_of_a_submitted_park_keeps_the_submit_context(tmp_path, mo
     record = load_record(state, run_id)
     assert record.state == "waiting"
     assert record.stage.get("submitted") is True
-    assert record.stage["syscall_launches"] == [{"name": "probe", "artifacts": ["out.txt"]}]
+    assert record.stage["syscall_launches"] == [
+        {"name": "probe", "minutes": 240, "artifacts": ["out.txt"]}
+    ]
     assert record.stage["launches_used"] == 1 and record.stage["sleeps_used"] == 1
+    # the deadline floor still covers the longest sibling launch (240 min) —
+    # an undershot floor would let the sweep cancel a healthy queued launch
+    assert record.deadline >= 1_000_100.0 + 240 * 60
 
 
 def test_resume_improved_pushes_and_opens_pr(tmp_path, monkeypatch) -> None:
@@ -2938,7 +2947,7 @@ def test_author_sleep_wake_can_sleep_again(tmp_path, monkeypatch) -> None:
     assert outcome.outcome == "parked"
     record = load_record(state, run_id)
     assert record.stage["phase"] == "author-sleep"
-    assert record.stage["syscall_launches"] == [{"name": "second", "artifacts": []}]
+    assert record.stage["syscall_launches"] == [{"name": "second", "minutes": 30, "artifacts": []}]
     assert record.stage["launches_used"] == 2 and record.stage["sleeps_used"] == 2
     # the second launch's job script was written for the sealed NEW tree
     assert (state / "runs" / run_id / "eval-launch-second" / "job.sh").exists()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -329,6 +329,36 @@ def test_failed_gate_submit_feeds_back_to_the_author(tmp_path: Path) -> None:
     assert harness.resumes == [None, "s1"]  # the author heard the gate result
 
 
+def test_inline_gate_never_dispatches_a_submits_sibling_launches(tmp_path: Path) -> None:
+    # terra #144 r2: siblings dispatch only once the gate has PROVEN dispatched
+    # (inside the MeasurementPending handler) — an inline gate would orphan
+    # launch jobs no wake ever gathers. The author is told they did not run
+    # and their budget stays unspent.
+    _write_syscall(
+        tmp_path,
+        {"launches": [{"name": "probe", "command": "x"}], "submit": True},
+    )
+    launched: list = []
+    harness = _SeqHarness(["the claim", "conceded"])
+    evaluator = FakeEvaluator(values=[13.9, 13.9, 13.9])
+    measurer, snapshot = _wire(evaluator, tmp_path)
+    result = climb_once(
+        CONFIG,
+        CONTRACT,
+        tmp_path,
+        harness,
+        measurer,
+        "base",
+        snapshot,
+        ruler="r",
+        changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+        created="t",
+        launcher=_fake_launcher(launched),
+    )
+    assert result.outcome == "no-improvement"
+    assert launched == []  # nothing dispatched, nothing orphaned
+
+
 def test_syscalls_are_ignored_without_a_launcher(tmp_path: Path) -> None:
     # feature off (no launcher wired): a stray request file is inert and the
     # climb behaves exactly as today.

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -268,6 +268,67 @@ def test_checkpoint_sleep_parks_with_no_dependency(tmp_path: Path) -> None:
     assert exc.value.launches_used == 0  # a checkpoint burns only the sleep
 
 
+def test_submit_parks_the_dispatched_gate_with_the_submitted_marker(tmp_path: Path) -> None:
+    # `submit` is a launch whose job is the GATE (buildout Phase B): the tree
+    # is sealed, the dispatched gate parks the run as a candidate carrying the
+    # submitted marker + budget counts, and a sibling launch rides the same
+    # afterany, submitted on the sealed sha.
+    from autoresearch.orchestrator import ClimbParked
+
+    _write_syscall(
+        tmp_path,
+        {"launches": [{"name": "probe", "command": "uv run probe.py"}], "submit": True},
+    )
+    launched: list = []
+    harness = FakeHarness(result=ok_session())
+    m = ParkingMeasurer(park_on_call=1)
+    with pytest.raises(ClimbParked) as exc:
+        climb_once(
+            CONFIG,
+            DEEP_CONTRACT,
+            tmp_path,
+            harness,
+            m,
+            "base",
+            _bare_snapshot(),
+            ruler="r",
+            changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+            created="t",
+            launcher=_fake_launcher(launched),
+        )
+    p = exc.value
+    assert p.phase == "candidate" and p.submitted
+    assert p.syscall is not None and p.syscall.submit
+    assert p.launches_used == 1 and p.sleeps_used == 1  # the submit rode one sleep
+    assert p.afterany.endswith(":900")  # gate evals + the sibling launch, one afterany
+    sha, request = launched[0]
+    assert sha == "cand1" and request.launches[0].name == "probe"
+
+
+def test_failed_gate_submit_feeds_back_to_the_author(tmp_path: Path) -> None:
+    # an inline gate that rejects a submitted candidate resumes the AUTHOR with
+    # the result (it decides what happens next) — never a silent terminal; the
+    # author's plain finish then ends the run honestly.
+    harness = _SeqHarness(["the claim", "conceded"], submit_on=(1,))
+    evaluator = FakeEvaluator(values=[13.9, 13.9, 13.9])
+    measurer, snapshot = _wire(evaluator, tmp_path)
+    result = climb_once(
+        CONFIG,
+        CONTRACT,
+        tmp_path,
+        harness,
+        measurer,
+        "base",
+        snapshot,
+        ruler="r",
+        changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+        created="t",
+        launcher=lambda sha, req: "",
+    )
+    assert result.outcome == "no-improvement"
+    assert harness.resumes == [None, "s1"]  # the author heard the gate result
+
+
 def test_syscalls_are_ignored_without_a_launcher(tmp_path: Path) -> None:
     # feature off (no launcher wired): a stray request file is inert and the
     # climb behaves exactly as today.
@@ -1052,15 +1113,28 @@ def test_shared_match_is_case_folded_like_the_other_path_checks(tmp_path: Path) 
 
 
 class _SeqHarness:
-    """Queued session results; records resume ids like the real backends."""
+    """Queued session results; records resume ids like the real backends.
+    A leg number in `submit_on` ends that leg with a staged `submit` syscall
+    (the author sealing its candidate for the gate + panel, buildout Phase B)."""
 
-    def __init__(self, texts: list[str], supports_resume: bool = True) -> None:
+    def __init__(
+        self, texts: list[str], supports_resume: bool = True, submit_on: tuple[int, ...] = ()
+    ) -> None:
         self._texts = list(texts)
         self.resumes: list[str | None] = []
         self.supports_resume = supports_resume
+        self.submit_on = set(submit_on)
 
     def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
         self.resumes.append(resume_session_id)
+        if len(self.resumes) in self.submit_on:
+            import json as _json
+
+            d = workspace / ".autoresearch"
+            d.mkdir(exist_ok=True)
+            (d / "syscall.json").write_text(
+                _json.dumps({"type": "sleep", "launches": [], "note": "", "submit": True})
+            )
         return SessionResult(
             stop_reason="end_turn",
             is_error=False,
@@ -1109,8 +1183,10 @@ def _verdict(blocking: bool, round_no: int):
     )
 
 
-def _run_panel_climb(tmp_path, values, verdicts, texts=None, revisions=1, supports_resume=True):
-    harness = _SeqHarness(texts or ["report r1", "report r2"], supports_resume=supports_resume)
+def _run_panel_climb(tmp_path, values, verdicts, texts=None, supports_resume=True, submit_on=()):
+    harness = _SeqHarness(
+        texts or ["report r1", "report r2"], supports_resume=supports_resume, submit_on=submit_on
+    )
     evaluator = FakeEvaluator(values=list(values))
     panel = _QueuedPanel(verdicts)
     measurer, snapshot = _wire(evaluator, tmp_path)
@@ -1126,7 +1202,11 @@ def _run_panel_climb(tmp_path, values, verdicts, texts=None, revisions=1, suppor
         changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
         created="t",
         panel_runner=panel,
-        panel_revisions=revisions,
+        # a stub launcher arms the syscall surface (submit rides it); no
+        # launch is ever staged by these tests so it must never be called
+        launcher=(lambda sha, req: (_ for _ in ()).throw(AssertionError("launcher called")))
+        if submit_on
+        else None,
     )
     return result, harness, evaluator, panel
 
@@ -1143,52 +1223,31 @@ def test_clean_panel_read_passes_through(tmp_path: Path) -> None:
     assert len(harness.resumes) == 1  # no wake
 
 
-def test_blocking_then_clean_revises_and_remeasures(tmp_path: Path) -> None:
+def test_blocking_verdict_on_a_submit_goes_back_to_the_author(tmp_path: Path) -> None:
+    # THE DEPTH-AXIS CORE (buildout Phase B): the author SUBMITS; the gate
+    # credits; the panel blocks -> the AUTHOR is resumed with the findings,
+    # revises, finishes -> re-measured, panel clean -> published.
     result, harness, evaluator, _panel = _run_panel_climb(
-        tmp_path, [13.9, 13.1, 13.0], [_verdict(True, 1), _verdict(False, 2)]
+        tmp_path,
+        [13.9, 13.1, 13.0],
+        [_verdict(True, 1), _verdict(False, 2)],
+        submit_on=(1,),
     )
     assert result.outcome == "improved"
     assert result.panel_rounds == 2 and not result.panel_blocking_open
-    # the wake resumed the SAME session and the revision was re-measured
+    # the verdict resumed the SAME session and the revision was re-measured
     assert harness.resumes == [None, "s1"]
     assert len(evaluator.calls) == 3  # baseline + candidate + revised candidate
     assert result.candidate == 13.0
     assert "round 1" in result.panel_transcript and "round 2" in result.panel_transcript
 
 
-def test_panel_revise_policy_decisions() -> None:
-    """The composition seam's decision policy (Phase 1): a pure function of the
-    read + the session's resumability. Clean -> halt; blocking+resumable+under-cap
-    -> revise; blocking but unresumable or capped -> halt-and-draft."""
-    from dataclasses import replace as dc_replace
-
-    from autoresearch.orchestrator import _Halt, _panel_revise_policy, _Revise
-
-    resumable = _SeqHarness([], supports_resume=True)
-    noresume = _SeqHarness([], supports_resume=False)
-    sess = ok_session()  # has session_id="s1"
-    no_id = dc_replace(sess, session_id="")
-
-    # clean read -> publish
-    assert _panel_revise_policy(_verdict(False, 1), sess, resumable, 1, 1) == _Halt()
-    # blocking, resumable, under the cap -> revise with the wake text
-    d = _panel_revise_policy(_verdict(True, 1), sess, resumable, 1, 1)
-    assert isinstance(d, _Revise) and d.prompt == _verdict(True, 1).wake_text
-    # blocking but no session id -> draft (can't resume)
-    assert _panel_revise_policy(_verdict(True, 1), no_id, resumable, 1, 1) == _Halt(True)
-    # blocking but a no-resume backend -> draft
-    assert _panel_revise_policy(_verdict(True, 1), sess, noresume, 1, 1) == _Halt(True)
-    # blocking but past the revision cap -> draft
-    assert _panel_revise_policy(_verdict(True, 2), sess, resumable, 2, 1) == _Halt(True)
-
-
 def test_a_backend_that_cannot_resume_drafts_a_blocking_finding(tmp_path: Path) -> None:
-    """a no-resume backend (hermes) declares supports_resume=False: a blocking
-    finding must DRAFT the verified improvement, never attempt a resume the
-    backend can't do that would lose it as a session-error (review #119 r2,
-    terra). Claude and codex both resume; hermes exercises this path."""
+    """a no-resume backend declares supports_resume=False: a blocking finding
+    on a SUBMITTED claim must DRAFT the verified improvement, never attempt a
+    resume the backend can't do that would lose it as a session-error."""
     result, harness, evaluator, _panel = _run_panel_climb(
-        tmp_path, [13.9, 13.1], [_verdict(True, 1)], supports_resume=False
+        tmp_path, [13.9, 13.1], [_verdict(True, 1)], supports_resume=False, submit_on=(1,)
     )
     assert result.outcome == "improved"  # improvement preserved, not session-error
     assert result.panel_blocking_open and result.panel_rounds == 1
@@ -1196,30 +1255,37 @@ def test_a_backend_that_cannot_resume_drafts_a_blocking_finding(tmp_path: Path) 
     assert len(evaluator.calls) == 2  # baseline + candidate only (no revise re-measure)
 
 
-def test_capped_out_blocking_stays_open_for_a_draft_pr(tmp_path: Path) -> None:
+def test_blocking_on_a_plain_finish_stays_open_for_a_draft_pr(tmp_path: Path) -> None:
+    # a finish WITHOUT a submit gets no author loop: blocking findings stay
+    # open and the caller drafts the PR for a human (the orchestrator-driven
+    # revision policy is retired — the author drives depth via submit)
     result, harness, _evaluator, _panel = _run_panel_climb(
-        tmp_path, [13.9, 13.1, 13.0], [_verdict(True, 1), _verdict(True, 2)]
+        tmp_path, [13.9, 13.1], [_verdict(True, 1)]
     )
     assert result.outcome == "improved"  # still credited; the PR will be a DRAFT
-    assert result.panel_blocking_open and result.panel_rounds == 2
-    assert len(harness.resumes) == 2  # exactly one revision at the cap
+    assert result.panel_blocking_open and result.panel_rounds == 1
+    assert harness.resumes == [None]  # NO resume without a submit
 
 
 def test_revision_that_loses_the_improvement_is_a_named_negative(tmp_path: Path) -> None:
-    result, _h, _e, _p = _run_panel_climb(tmp_path, [13.9, 13.1, 14.5], [_verdict(True, 1)])
+    # submit -> credited -> blocking -> the author revises... and the revision
+    # regresses. The gate ends it with the panel-context note. (The author is
+    # NOT resumed again: its submit was consumed; the regressed re-measure is
+    # a plain finish.)
+    result, _h, _e, _p = _run_panel_climb(
+        tmp_path, [13.9, 13.1, 14.5], [_verdict(True, 1)], submit_on=(1,)
+    )
     assert result.outcome == "no-improvement"
     assert "lost the improvement" in result.note
     assert result.panel_rounds == 1
 
 
 def test_panel_pr_body_carries_banner_and_transcript(tmp_path: Path) -> None:
-    result, _h, _e, _p = _run_panel_climb(
-        tmp_path, [13.9, 13.1, 13.0], [_verdict(True, 1), _verdict(True, 2)]
-    )
+    result, _h, _e, _p = _run_panel_climb(tmp_path, [13.9, 13.1], [_verdict(True, 1)])
     body = pr_body(result, CONFIG, redact_secrets=())
     assert body.startswith("> **Draft")
     assert "## Pre-PR verification" in body
-    assert "Verification round 2" in body
+    assert "Verification round 1" in body
 
 
 def test_degraded_final_read_marks_the_result_and_skips_the_wake(tmp_path: Path) -> None:

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -112,6 +112,15 @@ def test_invalid_requests_are_refused_loudly(tmp_path: Path, payload, match) -> 
         read_request(tmp_path)
 
 
+def test_read_request_carries_submit_and_rejects_a_non_bool(tmp_path: Path) -> None:
+    write_req(tmp_path, {"launches": [], "submit": True})
+    req = read_request(tmp_path)
+    assert req is not None and req.submit
+    write_req(tmp_path, {"launches": [], "submit": "yes"})
+    with pytest.raises(SyscallError, match="submit must be a boolean"):
+        read_request(tmp_path)
+
+
 def test_read_request_rejects_a_wrong_or_missing_type(tmp_path: Path) -> None:
     # a sleep is one syscall TYPE; a file with no type (a target-committed
     # booby-trap) or another type (a verdict) is not a sleep and is refused.

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -133,6 +133,17 @@ def test_artifact_path_check_matches_the_kernel(tmp_path: Path, capsys) -> None:
         assert tool_ok == kernel_ok(path), (path, tool_ok, kernel_ok(path))
 
 
+def test_submit_stages_and_rides_the_sleep(tmp_path: Path, capsys) -> None:
+    assert run(tmp_path, "submit") == 0
+    assert "sealed" in capsys.readouterr().out.lower()
+    assert run(tmp_path, "status") == 0
+    assert "submit staged" in capsys.readouterr().out
+    assert run(tmp_path, "sleep") == 0
+    assert "submit" in capsys.readouterr().out
+    req = read_request(tmp_path)
+    assert req is not None and req.submit and req.launches == ()
+
+
 def test_sleep_with_nothing_staged_is_a_checkpoint(tmp_path: Path, capsys) -> None:
     assert run(tmp_path, "sleep") == 0
     assert "checkpoint" in capsys.readouterr().out


### PR DESCRIPTION
## What

`syscall submit` — the author declares its candidate ready (buildout **Phase B**, role-cli **Phase 1**). Net **-30 lines**: the feature lands and the orchestrator-driven panel-revision loop retires in the same PR (invariant 3).

## The flow

- `submit` stages on the one syscall surface (a field on the sleep type — no second tool, no new dial); `sleep` commits it.
- The kernel seals the tree; the gate's paired evals and any **sibling launches** run as jobs on the sealed sha, merged into one `afterany`; the run parks as `candidate` with a `submitted` marker (counts + launches persisted like an author-sleep park).
- The wake reads the gate (and panel, on a credited claim):
  - **clean pass** → the sealed candidate publishes as a PR directly ("a clean first submit still opens a PR with no extra machinery");
  - **failed gate / blocking findings** → the SAME session resumes with the feedback leading its wake text (launch results + budgets follow) and the author decides: revise + resubmit, more experiments, or an honest negative finish.
- Inline (LocalMeasurer) deployments run the same loop in-session — one code path, `climb_once`'s decision loop.
- Budget: a submit costs only the sleep it rides on; `sleep_k` bounds the rounds.

## Retired (same PR)

`panel_revisions` / `--panel-revisions`, `_panel_revise_policy` (+ `_Revise`/`_Halt` seam), and the candidate wake's `_do_revise` re-entry. A plain finish (no submit) still runs the same gate + panel, but blocking findings now always **draft** the PR for a human — the kernel never re-enters the author by policy. The brief tells the author exactly this trade.

## Notes for review

- The submitted wake reuses the author-sleep wake frame (`_wake_author_sleep` + `extra_update`), so hibernation/park/lease semantics are identical to the live-validated Phase A path.
- Park floor for a submitted park with launches = max(gate eval walltime, longest launch).
- Single-job/plain-finish behavior is unchanged branch-for-branch; the no-resume-backend fallback (draft, never a blind resume) is preserved.

## Test plan

- New: dispatched submit park carries marker/counts/merged afterany; failed-gate submit feeds back to the author; blocking-verdict-on-submit resumes the author and re-parks the revision; CLI verb + ABI field validation.
- Rewritten: panel tests now pin the plain-finish-drafts and submit-loop behaviors; the `_do_revise`-internals tests are deleted with the machinery.
- Full suite: 778 passed; ruff check/format + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
