### PR TITLE
chore: comment de-slop — constraints stay, provenance goes

### DIFF
--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -152,8 +152,8 @@ def render_wake(update: str, budget: BudgetState) -> str:
     understanding, what it launched); the wake carries only what is new:
     results and the current budget. It explicitly supersedes the brief's
     wait-for-results instruction — a resumed agent honors standing
-    instructions, so a wake that silently contradicts one gets refused
-    (observed live on Torch). Task-level instructions only: contract scope,
+    instructions, so a wake that silently contradicts one gets refused.
+    Task-level instructions only: contract scope,
     budgets, and safety rules are never the wake's to relax.
     """
     return "\n".join(

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -243,9 +243,7 @@ def _best_effort(what: str, fn: Callable[[], object], secrets: tuple[str, ...] =
 
     The terminal sequence (record, report, issue post) must degrade
     independently: a full disk must not block the GitHub post, and a network
-    failure must not block the record. The 2026-08-07 quota crisis stranded a
-    run in `implementing` because the ending record itself hit EDQUOT inside
-    the except handler and took the report and issue post down with it.
+    failure must not block the record.
     """
     try:
         fn()
@@ -330,8 +328,7 @@ def _park_run(
     committed shas, drawn seeds, candidate snapshot ref, and afterany set a
     fresh process reconstructs the measure-and-decide phase from. The caller
     passes the EXACT `candidate_ref` it will keep alive (never re-derive it from
-    the commit — two snapshots can share a commit). The wake path (which reads
-    this and resumes) is a later PR."""
+    the commit — two snapshots can share a commit)."""
     from autoresearch.dispatch import effective_eval_minutes
 
     job_ids = afterany_ids(parked.afterany)
@@ -347,8 +344,8 @@ def _park_run(
         # branch a non-default `--base-branch` selected — the wake CLI otherwise
         # defaults to main and would mis-target.
         "base_branch": base_branch,
-        # verification-panel revisions taken so far — persisted so the next wake
-        # knows the cap position after a panel-driven revision re-park.
+        # verification-panel reads so far — persisted so the next wake
+        # continues the count.
         "panel_reads": panel_reads,
         # the session's write-up + spend, saved so a candidate wake can build
         # the PR body / panel claim and report the real cost WITHOUT re-running
@@ -375,8 +372,8 @@ def _park_run(
         # counts as of this park.
         stage["syscall_launches"] = [
             # minutes ride along so a RE-PARK's deadline floor still covers the
-            # longest launch (terra #144 r4) — without them a rebuilt descriptor
-            # would undershoot the floor and the sweep could cancel a healthy
+            # longest launch — without them a rebuilt descriptor would
+            # undershoot the floor and the sweep could cancel a healthy
             # queued sibling as "pending past deadline"
             {"name": launch.name, "minutes": launch.minutes, "artifacts": list(launch.artifacts)}
             for launch in parked.syscall.launches
@@ -388,9 +385,7 @@ def _park_run(
         stage["sleeps_used"] = parked.sleeps_used
     # A single-job park records its one pollable id; a MULTI-job park records
     # none — the sweep falls back to polling every id in the stage's `afterany`
-    # string and wakes only when ALL are done (tick._poll_targets). The park-time
-    # afterany wake job (zero-latency primary; the sweep stays backup) is still
-    # a later PR.
+    # string and wakes only when ALL are done (tick._poll_targets).
     experiment_job_id = job_ids[0] if len(job_ids) == 1 else ""
     # The deadline is a FLOOR: park time (`now` here is the park moment, passed
     # by the caller) + the eval walltime + a generous queue/grace slack, so a
@@ -613,10 +608,8 @@ def _wake_author_sleep(
 
     # The wake's climb IO: measures go through the DISPATCHED measurer (this is
     # a wake job with bounded walltime — the gate's evals run as their own jobs
-    # and park the run as a CANDIDATE), snapshots parent on base (same as the
-    # first pass: the clone was at base), and changed_paths carries no
-    # fingerprints (only the live inline publish needs them; every publish from
-    # here is the sealed-sha wake publish).
+    # and park the run as a CANDIDATE); snapshots parent on base (same as the
+    # first pass: the clone was at base).
     snapshots: list[Snapshot] = []
 
     def snapshot() -> str:
@@ -748,9 +741,9 @@ def resume_run(
     * **improved** — branch the SEALED `candidate_sha` (never the live tree,
       which may have drifted since the park; the diff was scope-checked so it
       carries only in-scope changes), layer the ledger update on top, push, and
-      open the PR. The mechanical moved-base merge the first pass does is
-      deliberately NOT here (docs/design/research-loop.md): a stale PR is a
-      re-wake, not an orchestrator auto-merge.
+      open the PR. A moved base is NOT merged and re-measured here
+      (docs/design/research-loop.md): a stale PR is a re-wake, not an
+      orchestrator auto-merge.
     """
     run_dir = run_root / "runs" / run_id
     workspace = run_dir / "ws"
@@ -871,7 +864,7 @@ def resume_run(
             # fanned out) still owes the author the gate+panel results and its
             # sibling launches' results — carry the submit context forward, or
             # the next wake drafts instead of waking the author and the launch
-            # descriptors are lost (terra #144 r3). Commands/minutes are spent
+            # descriptors are lost. Commands/minutes are spent
             # history; the wake needs only names + artifacts (as persisted).
             from autoresearch.syscall import Launch as _Launch
             from autoresearch.syscall import SyscallRequest as _SyscallRequest
@@ -960,8 +953,8 @@ def resume_run(
         and result.outcome in ("no-improvement", "suite-regression", "eval-error")
     ):
         # the submitted candidate failed the gate — including an eval that
-        # errored (terra #144 r1): feedback, never a silent terminal — the
-        # author decides what happens next (rounds stay bounded by sleep_k)
+        # errored: feedback, never a silent terminal — the author decides
+        # what happens next (rounds stay bounded by sleep_k)
         return _wake_author(
             "Your `submit` did NOT clear the gate: "
             f"{result.note or result.outcome} "
@@ -1077,11 +1070,9 @@ def resume_run(
             # dispatched improvement is not published unverified. It reads the
             # workspace tree, now checked out to the SEALED candidate_sha (the
             # dispatched evals ran on node-local scratch, so the tree is exactly
-            # what was measured), over base_sha. Slice 1: a blocking or degraded
+            # what was measured), over base_sha. A blocking or degraded
             # verdict opens a DRAFT PR carrying the findings and never arms
-            # auto-merge; a clean verdict (or no panel) arms. Waking the agent
-            # to REVISE on a blocking finding — the depth axis — is the next
-            # slice; for now a human triages the draft.
+            # auto-merge; a clean verdict (or no panel) arms.
             if panel_lenses:
                 # A panel ERROR (a git op in build_panel_runner, not a finding)
                 # must NOT abort the publish and drop the candidate snapshot —
@@ -1452,9 +1443,7 @@ def live_climb(
     workspace = run_dir / "ws"
 
     # The record exists before any network or clone work: every crash from
-    # here on has a record to end. (A run once stranded in `implementing`
-    # because the region between record creation and the contained call
-    # could still raise.)
+    # here on has a record to end.
     import os as _os
 
     record = RunRecord(
@@ -1499,8 +1488,8 @@ def live_climb(
         ws = Workspace.clone(_target_clone_url(config.target), workspace, auth=bot_auth)
         # Build ON the requested PR base: the clone checks out the remote
         # DEFAULT branch, which need not be `base_branch` — the session must
-        # edit, and the gate must measure, the tree the PR will land on
-        # (terra #147 r3). A missing base branch fails loudly as climb-error.
+        # edit, and the gate must measure, the tree the PR will land on.
+        # A missing base branch fails loudly as climb-error.
         ws.git("checkout", "-q", "-B", base_branch, f"origin/{base_branch}")
         contract_text = (workspace / ".autoresearch.yaml").read_text()
         contract = load_contract(contract_text, config.target)
@@ -1509,10 +1498,10 @@ def live_climb(
         # launches and the gate run as Slurm jobs) and a resumable backend (the
         # wake resumes the SAME session) — and the benchmark has not opted out
         # (`depth_k: 0`). With the channel (`.autoresearch/`) armed it never
-        # enters diffs, scope, or drift fingerprints — repo-local exclude. With
-        # the feature off, an untracked `.autoresearch/` file must be staged
-        # and judged like any other agent edit, not silently hidden by a magic
-        # dir name (terra, #132 r2 — the off state stays byte-identical).
+        # enters diffs or scope — repo-local exclude. With the feature off, an
+        # untracked `.autoresearch/` file must be staged and judged like any
+        # other agent edit, not silently hidden by a magic dir name (the off
+        # state stays byte-identical).
         _bench = next((b for b in contract.benchmarks if b.name == config.benchmark), None)
         author_syscalls = (
             dispatch is not None
@@ -1522,8 +1511,8 @@ def live_climb(
         )
         # The `.autoresearch/` channel must be KERNEL-OWNED. In a fresh clone,
         # anything already at that path was committed by the TARGET — a symlink
-        # (install would write through it to a host path with our permissions —
-        # terra #133 r1), a tracked request (free cluster compute — #132 r3), or
+        # (install would write through it to a host path with our permissions),
+        # a tracked request (free cluster compute), or
         # any other booby trap. If the path pre-exists in ANY form, disable the
         # feature for the run, loudly; otherwise we create a dir we own.
         channel = workspace / SYSCALL_DIR
@@ -1590,7 +1579,7 @@ def live_climb(
 
         # the panel's base is the PRE-SESSION commit — the exact tree the
         # baseline was measured on — never origin/<base_branch>, which can
-        # name a different branch than the clone's checkout (terra, #95 r3)
+        # name a different branch than the clone's checkout
         pre_session_sha = ws.git("rev-parse", "HEAD").strip()
         panel_runner = (
             build_panel_runner(
@@ -1679,7 +1668,7 @@ def live_climb(
             # The climb dispatched its measures and hibernated. Persist the
             # re-entry stage as a WAITING record (not an error), keep the
             # candidate snapshot alive for the wake, and end. The wake re-enters
-            # from the record (the wake path is a later PR). `parked` is set only
+            # from the record. `parked` is set only
             # AFTER a successful write: if _park_run raises, it stays None so the
             # finally drops every snapshot (no leak) and the outer handler ends
             # the run as an error rather than a half-written hibernation.
@@ -1785,12 +1774,10 @@ def live_climb(
     if result.outcome == "improved":
         try:
             # Publish the SEALED candidate sha — never the live tree, which
-            # may have drifted since the snapshot (eval caches, stray writes).
-            # The sha is exactly the measured, scope-checked content, so the
-            # old drift-fingerprint apparatus retires with the workspace
-            # commit. A base branch that moved during the climb is NOT merged
-            # and re-measured here: a stale PR is review's to handle — the
-            # stance the wake publish has always had (research-loop.md).
+            # may have drifted since the snapshot (eval caches, stray writes);
+            # the sha is exactly the measured, scope-checked content. A base
+            # branch that moved during the climb is NOT merged and re-measured
+            # here: a stale PR is review's to handle (research-loop.md).
             branch = f"{config.branch_prefix}/{run_id}"
             if result.baseline is None or result.candidate is None or not result.candidate_sha:
                 raise EvalError("improved result missing measurements or the sealed sha")
@@ -1968,7 +1955,7 @@ def arm_self_deadline(job_minutes: int, margin_s: float = 120.0) -> int:
     """Arm our own end-of-walltime alarm; returns the armed seconds (0 = off).
 
     Slurm delivers NO signal to our process on Torch before SIGKILL
-    (measured 2026-08-08: scancel and walltime timeout both signal the
+    (scancel and walltime timeout both signal the
     batch shell only) — so the only way to end a run richly before the
     wall is our own clock. SIGALRM fires `margin_s` before the job's
     walltime and raises Terminated into the ordinary containment; the
@@ -2154,15 +2141,15 @@ def main() -> int:
     # NOTE: the codex author is validated on the EFFECTIVE author per path — the
     # fresh climb on args (below), a wake on the parked run's persisted pair — not
     # here, where args.author_backend is the FLEET default and would misjudge a
-    # resume after a fleet flip (review: terra blocking).
+    # resume after a fleet flip.
     # each --codex-config KEY=VALUE becomes a `-c KEY=VALUE` pair for codex
     codex_extra = tuple(a for c in args.codex_config for a in ("-c", c))
 
     bot_auth = FileTokenProvider(Path(args.pat_file))
 
-    # --resume WAKES a parked dispatched run: no session, no api key, no panel —
-    # just rebuild the dispatched measurer and re-enter the decision. The wake
-    # job the WakeDispatcher submits runs exactly this.
+    # --resume WAKES a parked dispatched run: rebuild the dispatched measurer
+    # and re-enter the decision. The wake job the WakeDispatcher submits runs
+    # exactly this.
     if args.resume:
         if not (args.account and args.partition and args.image and Path(args.image).is_file()):
             parser.error(
@@ -2213,7 +2200,7 @@ def main() -> int:
         if wake_lenses:
             # the panel's judges need the verifier key; an author-sleep wake
             # alone does NOT — a panel-less deployment must not be forced to
-            # provision an unused credential (terra, #135 r1).
+            # provision an unused credential.
             wake_panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
         if (
             wake_lenses

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -159,8 +159,8 @@ class SlurmCompute:
     def submit_after(self, spec: JobSpec, after_job_id: str) -> str:
         """Submit `spec` to run when `after_job_id` terminates — however it
         terminates (afterany: the wake-on-failure semantics the fail-safe
-        design requires; verified live on Torch 2026-08-06). Refuses a spec
-        that already carries a dependency rather than silently replacing it."""
+        design requires). Refuses a spec that already carries a dependency
+        rather than silently replacing it."""
         if not after_job_id.isdigit():
             raise ValueError(f"not a job id: {after_job_id!r}")
         if spec.dependency:
@@ -255,7 +255,7 @@ class LocalCompute:
         argv = ["sh", spec.script, *spec.script_args] if spec.script else ["sh", "-c", spec.command]
         self._seq += 1
         job_id = str(_LOCAL_JOB_BASE + self._seq)
-        # An explicit env allowlist, like the evaluator this backend replaced:
+        # An explicit env allowlist:
         # the submitting process holds live keys (and any inherited
         # APPTAINERENV_* would cross --cleanenv into the container), so the
         # job script starts from a minimal environment and sets its own.

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -1,8 +1,7 @@
 """The dispatched-eval primitive: an eval as its own Slurm job.
 
-Phase 1 of docs/design/dispatcher.md. This module owns the three pieces the
-design specifies, and nothing else (the resumable climb transaction and the
-wake wiring build on these in the next stage):
+This module owns the three pieces docs/design/dispatcher.md specifies,
+and nothing else:
 
   * snapshot_tree  — a retained snapshot of a dirty workspace, taken
     against a TEMPORARY unique index seeded from the base commit (working
@@ -440,7 +439,7 @@ def eval_job_spec(
     """The JobSpec for one dispatched eval: the hint CLAMPED to our ceiling
     plus setup slack — a contract value above EVAL_JOB_MINUTES_CEILING must
     not create a longer Slurm job than the ceiling allows. GPU counts arrive
-    with the phase-3 contract fields; the parameter exists so the seam does
+    with later contract fields; the parameter exists so the seam does
     not change shape then."""
     return JobSpec(
         job_name=job_name[:60],

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -107,8 +107,8 @@ def context_comments(comments: list[dict], since_id: int) -> list[tuple[str, str
 
     Deliberately NOTHING else qualifies: on a public repo, arbitrary
     commenters would otherwise get their text injected into a session with
-    push access, guarded only by advisory fencing (review finding on this
-    change). A drive-by comment worth the agent's attention is a
+    push access, guarded only by advisory fencing. A drive-by comment
+    worth the agent's attention is a
     maintainer's to quote — quoting is the human act that grants standing.
     """
     picked: list[tuple[str, str]] = []
@@ -520,8 +520,7 @@ def _respond(
                         # cross-seed floor, same rule as the climb's publish
                         # path: this re-measure ran under a FRESH seed, so a
                         # sub-floor delta over the recorded best is pool
-                        # luck and must not ratchet the ledger (round-1
-                        # review finding)
+                        # luck and must not ratchet the ledger
                         # The floor explains only a delta that WOULD have
                         # improved: an outright regression must read as a
                         # regression (the `worse` flag), never as noise.
@@ -543,7 +542,7 @@ def _respond(
                         ):
                             # named on the thread, like the climb's ending
                             # note — a silently unchanged ledger row reads
-                            # as a bug (review finding)
+                            # as a bug
                             floor = benchmark_floor(
                                 prior.best, bench.min_delta, bench.min_delta_rel
                             )
@@ -617,7 +616,7 @@ def _respond(
         except Exception as exc:
             log.warning("candidate-row rewrite failed for %s#%s: %s", record.target, number, exc)
         # Code changed after publish: the body's report now describes an
-        # older tree. Mark it edited (maintainer decision 2026-08-09) so no
+        # older tree. Mark it edited so no
         # reader — human or verifier — mistakes the original report for the
         # current state; the authoritative update lives in the reply.
         try:
@@ -702,8 +701,7 @@ def main() -> int:
         help="codex `-c KEY=VALUE` config for the codex author (repeatable)",
     )
     # the tick passes the effective limit explicitly; this fallback follows
-    # the harness ceiling so a bare CLI run is never silently starved (a
-    # 40-turn default cost a live steward follow-up its whole session)
+    # the harness ceiling so a bare CLI run is never silently starved
     parser.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS)
     parser.add_argument("--bot-login", default="agentic-learning-bot")
     parser.add_argument(

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -284,7 +284,7 @@ class GitHubClient:
 
         The row is orchestrator-owned and mechanical — the ONE part of the
         body that must never go stale when a follow-up push re-measures
-        (maintainer decision 2026-08-09: rewrite the measured numbers,
+        (rewrite the measured numbers,
         never the narrative). Returns False when the row is not found
         (older body formats), in which case the Edit addendum still
         carries the number.
@@ -316,10 +316,9 @@ class GitHubClient:
     def append_pull_body(self, repo: str, number: int, addendum: str) -> None:
         """Upsert an EDIT addendum onto a PR body (read-modify-write PATCH).
 
-        Follow-up commits desync the report frozen into the body at publish
-        (found live on the first verifier exchange: round 2 reviewed a body
-        describing code the follow-up had already replaced). The addendum
-        marks the body EDITED rather than rewriting history in place — and
+        Follow-up commits desync the report frozen into the body at publish.
+        The addendum marks the body EDITED rather than rewriting history in
+        place — and
         REPLACES any previous addendum (marker-delimited) instead of
         stacking one per round, so the body stays bounded and always points
         at the latest state.

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -172,7 +172,7 @@ def outage(result: SessionResult) -> bool:
     # consulted ONLY when no detail exists AND it carries the legacy CLI
     # error shape ("API Error ..."), never agent prose — a failed session's
     # report that merely MENTIONS billing or limits must not trip a latch
-    # that pauses every lane (review findings, rounds 1 and 2).
+    # that pauses every lane.
     surface = result.error_detail.casefold()
     if not surface:
         text = result.final_text.strip().casefold()
@@ -288,8 +288,8 @@ def _resume_transcript_path(session_home: Path, session_id: str) -> Path:
 def _load_resume_transcript(session_home: Path, session_id: str) -> list[dict[str, str]] | None:
     """Load a saved transcript for `session_id`. None = not found (the caller
     must NOT silently start fresh — a resume with no restored context is an
-    error, exactly the failure the old no-resume refusal guarded against). The
-    per-run home is session-writable, so read without following a symlink."""
+    error). The per-run home is session-writable, so read without following a
+    symlink."""
     text = _read_no_follow(_resume_transcript_path(session_home, session_id))
     if text is None:
         return None
@@ -361,8 +361,8 @@ def _int(value: Any, default: int = 0) -> int:
 
 @dataclass
 class ClaudeCodeHarness:
-    """Headless Claude Code (`claude -p`), as validated in the Torch spike:
-    the JSON output carries cost, usage, session id, and stop reason.
+    """Headless Claude Code (`claude -p`): the JSON output carries cost,
+    usage, session id, and stop reason.
 
     `run` never raises: every failure comes back as an error SessionResult.
     """
@@ -385,7 +385,7 @@ class ClaudeCodeHarness:
     # as instructions. Off for author sessions, where the target repo's own
     # CLAUDE.md is useful contributor guidance.
     bare: bool = False
-    # Apptainer image for session containment (decided 2026-08-06). When set,
+    # Apptainer image for session containment. When set,
     # the session runs under `apptainer exec --containall --cleanenv`: no host
     # $HOME, no host env, no same-user absolute paths — the session sees only
     # the workspace, its per-run HOME, and the read-only claude binary. This
@@ -395,7 +395,7 @@ class ClaudeCodeHarness:
     apptainer_binary: str = "apptainer"
 
     CONTAINER_CLAUDE = "/opt/agent/claude"
-    supports_resume = True  # native --resume, bench-validated
+    supports_resume = True  # native --resume
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
@@ -547,9 +547,9 @@ class ClaudeCodeHarness:
         detail = f"{subtype}: {messages}" if subtype and messages else (subtype or messages)
         final_text = str(data.get("result") or "")
         # The CLI can flag is_error while stamping a content-free subtype
-        # ("success") and leaving the real cause only in `result` — observed on
-        # Torch: is_error, subtype "success", result "API Error: 400 ... usage
-        # limits". That machine "API Error ..." text (never agent prose) is the
+        # ("success") and leaving the real cause only in `result` (is_error,
+        # subtype "success", result "API Error: 400 ... usage limits"). That
+        # machine "API Error ..." text (never agent prose) is the
         # authoritative cause, so surface it as the detail: downstream notes,
         # the operator log, and the outage latch (its classifier AND its
         # throttle-duration check, which reads rate_limit/overloaded off the
@@ -680,7 +680,7 @@ def _parse_codex_result(
     Cost is left at 0 (these backends are subscription or token metered; the
     budget layer meters them by a session/token proxy). Never raises.
     """
-    # Event schema verified against codex-cli 0.130.0 (cluster0):
+    # Event schema verified against codex-cli 0.130.0:
     #   thread.started -> thread_id (the session id)
     #   error          -> message
     #   turn.failed    -> error.message
@@ -870,7 +870,7 @@ class CodexHarness:
             log.warning("could not create session home %s: %s", session_home, exc)
             return _error_result("workspace-error")
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
-        # (verified: the responses endpoint 401s on env-only). Write auth.json
+        # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`
         # (key on stdin, never argv) before exec.
         login_error = self._login(session_home)
@@ -973,7 +973,7 @@ def _hermes_command(
     extra_args: tuple[str, ...],
 ) -> list[str]:
     """Argv for one headless hermes run (`run_agent.py`, fire-style flags,
-    verified against the hermes-agent source, v0.20.1).
+    hermes-agent v0.20.1).
 
     The BRIEF is never in argv — it is written to a file and `query` is only a
     short pointer instruction. The API key is never in argv either: hermes
@@ -998,8 +998,7 @@ def _hermes_command(
         argv.append(f"--base_url={base_url}")
     # Embedded quotes are load-bearing: fire literal-evals flag values, so a
     # bare `a,b` becomes a Python TUPLE and hermes's .split(",") crashes.
-    # `"a,b"` evals to the string hermes expects (verified by the live smoke
-    # test, which caught exactly this).
+    # `"a,b"` evals to the string hermes expects.
     if enabled_toolsets:
         argv.append(f'--enabled_toolsets="{",".join(enabled_toolsets)}"')
     if disabled_toolsets:
@@ -1024,9 +1023,9 @@ def _parse_hermes_result(
         messages = sample
     elif isinstance(sample, dict):
         # run_agent.py --save_sample wraps the ShareGPT turns under
-        # "conversations" (verified against hermes v0.20.1, run_agent.py:8404);
-        # accept "messages"/"trajectory" too for other/older paths. Missing this
-        # key makes num_turns==0 and drops a real verdict as a bogus error.
+        # "conversations" (hermes v0.20.1); accept "messages"/"trajectory"
+        # too for other paths. Missing this key makes num_turns==0 and
+        # drops a real verdict as a bogus error.
         wrapped = (
             sample.get("conversations") or sample.get("messages") or sample.get("trajectory") or []
         )
@@ -1044,8 +1043,8 @@ def _parse_hermes_result(
         final_text = content if isinstance(content, str) else str(content)
     if not final_text:
         final_text = stdout.strip()[-20_000:]
-    # hermes exits 0 even when every API call failed (observed: HTTP 401 with
-    # a clean exit); a run with no assistant output is a failure, not a report
+    # hermes exits 0 even when every API call failed; a run with no
+    # assistant output is a failure, not a report
     is_error = returncode != 0 or num_turns == 0
     return SessionResult(
         stop_reason="error" if is_error else "completed",
@@ -1097,8 +1096,8 @@ class HermesHarness:
     provider: str = ""
     # approvals.deny: fnmatch globs hermes refuses before any yolo/mode-off
     # bypass (headless: a clean deny, never a hang). NOTE it matches SHELL
-    # COMMANDS (the terminal tool), NOT the write_file/patch tool calls (source
-    # verified). Useful to hardline-forbid specific dangerous commands.
+    # COMMANDS (the terminal tool), NOT the write_file/patch tool calls.
+    # Useful to hardline-forbid specific dangerous commands.
     approvals_deny: tuple[str, ...] = ()
     model: str = ""  # OpenRouter format (provider/model); empty -> hermes default
     base_url: str = ""  # empty -> the seeded provider's own endpoint

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1,7 +1,6 @@
 """Orchestrator v1: one climb attempt on one benchmark of one target.
 
-Deliberately narrow (Mengye, 2026-08-06: "choose one benchmark on pilot
-instead of launching everything"): `climb_once` runs a single
+Deliberately narrow: `climb_once` runs a single
 implement→evaluate→verify→PR cycle for the configured benchmark. Task
 selection across benchmarks, the planner, experiment sbatch + wakes, and
 notebook reports grow from here — each behind a seam that already exists.
@@ -73,7 +72,7 @@ PROTECTED_EVAL_ENV = frozenset(
 # ...and whole families: any UV_* steers uv's env/cache resolution, and any
 # APPTAINERENV_* is translated into the CONTAINER's environment by apptainer
 # (APPTAINERENV_HOME becomes HOME inside), so exact-name checks cannot
-# enumerate them (review finding).
+# enumerate them.
 # APPTAINER_* configures the HOST-side apptainer CLI (bind paths, home,
 # containment) — same family logic, different side of the boundary.
 # LD_/DYLD_ steer the dynamic loader; GIT_ redirects repo resolution.
@@ -94,13 +93,12 @@ class ClimbParked(Exception):
     """A dispatched climb submitted its measures and must hibernate until they
     finish. `climb_once` raises it (a park is an exceptional exit); the caller,
     which owns the run record and git, persists the fields below as the WAITING
-    stage — `afterany` among them, the dependency the wake PR will submit its
-    afterany wake job against (this PR only records it; `wake_job_id` stays
-    empty until then) — and ends the run's turn, keeping the candidate snapshot
-    alive so the wake can read it. `phase` is
-    WHICH park: `baseline` (before the session — the wake reruns the session)
-    or `candidate` (after it — the wake decides). The caller fills in the
-    candidate snapshot ref (which it holds) when writing the stage."""
+    stage — `afterany` among them, the dependency set the wake waits on — and
+    ends the run's turn, keeping the candidate snapshot alive so the wake can
+    read it. `phase` is WHICH park: `candidate` (after the session — the wake
+    decides) or `author-sleep` (the author launched work and slept). The caller
+    fills in the candidate snapshot ref (which it holds) when writing the
+    stage."""
 
     def __init__(
         self,
@@ -169,8 +167,7 @@ class SubprocessEvaluator:
         # (it shelters the PAT), and never the workspace — eval cache/state
         # artifacts must not masquerade as agent edits in the diff. The
         # CONTAINED eval needs it too (--home): apptainer's tmpfs home is
-        # size-capped and uv blows it extracting wheels (seen live: first
-        # climb died at baseline on a full tmpfs).
+        # size-capped and uv blows it extracting wheels.
         # Fresh per-EVAL home (never reused): baseline and candidate cannot
         # see each other's writes, and nothing survives to any later run.
         import os
@@ -256,17 +253,14 @@ class SubprocessEvaluator:
             argv = ["sh", "-c", command]
         env = {k: os.environ[k] for k in ("PATH", "LANG", "TMPDIR") if k in os.environ}
         # uv's cache does heavy small-file IO; on shared filesystems (NFS)
-        # that flakes with stale-handle/copy errors (seen live twice). Keep
-        # the cache on node-local scratch and copy across filesystems.
+        # that flakes with stale-handle/copy errors. Keep the cache on
+        # node-local scratch and copy across filesystems.
         env["UV_CACHE_DIR"] = str(cache_dir)
         env["UV_LINK_MODE"] = "copy"
-        # PRIVATE project env per eval (maintainer decision 2026-08-09:
-        # "either not share, or have a lock" — we don't share): the session
-        # builds ws/.venv for its own use, and a second process consuming a
-        # venv another process just wrote races NFS close-to-open
-        # consistency (seen live: the first steward validation spawned a
-        # pytest whose binary was not yet visible). The eval builds its own
-        # environment from the LOCKFILE on NODE-LOCAL scratch (beside the
+        # PRIVATE project env per eval: the session builds ws/.venv for its
+        # own use, and a second process consuming a venv another process
+        # just wrote races NFS close-to-open consistency. The eval builds
+        # its own environment from the LOCKFILE on NODE-LOCAL scratch (beside the
         # uv cache: fast IO, zero NFS in the venv path, dies with the
         # eval) — no shared mutable state, and the orchestrator never
         # executes session-authored entrypoints.
@@ -424,9 +418,9 @@ class ClimbResult:
     # must refuse to commit anything beyond this set
     measured_paths: tuple[str, ...] = ()
     # the sealed candidate snapshot this result was measured on (set on
-    # `improved`); a caller can publish THIS tree (the wake path already does,
-    # climb.py) and a depth loop can select the best across passes by it. "" on
-    # non-improved outcomes. (The in-job depth publish is wired in part 2.)
+    # `improved`); a caller can publish THIS tree (the wake path does,
+    # climb.py) and a depth loop can select the best across passes by it.
+    # "" on non-improved outcomes.
     candidate_sha: str = ""
     session: SessionResult | None = None
     note: str = ""
@@ -682,11 +676,10 @@ class Measurer(Protocol):
     """Obtains a climb's measurements. `results` returns every measure's value
     keyed by its name, or — for a dispatched backend — raises
     `MeasurementPending` after submitting the not-yet-done jobs, for the caller
-    to park on. Two backends behind this one seam: `LocalMeasurer` (inline
-    eval in the caller's existing worktrees, for cheap benchmarks and local
-    runs) and `measure.DispatchedMeasurer` (cluster jobs on a fresh checkout of
-    each committed sha, for expensive evals); the seam is what lets
-    `measure_and_decide` be re-enterable without knowing which."""
+    to park on. `measure.DispatchedMeasurer` runs each measure as a job on a
+    fresh checkout of its committed sha — on the cluster, or synchronously via
+    `LocalCompute`; the seam is what lets `measure_and_decide` be re-enterable
+    without knowing which."""
 
     def results(self, measures: list[Measure]) -> dict[str, float]: ...
 
@@ -730,11 +723,9 @@ def measure_and_decide(
     caller to write the waiting record and park on.
 
     `suite_seed` is an INPUT, not drawn here: a wake must reproduce the seed the
-    first pass used, so the caller draws it once and persists it (the in-job
-    path drew it inline, which a resume could not reproduce). And because the
-    baseline is a committed sha rather than a live pre-session workspace, the
-    gate can always measure its siblings — the old "no pristine baseline
-    workspace" fail-closed branch is gone.
+    first pass used, so the caller draws it once and persists it. And because
+    the baseline is a committed sha rather than a live pre-session workspace,
+    the gate can always measure its siblings.
     """
     # deferred like contract.py's managed_eval_env import: measure -> dispatch
     # -> orchestrator for the eval primitives, so orchestrator imports measure
@@ -816,8 +807,7 @@ def measure_and_decide(
     try:
         vals = measurer.results(sib_plan)
     except EvalError as exc:
-        # phase 1 already credited the main pair — carry it into the report,
-        # exactly as the old in-job suite-error path did.
+        # phase 1 already credited the main pair — carry it into the report.
         return ClimbResult(
             outcome="eval-error",
             baseline=baseline,
@@ -889,10 +879,8 @@ def resume_climb(
     improving candidate, "another round of experiments" — and it re-parks by
     raising `ClimbParked`, exactly as the first pass did.
 
-    This is the seam the depth axis (docs/design/research-loop.md) grows from:
-    slice 1 wakes the GRADER with the panel off; waking the AGENT with the
-    result — a panel revision, or a deeper experiment round it drives itself —
-    reuses this same re-entry and lands next.
+    This is the re-entry seam the depth axis (docs/design/research-loop.md)
+    builds on.
     """
     from autoresearch.measure import MeasurementPending
 
@@ -1223,7 +1211,7 @@ def climb_once(
                     # sleep it rides on is counted now; sibling launches are
                     # dispatched (and counted) only if the gate parks — an
                     # inline gate must never orphan launch jobs no wake would
-                    # gather (terra #144 r2).
+                    # gather.
                     submitted = request
                     sleeps_used += 1
                     break
@@ -1231,7 +1219,7 @@ def climb_once(
                 # path below: an out-of-scope tree is never snapshotted OR
                 # executed — the out-of-scope edit could be to the ruler
                 # itself, and a launch runs code from this tree in an external
-                # job (terra, #132 r4). Same ending as the candidate path.
+                # job. Same ending as the candidate path.
                 violations = out_of_scope(list(changed_paths()), contract)
                 if violations:
                     return ClimbResult(
@@ -1403,9 +1391,9 @@ def climb_once(
         if verdict.blocking and submitted is not None and _can_resume():
             # blocking findings on a SUBMITTED claim go back to the AUTHOR —
             # it revises and resubmits, runs more experiments, or concludes
-            # (buildout Phase B: the author drives the depth axis; the
-            # orchestrator-driven revision policy is retired). The loop then
-            # re-reads its next syscall; the revision re-measures from scratch.
+            # (buildout Phase B: the author drives the depth axis). The loop
+            # then re-reads its next syscall; the revision re-measures from
+            # scratch.
             failed = _resume(f"{verdict.wake_text}\n\n{_not_run_note(submitted)}{_budgets_line()}")
             if failed is not None:
                 return failed
@@ -1441,9 +1429,9 @@ def pr_body(
 ) -> str:
     """The PR body for an improved run: results table + the agent's report.
 
-    Human surfaces render at the benchmark's conventional precision
-    (maintainer decision 2026-08-09); full precision lives only in
-    results/leader.json, and every comparison runs on full floats.
+    Human surfaces render at the benchmark's conventional precision;
+    full precision lives only in results/leader.json, and every
+    comparison runs on full floats.
     """
     from autoresearch.progress import fmt_metric
 

--- a/src/autoresearch/posting.py
+++ b/src/autoresearch/posting.py
@@ -40,9 +40,8 @@ def post_round(
     """Post one NEW comment per round — numbered, stamped with the reviewed
     head — so every round notifies and stays visible (edits do neither).
     Shared by the advisory reviewer and the verifier; each counts rounds by
-    ITS OWN marker. The old one-thread upsert guarded against
-    synchronize-triggered spam; runs are now only PR-open or an explicit
-    label request, so volume is human-bounded.
+    ITS OWN marker. Runs are only PR-open or an explicit label request, so
+    volume is human-bounded.
     """
     stamp, round_label = _round_stamp(client, repo, number, marker, pr_data, reviewed_by)
     client.comment(repo, number, body.replace(marker, f"{marker}\n{stamp}", 1))

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -29,8 +29,7 @@ MARKER = "<!-- autoresearch:advisory-review -->"
 OPT_OUT_LABEL = "autoresearch:no-review"
 
 # One calm line: the mechanical defense against forged endorsements is the
-# approval-language redaction in sanitize(), not header volume. (Softened
-# 2026-08-08 on maintainer feedback — the old header shouted.)
+# approval-language redaction in sanitize(), not header volume.
 ADVISORY_HEADER = (
     "*Advisory findings from `autoresearch` — the code owner decides. "
     f"Reply to disagree; the `{OPT_OUT_LABEL}` label opts this PR out.*"
@@ -305,7 +304,7 @@ def commentable_lines(diff: str) -> dict[str, set[int]]:
             # INSIDE a hunk every line is +/-/context/backslash, so headers
             # are parsed only between hunks — an added line whose content
             # begins with "++ b/" (arriving as "+++ b/...") cannot rebind
-            # the file mid-hunk (review finding: contributor-controlled)
+            # the file mid-hunk (the diff is contributor-controlled)
             if not raw.startswith(("-", "\\")):
                 lines[current].add(new_line)  # added and context lines alike
                 new_line += 1

--- a/src/autoresearch/review_agent.py
+++ b/src/autoresearch/review_agent.py
@@ -179,9 +179,7 @@ def run_agent_review(
             if emit_path is not None:
                 # EVERY errored session surfaces on the PR in the split
                 # topology: this job's log is not the record — the stub the
-                # post job publishes is. Observed live 2026-08-15: terra's
-                # structured-output failures posted nothing and two rounds
-                # read as quiet clean days.
+                # post job publishes is.
                 _emit(
                     emit_path,
                     repo,

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -1,7 +1,7 @@
 """The role-runner: build a harness for a role, run one session, read its result.
 
-One loop replaces the per-role driver modules (docs/design/consolidation.md),
-and ONE construction replaces the per-role harness builders: `build_harness`
+One loop runs every role (docs/design/consolidation.md), and ONE
+construction builds every harness: `build_harness`
 maps a RoleSpec to any backend uniformly — backends are interchangeable, and
 containment is the deployment's business (`container_image` where a jail
 exists, the ephemeral runner where one doesn't), never a per-role tool posture.
@@ -9,10 +9,9 @@ Roles differ by prompt, verbs, and output handling.
 
 `run_role` runs a RoleSpec on a Harness. A role WITH an `output_schema` (a
 judge) records its verdict through the installed syscall tool (`finding` /
-`conclude`) and the kernel reads it back authoritatively (`read_verdict`) —
-each call was validated in-session, so the old parse-a-final-message-and-repair
-path is gone. It does NOT judge, gate, measure, or post — the result-policy
-(kernel) acts on the RoleResult.
+`conclude`) and the kernel reads it back authoritatively (`read_verdict`);
+each call is validated in-session. It does NOT judge, gate, measure, or
+post — the result-policy (kernel) acts on the RoleResult.
 """
 
 from __future__ import annotations

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -82,7 +82,7 @@ OUTAGE_MARKER = "<!-- autoresearch:outage-release -->"
 MAX_STEWARD_ATTEMPTS = 3
 # Outage releases don't count as attempts, but they cannot refund forever:
 # a PERMANENT refusal (revoked key, misconfigured key file) would otherwise
-# oscillate 0->1->0 below the cap and never reach a human (review finding).
+# oscillate 0->1->0 below the cap and never reach a human.
 # After this many outage releases the order waits for a human too — the
 # release comments on the thread say exactly why.
 MAX_OUTAGE_RELEASES = 5
@@ -256,7 +256,7 @@ def pick_steward_issue(
             # move the claim state. On a public repo, a stranger posting
             # a release (or an outage release) must be able to neither
             # free a claimed order, nor burn its attempts, nor erase them
-            # into an unbounded paid retry loop (review finding).
+            # into an unbounded paid retry loop.
             author = str((c.get("user") or {}).get("login", ""))
             if author.casefold() != bot_login.casefold():
                 continue
@@ -640,7 +640,7 @@ def live_steward(
         # malfunction: name it, and put the real cause in every surface a
         # human reads (record note, report, work-order comment) — "the
         # session used its full 120-turn budget" tells the maintainer what
-        # to decide; "ValueError: tool_use" told them nothing.
+        # to decide.
         budget = isinstance(exc, SessionFailure) and exc.budget
         api_outage = isinstance(exc, SessionFailure) and exc.outage
         exc_name = type(exc).__name__

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -14,11 +14,10 @@ ABI the tool commits, and the readers here are its authoritative validators
   the SAME session with every job's results delivered as data (`render_wake`).
   A session that ends with no request follows today's path (implicit submit).
 - The JUDGE's `conclude` syscall (`type: "verdict"`): a judge's `exit()`,
-  carrying its findings. `read_verdict` reads it — the same `{findings, notes}`
-  shape `run_role` used to parse from a final message, minus the parse-and-repair
-  loop (each finding was one validated call, so the verdict is well-formed BY
-  CONSTRUCTION). A judge that commits no verdict fails its round loudly (the
-  caller posts a skip stub) — there is no parse fallback.
+  carrying its findings. `read_verdict` reads a `{findings, notes}` verdict
+  that is well-formed BY CONSTRUCTION (each finding was one validated call).
+  A judge that commits no verdict fails its round loudly (the caller posts
+  a skip stub) — there is no parse fallback.
 
 The `.autoresearch/` directory is kernel-excluded from the diff via
 `.git/info/exclude` (repo-local, never a tracked edit), so requests and
@@ -459,7 +458,7 @@ def _deliver_artifacts(
     """Copy a launch's delivered artifacts into `.autoresearch/results/<name>/`.
 
     The author controls `.autoresearch/` in its sandbox, so the DESTINATION is
-    hostile too (terra #135 r2): a symlinked channel dir or output path would
+    hostile too: a symlinked channel dir or output path would
     make `shutil.copy` write through it to an arbitrary host path with the wake
     process's permissions. Defenses: refuse if any channel ANCESTOR is a symlink;
     remove any pre-existing `results/<name>` (symlink → unlink, dir → rmtree) so
@@ -514,8 +513,8 @@ def _read_text(path: Path, cap: int = 65_536) -> str:
 def _read_tail(path: Path, max_chars: int) -> str:
     """Read only the trailing bytes needed for `max_chars` — NEVER the whole
     file. Launch stdout/stderr is agent-controlled and can be arbitrarily large;
-    loading it before truncating could exhaust the wake process
-    (terra, #135 r1). 4 bytes/char covers the UTF-8 worst case; a codepoint cut
+    loading it before truncating could exhaust the wake process.
+    4 bytes/char covers the UTF-8 worst case; a codepoint cut
     at the window edge decodes as a replacement character, which is fine for a
     tail."""
     budget = max_chars * 4

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -101,7 +101,7 @@ class WakeDispatcher(Protocol):
     lease), or the Slurm job id of an asynchronous wake job that now owns the
     lease (released by that job on completion; reaped by TTL if it dies).
 
-    Contract for real (phase-5) dispatchers: a wake that RESULTS IN PROGRESS
+    Contract for real dispatchers: a wake that RESULTS IN PROGRESS
     must either move the run out of `waiting` or reset `wake_attempts` —
     the counter means "wakes since the run last made progress", and layer 5
     ends the run as stuck when it reaches MAX_WAKE_ATTEMPTS."""
@@ -192,8 +192,8 @@ class FollowupSpec:
 
 
 # Generous vs the ~2 h job walltimes plus queue wait, tight enough that
-# full trees + per-flight venvs cannot pile up for days (review finding);
-# same-day forensics is the norm, and the disk preflight is the backstop.
+# full trees + per-flight venvs cannot pile up for days; same-day
+# forensics is the norm, and the disk preflight is the backstop.
 FLIGHT_TTL_S = 24 * 3600
 
 
@@ -316,9 +316,8 @@ def contract_alarm(
 ) -> None:
     """Persistent contract failure must surface where humans look.
 
-    A rejected or unfetchable contract silently idles every launch lane
-    (this cost 36 hours once — the only signal was a log line on the
-    cluster). After CONTRACT_ALARM_AFTER consecutive failing ticks this
+    A rejected or unfetchable contract silently idles every launch lane.
+    After CONTRACT_ALARM_AFTER consecutive failing ticks this
     opens ONE issue on the target repo; the next successful load closes
     it and says so. Alarm plumbing is best-effort by construction: it
     must never break the tick it reports for."""
@@ -685,8 +684,7 @@ def sweep(
     """The backup wake layers, applied to every waiting run.
 
     dry_run reports what WOULD happen with zero writes — no leases, no
-    attempt counters, no dispatch — so the plumbing can run live before the
-    real dispatcher exists.
+    attempt counters, no dispatch.
     """
     woken: list[tuple[str, str]] = []
     deferred: list[str] = []
@@ -725,9 +723,9 @@ def sweep(
         deferred=tuple(deferred),
         reaped_leases=tuple(reaped),
         stuck=tuple(stuck),
-        # NOT the global dry_run: that flag exists because the WAKE
-        # dispatcher is still a placeholder; ending killed climbs' records
-        # dispatches nothing and must run live even while wakes stay dry.
+        # NOT the global dry_run: that flag only dries WAKE delivery;
+        # ending killed climbs' records dispatches nothing and must run
+        # live even while wakes stay dry.
         implementing_ended=tuple(_sweep_implementing(root, compute, now, grace_s)),
     )
 
@@ -741,9 +739,8 @@ def _sweep_implementing(root: Path, compute: SlurmCompute, now: float, grace_s: 
 
     A climb that CRASHES contains its own ending (climb.py); a climb that is
     KILLED — walltime, preemption, scancel after the SIGTERM grace, node
-    death — leaves no exception to contain, and before this pass its record
-    stranded in `implementing` forever (the picker's stranded guard freed
-    the lane but nothing ever recorded the ending). Slurm truth decides:
+    death — leaves no exception to contain, so this pass records the ending
+    (the picker's stranded guard only frees the lane). Slurm truth decides:
     job terminal or GONE, plus a grace so a just-finished healthy climb can
     write its own final state first. Outage never reads as dead. Legacy
     records without a job id age out on the stranded window instead.
@@ -852,9 +849,7 @@ def _poll_targets(record: RunRecord) -> list[str]:
     the common case; a MULTI-job park (candidate + siblings, or several author
     launches) records no single id — its jobs live in the stage's `afterany`
     dependency string, the one source that always names them all. Without
-    this fallback a multi-job park was a BLIND park riding the deadline floor
-    (~hours of dead time after evals that finished in minutes — observed live
-    2026-08-25)."""
+    this fallback a multi-job park is blind and rides the deadline floor."""
     if record.experiment_job_id:
         return [record.experiment_job_id]
     afterany = str((record.stage or {}).get("afterany", ""))
@@ -1074,8 +1069,8 @@ def tick(
                 contract_error = f"{type(exc).__name__}: {exc}"
             if contract_error is None:
                 # a bad panel config idles the same launch lanes a bad
-                # contract does — same silent-idle class ("this cost 36
-                # hours once"), so it rides the same alarm
+                # contract does — same silent-idle class, so it rides the
+                # same alarm
                 panel_error = _panel_preflight_error(followup_spec)
                 if panel_error:
                     contract_error = f"panel preflight: {panel_error}"
@@ -1385,7 +1380,7 @@ def _climb_limit_argv(limits: EffectiveLimits, job_minutes: int) -> list[str]:
     walltime rides along (contract budget + any panel allowance, clamped at
     the partition cap — exactly what the JobSpec gets) so the climb arms its
     self-deadline against the real clock (Slurm delivers no signals to our
-    processes on Torch — measured 2026-08-08). The session shrinks to fit a
+    processes on Torch). The session shrinks to fit a
     CAPPED job with the same rule limits.effective_limits applies to
     contract values — better a short session that ends cleanly than a full
     one the self-deadline kills mid-flight."""
@@ -1538,8 +1533,7 @@ def service_steward(
         from autoresearch.steward import release_orphaned_claims
 
         # ONE active run per target covers stewardships too: an env rewrite
-        # must not fly alongside a solver climb (the drift/freshness
-        # machinery does not coordinate them) or another stewardship.
+        # must not fly alongside a solver climb or another stewardship.
         records = list_runs(root)
         # reconcile first: killed jobs never post their own release — and
         # BEFORE the outage pause below, because a claim orphaned by the
@@ -1769,9 +1763,9 @@ def service_intake(
 
 @dataclass
 class LoggingDispatcher:
-    """Never dispatched in production today: main() runs the sweep in
-    dry_run mode until the real session dispatcher lands (phase 5), so no
-    lease is taken and no attempt is counted. This exists for the seam."""
+    """Never dispatched in production: main() runs the sweep dry unless
+    dispatched wake is armed, so no lease is taken and no attempt is
+    counted. This exists for the seam."""
 
     def dispatch(self, record: RunRecord, reason: str) -> str:
         log.info("WOULD WAKE %s (%s) — session dispatch lands in phase 5", record.run_id, reason)
@@ -1820,7 +1814,7 @@ class JobWakeDispatcher:
         # An AUTHOR-SLEEP wake resumes a FULL author session (not the short
         # read-decide a candidate wake runs), so the Slurm job must fit that
         # session or walltime kills the resumed session mid-run and the run just
-        # waits for another wake (terra #135 r3). Size the job to the session
+        # waits for another wake. Size the job to the session
         # budget + overhead and pass --session-minutes so the in-job
         # self-deadline fires BEFORE Slurm's walltime. A candidate wake keeps
         # the short budget (read results + panel).
@@ -1880,7 +1874,7 @@ def _wake_dispatcher_from_env(
     * armed (the `AUTORESEARCH_DISPATCH_WAKE` env var OR a `<root>/DISPATCH_WAKE`
       sentinel file) AND the chain env carries what a wake job needs -> the real
       `JobWakeDispatcher` and a LIVE sweep;
-    * otherwise -> the `LoggingDispatcher` and a DRY sweep (today's behavior).
+    * otherwise -> the `LoggingDispatcher` and a DRY sweep.
 
     The sentinel mirrors PAUSE: an operator arms/disarms with a touch/rm, no
     chain restart. So dispatched climbing is turned on deliberately, and a

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -11,10 +11,8 @@ instances, claims the evidence does not support).
 Same constitution as the reviewer, inverted population:
 - bot-authored PRs ONLY (a human PR is the advisory reviewer's job);
 - findings-only; never an approval; never blocks CI;
-- the header carries the not-a-certification semantics (formerly the
-  louder "silence is not endorsement" — softened 2026-08-08 on maintainer
-  feedback): a clean read must never be mistaken for a green light; the
-  human code owner still decides;
+- the header carries the not-a-certification semantics: a clean read must
+  never be mistaken for a green light; the human code owner still decides;
 - model output sanitized with the same approval-language redaction, so a
   prompt-injected diff cannot forge an endorsement through this channel.
 """
@@ -52,9 +50,8 @@ VERIFY_HEADER = (
 
 MAX_CONTRACT_CHARS = 10_000
 MAX_CLAIM_CHARS = 30_000
-# The discussion is context the verifier must not be blind to (found live:
-# round 2 raised "no reported numbers" while the author's rebuttal upthread
-# carried them) — most recent comments, bounded.
+# The discussion is context the verifier must not be blind to (a rebuttal
+# upthread can already answer a finding) — most recent comments, bounded.
 MAX_THREAD_COMMENTS = 12
 MAX_THREAD_COMMENT_CHARS = 4_000
 
@@ -90,9 +87,8 @@ def gather_thread(
     client: GitHubClient, repo: str, number: int, bot_login: str
 ) -> tuple[tuple[str, str], ...]:
     """The gated discussion, from ALL THREE places maintainers write —
-    issue comments, review bodies, inline review comments (the follow-up
-    lane learned this the hard way: independent collections, and feedback
-    lands in any of them)."""
+    issue comments, review bodies, inline review comments (independent
+    collections; feedback lands in any of them)."""
     sources = (
         client.list_comments(repo, number),
         client.list_pr_reviews(repo, number),
@@ -282,11 +278,9 @@ def build_verify_prompt(
     return "\n\n".join(parts)
 
 
-# Prepended to the shared rubric for the agent-session verifier: it has TWO
-# checkouts: the PR head (the change under
-# review) and the BASE branch (the trusted contract and ruler — the solver
-# cannot have shaped it). Ruler reads must target base: the ruler comes from
-# the base branch, never the PR.
+# Prepended to the shared rubric for the agent-session verifier: TWO
+# checkouts — the PR head (the change under review) and the BASE branch
+# (the trusted contract and ruler — the solver cannot have shaped it).
 DEFAULT_SYSCALL_CMD = "python .autoresearch/syscall"
 
 


### PR DESCRIPTION
The mass comment cleanup Mengye ordered. 90 sites, 16 files, **comments and docstrings only** — verified mechanically: every changed file's AST (docstrings normalized out) is identical to main's.

**Removed:** review-round citations ("(terra #135 r2)", "(review finding)"), dated war stories ("the 2026-08-07 quota crisis…", "cost a live steward follow-up its whole session"), was/now historical narration, "later PR"/"phase 5"/"Slice 1" roadmap remnants, and explanations phrased in terms of deleted machinery (drift fingerprints, LocalMeasurer, panel_revisions, moved-base merge).

**Kept, deliberately:** trust-boundary rationale, why-not-the-obvious-way explanations, cross-file coupling warnings, Slurm fail-safety semantics (GONE vs query-failure), version-pin facts (codex 0.130.0, hermes v0.20.1), and all docs/design pointers.

Net −48 lines. Full gate green (ruff check/format, mypy, 774 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)