### PR TITLE
feat: codex panel lenses — terra on the Torch panel, contained today

### DIFF
--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -147,12 +147,16 @@ if [ -r "$ENV_FILE" ]; then
 fi
 
 # The codex author binary is a host prerequisite; install it (idempotent, fast
-# path is a local version check) only when the fleet author is codex. Best-effort:
-# a failure here must never break the chain — the climb will report a missing
-# codex clearly if it comes to that.
-if [ "${AUTORESEARCH_AUTHOR_BACKEND:-}" = "codex" ]; then
-    bash "$AUTORESEARCH_HOME/scripts/install_codex.sh" || echo "deploy: codex install failed"
-fi
+# path is a local version check) when ANY codex role is deployed — the fleet
+# author, or a codex panel lens (a claude-author/codex-panel rollout still
+# bind-mounts the binary into every judge container). Best-effort: a failure
+# here must never break the chain — the climb will report a missing codex
+# clearly if it comes to that.
+case "${AUTORESEARCH_AUTHOR_BACKEND:-}:${AUTORESEARCH_PANEL:-}" in
+    codex:*|*:*codex*)
+        bash "$AUTORESEARCH_HOME/scripts/install_codex.sh" || echo "deploy: codex install failed"
+        ;;
+esac
 
 # --- 3. the tick itself (scrubbed of the PAT path; sessions are scrubbed
 #        further down in the harness) ---

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -126,7 +126,8 @@ if [ -r "$ENV_FILE" ]; then
                   AUTORESEARCH_HARNESS_KEY_FILE \
                   AUTORESEARCH_VERTEX_PROJECT AUTORESEARCH_VERTEX_REGION \
                   AUTORESEARCH_VERTEX_ADC \
-                  AUTORESEARCH_PANEL AUTORESEARCH_PANEL_KEY_FILE; do
+                  AUTORESEARCH_PANEL AUTORESEARCH_PANEL_KEY_FILE \
+                  AUTORESEARCH_PANEL_CODEX_KEY_FILE; do
             _line=$(grep -E "^${_k}=" "$ENV_FILE" 2>/dev/null | tail -1)
             # PRESENCE-based, not value-based: a key set to "" in .env is a
             # live OFF-SWITCH (AUTORESEARCH_PANEL="" disables the panel,

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1298,16 +1298,29 @@ def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
     from autoresearch.panel import parse_lenses
     from autoresearch.roles import reviewer_spec
 
-    panel_key = role_key(args.panel_key_file)  # panel judges run the claude backend
+    panel_key = role_key(args.panel_key_file)
     lenses = []
     for kind, backend, model in parse_lenses(args.panel):
         hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
+        # per-backend judge keys coexist — a codex lens is never handed the
+        # anthropic panel key, and role separation forbids defaulting to the
+        # AUTHOR's codex key: the judge key is its own, named explicitly
+        if backend == "codex":
+            codex_panel_key = os.environ.get("AUTORESEARCH_PANEL_CODEX_KEY_FILE", "").strip()
+            if not codex_panel_key:
+                raise ValueError(
+                    "a codex panel lens needs AUTORESEARCH_PANEL_CODEX_KEY_FILE "
+                    "(role separation: the judge's own key, never the author's)"
+                )
+            lens_key = role_key(codex_panel_key, "codex")
+        else:
+            lens_key = panel_key
         try:
             judge = build_harness(
-                panel_key,
+                lens_key,
                 reviewer_spec(),
                 backend=backend,
-                binary=args.claude_bin if backend == "claude" else None,
+                binary=args.claude_bin if backend == "claude" else args.codex_bin,
                 model=model or None,
                 # ALWAYS contained: the panel runs on the climb host next to key
                 # files, and a judge now holds a shell (codex `danger-full-access`),

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1314,6 +1314,14 @@ def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str
         # anthropic panel key, and role separation forbids defaulting to the
         # AUTHOR's codex key: the judge key is its own, named explicitly
         if backend == "codex":
+            if not args.image:
+                # --uncontained is a dev concession for CLAUDE sessions; a
+                # codex judge is danger-full-access and NEVER runs outside
+                # the image — a judge never runs uncontained next to key files
+                raise ValueError(
+                    "a codex panel lens requires --image (codex judges run "
+                    "danger-full-access and only ever inside the container)"
+                )
             codex_panel_key = os.environ.get("AUTORESEARCH_PANEL_CODEX_KEY_FILE", "").strip()
             if not codex_panel_key:
                 raise ValueError(

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1335,6 +1335,15 @@ def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str
                     f"codex panel key file {codex_panel_path} is the codex author "
                     "key (role separation: the judge needs its own key)"
                 )
+            claude_panel_path = Path(args.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
+            if codex_panel_path.resolve() == claude_panel_path.resolve():
+                # provider-key confusion: this would send the ANTHROPIC panel
+                # credential to codex (OpenAI) login
+                raise ValueError(
+                    f"codex panel key file {codex_panel_path} is the claude panel "
+                    "key file (a codex judge needs an OpenAI credential, and an "
+                    "anthropic key must never reach another provider's login)"
+                )
             lens_key = role_key(codex_panel_key, "codex")
             if lens_key:
                 secrets.append(lens_key)

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1298,9 +1298,12 @@ def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
     from autoresearch.panel import parse_lenses
     from autoresearch.roles import reviewer_spec
 
-    panel_key = role_key(args.panel_key_file)
+    parsed = parse_lenses(args.panel)
+    # the anthropic panel key is read only when a claude lens will use it —
+    # a codex-only panel must not demand an unrelated credential
+    panel_key = role_key(args.panel_key_file) if any(b == "claude" for _, b, _ in parsed) else ""
     lenses = []
-    for kind, backend, model in parse_lenses(args.panel):
+    for kind, backend, model in parsed:
         hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
         # per-backend judge keys coexist — a codex lens is never handed the
         # anthropic panel key, and role separation forbids defaulting to the

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1285,16 +1285,20 @@ def resume_run(
     return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
 
 
-def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
+def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str, ...]]:
     """Build the verification-panel lenses from the CLI args (empty `--panel`
-    disables it). Shared by the fresh-climb and the `--resume` wake paths so a
-    dispatched improvement runs the SAME panel as an inline one. Raises
-    ValueError on a bad panel/backend config — a configured gate must never
-    silently vanish."""
+    disables it), returning `(lenses, panel_secrets)` — the ONE owner of
+    panel credentials: each backend's judge key is read only when a lens uses
+    it, role separation is enforced HERE (a manual climb gets the same rule
+    as the tick preflight), and every key a judge holds joins the caller's
+    redaction set via `panel_secrets`. Shared by the fresh-climb and the
+    `--resume` wake paths so a dispatched improvement runs the SAME panel as
+    an inline one. Raises ValueError on a bad panel/backend config — a
+    configured gate must never silently vanish."""
     import os
 
     if not args.panel.strip():
-        return ()
+        return (), ()
     from autoresearch.panel import parse_lenses
     from autoresearch.roles import reviewer_spec
 
@@ -1303,6 +1307,7 @@ def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
     # a codex-only panel must not demand an unrelated credential
     panel_key = role_key(args.panel_key_file) if any(b == "claude" for _, b, _ in parsed) else ""
     lenses = []
+    secrets: list[str] = [panel_key] if panel_key else []
     for kind, backend, model in parsed:
         hermes_repo_env = os.environ.get("REVIEW_HERMES_REPO", "").strip()
         # per-backend judge keys coexist — a codex lens is never handed the
@@ -1315,7 +1320,16 @@ def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
                     "a codex panel lens needs AUTORESEARCH_PANEL_CODEX_KEY_FILE "
                     "(role separation: the judge's own key, never the author's)"
                 )
+            codex_panel_path = Path(codex_panel_key).expanduser()
+            codex_author_path = Path(resolve_author_key_file("codex")).expanduser()
+            if codex_panel_path.resolve() == codex_author_path.resolve():
+                raise ValueError(
+                    f"codex panel key file {codex_panel_path} is the codex author "
+                    "key (role separation: the judge needs its own key)"
+                )
             lens_key = role_key(codex_panel_key, "codex")
+            if lens_key:
+                secrets.append(lens_key)
         else:
             lens_key = panel_key
         try:
@@ -1338,7 +1352,7 @@ def _panel_lenses_from_args(args: Any) -> tuple[PanelLens, ...]:
         except ValueError as exc:
             raise ValueError(f"panel entry {kind}:{backend}: {exc}") from exc
         lenses.append(PanelLens(kind=kind, harness=judge))
-    return tuple(lenses)
+    return tuple(lenses), tuple(dict.fromkeys(secrets))
 
 
 def build_panel_runner(
@@ -2200,10 +2214,9 @@ def main() -> int:
         # the wake runs the SAME verification panel as a fresh climb, so a
         # dispatched improvement is not published unverified.
         try:
-            wake_lenses = _panel_lenses_from_args(args)
+            wake_lenses, wake_panel_secrets = _panel_lenses_from_args(args)
         except ValueError as exc:
             parser.error(str(exc))
-        wake_panel_key = ""
         wake_api_key = ""
         wake_harness = None
         wake_spec = None
@@ -2213,11 +2226,6 @@ def main() -> int:
         # with its launches' results). A panel-less candidate wake stays a pure
         # read-decide-publish job and must not require the author key.
         _wake_stage = getattr(_wake_record, "stage", None) or {}
-        if wake_lenses:
-            # the panel's judges need the verifier key; an author-sleep wake
-            # alone does NOT — a panel-less deployment must not be forced to
-            # provision an unused credential.
-            wake_panel_key = role_key(args.panel_key_file)
         if (
             wake_lenses
             or _wake_stage.get("phase") == "author-sleep"
@@ -2247,7 +2255,9 @@ def main() -> int:
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,
                 now=time.time(),
-                secrets=tuple(k for k in (bot_auth.token(), wake_panel_key, wake_api_key) if k),
+                secrets=tuple(
+                    k for k in (bot_auth.token(), *wake_panel_secrets, wake_api_key) if k
+                ),
                 base_branch=args.base_branch,
                 panel_lenses=wake_lenses,
                 harness=wake_harness,
@@ -2316,12 +2326,9 @@ def main() -> int:
     # Pre-PR panel lenses: judge sessions on the verifier's own key (separate
     # identity from the author). kind[:backend[:model]]; claude by default.
     try:
-        panel_lenses = _panel_lenses_from_args(args)
+        panel_lenses, panel_secrets = _panel_lenses_from_args(args)
     except ValueError as exc:
         parser.error(str(exc))
-    # the panel key joins the redaction set: judge error text can echo request
-    # material like any other model error.
-    panel_key = role_key(args.panel_key_file) if args.panel.strip() else ""
 
     # Dispatched measurement needs the full cluster triple AND a real image
     # file to bind against; missing any, the climb measures inline (the tick
@@ -2367,7 +2374,7 @@ def main() -> int:
                     for k in (
                         api_key,
                         bot_auth.token(),
-                        panel_key,
+                        *panel_secrets,
                     )
                     if k
                 ),

--- a/src/autoresearch/panel.py
+++ b/src/autoresearch/panel.py
@@ -44,10 +44,11 @@ def parse_lenses(panel: str) -> tuple[tuple[str, str, str], ...]:
     parser.error, and the tick preflights the SAME rules before claiming an
     intake issue — otherwise a typo'd spec passes the tick, the issue is
     claimed, and the climb dies at argument parsing with the claim stranded.
-    Only the claude backend is accepted for panel judges: non-claude judges
-    execute or read broadly and would run UNCONTAINED on the orchestrator
-    host, next to key files. The seam supports them; enable when their
-    containment on that host lands (claude runs inside the climb's image)."""
+    Backends are peers on the panel as everywhere else; the one gate is
+    CONTAINMENT on the orchestrator host (judges hold a shell and run next
+    to key files): claude and codex run inside the climb's image, hermes
+    has no container mode yet — its lens is refused until that wrapper
+    exists, never run uncontained."""
     entries: list[tuple[str, str, str]] = []
     for raw in panel.split(","):
         entry = raw.strip()
@@ -56,10 +57,12 @@ def parse_lenses(panel: str) -> tuple[tuple[str, str, str], ...]:
         backend = backend or "claude"
         if kind not in LENS_KINDS:
             raise ValueError(f"panel entry {entry!r}: unknown kind (use {LENS_KINDS})")
-        if backend != "claude":
+        if backend not in ("claude", "codex"):
             raise ValueError(
-                f"panel entry {entry!r}: only the claude backend is contained "
-                "on the orchestrator host so far"
+                f"panel entry {entry!r}: backend {backend!r} has no container "
+                "mode on the orchestrator host yet (claude and codex run "
+                "inside the climb's image); a judge never runs uncontained "
+                "next to key files"
             )
         entries.append((kind, backend, model))
     return tuple(entries)

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1323,6 +1323,12 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
                     f"codex panel key file {codex_panel} is the codex author key "
                     "(role separation: the judge needs its own key)"
                 )
+            claude_panel = Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
+            if codex_panel.resolve() == claude_panel.resolve():
+                return (
+                    f"codex panel key file {codex_panel} is the claude panel key "
+                    "file (an anthropic key must never reach codex login)"
+                )
             FileTokenProvider(codex_panel).token()
         if not any(backend == "claude" for _, backend, _ in lenses):
             return ""  # codex-only panel: the claude key checks below don't apply

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1291,12 +1291,32 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
         return ""
     try:
         from autoresearch.climb import PANEL_KEY_DEFAULT, resolve_author_key_file
+        from autoresearch.github import FileTokenProvider
         from autoresearch.panel import parse_lenses
 
         try:
-            parse_lenses(spec.panel)
+            lenses = parse_lenses(spec.panel)
         except ValueError as exc:
             return str(exc)
+        if any(backend == "codex" for _, backend, _ in lenses):
+            # mirror the climb's rule exactly: a codex lens needs the JUDGE's
+            # own key, named explicitly — role separation forbids the author's
+            codex_panel_raw = os.environ.get("AUTORESEARCH_PANEL_CODEX_KEY_FILE", "").strip()
+            if not codex_panel_raw:
+                return (
+                    "a codex panel lens needs AUTORESEARCH_PANEL_CODEX_KEY_FILE "
+                    "(role separation: the judge's own key, never the author's)"
+                )
+            codex_panel = Path(codex_panel_raw).expanduser()
+            if not codex_panel.is_absolute():
+                return f"codex panel key path {codex_panel} is relative; only absolute paths fly"
+            codex_author = Path(resolve_author_key_file("codex")).expanduser()
+            if codex_panel.resolve() == codex_author.resolve():
+                return (
+                    f"codex panel key file {codex_panel} is the codex author key "
+                    "(role separation: the judge needs its own key)"
+                )
+            FileTokenProvider(codex_panel).token()
         path = Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
         if not path.is_absolute():
             # the climb runs from a flight directory, not the tick's cwd — a

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1299,7 +1299,14 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
         except ValueError as exc:
             return str(exc)
         if any(backend == "codex" for _, backend, _ in lenses):
-            # mirror the climb's rule exactly: a codex lens needs the JUDGE's
+            # mirror the climb's rules exactly. (1) a codex judge only ever
+            # runs inside the image:
+            if not spec.image or not Path(spec.image).is_file():
+                return (
+                    f"a codex panel lens requires a real container image "
+                    f"(AUTORESEARCH_IMAGE={spec.image!r})"
+                )
+            # (2) a codex lens needs the JUDGE's
             # own key, named explicitly — role separation forbids the author's
             codex_panel_raw = os.environ.get("AUTORESEARCH_PANEL_CODEX_KEY_FILE", "").strip()
             if not codex_panel_raw:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1317,6 +1317,8 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
                     "(role separation: the judge needs its own key)"
                 )
             FileTokenProvider(codex_panel).token()
+        if not any(backend == "claude" for _, backend, _ in lenses):
+            return ""  # codex-only panel: the claude key checks below don't apply
         path = Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
         if not path.is_absolute():
             # the climb runs from a flight directory, not the tick's cwd — a

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2722,3 +2722,25 @@ def test_author_sleep_wake_without_harness_ends_loudly(tmp_path, monkeypatch) ->
     assert record.state == "ended"
     assert "author harness" in record.ending_note
     assert _git(wsroot, "for-each-ref", "refs/dispatch/").strip() == ""
+
+
+def test_codex_panel_lens_requires_the_judges_own_key(monkeypatch) -> None:
+    # role separation: a codex lens must name the JUDGE's key explicitly —
+    # never inherit the anthropic panel key or default to the author's
+    import argparse
+
+    import pytest
+
+    from autoresearch.climb import _panel_lenses_from_args
+
+    monkeypatch.delenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", raising=False)
+    args = argparse.Namespace(
+        panel="review:codex:gpt-5.6-terra",
+        panel_key_file="/dev/null",
+        claude_bin="claude",
+        codex_bin="codex",
+        image="/img.sif",
+    )
+    monkeypatch.setattr("autoresearch.climb.role_key", lambda *a, **k: "k")
+    with pytest.raises(ValueError, match="AUTORESEARCH_PANEL_CODEX_KEY_FILE"):
+        _panel_lenses_from_args(args)

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2763,5 +2763,31 @@ def test_codex_only_panel_never_reads_the_claude_key(monkeypatch, tmp_path) -> N
         codex_bin="codex",
         image="/img.sif",
     )
-    lenses = _panel_lenses_from_args(args)
+    lenses, secrets = _panel_lenses_from_args(args)
     assert len(lenses) == 1 and lenses[0].kind == "review"
+    assert secrets == ("sk-judge",)  # the codex judge key joins the redaction set
+
+
+def test_codex_panel_key_must_not_be_the_author_key(monkeypatch, tmp_path) -> None:
+    # role separation enforced in the BUILDER, so a manual climb (not just the
+    # tick preflight) refuses a judge running on the author's token
+    import argparse
+
+    import pytest
+
+    from autoresearch.climb import _panel_lenses_from_args
+
+    author_key = tmp_path / "codex_key"
+    author_key.write_text("sk-author")
+    author_key.chmod(0o600)
+    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", str(author_key))
+    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(author_key))
+    args = argparse.Namespace(
+        panel="review:codex:gpt-5.6-terra",
+        panel_key_file="/dev/null",
+        claude_bin="claude",
+        codex_bin="codex",
+        image="/img.sif",
+    )
+    with pytest.raises(ValueError, match="role separation"):
+        _panel_lenses_from_args(args)

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2744,3 +2744,24 @@ def test_codex_panel_lens_requires_the_judges_own_key(monkeypatch) -> None:
     monkeypatch.setattr("autoresearch.climb.role_key", lambda *a, **k: "k")
     with pytest.raises(ValueError, match="AUTORESEARCH_PANEL_CODEX_KEY_FILE"):
         _panel_lenses_from_args(args)
+
+
+def test_codex_only_panel_never_reads_the_claude_key(monkeypatch, tmp_path) -> None:
+    # a codex-only panel must not demand the (unused) anthropic panel key
+    import argparse
+
+    from autoresearch.climb import _panel_lenses_from_args
+
+    codex_key = tmp_path / "panel_codex_key"
+    codex_key.write_text("sk-judge")
+    codex_key.chmod(0o600)
+    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(codex_key))
+    args = argparse.Namespace(
+        panel="review:codex:gpt-5.6-terra",
+        panel_key_file=str(tmp_path / "no-such-anthropic-key"),  # absent, must not matter
+        claude_bin="claude",
+        codex_bin="codex",
+        image="/img.sif",
+    )
+    lenses = _panel_lenses_from_args(args)
+    assert len(lenses) == 1 and lenses[0].kind == "review"

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2793,6 +2793,30 @@ def test_codex_panel_key_must_not_be_the_author_key(monkeypatch, tmp_path) -> No
         _panel_lenses_from_args(args)
 
 
+def test_codex_panel_key_must_not_be_the_claude_panel_key(monkeypatch, tmp_path) -> None:
+    # provider-key confusion: pointing the codex lens at the claude panel key
+    # would send the anthropic credential to OpenAI login
+    import argparse
+
+    import pytest
+
+    from autoresearch.climb import _panel_lenses_from_args
+
+    shared = tmp_path / "verifier_key"
+    shared.write_text("sk-ant")
+    shared.chmod(0o600)
+    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(shared))
+    args = argparse.Namespace(
+        panel="review:codex:gpt-5.6-terra",
+        panel_key_file=str(shared),
+        claude_bin="claude",
+        codex_bin="codex",
+        image="/img.sif",
+    )
+    with pytest.raises(ValueError, match="another provider"):
+        _panel_lenses_from_args(args)
+
+
 def test_codex_panel_lens_refuses_to_run_uncontained(monkeypatch, tmp_path) -> None:
     # --uncontained (image="") must never produce a danger-full-access codex
     # judge on the host

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2791,3 +2791,27 @@ def test_codex_panel_key_must_not_be_the_author_key(monkeypatch, tmp_path) -> No
     )
     with pytest.raises(ValueError, match="role separation"):
         _panel_lenses_from_args(args)
+
+
+def test_codex_panel_lens_refuses_to_run_uncontained(monkeypatch, tmp_path) -> None:
+    # --uncontained (image="") must never produce a danger-full-access codex
+    # judge on the host
+    import argparse
+
+    import pytest
+
+    from autoresearch.climb import _panel_lenses_from_args
+
+    judge_key = tmp_path / "panel_codex_key"
+    judge_key.write_text("sk-judge")
+    judge_key.chmod(0o600)
+    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(judge_key))
+    args = argparse.Namespace(
+        panel="review:codex:gpt-5.6-terra",
+        panel_key_file="/dev/null",
+        claude_bin="claude",
+        codex_bin="codex",
+        image="",  # dev --uncontained
+    )
+    with pytest.raises(ValueError, match="requires --image"):
+        _panel_lenses_from_args(args)

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -113,3 +113,17 @@ def test_no_verdict_degrades_the_read(tmp_path: Path) -> None:
         (PanelLens("review", _Judge(_VERIFY_CLEAN)),), tmp_path, _PR, "c", "t", round_no=1
     )
     assert not clean.degraded
+
+
+def test_parse_lenses_admits_codex_and_refuses_uncontainable_backends() -> None:
+    import pytest
+
+    from autoresearch.panel import parse_lenses
+
+    # backends are peers; the one gate is containment on the climb host
+    assert parse_lenses("verify:claude:claude-fable-5,review:codex:gpt-5.6-terra") == (
+        ("verify", "claude", "claude-fable-5"),
+        ("review", "codex", "gpt-5.6-terra"),
+    )
+    with pytest.raises(ValueError, match="no container mode"):
+        parse_lenses("review:hermes:gpt-5.6-terra")

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1930,6 +1930,22 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     assert "no container mode" in _panel_preflight_error(
         make(panel="verify:hermes", panel_key_file=str(good))
     )
+    # a codex lens preflights the image requirement too (climb parity)
+    judge = tmp_path / "panel_codex_key"
+    judge.write_text("sk-judge")
+    judge.chmod(0o600)
+    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(judge))
+    no_image = FollowupSpec(
+        target="org/pilot",
+        account="a",
+        partition="p",
+        run_root=tmp_path,
+        image="",
+        home=tmp_path,
+        panel="review:codex:gpt-5.6-terra",
+        panel_key_file=str(good),
+    )
+    assert "requires a real container image" in _panel_preflight_error(no_image)
     assert "relative" in _panel_preflight_error(make(panel_key_file="good"))
     # role separation: the panel key must not BE the (resolved) author key. The
     # author key is now config-driven — resolved per the fleet backend from env —

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1927,7 +1927,7 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     err = _panel_preflight_error(both_wrong)
     assert "unknown kind" in err  # kind is checked before backend
     assert "claude backend" not in err
-    assert "only the claude backend" in _panel_preflight_error(
+    assert "no container mode" in _panel_preflight_error(
         make(panel="verify:hermes", panel_key_file=str(good))
     )
     assert "relative" in _panel_preflight_error(make(panel_key_file="good"))


### PR DESCRIPTION
Mengye's catch: the model (gpt-5.6-terra) was never coupled to the hermes harness — the **codex backend** reaches it and is already containment-proven on Torch (it's the author's harness, `danger-full-access` inside the climb image). So `review:codex:gpt-5.6-terra` puts terra on the panel **now**; the hermes container wrapper drops from prerequisite to someday.

- `parse_lenses` lifts to claude+codex (backends are peers; the one gate is containment on the climb host). Hermes stays refused with the accurate reason.
- A codex lens requires `AUTORESEARCH_PANEL_CODEX_KEY_FILE` — the judge's **own** key (role separation: never the anthropic panel key, never the author's codex key). Tick preflight mirrors the rule (set / absolute / ≠ author key / readable) so nothing strands.
- Pins: grammar admits codex + refuses hermes; the judge-key requirement; preflight message updated.

Rollout after merge: mint a second OpenAI key → `torch:~/.config/autoresearch/panel_codex_key` (0600), add `AUTORESEARCH_PANEL_CODEX_KEY_FILE` to .env, and set `AUTORESEARCH_PANEL=verify:claude:claude-fable-5,review:codex:gpt-5.6-terra` (the .env panel flip rides #151).

Full gate: 781 tests, ruff both checks, mypy — all explicit-exit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)