### PR TITLE
feat: contract-driven author syscalls — default-on, generous budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Author syscalls are CONTRACT-DRIVEN and on by default: the launch/sleep/
+  submit tool arms whenever the deployment can deliver it (dispatch coords +
+  a resumable backend) and the benchmark has not opted out. `depth_k: 0` is
+  the per-benchmark opt-out; defaults are now generous (`depth_k` 10, bounds
+  [0, 16]; `sleep_k` 20, bounds [1, 32]) — aggregate spend stays bounded by
+  the contract's `runs_per_week` plus the per-session walltime/turn caps.
+
+### Removed (enablement scaffolding)
+
+- The transitional dark-launch scaffolding around author syscalls, now that
+  the substrate is live-validated: the `AUTORESEARCH_AUTHOR_SYSCALLS` env
+  flag, the `climb --author-syscalls` one-off switch, and the dead
+  `AUTHOR_SLEEP_WAKE_READY` constant. Enablement lives in the contract, where
+  a per-benchmark knob belongs.
+
 ### Fixed
 
 - Multi-job parks are no longer blind: the tick's backup sweep now polls every

--- a/docs/design/role-cli.md
+++ b/docs/design/role-cli.md
@@ -72,7 +72,8 @@ lands with tests, and deletes what it replaces.
 The wake for `author-sleep` parks: gather each launch's results from the run
 dir, deliver declared artifacts into `.autoresearch/results/<name>/`, resume
 the **same session** through the climb's resume-entry (#129) with the results
-data-fenced, update the budget file, and flip `AUTHOR_SLEEP_WAKE_READY`. Plus
+data-fenced, update the budget file. (The transitional `AUTHOR_SLEEP_WAKE_READY`
+constant and env-flag arming have since retired: enablement is contract-driven.) Plus
 the brief/skill section that advertises the tool (never advertised before it
 can wake). **Acceptance:** an armed author launches, hibernates through a real
 (faked-Slurm in tests) job, wakes with output + artifacts, continues, and the

--- a/docs/validation/author-syscalls.md
+++ b/docs/validation/author-syscalls.md
@@ -1,21 +1,22 @@
 # Validating the author sleep/wake substrate (live)
 
-The author launch/sleep syscalls (`.autoresearch/syscall`, park→wake, artifact
-copy-out) are **fake-tested only** — never run on a real cluster. Before the
-substrate goes live (and before the `submit` verb, the env-flag decommission, or
-the `climb → attempt` rename build on it), run this once on Torch and watch the
-whole loop.
+> **VALIDATED 2026-08-25** on Torch (run `tsp-20260825-141345`): all six
+> milestones green — the codex author launched + slept unprompted, the same
+> session resumed with its launch's post-hibernation results, and the run
+> reached an honest negative terminal. The `--author-syscalls` /
+> `AUTORESEARCH_AUTHOR_SYSCALLS` arming described by the original runbook has
+> since RETIRED: enablement is contract-driven (dispatch coords + a resumable
+> backend + `depth_k > 0`; `depth_k: 0` is a benchmark's opt-out). The steps
+> below are kept for re-validation after substrate changes.
 
 ## Arm it (one climb only)
 
-`--author-syscalls` arms the feature for a SINGLE climb (ORed with the
-`AUTORESEARCH_AUTHOR_SYSCALLS` env flag), so you do **not** arm the whole tick.
-Two conditions must both hold:
+Enablement is contract-driven; a one-off validation climb just needs:
 
 - **Dispatch coords** (`--image` + account/partition): launches are jailed
-  Slurm jobs, so without them nothing launches.
-- **A launch budget**: `depth_k` (default 1 = one launch) caps launches; raise
-  it in the target's `.autoresearch.yaml` to test more.
+  Slurm jobs, so without them nothing launches (and the tool is not offered).
+- **A launch budget**: `depth_k` (default 10) caps launches; `depth_k: 0` in
+  the target's `.autoresearch.yaml` opts that benchmark out.
 
 Then run one climb by hand (not via the tick):
 
@@ -24,7 +25,6 @@ source env.sh
 uv run python -m autoresearch.climb \
   --target <org/repo> --benchmark <a-cheap-benchmark> \
   --run-root <run-root> --image <image.sif> \
-  --author-syscalls \
   <the account/partition/limit args the tick normally passes>
 ```
 
@@ -71,12 +71,13 @@ The lifecycle to confirm, in order:
 
 ## Kill switch
 
-The flag is per-run: to disable, just don't pass `--author-syscalls` (and keep
-`AUTORESEARCH_AUTHOR_SYSCALLS` unset so the tick stays off). A parked run with no
-wake ends with a named `session-error`, never a silent stuck loop.
+Per-benchmark: `depth_k: 0` in the target's `.autoresearch.yaml`; per-deployment:
+remove the dispatch coords. A parked run with no wake ends with a named
+`session-error`, never a silent stuck loop.
 
-## After green
+## After green (done 2026-08-25)
 
-Report back and the follow-ups unblock: build `submit` on the proven substrate
-(retiring the panel-revision loop), remove the dead `AUTHOR_SLEEP_WAKE_READY`
-constant, and migrate the env flag into contract-driven enablement.
+The follow-ups this validation unblocked have landed: `submit` on the proven
+substrate (the panel-revision loop retired with it), the dead
+`AUTHOR_SLEEP_WAKE_READY` constant removed, and the env flag migrated into
+contract-driven enablement.

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -290,13 +290,6 @@ def _post_issue_finished(
 # would cancel a still-queued job as "unschedulable".
 PARK_QUEUE_SLACK_MIN = 12 * 60
 
-# Author syscalls (research-loop-buildout.md Phase A) ship in two parts: the
-# sleep side exists, the WAKE (gather launch results, resume the session) is
-# part 2. Until part 2 flips this, arming AUTORESEARCH_AUTHOR_SYSCALLS alone
-# must not produce an unwakeable author-sleep park (terra, #132 r5) — the
-# feature stays off, loudly.
-AUTHOR_SLEEP_WAKE_READY = True  # Phase A part 2 shipped: the wake services author-sleep parks
-
 
 def _park_run(
     run_root: Path,
@@ -1469,7 +1462,6 @@ def live_climb(
     spec: RoleSpec | None = None,
     panel_lenses: tuple[PanelLens, ...] = (),
     dispatch: DispatchSettings | None = None,
-    author_syscalls: bool = False,
 ) -> LiveClimbOutcome:
     """Run one climb against the real target repo. With `panel_lenses`, the
     pre-PR verification panel gates the claim before any PR exists
@@ -1532,21 +1524,22 @@ def live_climb(
         base_sha = ws.git("rev-parse", f"origin/{base_branch}").strip()
         contract_text = (workspace / ".autoresearch.yaml").read_text()
         contract = load_contract(contract_text, config.target)
-        # With author syscalls armed, the channel (`.autoresearch/`) never
-        # enters diffs, scope, or drift fingerprints — repo-local exclude.
-        # Enabled by the `author_syscalls` arg OR the env flag (the tick inherits
-        # env; a one-off validation climb passes `--author-syscalls` so it need
-        # not arm the whole tick). With the feature off, an untracked
-        # `.autoresearch/` file must be staged and judged like any other agent
-        # edit, not silently hidden by a magic dir name (terra, #132 r2 — the off
-        # state stays byte-identical to today).
-        author_syscalls = author_syscalls or bool(os.environ.get("AUTORESEARCH_AUTHOR_SYSCALLS"))
-        if author_syscalls and not AUTHOR_SLEEP_WAKE_READY:
-            log.warning(
-                "AUTORESEARCH_AUTHOR_SYSCALLS is set but the wake side is not "
-                "built yet (Phase A part 2); author syscalls stay OFF this run"
-            )
-            author_syscalls = False
+        # Author syscalls (research-loop.md, "one syscall") are CONTRACT-DRIVEN:
+        # armed whenever the deployment can deliver them — dispatch coords (the
+        # launches and the gate run as Slurm jobs) and a resumable backend (the
+        # wake resumes the SAME session) — and the benchmark has not opted out
+        # (`depth_k: 0`). With the channel (`.autoresearch/`) armed it never
+        # enters diffs, scope, or drift fingerprints — repo-local exclude. With
+        # the feature off, an untracked `.autoresearch/` file must be staged
+        # and judged like any other agent edit, not silently hidden by a magic
+        # dir name (terra, #132 r2 — the off state stays byte-identical).
+        _bench = next((b for b in contract.benchmarks if b.name == config.benchmark), None)
+        author_syscalls = (
+            dispatch is not None
+            and getattr(harness, "supports_resume", True)
+            and _bench is not None
+            and _bench.depth_k > 0
+        )
         # The `.autoresearch/` channel must be KERNEL-OWNED. In a fresh clone,
         # anything already at that path was committed by the TARGET — a symlink
         # (install would write through it to a host path with our permissions —
@@ -1562,18 +1555,17 @@ def live_climb(
             )
             author_syscalls = False
         if author_syscalls:
+            assert _bench is not None
             syscall_excluded(workspace)
             # the author's interface is the TOOL (`python .autoresearch/syscall
             # launch ... -- <cmd>`; `... sleep`), never the raw ABI file —
             # install it plus the informational budget its `status` shows.
             syscall_install_tool(workspace)
-            _bench = next((b for b in contract.benchmarks if b.name == config.benchmark), None)
-            if _bench is not None:
-                syscall_write_budget(
-                    workspace,
-                    launches_remaining=_bench.depth_k,
-                    sleeps_remaining=_bench.sleep_k,
-                )
+            syscall_write_budget(
+                workspace,
+                launches_remaining=_bench.depth_k,
+                sleeps_remaining=_bench.sleep_k,
+            )
 
         def changed_paths() -> list[str]:
             ws.git("add", "-A")
@@ -1678,15 +1670,14 @@ def live_climb(
             snapshots.append(snap)
             return snap.commit
 
-        # Author syscalls (research-loop-buildout.md Phase A), dark by default:
-        # offered only when the operator arms AUTORESEARCH_AUTHOR_SYSCALLS, the
-        # dispatcher has cluster coordinates (the launches are Slurm jobs), and
-        # the backend can resume (the wake resumes the SAME session).
-        # `author_syscalls` already reflects the channel-ownership guard above
-        # (a target-shipped `.autoresearch` — symlink, tracked request, or any
-        # other pre-existing form — has disabled the feature for this run).
+        # `author_syscalls` already folds every enablement condition — dispatch
+        # coords, a resumable backend, the benchmark's opt-out, and the
+        # channel-ownership guard above (a target-shipped `.autoresearch` —
+        # symlink, tracked request, or any other pre-existing form — has
+        # disabled the feature for this run).
         launcher = None
-        if author_syscalls and dispatch is not None and getattr(harness, "supports_resume", True):
+        if author_syscalls:
+            assert dispatch is not None  # folded into author_syscalls above
             launcher = _make_launcher(dispatch, run_dir, workspace, run_id)
 
         parked: ClimbParked | None = None
@@ -2367,16 +2358,6 @@ def main() -> int:
         help="key file for panel judge sessions (the verifier's own key, never the author's)",
     )
     parser.add_argument(
-        "--author-syscalls",
-        action="store_true",
-        help="arm the author launch/sleep syscalls for THIS climb (a one-off "
-        "validation switch; equivalent to AUTORESEARCH_AUTHOR_SYSCALLS=1 but "
-        "scoped to this run, so it need not arm the whole tick). Launches need "
-        "dispatch coords (--image + account/partition) — without a launcher the "
-        "tool is simply not offered. The benchmark's depth_k caps how many "
-        "launches the author may make (default 1, enough to validate one).",
-    )
-    parser.add_argument(
         "--job-minutes",
         type=int,
         default=0,
@@ -2613,7 +2594,6 @@ def main() -> int:
                 spec=spec,
                 panel_lenses=panel_lenses,
                 dispatch=dispatch,
-                author_syscalls=args.author_syscalls,
                 evaluator=SubprocessEvaluator(container_image=args.image),
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -95,18 +95,18 @@ class Benchmark(_StrictModel):
     # Depth budget (docs/design/research-loop.md, "one syscall, author-directed"):
     # how many external experiment jobs the author may LAUNCH within one attempt.
     # A generous meter on actions, not a loop the kernel drives — the author
-    # decides what each launch is for. One of three independent counts (launches
-    # here; submit and sleep counts are its sibling knobs, landing with Phase A).
-    # 1 = today's one-shot. Per-benchmark so "does depth pay here?" is answerable
-    # per benchmark. The launch/sleep syscalls that consume it are the buildout's
-    # Phase A; the [1, 8] bound can widen then.
-    depth_k: int = Field(default=1, ge=1, le=8)
+    # decides what each launch is for. Per-benchmark so "does depth pay here?"
+    # is answerable per benchmark. The syscalls are CONTRACT-DRIVEN and on by
+    # default wherever the deployment can deliver them (dispatch coords + a
+    # resumable backend); `depth_k: 0` is a benchmark's opt-out — the tool is
+    # then not offered at all. Weekly spend stays bounded by `runs_per_week`.
+    depth_k: int = Field(default=10, ge=0, le=16)
     # Sleep budget, the sibling knob: how many dispatch->sleep->wake cycles the
     # author may spend. Independent of depth_k — launches meter external compute,
     # sleeps meter wake cycles (without this an author could checkpoint-refresh
     # its session clock forever and never launch). Batching is rewarded: many
-    # launches under one sleep burn one sleep.
-    sleep_k: int = Field(default=4, ge=1, le=16)
+    # launches under one sleep burn one sleep; a `submit` also rides one sleep.
+    sleep_k: int = Field(default=20, ge=1, le=32)
 
     @field_validator("seed_env")
     @classmethod

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -227,7 +227,6 @@ def _seed_target(tmp_path: Path, monkeypatch, contract: str) -> Path:
     bare = tmp_path / "origin.git"
     _git(tmp_path, "clone", "-q", "--bare", str(seed), str(bare))
 
-    from autoresearch import climb as climb_mod
     from autoresearch.github import Workspace
 
     real_clone = Workspace.clone
@@ -333,7 +332,6 @@ def run_live(
     author_backend="claude",
     author_model="claude-opus-5",
     author_key_file="",
-    author_syscalls=False,
 ) -> tuple:
     github = FakeGitHub()
     outcome = live_climb(
@@ -351,7 +349,6 @@ def run_live(
         author_backend=author_backend,
         author_model=author_model,
         author_key_file=author_key_file,
-        author_syscalls=author_syscalls,
     )
     return outcome, github
 
@@ -1000,7 +997,6 @@ def test_issue_run_references_issue_and_reports_back(tmp_path, target_repo) -> N
 def test_clone_crash_ends_record_and_reports_to_issue(tmp_path, monkeypatch) -> None:
     """A crash BEFORE the contained call (clone/contract/claim) must end the
     record and surface on the issue — not strand `implementing`."""
-    from autoresearch import climb as climb_mod
 
     def exploding_clone(url, dest, auth=None, dry_run=False):
         raise OSError(122, "Disk quota exceeded")
@@ -1032,7 +1028,6 @@ def test_clone_crash_ends_record_and_reports_to_issue(tmp_path, monkeypatch) -> 
 def _save_failing_after_first(monkeypatch):
     """save_record succeeds once (the implementing record) then raises — the
     quota-crisis failure mode where the ENDING write is what dies."""
-    from autoresearch import climb as climb_mod
 
     real_save = climb_mod.save_record
     calls = {"n": 0}
@@ -1103,7 +1098,6 @@ def test_final_record_failure_does_not_lose_pr_or_issue_report(
 def test_first_record_write_failure_is_contained(tmp_path, target_repo, monkeypatch) -> None:
     """If not even the initial record can be written, the run must not
     proceed invisibly OR crash the caller: climb-error plus an issue post."""
-    from autoresearch import climb as climb_mod
 
     def always_failing(root, record, now):
         raise OSError(122, "Disk quota exceeded")
@@ -1746,6 +1740,7 @@ def test_cheap_benchmark_ignores_dispatch_and_measures_inline(tmp_path, target_r
 
 
 CONTRACT_SYSCALLS = CONTRACT.replace("    direction: min\n", "    direction: min\n    depth_k: 3\n")
+CONTRACT_OPTOUT = CONTRACT.replace("    direction: min\n", "    direction: min\n    depth_k: 0\n")
 
 
 @pytest.fixture
@@ -1753,16 +1748,16 @@ def target_repo_syscalls(tmp_path: Path, monkeypatch) -> Path:
     return _seed_target(tmp_path, monkeypatch, CONTRACT_SYSCALLS)
 
 
-def test_author_syscalls_flag_arms_the_feature_without_the_env(
-    tmp_path, target_repo_syscalls, monkeypatch
-) -> None:
-    # the one-off validation switch: `--author-syscalls` (run_live's
-    # author_syscalls=True) arms the launch/sleep feature with the env flag
-    # UNSET, so a validation climb need not arm the whole tick.
+@pytest.fixture
+def target_repo_optout(tmp_path: Path, monkeypatch) -> Path:
+    return _seed_target(tmp_path, monkeypatch, CONTRACT_OPTOUT)
+
+
+def test_syscalls_arm_by_default_with_dispatch_and_resume(tmp_path, target_repo_syscalls) -> None:
+    # CONTRACT-DRIVEN enablement: no flag, no env — dispatch coords + a
+    # resumable backend + a benchmark that has not opted out arm the feature.
     import json as json_mod
 
-    monkeypatch.delenv("AUTORESEARCH_AUTHOR_SYSCALLS", raising=False)
-    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
     outcome, _ = run_live(
         tmp_path,
         target_repo_syscalls,
@@ -1774,11 +1769,29 @@ def test_author_syscalls_flag_arms_the_feature_without_the_env(
         },
         values=[],  # parked before any measurement
         dispatch=_fake_dispatch(),
-        author_syscalls=True,  # armed by the flag, not the env
     )
     assert outcome.outcome == "parked"
     record = load_record(tmp_path / "state", "tsp-1")
     assert record.state == "waiting" and record.stage["phase"] == "author-sleep"
+
+
+def test_depth_k_zero_opts_the_benchmark_out(tmp_path, target_repo_optout) -> None:
+    # `depth_k: 0` is the per-benchmark off switch: even with dispatch coords
+    # and a resumable backend, the tool is not installed and a stray request
+    # file is staged and judged like any other edit.
+    import json as json_mod
+
+    outcome, _ = run_live(
+        tmp_path,
+        target_repo_optout,
+        edits={
+            "src/pilot/solvers/tsp.py": "def solve(): return 'better'\n",
+            ".autoresearch/syscall.json": json_mod.dumps({"type": "sleep", "launches": []}),
+        },
+        values=[],  # scope refuses before any measurement
+        dispatch=_fake_dispatch(),
+    )
+    assert outcome.outcome == "scope-violation"  # staged + judged, not honored
 
 
 def test_author_sleep_live_parks_and_submits_launch_jobs(
@@ -1787,12 +1800,10 @@ def test_author_sleep_live_parks_and_submits_launch_jobs(
     # end-to-end sleep side (research-loop-buildout.md Phase A): the session
     # writes a syscall request and ends; the climb seals the tree, submits the
     # launch as a jailed job, and parks as author-sleep with the request +
-    # counts aboard. Feature armed via the env flag; cheap benchmark (no eval
-    # hint) — launches do not require a dispatched GATE, only dispatch coords.
+    # counts aboard. Cheap benchmark (no eval hint) — launches do not require
+    # a dispatched GATE, only dispatch coords.
     import json as json_mod
 
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_SYSCALLS", "1")
-    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
     outcome, github = run_live(
         tmp_path,
         target_repo_syscalls,
@@ -1834,7 +1845,7 @@ def test_author_sleep_live_parks_and_submits_launch_jobs(
     ws = tmp_path / "state" / "runs" / "tsp-1" / "ws"
     assert (ws / ".autoresearch" / "syscall").exists()
     budget = _json.loads((ws / ".autoresearch" / "budget.json").read_text())
-    assert budget == {"launches_remaining": 3, "sleeps_remaining": 4}
+    assert budget == {"launches_remaining": 3, "sleeps_remaining": 20}
     # the job is the eval jail on the sealed tree; the author's command travels
     # via command.txt (never shell-interpolated into the script)
     ev = tmp_path / "state" / "runs" / "tsp-1" / "eval-launch-probe"
@@ -1848,8 +1859,6 @@ def test_symlinked_channel_disables_syscalls_and_never_writes_through_it(
     # a target that commits `.autoresearch` as a SYMLINK to a host path must not
     # get the tool/exclude/budget written THROUGH it (terra #133 r1): a
     # pre-existing channel in any form disables the feature for the run.
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_SYSCALLS", "1")
-    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
     target = _seed_target(tmp_path, monkeypatch, CONTRACT_SYSCALLS)
     seed = tmp_path / "seed"
     escape = tmp_path / "ESCAPE"
@@ -1878,8 +1887,6 @@ def test_tracked_request_file_disables_syscalls_for_the_run(tmp_path, monkeypatc
     # the run and the climb proceeds normally (terra #132 r3).
     import json as json_mod
 
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_SYSCALLS", "1")
-    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
     target = _seed_target(tmp_path, monkeypatch, CONTRACT_SYSCALLS)
     seed = tmp_path / "seed"
     (seed / ".autoresearch").mkdir()
@@ -1913,35 +1920,10 @@ def test_tracked_request_file_disables_syscalls_for_the_run(tmp_path, monkeypatc
     assert sbatched == []
 
 
-def test_armed_flag_without_wake_ready_stays_fully_off(tmp_path, target_repo, monkeypatch) -> None:
-    # the interlock mechanism: with the wake declared not-ready, arming the env
-    # flag must not produce an unwakeable author-sleep park — the feature stays
-    # off for the run and the request file is inert AND staged like any edit
-    # (terra #132 r5). The shipped default is now READY (part 2 landed), so the
-    # not-ready state is set explicitly here to pin the guard itself.
-    import json as json_mod
-
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_SYSCALLS", "1")
-    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", False)
-    outcome, _ = run_live(
-        tmp_path,
-        target_repo,
-        edits={
-            "src/pilot/solvers/tsp.py": "def solve(): return 'better'\n",
-            ".autoresearch/syscall.json": json_mod.dumps(
-                {"launches": [{"name": "x", "command": "y"}]}
-            ),
-        },
-        values=[],
-        dispatch=_fake_dispatch(),
-    )
-    assert outcome.outcome == "scope-violation"  # staged + judged, exactly like flag-off
-
-
-def test_flag_off_stages_stray_syscall_files_like_any_edit(tmp_path, target_repo) -> None:
-    # with the feature OFF, the `.autoresearch/` name is NOT magic: an
-    # untracked file there is staged and judged like any other agent edit
-    # (here: out of scope), byte-identical to today (terra #132 r2).
+def test_syscalls_off_without_dispatch_treats_stray_files_as_edits(tmp_path, target_repo) -> None:
+    # with the feature OFF (no dispatch coords -> no launcher), the
+    # `.autoresearch/` name is NOT magic: an untracked file there is staged
+    # and judged like any other agent edit (here: out of scope) (terra #132 r2).
     outcome, _ = run_live(
         tmp_path,
         target_repo,
@@ -1954,13 +1936,10 @@ def test_flag_off_stages_stray_syscall_files_like_any_edit(tmp_path, target_repo
     assert outcome.outcome == "scope-violation"
 
 
-def test_flag_on_excludes_the_channel_from_the_candidate(
-    tmp_path, target_repo, monkeypatch
-) -> None:
-    # with the feature ON, the channel dir is invisible to diffs/scope/drift:
-    # a stray non-request file there neither blocks nor ships.
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_SYSCALLS", "1")
-    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
+def test_armed_syscalls_exclude_the_channel_from_the_candidate(tmp_path, target_repo) -> None:
+    # with the feature ON (dispatch coords present), the channel dir is
+    # invisible to diffs/scope/drift: a stray non-request file there neither
+    # blocks nor ships.
     outcome, _ = run_live(
         tmp_path,
         target_repo,
@@ -1969,6 +1948,7 @@ def test_flag_on_excludes_the_channel_from_the_candidate(
             ".autoresearch/notes.txt": "scratch",
         },
         values=[13.876, 13.1],
+        dispatch=_fake_dispatch(),
     )
     assert outcome.outcome == "improved"
 
@@ -1984,8 +1964,6 @@ def test_author_sleep_partial_submit_failure_cancels_earlier_jobs(
     from autoresearch.compute import CommandResult, SlurmCompute
     from autoresearch.measure import DispatchSettings
 
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_SYSCALLS", "1")
-    monkeypatch.setattr(climb_mod, "AUTHOR_SLEEP_WAKE_READY", True)
     cancelled: list[str] = []
     calls = {"sbatch": 0}
 
@@ -2032,7 +2010,6 @@ def test_failed_park_write_cancels_orphaned_eval_jobs(
     # the candidate park dispatched baseline+candidate (two jobs); if the
     # WAITING record then fails to write, nothing will ever wake those jobs, so
     # BOTH must be cancelled rather than left orphaned in the queue.
-    from autoresearch import climb as climb_mod
 
     cancelled: list[str] = []
     dispatch = _fake_dispatch(cancelled=cancelled)
@@ -2353,7 +2330,6 @@ def test_resume_negative_keeps_snapshot_if_the_record_save_fails(tmp_path, monke
     # a negative wake must save the ENDED record BEFORE dropping the snapshot:
     # if the save fails, the run stays recoverable (snapshot intact), never
     # WAITING with the candidate gone.
-    from autoresearch import climb as climb_mod
 
     state, run_id = _write_parked_candidate(
         tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
@@ -2402,7 +2378,6 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
     # the wake job holds the run's lease (transferred by the sweep on dispatch);
     # the --resume CLI must release it on every exit so a re-parked run is
     # immediately eligible for the next sweep, not stuck until the TTL reap.
-    from autoresearch import climb as climb_mod
     from autoresearch.climb import LiveClimbOutcome, main
     from autoresearch.runstate import acquire_lease, run_dir
 
@@ -2611,7 +2586,6 @@ def test_resume_panel_does_not_see_untracked_workspace_cruft(tmp_path, monkeypat
 def test_resume_panel_error_drafts_and_keeps_candidate(tmp_path, monkeypatch) -> None:
     # a panel ERROR (not a finding) must not abort the publish and drop the
     # candidate snapshot — the improvement is real. Fail closed to a DRAFT.
-    from autoresearch import climb as climb_mod
     from autoresearch.panel import PanelLens
 
     def boom(*a, **k):
@@ -2905,7 +2879,7 @@ def test_author_sleep_wake_delivers_results_and_flows_to_a_candidate_park(
     assert resumed == "s1"
     assert "tail improvement: 0.7" in wake_text  # the job's stdout, delivered
     assert "compare against the sweep" in wake_text  # the author's note, echoed
-    assert "2 launches and 3 sleeps remaining" in wake_text  # budgets visible
+    assert "2 launches and 19 sleeps remaining" in wake_text  # budgets visible
     assert ".autoresearch/results/probe/out.json" in wake_text
     # the artifact really landed in the excluded channel
     assert (wsroot / ".autoresearch" / "results" / "probe" / "out.json").read_text() == (

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -170,7 +170,7 @@ roadmap: docs/roadmap.md
         load_contract(base % "-0.1", "org/pilot")
 
 
-def test_depth_k_defaults_to_one_and_validates_range() -> None:
+def test_depth_k_defaults_generous_and_validates_range() -> None:
     # the per-benchmark depth dial: default 1 (single pass), bounded [1, 8].
     from autoresearch.contract import load_contract
 
@@ -181,9 +181,11 @@ budgets: {gpu_hours_per_run: 1, runs_per_week: 3}
 scope: {allowed: [src/]}
 roadmap: docs/roadmap.md
 """
-    assert load_contract(base % "", "org/pilot").benchmarks[0].depth_k == 1
+    assert load_contract(base % "", "org/pilot").benchmarks[0].depth_k == 10
     assert load_contract(base % ", depth_k: 4", "org/pilot").benchmarks[0].depth_k == 4
-    for bad in (", depth_k: 0", ", depth_k: 9"):
+    # 0 is the per-benchmark opt-out (syscalls off); negatives/over-cap refuse
+    assert load_contract(base % ", depth_k: 0", "org/pilot").benchmarks[0].depth_k == 0
+    for bad in (", depth_k: -1", ", depth_k: 17"):
         with pytest.raises(ValidationError):
             load_contract(base % bad, "org/pilot")
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -369,7 +369,7 @@ def test_syscalls_are_ignored_without_a_launcher(tmp_path: Path) -> None:
 
 
 def test_over_budget_request_wakes_one_refusal_then_measures(tmp_path: Path) -> None:
-    # default depth_k=1: a two-launch ask exceeds the budget. The author is
+    # depth_k=1 here: a two-launch ask exceeds the budget. The author is
     # woken ONCE with the refusal (same session), then the climb measures the
     # tree as it stands. Nothing was launched.
     _write_syscall(
@@ -377,7 +377,10 @@ def test_over_budget_request_wakes_one_refusal_then_measures(tmp_path: Path) -> 
         {"launches": [{"name": "a", "command": "x"}, {"name": "b", "command": "y"}]},
     )
     launched: list = []
-    result, harness, _ = run_climb(tmp_path, [13.876, 13.10], launcher=_fake_launcher(launched))
+    tight = CONTRACT.replace("    direction: min\n", "    direction: min\n    depth_k: 1\n", 1)
+    result, harness, _ = run_climb(
+        tmp_path, [13.876, 13.10], contract=tight, launcher=_fake_launcher(launched)
+    )
     assert result.outcome == "improved" and launched == []
     refusal_text, _ws, resumed = harness.calls[1]  # second call = the refusal wake
     assert "REFUSED" in refusal_text and "launch budget" in refusal_text


### PR DESCRIPTION
## What

The last cleanup the live validation unblocked: author syscalls become **contract-driven and on by default**, and the dark-launch scaffolding retires. Net −22 lines.

## Enablement (one rule, no flags)

The launch/sleep/submit tool arms iff:
- the deployment can deliver it — **dispatch coords** (launches and the gate run as Slurm jobs) + a **resumable backend** (the wake resumes the same session), and
- the benchmark has not opted out — **`depth_k: 0`** is the per-benchmark off switch.

Removed: `AUTORESEARCH_AUTHOR_SYSCALLS`, `climb --author-syscalls`, and the dead `AUTHOR_SLEEP_WAKE_READY` constant. The channel-ownership guard (a target-shipped `.autoresearch` disables the run's feature, loudly) and the off-state (stray channel files are staged and judged like any edit) are unchanged.

## Budgets (maintainer decision)

`depth_k` default **10** (bounds [0, 16]), `sleep_k` default **20** (bounds [1, 32]). Aggregate spend stays bounded by the contract's `runs_per_week` (enforced by the tick's picker), the one-active-run rule, and per-session walltime/turn caps.

## Fleet impact

At the next tick deploy, every dispatched climb (codex author resumes) arms the tool with 10/20 budgets — depth becomes part of the substrate, per docs/design/research-loop.md. In-flight parked runs are unaffected (the wake path never read the flag).

## Test plan

- New: default-on arming with no flag/env; `depth_k: 0` opt-out (tool not installed, stray request staged+judged).
- Updated: budget expectations (10/20), contract bounds, the over-budget refusal test pins `depth_k: 1` explicitly.
- Deleted with the machinery: the wake-ready interlock test.
- Full suite: 782 passed; ruff check/format + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
