### PR TITLE
feat: Claude-on-Vertex (ADC) billing for claude-backend roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- Claude-on-Vertex (ADC) billing, config-driven: set
+  `AUTORESEARCH_VERTEX_PROJECT` (+ optional `_REGION`, `_ADC` file) and every
+  claude-backend session — author, panel judge, reviewer — authenticates to
+  Vertex AI via Application Default Credentials instead of an Anthropic API
+  key (the session env then carries no key at all; contained sessions get the
+  ADC file bind-mounted read-only). One env owner (`harness.vertex_from_env`);
+  unset the project to fall back to API-key billing instantly. Codex/hermes
+  are unaffected — OpenAI models are not on GCP.
+
 ### Changed
 
 - One publish — the sealed candidate sha, everywhere. `live_climb`'s inline

--- a/docs/install.md
+++ b/docs/install.md
@@ -181,6 +181,26 @@ the same way.
 
 ---
 
+## Billing Claude sessions to GCP credits (Vertex AI)
+
+Anthropic-billed roles (authors, panel judges, reviewers on the claude
+backend) can run on Claude-in-Vertex instead of an Anthropic API key —
+useful when GCP credits are the budget. Config-driven, one env owner:
+
+```bash
+AUTORESEARCH_VERTEX_PROJECT=your-gcp-project   # presence flips vertex ON
+AUTORESEARCH_VERTEX_REGION=global              # optional (default: global)
+AUTORESEARCH_VERTEX_ADC=~/.config/autoresearch/vertex_adc.json  # ADC file
+```
+
+Enable the Claude models in the project's Model Garden, mint ADC
+(`gcloud auth application-default login` +
+`set-quota-project <project>`), and place the credential at the configured
+path. Contained sessions get the ADC file bind-mounted read-only; the
+session env then carries no Anthropic key at all. Unset the project var to
+fall back to API-key billing. OpenAI-backed roles (codex/hermes) are
+unaffected — those models are not on GCP.
+
 ## Safety defaults
 
 On by default. Think hard before changing any of them:

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -123,7 +123,9 @@ if [ -r "$ENV_FILE" ]; then
     if [ "$owner" = "$(id -u)" ] && [ $((8#$perms & 8#022)) -eq 0 ]; then
         for _k in AUTORESEARCH_AUTHOR_BACKEND AUTORESEARCH_AUTHOR_MODEL \
                   AUTORESEARCH_CODEX_BIN AUTORESEARCH_CODEX_KEY_FILE \
-                  AUTORESEARCH_HARNESS_KEY_FILE; do
+                  AUTORESEARCH_HARNESS_KEY_FILE \
+                  AUTORESEARCH_VERTEX_PROJECT AUTORESEARCH_VERTEX_REGION \
+                  AUTORESEARCH_VERTEX_ADC; do
             _v=$(grep -E "^${_k}=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2-)
             _v=${_v%$'\r'}                         # CRLF-edited file
             _v=${_v#[\"\']}; _v=${_v%[\"\']}       # optional surrounding quote

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -57,7 +57,7 @@ from autoresearch.progress import (
     write_progress,
 )
 from autoresearch.review import PullRequest
-from autoresearch.role_runner import build_harness
+from autoresearch.role_runner import build_harness, role_key
 from autoresearch.roles import author_spec
 from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
@@ -1298,7 +1298,7 @@ def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
     from autoresearch.panel import parse_lenses
     from autoresearch.roles import reviewer_spec
 
-    panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+    panel_key = role_key(args.panel_key_file)  # panel judges run the claude backend
     lenses = []
     for kind, backend, model in parse_lenses(args.panel):
         hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
@@ -2201,13 +2201,13 @@ def main() -> int:
             # the panel's judges need the verifier key; an author-sleep wake
             # alone does NOT — a panel-less deployment must not be forced to
             # provision an unused credential.
-            wake_panel_key = FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+            wake_panel_key = role_key(args.panel_key_file)
         if (
             wake_lenses
             or _wake_stage.get("phase") == "author-sleep"
             or _wake_stage.get("submitted")
         ):
-            wake_api_key = FileTokenProvider(Path(wake_key_file)).token()
+            wake_api_key = role_key(wake_key_file, wake_backend)
             wake_spec = author_spec(max_turns=args.max_turns, walltime_s=args.session_minutes * 60)
             wake_harness = build_harness(
                 wake_api_key,
@@ -2257,8 +2257,9 @@ def main() -> int:
     # config-driven: the author key defaults per backend (claude vs codex) so the
     # tick never threads it — see resolve_author_key_file (result is ~-expanded).
     args.key_file = resolve_author_key_file(args.author_backend, args.key_file)
-    # same 0600 discipline as the PAT: this key spends real money
-    api_key = FileTokenProvider(Path(args.key_file)).token()
+    # same 0600 discipline as the PAT: this key spends real money. A missing
+    # file is tolerated only when Vertex (ADC) covers the claude backend.
+    api_key = role_key(args.key_file, args.author_backend)
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_id = f"{args.benchmark}-{stamp}"
 
@@ -2305,7 +2306,7 @@ def main() -> int:
     # the panel key joins the redaction set: judge error text can echo request
     # material like any other model error.
     panel_key = (
-        FileTokenProvider(Path(args.panel_key_file).expanduser()).token()
+        role_key(args.panel_key_file)
         if args.panel.strip()
         else ""
     )

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -2305,11 +2305,7 @@ def main() -> int:
         parser.error(str(exc))
     # the panel key joins the redaction set: judge error text can echo request
     # material like any other model error.
-    panel_key = (
-        role_key(args.panel_key_file)
-        if args.panel.strip()
-        else ""
-    )
+    panel_key = role_key(args.panel_key_file) if args.panel.strip() else ""
 
     # Dispatched measurement needs the full cluster triple AND a real image
     # file to bind against; missing any, the climb measures inline (the tick

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -39,7 +39,7 @@ from autoresearch.progress import (
     write_progress,
 )
 from autoresearch.review import APPROVAL_PATTERN, REDACTED
-from autoresearch.role_runner import run_role
+from autoresearch.role_runner import role_key, run_role
 from autoresearch.roles import followup_spec
 from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
@@ -750,7 +750,7 @@ def main() -> int:
         resolve_author_key_file(author_backend, args.key_file) if args.key_file else author_key
     )
     codex_extra = tuple(a for c in args.codex_config for a in ("-c", c))
-    api_key = FileTokenProvider(Path(args.key_file)).token()
+    api_key = role_key(args.key_file, author_backend)
     bot_auth = FileTokenProvider(Path(args.pat_file))
 
     # Same self-deadline as the climb: Slurm never signals this process,

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -101,6 +101,41 @@ def session_env(api_key: str, key_variable: str, home: Path) -> dict[str, str]:
     return env
 
 
+@dataclass(frozen=True)
+class VertexConfig:
+    """Claude-on-Vertex auth (ADC): set to bill Anthropic sessions to a GCP
+    project instead of an Anthropic API key. The single owner of the
+    AUTORESEARCH_VERTEX_* env contract is `vertex_from_env`."""
+
+    project: str
+    region: str = "global"
+    adc_file: str = ""  # GOOGLE_APPLICATION_CREDENTIALS; "" = ambient ADC
+
+    def env(self) -> dict[str, str]:
+        out = {
+            "CLAUDE_CODE_USE_VERTEX": "1",
+            "ANTHROPIC_VERTEX_PROJECT_ID": self.project,
+            "CLOUD_ML_REGION": self.region,
+        }
+        if self.adc_file:
+            out["GOOGLE_APPLICATION_CREDENTIALS"] = self.adc_file
+        return out
+
+
+def vertex_from_env() -> VertexConfig | None:
+    """The deployment's Vertex coordinates, or None (Anthropic-direct). A live
+    flip needs only the env: set AUTORESEARCH_VERTEX_PROJECT to route every
+    claude session through Vertex; unset it to fall back to the API key."""
+    project = os.environ.get("AUTORESEARCH_VERTEX_PROJECT", "").strip()
+    if not project:
+        return None
+    return VertexConfig(
+        project=project,
+        region=os.environ.get("AUTORESEARCH_VERTEX_REGION", "global").strip() or "global",
+        adc_file=os.path.expanduser(os.environ.get("AUTORESEARCH_VERTEX_ADC", "").strip()),
+    )
+
+
 def redact(text: str, secrets: tuple[str, ...]) -> str:
     """Strip known secrets from text before it is stored anywhere."""
     for secret in secrets:
@@ -393,8 +428,12 @@ class ClaudeCodeHarness:
     # generic (python + uv + git); the binary is bind-mounted in.
     container_image: str = ""
     apptainer_binary: str = "apptainer"
+    # Claude-on-Vertex (ADC) instead of the Anthropic API key; the api_key is
+    # ignored when set. Contained sessions get the ADC file bind-mounted.
+    vertex: VertexConfig | None = None
 
     CONTAINER_CLAUDE = "/opt/agent/claude"
+    CONTAINER_ADC = "/opt/agent/adc.json"
     supports_resume = True  # native --resume
 
     def run(
@@ -466,6 +505,11 @@ class ClaudeCodeHarness:
                 f"{session_home}:{session_home}",
                 "--bind",
                 f"{self.binary}:{self.CONTAINER_CLAUDE}:ro",
+                *(
+                    ["--bind", f"{Path(self.vertex.adc_file).resolve()}:{self.CONTAINER_ADC}:ro"]
+                    if self.vertex is not None and self.vertex.adc_file
+                    else []
+                ),
                 "--pwd",
                 str(workspace),
                 self.container_image,
@@ -478,13 +522,26 @@ class ClaudeCodeHarness:
             # children included) in one process group we can kill as a unit —
             # a timed-out session must not leave orphans holding the API key
             # and writing into the clone.
-            env = session_env(self.api_key, "ANTHROPIC_API_KEY", session_home)
-            if self.container_image:
-                # --cleanenv drops the host environment inside the container
-                # EXCEPT APPTAINERENV_* variables, which apptainer injects
-                # with the prefix stripped — the key travels via the
-                # environment, never argv (argv is world-readable in /proc).
-                env["APPTAINERENV_ANTHROPIC_API_KEY"] = self.api_key
+            if self.vertex is not None:
+                # vertex auth: ADC only — ANTHROPIC_API_KEY is deliberately
+                # absent so the CLI cannot fall back to direct billing
+                env = session_env("", "ANTHROPIC_API_KEY", session_home)
+                del env["ANTHROPIC_API_KEY"]
+                vertex_env = dict(self.vertex.env())
+                if self.container_image and self.vertex.adc_file:
+                    vertex_env["GOOGLE_APPLICATION_CREDENTIALS"] = self.CONTAINER_ADC
+                env |= vertex_env
+                if self.container_image:
+                    for k, v in vertex_env.items():
+                        env[f"APPTAINERENV_{k}"] = v
+            else:
+                env = session_env(self.api_key, "ANTHROPIC_API_KEY", session_home)
+                if self.container_image:
+                    # --cleanenv drops the host environment inside the container
+                    # EXCEPT APPTAINERENV_* variables, which apptainer injects
+                    # with the prefix stripped — the key travels via the
+                    # environment, never argv (argv is world-readable in /proc).
+                    env["APPTAINERENV_ANTHROPIC_API_KEY"] = self.api_key
             process = subprocess.Popen(
                 command,
                 cwd=workspace,

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -109,7 +109,12 @@ class VertexConfig:
 
     project: str
     region: str = "global"
-    adc_file: str = ""  # GOOGLE_APPLICATION_CREDENTIALS; "" = ambient ADC
+    # GOOGLE_APPLICATION_CREDENTIALS. Sessions run with a scrubbed per-run
+    # HOME, so ambient ADC discovery inside the session can never find the
+    # real ~/.config/gcloud — vertex_from_env resolves that default to an
+    # explicit path up front. "" only where a metadata server provides
+    # credentials (GCE / workload identity).
+    adc_file: str = ""
 
     def env(self) -> dict[str, str]:
         out = {
@@ -129,10 +134,18 @@ def vertex_from_env() -> VertexConfig | None:
     project = os.environ.get("AUTORESEARCH_VERTEX_PROJECT", "").strip()
     if not project:
         return None
+    adc = os.path.expanduser(os.environ.get("AUTORESEARCH_VERTEX_ADC", "").strip())
+    if not adc:
+        # resolve the gcloud default NOW, under the real HOME — the session's
+        # HOME is a scrubbed per-run directory where ambient discovery would
+        # find nothing. Absent file: leave "" for metadata-server credentials.
+        default = os.path.expanduser("~/.config/gcloud/application_default_credentials.json")
+        if os.path.isfile(default):
+            adc = default
     return VertexConfig(
         project=project,
         region=os.environ.get("AUTORESEARCH_VERTEX_REGION", "global").strip() or "global",
-        adc_file=os.path.expanduser(os.environ.get("AUTORESEARCH_VERTEX_ADC", "").strip()),
+        adc_file=adc,
     )
 
 

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -100,8 +100,14 @@ def main() -> int:
                 reviewed_by=backend,
             )
         return 0
+    from autoresearch.harness import vertex_from_env
+
     api_key = os.environ.get(key_var, "").strip()
-    if not api_key:
+    # an ADC-only deployment holds no Anthropic key: Vertex covering the
+    # claude backend stands in for it (same tolerance as role_key), so the
+    # skip-stub fires only when NEITHER credential source exists
+    vertex_covers = backend == "claude" and vertex_from_env() is not None
+    if not api_key and not vertex_covers:
         log.warning("%s is unset or empty; skipping review", key_var)
         if emit_env:
             # a standing second-opinion service must not die silently when

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -27,6 +27,7 @@ from autoresearch.harness import (
     Harness,
     HermesHarness,
     SessionResult,
+    vertex_from_env,
 )
 from autoresearch.rolespec import RoleSpec
 
@@ -141,6 +142,10 @@ def build_harness(
         # / hooks / project settings as instructions (defence in depth beside
         # the caller's sanitize_checkout)
         bare=spec.output_schema is not None,
+        # Vertex (ADC) billing when the deployment configures it; the env
+        # contract has ONE owner (harness.vertex_from_env), so every claude
+        # role on every CLI flips together and the API key stays the fallback
+        vertex=vertex_from_env(),
     )
 
 

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -64,6 +64,22 @@ _HERMES_PROVIDERS = {
 }
 
 
+def role_key(key_file: str | Path, backend: str = "claude") -> str:
+    """Read a role's API key file — tolerating its ABSENCE exactly when the
+    deployment's Vertex config covers the claude backend (an ADC-only
+    deployment holds no Anthropic key at all; the harness then authenticates
+    via ADC and ignores api_key). Every other backend, and claude without
+    Vertex, still fails loudly on a missing/lax key file."""
+    from autoresearch.harness import vertex_from_env
+
+    path = Path(key_file).expanduser()
+    if backend == "claude" and vertex_from_env() is not None and not path.is_file():
+        return ""
+    from autoresearch.github import FileTokenProvider
+
+    return FileTokenProvider(path).token()
+
+
 def build_harness(
     api_key: str,
     spec: RoleSpec,

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -53,7 +53,7 @@ from autoresearch.progress import (
     load_leader,
     write_progress,
 )
-from autoresearch.role_runner import build_harness, run_role
+from autoresearch.role_runner import build_harness, role_key, run_role
 from autoresearch.roles import steward_spec
 from autoresearch.rolespec import RoleSpec
 from autoresearch.runstate import (
@@ -781,7 +781,7 @@ def main() -> int:
     if not args.image and not args.uncontained:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")
 
-    api_key = FileTokenProvider(Path(args.key_file)).token()
+    api_key = role_key(args.key_file)  # steward runs the claude backend
     bot_auth = FileTokenProvider(Path(args.pat_file))
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     run_id = f"steward-{args.benchmark}-{stamp}"

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1291,7 +1291,6 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
         return ""
     try:
         from autoresearch.climb import PANEL_KEY_DEFAULT, resolve_author_key_file
-        from autoresearch.github import FileTokenProvider
         from autoresearch.panel import parse_lenses
 
         try:
@@ -1319,7 +1318,12 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
                 f"panel key file {path} is the author key file "
                 "(role separation: the verifier needs its own key)"
             )
-        FileTokenProvider(path).token()
+        # ADC-only deployments (Vertex covering the claude panel) hold no
+        # Anthropic key at all — the same tolerance role_key applies at run
+        # time, so the preflight and the climb agree.
+        from autoresearch.role_runner import role_key
+
+        role_key(path)
         return ""
     except Exception as exc:
         # never raises: an unexpected failure (partial deploy, ELOOP, unset

--- a/src/autoresearch/verify_agent_cli.py
+++ b/src/autoresearch/verify_agent_cli.py
@@ -35,8 +35,12 @@ def main() -> int:
     if not bot_login:
         log.warning("REVIEW_BOT_LOGIN is unset; skipping (cannot identify bot-authored PRs)")
         return 0
+    from autoresearch.harness import vertex_from_env
+
     api_key = os.environ.get("ANTHROPIC_VERIFIER_KEY", "").strip()
-    if not api_key:
+    # ADC-only deployments: Vertex covering the (claude) verifier stands in
+    # for the key, same tolerance as role_key
+    if not api_key and vertex_from_env() is None:
         log.warning("ANTHROPIC_VERIFIER_KEY is unset or empty; skipping verification")
         return 0
     # The directory holding the workflow's two checkouts: pr-head/

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -746,3 +746,71 @@ def test_no_container_means_no_apptainer(tmp_path: Path) -> None:
     argv = (tmp_path / "seen_argv").read_text()
     assert "apptainer" not in argv and "--containall" not in argv
     assert "APPTAINERENV_" not in (tmp_path / "seen_env").read_text()
+
+
+def test_vertex_mode_swaps_the_key_for_adc_env(tmp_path: Path, monkeypatch) -> None:
+    # vertex on: the session env carries the Vertex triple + ADC path and NO
+    # ANTHROPIC_API_KEY (the CLI must not silently fall back to direct billing)
+    from autoresearch.harness import ClaudeCodeHarness, VertexConfig
+
+    captured = {}
+
+    def fake_popen(command, cwd, env, **kw):
+        captured["command"] = command
+        captured["env"] = env
+        raise OSError("stop here")  # run() contains it as an error result
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    h = ClaudeCodeHarness(
+        api_key="sk-should-not-appear",
+        vertex=VertexConfig(project="p-123", region="global", adc_file=str(tmp_path / "adc.json")),
+    )
+    result = h.run("brief", tmp_path)
+    assert result.is_error  # the fake Popen stopped the run
+    env = captured["env"]
+    assert env["CLAUDE_CODE_USE_VERTEX"] == "1"
+    assert env["ANTHROPIC_VERTEX_PROJECT_ID"] == "p-123"
+    assert env["CLOUD_ML_REGION"] == "global"
+    assert env["GOOGLE_APPLICATION_CREDENTIALS"] == str(tmp_path / "adc.json")
+    assert "ANTHROPIC_API_KEY" not in env
+
+
+def test_vertex_contained_session_binds_the_adc_file(tmp_path: Path, monkeypatch) -> None:
+    from autoresearch.harness import ClaudeCodeHarness, VertexConfig
+
+    adc = tmp_path / "adc.json"
+    adc.write_text("{}")
+    captured = {}
+
+    def fake_popen(command, cwd, env, **kw):
+        captured["command"] = command
+        captured["env"] = env
+        raise OSError("stop here")
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+    h = ClaudeCodeHarness(
+        api_key="",
+        binary="/abs/claude",
+        container_image="/img.sif",
+        vertex=VertexConfig(project="p-123", adc_file=str(adc)),
+    )
+    h.run("brief", tmp_path)
+    cmd = captured["command"]
+    assert f"{adc.resolve()}:{ClaudeCodeHarness.CONTAINER_ADC}:ro" in cmd
+    env = captured["env"]
+    # inside the container the credential path is the BOUND path
+    assert env["APPTAINERENV_GOOGLE_APPLICATION_CREDENTIALS"] == ClaudeCodeHarness.CONTAINER_ADC
+    assert env["APPTAINERENV_CLAUDE_CODE_USE_VERTEX"] == "1"
+    assert "APPTAINERENV_ANTHROPIC_API_KEY" not in env
+
+
+def test_vertex_from_env_is_the_single_owner(monkeypatch) -> None:
+    from autoresearch.harness import vertex_from_env
+
+    monkeypatch.delenv("AUTORESEARCH_VERTEX_PROJECT", raising=False)
+    assert vertex_from_env() is None
+    monkeypatch.setenv("AUTORESEARCH_VERTEX_PROJECT", "p-9")
+    monkeypatch.setenv("AUTORESEARCH_VERTEX_ADC", "~/adc.json")
+    cfg = vertex_from_env()
+    assert cfg is not None and cfg.project == "p-9" and cfg.region == "global"
+    assert cfg.adc_file.endswith("/adc.json") and not cfg.adc_file.startswith("~")

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -836,9 +836,9 @@ def test_role_key_tolerates_a_missing_file_only_under_vertex(tmp_path, monkeypat
 
     missing = tmp_path / "no-such-key"
     monkeypatch.delenv("AUTORESEARCH_VERTEX_PROJECT", raising=False)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         role_key(missing)  # no vertex: loud, as ever
     monkeypatch.setenv("AUTORESEARCH_VERTEX_PROJECT", "p-9")
     assert role_key(missing) == ""  # ADC-only claude deployment
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         role_key(missing, "codex")  # vertex never excuses a non-claude backend

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -829,3 +829,16 @@ def test_vertex_from_env_resolves_ambient_adc_under_the_real_home(tmp_path, monk
     monkeypatch.delenv("AUTORESEARCH_VERTEX_ADC", raising=False)
     cfg = vertex_from_env()
     assert cfg is not None and cfg.adc_file == str(default)
+
+
+def test_role_key_tolerates_a_missing_file_only_under_vertex(tmp_path, monkeypatch) -> None:
+    from autoresearch.role_runner import role_key
+
+    missing = tmp_path / "no-such-key"
+    monkeypatch.delenv("AUTORESEARCH_VERTEX_PROJECT", raising=False)
+    with pytest.raises(Exception):
+        role_key(missing)  # no vertex: loud, as ever
+    monkeypatch.setenv("AUTORESEARCH_VERTEX_PROJECT", "p-9")
+    assert role_key(missing) == ""  # ADC-only claude deployment
+    with pytest.raises(Exception):
+        role_key(missing, "codex")  # vertex never excuses a non-claude backend

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -814,3 +814,18 @@ def test_vertex_from_env_is_the_single_owner(monkeypatch) -> None:
     cfg = vertex_from_env()
     assert cfg is not None and cfg.project == "p-9" and cfg.region == "global"
     assert cfg.adc_file.endswith("/adc.json") and not cfg.adc_file.startswith("~")
+
+
+def test_vertex_from_env_resolves_ambient_adc_under_the_real_home(tmp_path, monkeypatch) -> None:
+    # sessions get a scrubbed per-run HOME, so the gcloud default must be
+    # resolved to an explicit path at config time, under the REAL home
+    from autoresearch.harness import vertex_from_env
+
+    default = tmp_path / ".config" / "gcloud" / "application_default_credentials.json"
+    default.parent.mkdir(parents=True)
+    default.write_text("{}")
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AUTORESEARCH_VERTEX_PROJECT", "p-9")
+    monkeypatch.delenv("AUTORESEARCH_VERTEX_ADC", raising=False)
+    cfg = vertex_from_env()
+    assert cfg is not None and cfg.adc_file == str(default)


### PR DESCRIPTION
Routes Anthropic-billed sessions onto Mengye's GCP credits (75k). Org policy is ADC-only (API keys disallowed), so this is pure ADC.

## How

- `VertexConfig` + `vertex_from_env()` in harness.py — the ONE owner of the `AUTORESEARCH_VERTEX_*` env contract, read inside `build_harness`, so every claude role on every CLI flips together.
- Vertex mode session env: `CLAUDE_CODE_USE_VERTEX=1`, project, region, `GOOGLE_APPLICATION_CREDENTIALS` — and **no `ANTHROPIC_API_KEY`** (the CLI must not silently fall back to direct billing). Contained sessions bind-mount the ADC file read-only at a fixed path and point the container env at it.
- Fallback = unset `AUTORESEARCH_VERTEX_PROJECT`; keys stay on disk untouched.
- Codex/hermes unaffected (OpenAI proprietary is not on GCP) — a billing knob, not a backend asymmetry.

## Rollout (after merge)

1. Mengye: Model Garden enablement (Opus 5 + Fable 5, in progress) + ADC minted and copied to Torch (`~/.config/autoresearch/vertex_adc.json`).
2. Pilot: add the three vars to `~/.config/autoresearch/.env` allowlist read — note: the tick chain's `.env` allowlist must include them (follow-up line in tick_chain.sbatch) — then watch one panel round bill to GCP.
3. GH-Actions reviewers later via workload identity federation.

## Tests

Vertex env swap (no key present), contained bind + container-path credential, env-owner parsing (`~` expansion, default region). Full suite 775 green, ruff+mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)