### PR TITLE
docs: wide-first-round review — design note

### DIFF
--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -186,6 +186,44 @@ model key, no write credential). The split workflow is what gates accepting
 fork PRs after the repo goes public. See `public-surface.md` for that threat
 model.
 
+## Wide first round, narrow convergence (design note, 2026-08-26)
+
+A single reviewer SATISFICES: it reports the most salient defect and stops,
+so a defect-dense PR converges one-finding-per-round. Measured on the codex-
+panel-lens PR (#152): eight rounds, seven distinct confirmed defects — about
+five of which existed at PR-open and could in principle have been found
+together. The serial loop's cost is not tokens (a round is cents); it is
+wall-clock and the operator's fix-context-switch per round trip.
+
+Two facts bound what parallelism can buy:
+
+- Breadth pays through DISTINCT LENSES, not reviewer count. The one
+  large-panel experiment (20 same-model agents, ~2M tokens, PR #147) yielded
+  one unique blocking find; its few dimension-scoped reviewers did the
+  productive work, its many same-lens verifiers mostly re-found.
+- Roughly a quarter of findings across the recent arc were introduced by the
+  FIXES to earlier findings. Those defects did not exist at PR-open; only a
+  serial re-review can catch them. Parallelism compresses the discovery
+  prefix, never the fix-review-fix tail.
+
+**The design:** for PRs touching credentials, deployment plumbing (env
+allowlists, provisioning, preflights), or the publish/trust path, the FIRST
+round fans out 2–3 opinions with distinct lens prompts — e.g. (a)
+credentials & containment, (b) the deployment chain end-to-end, (c)
+test-honesty/coverage of the diff. A SUMMARIZER session then merges the
+opinions into the one posted round: dedup by file/claim, rank blocking
+first, attribute each finding to its lens, and drop nothing silently (a
+finding the summarizer rejects is listed as rejected, with the reason).
+Subsequent rounds revert to the single reviewer until one finds nothing —
+the convergence rule is unchanged. Ordinary PRs keep the single-reviewer
+flow throughout.
+
+The pieces mostly exist: `advisory-review-agent.yml` already supports
+parallel opinions (`opinion_id`), and the summarizer is one more cheap
+session whose input is the k verdicts, not the diff. Build when the review
+volume justifies it; until then this note is the record of why one-per-round
+is expected behavior and not a reviewer defect.
+
 ## What's next
 
 The harness runs agent sessions over the PR-head checkout — that part is done,


### PR DESCRIPTION
Design note only, no behavior: records the wide-first-round / narrow-convergence review design (2–3 distinct-lens opinions + a summarizer session for the first round on credential/deployment/publish-touching PRs), the measured motivation (#152: 8 rounds, 7 defects, ~5 present at open; single reviewers satisfice), and the bound (fix-introduced defects keep the convergence tail serial). Build when review volume justifies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)