### PR TITLE
feat: one publish — the sealed candidate sha, everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- One publish — the sealed candidate sha, everywhere. `live_climb`'s inline
+  publish (workspace commit + drift fingerprints + the moved-base
+  merge/re-measure machinery) is retired: every improved run now branches the
+  SEALED `candidate_sha` and layers only the ledger commit on top, exactly as
+  the wake publish always has. With every gate eval running on a fresh
+  checkout of its sealed sha (the compute unification), eval-time workspace
+  drift is structurally impossible, so the fingerprint forensics guarded
+  nothing. A base branch that moves during a climb is no longer merged and
+  re-measured by the orchestrator — the PR opens against the moved base as-is
+  and review handles staleness, the wake path's long-standing stance
+  (docs/design/research-loop.md: a stale PR is a re-wake, not an auto-merge).
+
 - One compute interface, one measurer (`SlurmCompute` vs `LocalCompute` —
   Mengye's framing): `LocalCompute` runs the identical eval-job scripts as
   synchronous subprocesses in the current allocation, so `DispatchedMeasurer`

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -195,9 +195,9 @@ which wakes any run whose job reads terminal after the grace period —
 plus GONE past the deadline (vanished) and PENDING past the deadline
 (cancel, then wake as unschedulable); a still-RUNNING job is deliberately
 left alone, bounded by its own walltime; wakes that fire without producing
-progress -> `stuck` at MAX_WAKE_ATTEMPTS. A moved base during the wait -> the existing
-merged-tree re-gate covers it, since re-entry re-checks freshness like any
-other resumption. Worktree cleanup has a named owner at every exit: the
+progress -> `stuck` at MAX_WAKE_ATTEMPTS. A moved base during the wait is
+review's to handle — the sealed candidate publishes as-is (research-loop.md:
+a stale PR is a re-wake, never an orchestrator auto-merge). Worktree cleanup has a named owner at every exit: the
 wake's own finally (primary, as in-job measures do today), the sweep's
 run-ending path when a run dies waiting (best-effort rmtree of the run
 dir's measure worktrees, same never-silent discipline), and ended-run

--- a/docs/design/roles.md
+++ b/docs/design/roles.md
@@ -54,7 +54,7 @@ flowchart TD
     subgraph climb [Climb job - bounded by contract limits]
         C["clone (bot auth) + record FIRST"] --> B["orchestrator measures baseline"]
         B --> A["author session<br/>(contained, scrubbed env,<br/>self-deadline armed)"]
-        A --> E["orchestrator measures candidate<br/>scope + drift fingerprints"]
+        A --> E["orchestrator measures candidate<br/>(sealed sha, fresh checkout) + scope"]
         E --> F{improved?}
     end
 
@@ -210,7 +210,7 @@ finding survives.
 
 | Boundary | Enforced by |
 |---|---|
-| Solver never touches ruler/contract/progress files | scope veto + commit veto + drift fingerprints (code) |
+| Solver never touches ruler/contract/progress files | scope veto + ledger-only publish commit on the sealed sha (code) |
 | Numbers come only from the orchestrator | climb_once re-measures; PR body states it; CI re-verifies |
 | Reviewer never reviews its own pipeline's PRs automatically | bot-author skip (code) |
 | Verifier ≠ author | different role, prompt, key; reads adversarially |

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1497,6 +1497,11 @@ def live_climb(
 
     try:
         ws = Workspace.clone(_target_clone_url(config.target), workspace, auth=bot_auth)
+        # Build ON the requested PR base: the clone checks out the remote
+        # DEFAULT branch, which need not be `base_branch` — the session must
+        # edit, and the gate must measure, the tree the PR will land on
+        # (terra #147 r3). A missing base branch fails loudly as climb-error.
+        ws.git("checkout", "-q", "-B", base_branch, f"origin/{base_branch}")
         contract_text = (workspace / ".autoresearch.yaml").read_text()
         contract = load_contract(contract_text, config.target)
         # Author syscalls (research-loop.md, "one syscall") are CONTRACT-DRIVEN:

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -164,6 +164,41 @@ def _target_clone_url(target: str) -> str:
     return f"https://github.com/{target}.git"
 
 
+def _arm_unless_base_moved(
+    github: GitHubClient,
+    ws: Workspace,
+    target: str,
+    pr_number: str,
+    base_branch: str,
+    measured_base_sha: str,
+    secrets: tuple[str, ...],
+) -> None:
+    """Arm auto-merge only while origin/<base_branch> still equals the base the
+    claim was measured against. A moved base still OPENS the PR — review owns
+    staleness — but never ARMS it: merging a tree whose gate/suite/panel read
+    is stale must be a human's deliberate act, not an armed automation. A
+    failed freshness fetch also declines to arm (fail-safe: un-armed is just a
+    normal PR). Best-effort throughout, like arming itself."""
+
+    def _check_and_arm() -> None:
+        ws.git_network("fetch", str(ws.url or ws.remote_url()), base_branch)
+        fresh = ws.git("rev-parse", "FETCH_HEAD").strip()
+        if fresh != measured_base_sha:
+            log.info(
+                "not arming auto-merge on %s#%s: %s moved since the claim was "
+                "measured (%s -> %s); a human merges this one",
+                target,
+                pr_number,
+                base_branch,
+                measured_base_sha[:12],
+                fresh[:12],
+            )
+            return
+        github.arm_auto_merge_when_review_required(target, int(pr_number))
+
+    _best_effort("auto-merge arming", _check_and_arm, secrets)
+
+
 def _title_pair(a: float, b: float) -> str:
     """Compact but never ambiguous: widen precision until the two numbers
     render differently (a title reading '10.00 -> 10.00' looks like no
@@ -988,12 +1023,8 @@ def resume_run(
             )
             pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
             if pr_number.isdigit() and not existing.get("draft"):
-                _best_effort(
-                    "auto-merge arming",
-                    lambda: github.arm_auto_merge_when_review_required(
-                        config.target, int(pr_number)
-                    ),
-                    secrets,
+                _arm_unless_base_moved(
+                    github, ws, config.target, pr_number, base_branch, base_sha, secrets
                 )
             report_path = run_dir / "report.md"
             _best_effort(
@@ -1162,12 +1193,8 @@ def resume_run(
             )
             pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
             if pr_number.isdigit() and not draft:
-                _best_effort(
-                    "auto-merge arming",
-                    lambda: github.arm_auto_merge_when_review_required(
-                        config.target, int(pr_number)
-                    ),
-                    secrets,
+                _arm_unless_base_moved(
+                    github, ws, config.target, pr_number, base_branch, base_sha, secrets
                 )
         except Exception as exc:
             # push / PR / commit failed — end as an error. Save the ENDED record
@@ -1828,15 +1855,12 @@ def live_climb(
             )
             # Arm auto-merge, best-effort, and ONLY when branch protection
             # requires a human review — the guard keeps bot-never-merges
-            # enforced in code, not in per-repo config. Never arm a draft.
+            # enforced in code, not in per-repo config. Never arm a draft,
+            # and never arm a claim whose base has moved (_arm_unless_base_moved).
             pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
             if pr_number.isdigit() and not (result.panel_blocking_open or result.panel_degraded):
-                _best_effort(
-                    "auto-merge arming",
-                    lambda: github.arm_auto_merge_when_review_required(
-                        config.target, int(pr_number)
-                    ),
-                    secrets,
+                _arm_unless_base_moved(
+                    github, ws, config.target, pr_number, base_branch, pre_session_sha, secrets
                 )
             final = RunRecord(
                 **{

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -33,7 +33,6 @@ from autoresearch.dispatch import (
 )
 from autoresearch.github import (
     FileTokenProvider,
-    GitError,
     GitHubClient,
     Workspace,
 )
@@ -44,18 +43,12 @@ from autoresearch.orchestrator import (
     ClimbParked,
     ClimbResult,
     EvalError,
-    Evaluator,
     Measurer,
-    SubprocessEvaluator,
-    SuiteMeasurement,
     _benchmark,
     climb_once,
-    out_of_scope,
     pr_body,
     resume_climb,
-    suite_regressed,
 )
-from autoresearch.orchestrator import improved as orch_improved
 from autoresearch.panel import PanelLens, PanelVerdict, run_panel
 from autoresearch.progress import (
     PROGRESS_PATHS,
@@ -162,12 +155,6 @@ def resume_author(record: object, fleet_model: str) -> tuple[str, str, str]:
 
 class WorkspaceDrift(RuntimeError):
     """The tree changed between measurement and commit."""
-
-
-class SuiteRegressed(RuntimeError):
-    """A sibling benchmark regressed beyond its floor on the landing tree —
-    the improvement was bought by breaking siblings. An honest negative
-    result wherever it is caught, never an abort."""
 
 
 def _target_clone_url(target: str) -> str:
@@ -1280,39 +1267,6 @@ def resume_run(
     return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
 
 
-def _measure_committed(
-    ws: Workspace,
-    evaluator: Evaluator,
-    run_dir: Path,
-    name: str,
-    sha: str,
-    bench: Any,
-    extra_env: dict[str, str] | None = None,
-) -> float:
-    """Measure a COMMITTED tree in a throwaway worktree.
-
-    Both sides of the post-merge comparison run in equivalent pristine
-    environments — the long-lived workspace carries session-created caches
-    and virtualenvs a fresh tree lacks, so measuring one side there would
-    bias the accept/reject decision. Eval writes are discarded with the
-    worktree, and the measured content is exactly the commit: the sha IS
-    the drift fingerprint.
-    """
-    wt = run_dir / f"measure-{name}"
-    ws.git("worktree", "add", "--detach", str(wt), sha)
-    try:
-        return float(evaluator.evaluate(wt, bench.command, bench.metric, extra_env=extra_env))
-    finally:
-        removed = _best_effort(
-            "worktree cleanup", lambda: ws.git("worktree", "remove", "--force", str(wt))
-        )
-        if not removed:  # never silent: a leaked worktree is a disk leak —
-            # and prune alone only drops the ADMIN entry, so delete the
-            # directory itself first
-            _best_effort("worktree dir removal", lambda: shutil.rmtree(wt, ignore_errors=True))
-            _best_effort("worktree prune", lambda: ws.git("worktree", "prune"))
-
-
 def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
     """Build the verification-panel lenses from the CLI args (empty `--panel`
     disables it). Shared by the fresh-climb and the `--resume` wake paths so a
@@ -1446,7 +1400,6 @@ def live_climb(
     run_root: Path,
     run_id: str,
     harness: Harness,
-    evaluator: Evaluator,
     github: GitHubClient,
     bot_auth: FileTokenProvider,
     now: float,
@@ -1515,13 +1468,8 @@ def live_climb(
             )
         return LiveClimbOutcome(run_id=run_id, outcome="climb-error")
 
-    tree_hashes: list[str] = []
     try:
         ws = Workspace.clone(_target_clone_url(config.target), workspace, auth=bot_auth)
-        # the BASE BRANCH tip, not HEAD: they differ if the PR base is ever
-        # not the clone's default branch, and the freshness comparison below
-        # must be against the branch the PR will actually land on
-        base_sha = ws.git("rev-parse", f"origin/{base_branch}").strip()
         contract_text = (workspace / ".autoresearch.yaml").read_text()
         contract = load_contract(contract_text, config.target)
         # Author syscalls (research-loop.md, "one syscall") are CONTRACT-DRIVEN:
@@ -1570,10 +1518,6 @@ def live_climb(
         def changed_paths() -> list[str]:
             ws.git("add", "-A")
             paths = ws.staged_paths()
-            # Content fingerprint of the whole tree: the drift check must
-            # catch a file REWRITTEN during eval (same path set, different
-            # bytes), not only files created or deleted.
-            tree_hashes.append(ws.git("write-tree").strip())
             ws.git("reset")
             return paths
 
@@ -1793,6 +1737,11 @@ def live_climb(
             report_path=str(report_path) if wrote else "",
         )
 
+    if result.outcome == "improved" and not result.measured_paths:
+        # a zero-change "improvement" is metric noise, not progress — never a
+        # PR (same rule as the wake publish)
+        result = dc_replace(result, outcome="no-improvement", note="no code change; metric noise")
+
     report = result.report(config, redact_secrets=secrets)
     report_path = run_dir / "report.md"
     wrote_report = _best_effort("run report", lambda: report_path.write_text(report), secrets)
@@ -1803,208 +1752,25 @@ def live_climb(
     pushed = False
     if result.outcome == "improved":
         try:
-            # The committed tree must be EXACTLY the measured tree: code the
-            # agent's solver wrote during the candidate eval was neither
-            # scope-checked nor measured, so its presence voids the claim.
-            if not result.measured_paths:
-                raise WorkspaceDrift("improved with zero code changes — metric noise, not progress")
-            post_eval = set(changed_paths())
-            if post_eval != set(result.measured_paths):
-                drift = sorted(post_eval.symmetric_difference(result.measured_paths))
-                raise WorkspaceDrift(f"workspace changed during eval: {drift[:10]}")
-            # Fail CLOSED: two fingerprints must exist (pre-eval from
-            # climb_once's scope check, post-eval from just above) — a
-            # missing one means the drift protection did not run.
-            if len(tree_hashes) < 2:
-                raise WorkspaceDrift("content fingerprints missing; drift check did not run")
-            if tree_hashes[-1] != tree_hashes[-2]:
-                raise WorkspaceDrift(
-                    "file contents changed during eval (same paths, different bytes)"
-                )
-            # unique branch per run: a fixed name collides on the second run
+            # Publish the SEALED candidate sha — never the live tree, which
+            # may have drifted since the snapshot (eval caches, stray writes).
+            # The sha is exactly the measured, scope-checked content, so the
+            # old drift-fingerprint apparatus retires with the workspace
+            # commit. A base branch that moved during the climb is NOT merged
+            # and re-measured here: a stale PR is review's to handle — the
+            # stance the wake publish has always had (research-loop.md).
             branch = f"{config.branch_prefix}/{run_id}"
-            ws.branch(branch)
-            if result.baseline is None or result.candidate is None:
-                raise WorkspaceDrift("improved result missing measurements")
+            if result.baseline is None or result.candidate is None or not result.candidate_sha:
+                raise EvalError("improved result missing measurements or the sealed sha")
             bench = next(b for b in contract.benchmarks if b.name == config.benchmark)
             baseline, candidate = result.baseline, result.candidate
-
-            # Freshness: the base branch may have MOVED during the climb
-            # (sessions run for many minutes; another PR can merge meanwhile).
-            # Landing the change on the clone's snapshot would open a
-            # conflicted PR — or worse, a clean-merging one whose claim was
-            # never measured against what it actually lands on. So: merge the
-            # moved base INTO the run branch (merge commit — never rebase)
-            # and re-measure on the merged tree before anything is pushed.
-            ws.git_network("fetch", str(ws.url or ws.remote_url()), base_branch)
-            fresh_base = ws.git("rev-parse", "FETCH_HEAD").strip()
-            base_moved = fresh_base != base_sha
-            if base_moved:
-                # the agent's work goes in its own commit first, so the merge
-                # commit stays a pure merge
-                ws.commit_all(
-                    f"agent: improve {config.benchmark}\n\nAgent: {config.agent_id}",
-                    author=config.bot_login,
-                    forbidden=lambda p: bool(out_of_scope([p], contract)),
-                )
-                try:
-                    ws.git(
-                        "-c",
-                        f"user.name={config.bot_login}",
-                        "-c",
-                        f"user.email={config.bot_login}@users.noreply.github.com",
-                        "merge",
-                        "--no-edit",
-                        "FETCH_HEAD",
-                    )
-                except GitError as exc:
-                    # a content conflict and an infrastructure failure need
-                    # different triage — do not report one as the other
-                    conflicted = False
-                    with contextlib.suppress(GitError):
-                        conflicted = bool(ws.git("ls-files", "-u").strip())
-                    with contextlib.suppress(GitError):
-                        ws.git("merge", "--abort")
-                    if conflicted:
-                        raise WorkspaceDrift(
-                            f"base branch moved during the climb and the merge "
-                            f"conflicted: {str(exc)[:300]}"
-                        ) from exc
-                    raise WorkspaceDrift(
-                        f"base branch moved and the merge FAILED (not a content "
-                        f"conflict): {str(exc)[:300]}"
-                    ) from exc
-                # The claim must hold on the tree that actually lands —
-                # BOTH sides of it. Upstream may have changed the metric for
-                # everyone, so comparing a merged-tree candidate against the
-                # pre-merge baseline would describe a delta that never
-                # existed on any single tree (and could push a regression
-                # relative to the fresh base). Both sides are measured in
-                # throwaway worktrees of COMMITS — equivalent pristine
-                # environments, and no dirty-tree check needed: eval writes
-                # are discarded with the worktree and the shas pin content.
-                merged_sha = ws.git("rev-parse", "HEAD").strip()
-                seed_env = (
-                    {bench.seed_env: str(result.run_seed)}
-                    if bench.seed_env and result.run_seed
-                    else None
-                )
-                baseline = _measure_committed(
-                    ws, evaluator, run_dir, "fresh-base", fresh_base, bench, seed_env
-                )
-                candidate = _measure_committed(
-                    ws, evaluator, run_dir, "merged", merged_sha, bench, seed_env
-                )
-                if not orch_improved(
-                    baseline, candidate, bench.direction, config.min_relative_improvement
-                ):
-                    raise WorkspaceDrift(
-                        f"candidate {candidate} does not beat the fresh base's "
-                        f"{baseline} after merging the moved base (upstream "
-                        f"absorbed or invalidated the improvement)"
-                    )
-                suite = result.suite
-                if suite:
-                    # the suite gate must hold on the tree that actually lands,
-                    # same as the claim itself — re-measure every sibling on
-                    # the fresh pair under the recorded suite seed
-                    rows = []
-                    for i, row in enumerate(suite):
-                        sib = next(b for b in contract.benchmarks if b.name == row.name)
-                        env = (
-                            {sib.seed_env: str(result.suite_seed)}
-                            if sib.seed_env and result.suite_seed
-                            else None
-                        )
-                        # worktree labels use the sibling INDEX: the name is
-                        # contract text (untrusted) and must not shape a path
-                        sib_base = _measure_committed(
-                            ws, evaluator, run_dir, f"fresh-base-sib{i}", fresh_base, sib, env
-                        )
-                        sib_cand = _measure_committed(
-                            ws, evaluator, run_dir, f"merged-sib{i}", merged_sha, sib, env
-                        )
-                        regressed = suite_regressed(
-                            sib_base, sib_cand, sib.direction, sib.min_delta, sib.min_delta_rel
-                        )
-                        if regressed:
-                            raise SuiteRegressed(
-                                f"suite regression after merging the moved base: "
-                                f"{sib.name} {sib_base} -> {sib_cand}"
-                            )
-                        rows.append(
-                            SuiteMeasurement(
-                                name=sib.name,
-                                baseline=sib_base,
-                                candidate=sib_cand,
-                                regressed=False,
-                                display_digits=sib.display_digits,
-                            )
-                        )
-                    suite = tuple(rows)
-                if panel_lenses:
-                    # the merged tree may carry an UPDATED contract: the
-                    # fresh panel judges by the rules it will land under
-                    try:
-                        fresh_contract = ws.git("show", f"{fresh_base}:.autoresearch.yaml")
-                    except GitError:
-                        fresh_contract = contract_text
-                    # the panel's verdict must hold on the tree that actually
-                    # lands, same as the claim and the suite gate (terra, #95
-                    # round 5). No wake here — the session has concluded, so
-                    # blocking or degraded goes straight to the draft path.
-                    merged_runner = build_panel_runner(
-                        ws,
-                        run_dir,
-                        fresh_base,
-                        panel_lenses,
-                        fresh_contract,
-                        config.target,
-                        config.benchmark,
-                        config.bot_login,
-                        created[:10],
-                        start_round=result.panel_rounds,
-                    )
-                    verdict = merged_runner(
-                        baseline,
-                        candidate,
-                        result.session.final_text if result.session else "",
-                    )
-                    joined = (
-                        f"{result.panel_transcript}\n\n{verdict.transcript}"
-                        if result.panel_transcript
-                        else verdict.transcript
-                    )
-                    result = dc_replace(
-                        result,
-                        panel_transcript=joined,
-                        panel_rounds=result.panel_rounds + 1,
-                        panel_blocking_open=result.panel_blocking_open or bool(verdict.blocking),
-                        panel_degraded=verdict.degraded,
-                    )
-                result = dc_replace(result, baseline=baseline, candidate=candidate, suite=suite)
-
-            # the report was written from the PRE-freshness result: refresh
-            # it so the merged-tree measurements and panel verdict are the
-            # record (terra note, #95 round 7)
-            _best_effort(
-                "run report refresh",
-                lambda: report_path.write_text(result.report(config, redact_secrets=secrets)),
-                secrets,
-            )
-
-            # Progress record (BENCHMARKS.md + results/leader.json), written
-            # by the orchestrator from ITS measurements after the drift check
-            # — read from the (possibly merged) tree, so the leader check runs
-            # against the FRESH ledger, not the clone's snapshot.
-            # We credit BEATING YOUR OWN BASELINE, not only beating the recorded
-            # best (docs/design/research-loop.md, "two kinds of win"): a clean
-            # composable win — improving over base_sha by the gate's threshold —
-            # is a valid PR even when it is not the new SOTA. So there is no
-            # recorded-best hard-fail here; the gate (`measure_and_decide`) has
-            # already required candidate to beat base_sha on paired seeds. The
-            # ledger's `best` still only advances on a genuine improvement over
-            # it (update_leader), so SOTA stays tracked — just not required.
+            # FORCE-checkout: the workspace still holds the session's dirty
+            # tree. The snapshot commit is anchored by the new branch (the
+            # dropped dispatch ref left it unreferenced; nothing pruned it in
+            # this process). clean -fd drops post-snapshot cruft so the
+            # pushed tree is exactly candidate_sha plus the ledger commit.
+            ws.git("checkout", "-f", "-B", branch, result.candidate_sha)
+            ws.git("clean", "-fd")
             entries = update_leader(
                 load_leader(workspace),
                 benchmark=bench.name,
@@ -2022,26 +1788,24 @@ def live_climb(
                 config.target,
                 digits={b.name: b.display_digits for b in contract.benchmarks if b.display_digits},
             )
-            # The commit veto re-checks FULL scope (allowed + forbidden) as
-            # defense in depth behind climb_once's pre-eval check. The two
-            # orchestrator-written progress files are the only exemption.
-            # (When the base moved, the agent's work is already committed and
-            # only the progress files remain to stage.)
-            ws.commit_all(
-                f"agent: improve {config.benchmark} "
-                f"({_title_pair(baseline, candidate)})"
-                f"\n\nAgent: {config.agent_id}",
-                author=config.bot_login,
-                forbidden=lambda p: p not in PROGRESS_PATHS and bool(out_of_scope([p], contract)),
-            )
-            # Last-moment re-check: the re-measurement above can take
-            # minutes, and the base can move AGAIN meanwhile. This narrows
-            # the unverified window to seconds; it cannot eliminate it.
-            ws.git_network("fetch", str(ws.url or ws.remote_url()), base_branch)
-            if ws.git("rev-parse", "FETCH_HEAD").strip() != fresh_base:
-                raise WorkspaceDrift(
-                    "base branch moved again during re-measurement; "
-                    "ending without pushing (a later run will retry)"
+            # Stage ONLY the ledger files on top of the sealed candidate —
+            # never `git add -A`, which would sweep in anything a session or
+            # eval left behind (same rule as the wake publish).
+            ws.git("add", "--", *PROGRESS_PATHS)
+            staged = ws.staged_paths()
+            extra = [p for p in staged if p not in PROGRESS_PATHS]
+            if extra:
+                raise WorkspaceDrift(f"publish would stage non-ledger paths: {extra[:10]}")
+            if staged:
+                ws.git(
+                    "-c",
+                    f"user.name={config.bot_login}",
+                    "-c",
+                    f"user.email={config.bot_login}@users.noreply.github.com",
+                    "commit",
+                    "-m",
+                    f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
+                    f"\n\nAgent: {config.agent_id}",
                 )
             ws.push(branch)
             pushed = True
@@ -2058,18 +1822,14 @@ def live_climb(
                 head=branch,
                 base=base_branch,
                 body=body,
-                # blocking findings open at the panel cap, or a degraded
-                # final read: visible, plainly not merge-ready
+                # blocking findings open at the panel, or a degraded final
+                # read: visible, plainly not merge-ready
                 draft=result.panel_blocking_open or result.panel_degraded,
             )
             # Arm auto-merge, best-effort, and ONLY when branch protection
             # requires a human review — the guard keeps bot-never-merges
-            # enforced in code, not in per-repo config. Repos without
-            # auto-merge enabled just log the refusal.
+            # enforced in code, not in per-repo config. Never arm a draft.
             pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
-            # never arm a draft: open blocking findings or an uncertified
-            # read mean a human must look; approving+arming would route
-            # around the panel
             if pr_number.isdigit() and not (result.panel_blocking_open or result.panel_degraded):
                 _best_effort(
                     "auto-merge arming",
@@ -2085,20 +1845,6 @@ def live_climb(
                     "pr_url": pr_url,
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
-                }
-            )
-        except SuiteRegressed as exc:
-            # the gate's verdict is the same wherever it fires: an honest
-            # negative, not an abort — the merged tree just answered later
-            outcome_name = "suite-regression"
-            result = dc_replace(result, outcome="suite-regression", note=str(exc))
-            log.info("suite-regressed for %s: %s", run_id, exc)
-            final = RunRecord(
-                **{
-                    **record.__dict__,
-                    "state": ENDED,
-                    "ending": NEGATIVE_RESULT,
-                    "ending_note": redact(str(exc), secrets)[:480],
                 }
             )
         except Exception as exc:
@@ -2580,7 +2326,6 @@ def main() -> int:
                 spec=spec,
                 panel_lenses=panel_lenses,
                 dispatch=dispatch,
-                evaluator=SubprocessEvaluator(container_image=args.image),
                 eval_image=args.image,
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -409,7 +409,6 @@ def run_live(
             run_root=tmp_path / "state",
             run_id=run_id,
             harness=ScriptedHarness(edits=edits),
-            evaluator=QueueEvaluator(values=queue),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -644,7 +643,6 @@ def test_session_error_aborts_cleanly(tmp_path, target_repo) -> None:
             run_root=tmp_path / "state",
             run_id="tsp-err",
             harness=DeadHarness(),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -679,7 +677,6 @@ def test_exhausted_live_climb_ends_budget_exhausted(tmp_path, target_repo) -> No
             run_root=tmp_path / "state",
             run_id="tsp-dry",
             harness=DryHarness(),
-            evaluator=QueueEvaluator(values=_q),
             github=FakeGitHub(),  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -719,7 +716,6 @@ def test_branch_is_kept_and_recorded_after_pr_failure(tmp_path, target_repo) -> 
             run_root=tmp_path / "state",
             run_id="tsp-orphan",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "q=4\n"}),
-            evaluator=QueueEvaluator(values=_q),
             github=FailingGitHub2(),  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -816,7 +812,6 @@ def test_climb_error_still_writes_a_report(tmp_path, target_repo) -> None:
             run_root=tmp_path / "state",
             run_id="chess-2",
             harness=ScriptedHarness(edits={}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -844,7 +839,6 @@ def test_issue_run_references_issue_and_reports_back(tmp_path, target_repo) -> N
             run_root=tmp_path / "state",
             run_id="tsp-iss",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "i=1\n"}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -878,7 +872,6 @@ def test_clone_crash_ends_record_and_reports_to_issue(tmp_path, monkeypatch) -> 
             run_root=tmp_path / "state",
             run_id="tsp-clonefail",
             harness=ScriptedHarness(edits={}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -924,7 +917,6 @@ def test_ending_steps_degrade_independently(tmp_path, target_repo, monkeypatch) 
             run_root=tmp_path / "state",
             run_id="chess-disk",
             harness=ScriptedHarness(edits={}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -952,7 +944,6 @@ def test_final_record_failure_does_not_lose_pr_or_issue_report(
             run_root=tmp_path / "state",
             run_id="tsp-finaldisk",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "z=1\n"}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -985,7 +976,6 @@ def test_first_record_write_failure_is_contained(tmp_path, target_repo, monkeypa
             run_root=tmp_path / "state",
             run_id="tsp-recfail",
             harness=ScriptedHarness(edits={}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -1022,7 +1012,6 @@ def test_arming_failure_never_fails_the_publish(tmp_path, target_repo) -> None:
             run_root=tmp_path / "state",
             run_id="tsp-noarm",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "na=2\n"}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -1031,6 +1020,36 @@ def test_arming_failure_never_fails_the_publish(tmp_path, target_repo) -> None:
     assert outcome.outcome == "improved"
     assert outcome.pr_url.endswith("/pull/1")
     assert github.armed == []
+
+
+def test_moved_base_publishes_the_sealed_candidate_without_merging(tmp_path, target_repo) -> None:
+    # main moves during the climb: the SEALED candidate publishes as-is — no
+    # orchestrator merge, no re-measure (the wake path's long-standing stance,
+    # now the one publish). A stale PR is review's to handle.
+    class MovingHarness(ScriptedHarness):
+        def run(self, brief_text, workspace, resume_session_id=None):
+            _push_upstream(target_repo, tmp_path, "docs/roadmap.md", "moved\n", "mid-climb")
+            return super().run(brief_text, workspace, resume_session_id)
+
+    _q = [13.876, 13.1]
+    github = FakeGitHub()
+    with _queued_local(_q):
+        outcome = live_climb(
+            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+            run_root=tmp_path / "state",
+            run_id="tsp-moved",
+            harness=MovingHarness(edits={"src/pilot/solvers/tsp.py": "m=1\n"}),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="t",
+        )
+    assert outcome.outcome == "improved"
+    branch = "feat/auto/agent-01/tsp-moved"
+    # no merge commit — the branch parents on the CLONED base, not the moved tip
+    assert _git(target_repo, "log", "--merges", "--oneline", branch).strip() == ""
+    # the upstream commit is NOT folded into the branch
+    assert _git(target_repo, "show", f"{branch}:docs/roadmap.md") != "moved\n"
 
 
 def _push_upstream(target_repo, tmp_path, rel_path: str, content: str, name: str) -> None:
@@ -1043,153 +1062,6 @@ def _push_upstream(target_repo, tmp_path, rel_path: str, content: str, name: str
     _git(side, "-c", "user.name=u", "-c", "user.email=u@u", "add", "-A")
     _git(side, "-c", "user.name=u", "-c", "user.email=u@u", "commit", "-qm", f"upstream {name}")
     _git(side, "push", "-q", "origin", "main")
-
-
-@dataclass
-class RacingHarness(ScriptedHarness):
-    """Applies its edits AND lands an upstream commit mid-session."""
-
-    target_repo: object = None
-    tmp_path: object = None
-    upstream_path: str = "docs/roadmap.md"
-    upstream_content: str = "# roadmap moved\n"
-
-    def run(self, brief_text, workspace, resume_session_id=None):
-        _push_upstream(
-            self.target_repo, self.tmp_path, self.upstream_path, self.upstream_content, "race"
-        )
-        return super().run(brief_text, workspace, resume_session_id)
-
-
-@dataclass
-class DirCheckingEvaluator(QueueEvaluator):
-    """Pops values like QueueEvaluator but also records, per call, whether
-    the tree it was handed contained the agent's edit — proving the two
-    post-merge measurements ran on the intended PRISTINE trees, not on the
-    session's long-lived workspace."""
-
-    saw_agent_edit: list = field(default_factory=list)
-
-    def evaluate(self, workspace, command, metric, extra_env=None) -> float:
-        solver = Path(workspace) / "src" / "pilot" / "solvers" / "tsp.py"
-        self.saw_agent_edit.append(solver.exists() and "r=1" in solver.read_text())
-        return super().evaluate(workspace, command, metric)
-
-
-def test_moved_base_is_merged_and_remeasured_before_push(tmp_path, target_repo) -> None:
-    """Main moves during the climb (disjoint file): the branch merges the
-    fresh base (merge commit, never rebase), the claim is RE-MEASURED on the
-    merged tree, and the PR lands with both histories."""
-    github = FakeGitHub()
-    # values: session baseline, session candidate (the gate's local eval jobs),
-    # then the post-merge pair — fresh-base baseline (worktree of FETCH_HEAD)
-    # and merged-tree candidate — measured through the evaluator
-    _q = [13.876, 13.1, 13.9, 13.2]
-    evaluator = DirCheckingEvaluator(values=_q)
-    with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
-            run_root=tmp_path / "state",
-            run_id="tsp-race",
-            harness=RacingHarness(
-                edits={"src/pilot/solvers/tsp.py": "r=1\n"},
-                target_repo=target_repo,
-                tmp_path=tmp_path,
-            ),
-            evaluator=evaluator,
-            github=github,  # type: ignore[arg-type]
-            bot_auth=NoAuth(),  # type: ignore[arg-type]
-            now=1_000_000.0,
-            created="2026-08-07T00:00:00Z",
-        )
-    assert outcome.outcome == "improved"
-    assert _q == []  # both post-merge measurements actually ran
-    # the evaluator sees only the post-merge pair: fresh base WITHOUT the
-    # agent edit, then the merged tree WITH it
-    assert evaluator.saw_agent_edit == [False, True]
-    # the worktrees were cleaned up (no disk leak in the run dir)
-    leftovers = [p.name for p in (tmp_path / "state" / "runs" / "tsp-race").iterdir()]
-    assert "measure-fresh-base" not in leftovers and "measure-merged" not in leftovers
-    assert github.prs and github.prs[0]["head"] == "feat/auto/agent-01/tsp-race"
-    # the PR claims the post-merge pair, not the session-time numbers
-    assert "13.9 -> 13.2" in github.prs[0]["title"]
-    # a true merge commit landed (never a rebase)
-    assert _git(target_repo, "log", "--merges", "--oneline", "feat/auto/agent-01/tsp-race")
-    # the branch contains the upstream commit (merged, not ignored)
-    branch_files = _git(target_repo, "ls-tree", "-r", "--name-only", "feat/auto/agent-01/tsp-race")
-    assert "docs/roadmap.md" in branch_files
-    upstream_on_branch = _git(target_repo, "show", "feat/auto/agent-01/tsp-race:docs/roadmap.md")
-    assert upstream_on_branch == "# roadmap moved\n"
-    # vs the MOVED main, the branch changes only solver + progress files
-    files = set(
-        _git(target_repo, "diff", "--name-only", "main", "feat/auto/agent-01/tsp-race").split()
-    )
-    assert files == {"src/pilot/solvers/tsp.py", "BENCHMARKS.md", "results/leader.json"}
-
-
-def test_conflicting_moved_base_is_publish_error_not_a_broken_pr(tmp_path, target_repo) -> None:
-    """Upstream rewrites the SAME file the agent edited: the merge conflicts,
-    nothing is pushed, and the run ends honestly instead of opening an
-    unmergeable PR."""
-    github = FakeGitHub()
-    _q = list([13.876, 13.1])
-    with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
-            run_root=tmp_path / "state",
-            run_id="tsp-clash",
-            harness=RacingHarness(
-                edits={"src/pilot/solvers/tsp.py": "mine=1\n"},
-                target_repo=target_repo,
-                tmp_path=tmp_path,
-                upstream_path="src/pilot/solvers/tsp.py",
-                upstream_content="theirs=2\n",
-            ),
-            evaluator=QueueEvaluator(values=_q),
-            github=github,  # type: ignore[arg-type]
-            bot_auth=NoAuth(),  # type: ignore[arg-type]
-            now=1_000_000.0,
-            created="t",
-        )
-    assert outcome.outcome == "publish-error"
-    assert github.prs == []
-    assert "feat/auto/agent-01/tsp-clash" not in _git(target_repo, "branch", "--list")
-    record = load_record(tmp_path / "state", "tsp-clash")
-    # pin the TRIAGE branch, not just the topic: this is a content conflict,
-    # and must not be reported through the infrastructure-failure message
-    assert "conflicted" in record.ending_note
-    assert "not a content conflict" not in record.ending_note
-
-
-def test_absorbed_improvement_after_merge_is_rejected(tmp_path, target_repo) -> None:
-    """The merged tree no longer beats the baseline (upstream absorbed the
-    win): re-measurement vetoes the push."""
-    github = FakeGitHub()
-    _q = list([13.876, 13.1, 13.0, 13.05])
-    with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
-            run_root=tmp_path / "state",
-            run_id="tsp-absorbed",
-            harness=RacingHarness(
-                edits={"src/pilot/solvers/tsp.py": "a=1\n"},
-                target_repo=target_repo,
-                tmp_path=tmp_path,
-            ),
-            # post-merge: fresh base measures 13.0, merged tree only 13.05 —
-            # upstream absorbed the win; the candidate REGRESSES the fresh base
-            evaluator=QueueEvaluator(values=_q),
-            github=github,  # type: ignore[arg-type]
-            bot_auth=NoAuth(),  # type: ignore[arg-type]
-            now=1_000_000.0,
-            created="t",
-        )
-    assert outcome.outcome == "publish-error"
-    assert github.prs == []
-    assert (
-        "does not beat the fresh base"
-        in load_record(tmp_path / "state", "tsp-absorbed").ending_note
-    )
 
 
 def test_terminated_is_contained_like_any_crash(tmp_path, target_repo) -> None:
@@ -1210,7 +1082,6 @@ def test_terminated_is_contained_like_any_crash(tmp_path, target_repo) -> None:
             run_root=tmp_path / "state",
             run_id="tsp-term",
             harness=KilledHarness(edits={}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -1333,54 +1204,6 @@ def test_self_deadline_raises_terminated_into_containment(monkeypatch) -> None:
         signal.signal(signal.SIGALRM, original)
 
 
-def test_moved_base_regates_the_suite_on_the_merged_tree(tmp_path, target_repo) -> None:
-    """The suite gate must hold on the tree that actually lands: the sibling
-    passed at session time, but the merged tree regresses it — re-measurement
-    vetoes the push, same as an absorbed improvement."""
-    _push_contract(
-        tmp_path,
-        target_repo,
-        CONTRACT.replace(
-            "budgets:",
-            "  - name: sokoban\n"
-            "    command: uv run python -m pilot.eval --benchmark sokoban --json\n"
-            "    metric: solve_rate\n"
-            "    direction: max\n"
-            "budgets:",
-        ).replace(
-            "scope: {allowed: [src/pilot/solvers/]}",
-            "scope: {allowed: [src/pilot/], shared: [src/pilot/model/]}",
-        ),
-        "suite",
-    )
-    github = FakeGitHub()
-    _q = list([13.876, 13.1, 0.8, 0.8, 13.9, 13.2, 0.8, 0.5])
-    with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
-            run_root=tmp_path / "state",
-            run_id="tsp-suite-race",
-            harness=RacingHarness(
-                edits={"src/pilot/model/encoder.py": "shared=1\n"},
-                target_repo=target_repo,
-                tmp_path=tmp_path,
-            ),
-            # session pair, sibling pair (passes: 0.8 flat), then post-merge:
-            # climbed pair still improves, but the merged tree's sibling drops
-            evaluator=QueueEvaluator(values=_q),
-            github=github,  # type: ignore[arg-type]
-            bot_auth=NoAuth(),  # type: ignore[arg-type]
-            now=1_000_000.0,
-            created="t",
-        )
-    assert outcome.outcome == "suite-regression"
-    assert github.prs == []
-    record = load_record(tmp_path / "state", "tsp-suite-race")
-    assert record.ending == "negative-result"  # the gate's promise: never an abort
-    assert "suite regression after merging" in record.ending_note
-    assert "sokoban" in record.ending_note
-
-
 def test_author_harness_is_built_from_the_spec() -> None:
     """The spec is the single source for the session budget: manifest and
     harness cannot disagree (one build_harness for every role)."""
@@ -1479,7 +1302,6 @@ def test_panel_clean_read_lands_a_normal_pr_with_transcript(tmp_path, target_rep
             run_root=tmp_path / "state",
             run_id="tsp-panel-ok",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "p=1\n"}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -1528,7 +1350,6 @@ def test_panel_capped_blocking_opens_a_draft_and_never_arms(tmp_path, target_rep
             run_root=tmp_path / "state",
             run_id="tsp-panel-draft",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "p=2\n"}),
-            evaluator=QueueEvaluator(values=_q),
             github=github,  # type: ignore[arg-type]
             bot_auth=NoAuth(),  # type: ignore[arg-type]
             now=1_000_000.0,
@@ -1541,58 +1362,6 @@ def test_panel_capped_blocking_opens_a_draft_and_never_arms(tmp_path, target_rep
     assert pr["body"].startswith("> **Draft")
     assert "suspicious lever" in pr["body"]
     assert github.armed == []  # a draft with open blocking findings never arms
-
-
-def test_moved_base_gets_a_fresh_panel_read_and_blocking_drafts(tmp_path, target_repo) -> None:
-    """The panel's verdict must hold on the tree that actually lands: clean at
-    session time, blocking on the merged tree -> DRAFT PR, never armed."""
-    import json as _json
-
-    from autoresearch.panel import PanelLens
-
-    clean = _json.dumps({"findings": [], "notes": "clean"})
-    blocking = _json.dumps(
-        {
-            "findings": [
-                {
-                    "file": "src/pilot/solvers/tsp.py",
-                    "line": 1,
-                    "confidence": "high",
-                    "summary": "merged-tree interaction looks gamed",
-                    "detail": "d",
-                    "blocking": True,
-                }
-            ],
-            "notes": "",
-        }
-    )
-    judge = _panel_judge([clean, blocking])
-    github = FakeGitHub()
-    _q = list([13.876, 13.1, 13.9, 13.2])
-    with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
-            run_root=tmp_path / "state",
-            run_id="tsp-panel-race",
-            harness=RacingHarness(
-                edits={"src/pilot/solvers/tsp.py": "r=9\n"},
-                target_repo=target_repo,
-                tmp_path=tmp_path,
-            ),
-            # session pair, then the post-merge climbed pair
-            evaluator=QueueEvaluator(values=_q),
-            github=github,  # type: ignore[arg-type]
-            bot_auth=NoAuth(),  # type: ignore[arg-type]
-            now=1_000_000.0,
-            created="2026-08-15T00:00:00Z",
-            panel_lenses=(PanelLens("review", judge),),
-        )
-    assert outcome.outcome == "improved"
-    pr = github.prs[0]
-    assert pr["draft"] is True
-    assert "merged-tree interaction looks gamed" in pr["body"]
-    assert "Verification round 2" in pr["body"]  # numbering continued post-merge
-    assert github.armed == []
 
 
 def test_expensive_benchmark_runs_session_then_parks_candidate(tmp_path, target_repo_dispatch):

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1052,6 +1052,69 @@ def test_moved_base_publishes_the_sealed_candidate_without_merging(tmp_path, tar
     assert _git(target_repo, "show", f"{branch}:docs/roadmap.md") != "moved\n"
 
 
+def test_inline_publish_ships_the_sealed_sha_not_the_live_workspace(tmp_path, target_repo) -> None:
+    # THE unification's core pin: after the seal, the workspace diverges (an
+    # untracked file appears AND a tracked file is rewritten — eval cruft, a
+    # stray write, anything). The pushed branch must be exactly the SEALED
+    # candidate plus the ledger commit — the divergence never ships.
+    class DivergingCompute(QueueCompute):
+        def __init__(self, values, ws_root):
+            super().__init__(values=values)
+            self.ws_root = ws_root
+
+        def submit(self, spec) -> str:
+            # runs AFTER snapshot(): the gate's eval jobs are submitted on the
+            # sealed sha, so this write postdates the seal
+            (self.ws_root / "post-seal-cruft.tmp").write_text("junk\n")
+            (self.ws_root / "src" / "pilot" / "solvers" / "tsp.py").write_text(
+                "def solve(): return 'REWRITTEN AFTER SEAL'\n"
+            )
+            return super().submit(spec)
+
+    ws_root = tmp_path / "state" / "runs" / "tsp-seal" / "ws"
+    _q = [13.876, 13.1]
+    github = FakeGitHub()
+    import autoresearch.climb as _climb_mod
+
+    orig = _climb_mod.LocalCompute
+    _climb_mod.LocalCompute = lambda: DivergingCompute(_q, ws_root)  # type: ignore[assignment,misc]
+    try:
+        outcome = live_climb(
+            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+            run_root=tmp_path / "state",
+            run_id="tsp-seal",
+            harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "def solve(): return 7\n"}),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="t",
+        )
+    finally:
+        _climb_mod.LocalCompute = orig  # type: ignore[misc]
+    assert outcome.outcome == "improved"
+    branch = "feat/auto/agent-01/tsp-seal"
+    files = set(_git(target_repo, "diff", "--name-only", "main", branch).split())
+    assert files == {"src/pilot/solvers/tsp.py", "BENCHMARKS.md", "results/leader.json"}
+    # the tracked file ships at its SEALED content, not the post-seal rewrite
+    assert "return 7" in _git(target_repo, "show", f"{branch}:src/pilot/solvers/tsp.py")
+
+
+def test_zero_change_improvement_is_a_negative_result_not_a_pr(tmp_path, target_repo) -> None:
+    # the gate reporting improved with an EMPTY sealed diff is metric noise:
+    # the run ends no-improvement (negative-result), nothing is pushed
+    outcome, github = run_live(
+        tmp_path,
+        target_repo,
+        edits={},  # the session changes nothing
+        values=[13.876, 13.1],
+    )
+    assert outcome.outcome == "no-improvement"
+    assert github.prs == []
+    assert "feat/auto" not in _git(target_repo, "branch", "--list")
+    record = load_record(tmp_path / "state", "tsp-1")
+    assert record.ending == "negative-result"
+
+
 def _push_upstream(target_repo, tmp_path, rel_path: str, content: str, name: str) -> None:
     """Simulate a concurrent merge: land a commit on the origin's main."""
     side = tmp_path / f"side-{name}"

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -1115,6 +1115,39 @@ def test_zero_change_improvement_is_a_negative_result_not_a_pr(tmp_path, target_
     assert record.ending == "negative-result"
 
 
+def test_non_default_base_branch_is_built_on_and_measured(tmp_path, target_repo) -> None:
+    # --base-branch=dev: the session edits, the gate measures, and the PR
+    # branch parents on DEV's tree — never the clone's default checkout
+    side = tmp_path / "side-dev"
+    _git(tmp_path, "clone", "-q", str(target_repo), str(side))
+    _git(side, "checkout", "-q", "-b", "dev")
+    (side / "ONLY_ON_DEV.md").write_text("dev base\n")
+    _git(side, "-c", "user.name=u", "-c", "user.email=u@u", "add", "-A")
+    _git(side, "-c", "user.name=u", "-c", "user.email=u@u", "commit", "-qm", "dev base")
+    _git(side, "push", "-q", "origin", "dev")
+    _q = [13.876, 13.1]
+    github = FakeGitHub()
+    with _queued_local(_q):
+        outcome = live_climb(
+            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+            run_root=tmp_path / "state",
+            run_id="tsp-dev",
+            harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "d=1\n"}),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="t",
+            base_branch="dev",
+        )
+    assert outcome.outcome == "improved"
+    assert github.prs[0]["base"] == "dev"
+    branch = "feat/auto/agent-01/tsp-dev"
+    # the pushed branch carries dev's tree (the dev-only file), i.e. it was
+    # built on and sealed against the requested base — not the default branch
+    files = _git(target_repo, "ls-tree", "-r", "--name-only", branch)
+    assert "ONLY_ON_DEV.md" in files
+
+
 def _push_upstream(target_repo, tmp_path, rel_path: str, content: str, name: str) -> None:
     """Simulate a concurrent merge: land a commit on the origin's main."""
     side = tmp_path / f"side-{name}"


### PR DESCRIPTION
## What

**One publish — the sealed candidate sha, everywhere.** Net **−474 lines**. The inline publish (workspace commit guarded by drift fingerprints, plus the moved-base merge/re-measure/re-panel machinery) retires; every improved run now publishes exactly the way the live-validated wake path always has: check out the SEALED `candidate_sha` into the run branch, layer only the ledger commit on top, push, open the PR.

## Why it's safe now

Since #146, every gate eval runs on a fresh checkout of its sealed sha — the workspace is never measured, so eval-time workspace drift is structurally impossible and the fingerprint forensics guarded nothing. The sealed sha *is* the drift fingerprint.

## Behavior change (deliberate)

A base branch that moves during a climb is **no longer merged and re-measured by the orchestrator** — the PR opens against the moved base as-is, and review handles staleness. This is the wake publish's long-standing documented stance (research-loop.md: "a stale PR is a re-wake, not an orchestrator auto-merge"), now the one behavior. The ~200-line moved-base block (merge, paired re-measure, suite re-gate, fresh panel read, `_measure_committed`, `SuiteRegressed`) deletes outright.

## Also

- Zero-change "improvements" convert to `no-improvement` before the report (the wake's rule).
- `live_climb` drops its now-unused `evaluator` param; docs swept (roles.md flow/table, dispatcher.md moved-base note).

## Tests

- New pin: mid-climb upstream commit → publish succeeds with **no merge commit** and the upstream edit **not folded in**.
- Deleted with the machinery: the two drift-scenario tests, five moved-base tests, and their harness fakes.
- The main e2e still pins the pushed tree exactly (solver edit + two ledger files, nothing else).
- Full suite: 771 passed; ruff check/format + mypy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
