### PR TITLE
feat: hermes container mode — the last backend becomes a peer on Torch

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -35,8 +35,9 @@ jobs:
       # OpenAI account is tax-exempt); model id is provider-native
       hermes_provider: openai
       model: gpt-5.6-terra
-      # `general` runs unlensed (empty REVIEW_LENS = the full rubric)
-      lens: ${{ matrix.lens == 'general' && '' || matrix.lens }}
+      # `general` is a real lens name meaning the full rubric (no empty-string
+      # ternary — its GitHub Actions form silently falls through to the else)
+      lens: ${{ matrix.lens }}
       opinion_id: lens-${{ matrix.lens }}
       post: false
     secrets:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Hermes container mode: `HermesHarness` runs under apptainer like the other
+  backends when an image is set — workspace and per-run home bound, the
+  pinned hermes-agent clone read-only, the project venv and uv cache in the
+  per-run home, key and uv vars via `APPTAINERENV_*` (never argv). With
+  containment uniform, the panel gate admits `hermes` lenses: the shelled-
+  judge rules (image required; the judge's OWN key, neither the author's nor
+  the claude panel key) move into one shared helper covering codex and
+  hermes, mirrored in the tick preflight; `AUTORESEARCH_PANEL_HERMES_KEY_FILE`
+  + `REVIEW_HERMES_*` ride the .env allowlist, and the chain provisions the
+  pinned clone (`scripts/install_hermes.sh`) when the panel names hermes.
+
+### Added
+
 - Wide first round, narrow convergence (docs/design/reviewer-infra.md): on
   PR open, the advisory review fans out three distinct-lens terra opinions
   (credentials & containment; the deployment chain end-to-end; test honesty)

--- a/scripts/install_hermes.sh
+++ b/scripts/install_hermes.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Idempotent install of the pinned hermes-agent clone (the hermes panel lens's
+# host prerequisite, like codex's binary). The clone itself is read-only at
+# session time — the harness binds it :ro and builds the venv in the per-run
+# home — so this only materializes source at a pinned tag. Safe to run
+# repeatedly: the fast path checks the tag already checked out.
+#
+# Usage: install_hermes.sh [target_dir]
+#   target_dir  where the clone lives (default: $REVIEW_HERMES_REPO,
+#               else ~/hermes-agent)
+set -euo pipefail
+
+# Pinned: the tag the GH review workflows run (bump deliberately, everywhere
+# at once — the workflows' HERMES_REF and this pin must move together).
+WANT="v2026.8.13"
+TARGET="${1:-${REVIEW_HERMES_REPO:-$HOME/hermes-agent}}"
+
+if [ -d "$TARGET/.git" ]; then
+    have=$(git -C "$TARGET" describe --tags --exact-match 2>/dev/null || echo none)
+    if [ "$have" = "$WANT" ]; then
+        echo "hermes-agent $WANT already at $TARGET"
+        exit 0
+    fi
+    echo "hermes-agent at $TARGET is $have; re-pinning to $WANT"
+    git -C "$TARGET" fetch --depth 1 origin "refs/tags/$WANT:refs/tags/$WANT"
+    git -C "$TARGET" checkout -q "tags/$WANT"
+else
+    git clone --depth 1 --branch "$WANT" \
+        https://github.com/NousResearch/hermes-agent "$TARGET"
+fi
+echo "hermes-agent $WANT ready at $TARGET"

--- a/scripts/install_hermes.sh
+++ b/scripts/install_hermes.sh
@@ -10,22 +10,32 @@
 #               else ~/hermes-agent)
 set -euo pipefail
 
-# Pinned: the tag the GH review workflows run (bump deliberately, everywhere
-# at once — the workflows' HERMES_REF and this pin must move together).
+# Pinned tag AND its commit sha: the tag names the version for humans, the
+# sha is the integrity pin (tags are mutable; a moved tag must fail loudly,
+# never run with the panel key). Bump both together, in lockstep with the
+# GH review workflows' HERMES_REF.
 WANT="v2026.8.13"
+WANT_SHA="4e693dc685b5716e7da22656eccc6ece37c5db72"
 TARGET="${1:-${REVIEW_HERMES_REPO:-$HOME/hermes-agent}}"
 
-if [ -d "$TARGET/.git" ]; then
-    have=$(git -C "$TARGET" describe --tags --exact-match 2>/dev/null || echo none)
-    if [ "$have" = "$WANT" ]; then
-        echo "hermes-agent $WANT already at $TARGET"
-        exit 0
-    fi
-    echo "hermes-agent at $TARGET is $have; re-pinning to $WANT"
-    git -C "$TARGET" fetch --depth 1 origin "refs/tags/$WANT:refs/tags/$WANT"
-    git -C "$TARGET" checkout -q "tags/$WANT"
-else
+if [ ! -d "$TARGET/.git" ]; then
     git clone --depth 1 --branch "$WANT" \
         https://github.com/NousResearch/hermes-agent "$TARGET"
 fi
-echo "hermes-agent $WANT ready at $TARGET"
+head=$(git -C "$TARGET" rev-parse HEAD)
+dirty=$(git -C "$TARGET" status --porcelain)
+if [ "$head" != "$WANT_SHA" ] || [ -n "$dirty" ]; then
+    # a wrong or DIRTY checkout must never run with the panel key: re-pin
+    # hard (this clone is a provisioned artifact, not a dev tree)
+    echo "hermes-agent at $TARGET is $head (dirty=$([ -n "$dirty" ] && echo yes || echo no)); re-pinning to $WANT"
+    git -C "$TARGET" fetch --depth 1 origin "refs/tags/$WANT:refs/tags/$WANT"
+    git -C "$TARGET" checkout -q --detach "tags/$WANT"
+    git -C "$TARGET" reset --hard -q "tags/$WANT"
+    git -C "$TARGET" clean -fdxq
+fi
+head=$(git -C "$TARGET" rev-parse HEAD)
+if [ "$head" != "$WANT_SHA" ]; then
+    echo "hermes-agent: tag $WANT resolves to $head, expected $WANT_SHA — refusing" >&2
+    exit 1
+fi
+echo "hermes-agent $WANT ($WANT_SHA) ready at $TARGET"

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -161,7 +161,12 @@ case "${AUTORESEARCH_AUTHOR_BACKEND:-}:${AUTORESEARCH_PANEL:-}" in
 esac
 case "${AUTORESEARCH_PANEL:-}" in
     *hermes*)
-        bash "$AUTORESEARCH_HOME/scripts/install_hermes.sh" || echo "deploy: hermes install failed"
+        # the default install location IS the default config: exporting it
+        # here connects the provisioned clone to the preflight/climb without
+        # requiring the operator to name a path they didn't choose
+        export REVIEW_HERMES_REPO="${REVIEW_HERMES_REPO:-$HOME/hermes-agent}"
+        bash "$AUTORESEARCH_HOME/scripts/install_hermes.sh" "$REVIEW_HERMES_REPO" \
+            || echo "deploy: hermes install failed"
         ;;
 esac
 

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -127,7 +127,9 @@ if [ -r "$ENV_FILE" ]; then
                   AUTORESEARCH_VERTEX_PROJECT AUTORESEARCH_VERTEX_REGION \
                   AUTORESEARCH_VERTEX_ADC \
                   AUTORESEARCH_PANEL AUTORESEARCH_PANEL_KEY_FILE \
-                  AUTORESEARCH_PANEL_CODEX_KEY_FILE; do
+                  AUTORESEARCH_PANEL_CODEX_KEY_FILE \
+                  AUTORESEARCH_PANEL_HERMES_KEY_FILE \
+                  REVIEW_HERMES_REPO REVIEW_HERMES_PROVIDER; do
             _line=$(grep -E "^${_k}=" "$ENV_FILE" 2>/dev/null | tail -1)
             # PRESENCE-based, not value-based: a key set to "" in .env is a
             # live OFF-SWITCH (AUTORESEARCH_PANEL="" disables the panel,
@@ -155,6 +157,11 @@ fi
 case "${AUTORESEARCH_AUTHOR_BACKEND:-}:${AUTORESEARCH_PANEL:-}" in
     codex:*|*:*codex*)
         bash "$AUTORESEARCH_HOME/scripts/install_codex.sh" || echo "deploy: codex install failed"
+        ;;
+esac
+case "${AUTORESEARCH_PANEL:-}" in
+    *hermes*)
+        bash "$AUTORESEARCH_HOME/scripts/install_hermes.sh" || echo "deploy: hermes install failed"
         ;;
 esac
 

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1285,6 +1285,47 @@ def resume_run(
     return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
 
 
+def _judge_lens_key(
+    *,
+    backend: str,
+    key_file_env: str,
+    author_backend: str,
+    claude_panel_path: Path,
+    image: str,
+) -> str:
+    """Resolve a non-claude judge lens's OWN key file, enforcing the three
+    separations every shelled judge shares (codex, hermes, any future
+    backend): the image is required (a judge never runs uncontained next to
+    key files), the key must be named explicitly, and it must differ from BOTH
+    the author's key of the same provider AND the claude panel key (a
+    cross-provider send would leak an anthropic credential to another login).
+    Returns the redacted key (or "" under an ADC-covered deployment)."""
+    if not image:
+        raise ValueError(
+            f"a {backend} panel lens requires --image (a shelled judge only "
+            "ever runs inside the container)"
+        )
+    raw = os.environ.get(key_file_env, "").strip()
+    if not raw:
+        raise ValueError(
+            f"a {backend} panel lens needs {key_file_env} "
+            "(role separation: the judge's own key, never the author's)"
+        )
+    path = Path(raw).expanduser()
+    author_path = Path(resolve_author_key_file(author_backend)).expanduser()
+    if path.resolve() == author_path.resolve():
+        raise ValueError(
+            f"{backend} panel key file {path} is the {author_backend} author key "
+            "(role separation: the judge needs its own key)"
+        )
+    if path.resolve() == claude_panel_path.resolve():
+        raise ValueError(
+            f"{backend} panel key file {path} is the claude panel key file "
+            "(an anthropic key must never reach another provider's login)"
+        )
+    return role_key(raw, author_backend)
+
+
 def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str, ...]]:
     """Build the verification-panel lenses from the CLI args (empty `--panel`
     disables it), returning `(lenses, panel_secrets)` — the ONE owner of
@@ -1313,38 +1354,29 @@ def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str
         # per-backend judge keys coexist — a codex lens is never handed the
         # anthropic panel key, and role separation forbids defaulting to the
         # AUTHOR's codex key: the judge key is its own, named explicitly
+        claude_panel_path = Path(args.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
         if backend == "codex":
-            if not args.image:
-                # --uncontained is a dev concession for CLAUDE sessions; a
-                # codex judge is danger-full-access and NEVER runs outside
-                # the image — a judge never runs uncontained next to key files
-                raise ValueError(
-                    "a codex panel lens requires --image (codex judges run "
-                    "danger-full-access and only ever inside the container)"
-                )
-            codex_panel_key = os.environ.get("AUTORESEARCH_PANEL_CODEX_KEY_FILE", "").strip()
-            if not codex_panel_key:
-                raise ValueError(
-                    "a codex panel lens needs AUTORESEARCH_PANEL_CODEX_KEY_FILE "
-                    "(role separation: the judge's own key, never the author's)"
-                )
-            codex_panel_path = Path(codex_panel_key).expanduser()
-            codex_author_path = Path(resolve_author_key_file("codex")).expanduser()
-            if codex_panel_path.resolve() == codex_author_path.resolve():
-                raise ValueError(
-                    f"codex panel key file {codex_panel_path} is the codex author "
-                    "key (role separation: the judge needs its own key)"
-                )
-            claude_panel_path = Path(args.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
-            if codex_panel_path.resolve() == claude_panel_path.resolve():
-                # provider-key confusion: this would send the ANTHROPIC panel
-                # credential to codex (OpenAI) login
-                raise ValueError(
-                    f"codex panel key file {codex_panel_path} is the claude panel "
-                    "key file (a codex judge needs an OpenAI credential, and an "
-                    "anthropic key must never reach another provider's login)"
-                )
-            lens_key = role_key(codex_panel_key, "codex")
+            lens_key = _judge_lens_key(
+                backend="codex",
+                key_file_env="AUTORESEARCH_PANEL_CODEX_KEY_FILE",
+                author_backend="codex",
+                claude_panel_path=claude_panel_path,
+                image=args.image,
+            )
+            if lens_key:
+                secrets.append(lens_key)
+        elif backend == "hermes":
+            # hermes reads its key from its provider's env var, but the FILE
+            # is resolved and separated exactly like codex's (the key still
+            # lands next to the session). The author's OpenAI key coexists, so
+            # separate against the codex author key.
+            lens_key = _judge_lens_key(
+                backend="hermes",
+                key_file_env="AUTORESEARCH_PANEL_HERMES_KEY_FILE",
+                author_backend="codex",
+                claude_panel_path=claude_panel_path,
+                image=args.image,
+            )
             if lens_key:
                 secrets.append(lens_key)
         else:

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -1187,6 +1187,14 @@ class HermesHarness:
         "memory",
     )
     extra_args: tuple[str, ...] = field(default_factory=tuple)
+    # Apptainer image for session containment, same stance as the other
+    # backends: when set, the session runs under `apptainer exec --containall
+    # --cleanenv` seeing only the workspace, the per-run home, and a read-only
+    # bind of the pinned hermes repo. The project venv and uv cache live in
+    # the per-run home (UV_PROJECT_ENVIRONMENT/UV_CACHE_DIR), so the repo
+    # bind stays read-only and nothing survives across runs.
+    container_image: str = ""
+    apptainer_binary: str = "apptainer"
 
     def run(
         self, brief_text: str, workspace: Path, resume_session_id: str | None = None
@@ -1252,8 +1260,42 @@ class HermesHarness:
             self.disabled_toolsets,
             self.extra_args,
         )
+        if self.container_image:
+            workspace_abs = workspace.resolve()
+            home_abs = session_home.resolve()
+            repo_abs = Path(self.repo_dir).resolve()
+            command = [
+                self.apptainer_binary,
+                "exec",
+                "--containall",
+                "--cleanenv",
+                "--bind",
+                f"{workspace_abs}:{workspace_abs}",
+                # --home mounts the per-run home at the same path inside and
+                # sets $HOME to it — hermes config, brief, samples, and the
+                # resume transcript all persist on the shared FS
+                "--home",
+                f"{home_abs}:{home_abs}",
+                "--bind",
+                f"{repo_abs}:{repo_abs}:ro",
+                "--pwd",
+                str(home_abs),
+                self.container_image,
+                *command,
+            ]
         try:
             env = session_env(self.api_key, self.key_env, session_home)
+            # the repo bind is read-only: uv builds the project venv and its
+            # cache in the per-run home instead (fresh per run; nothing shared
+            # across sessions)
+            env["UV_PROJECT_ENVIRONMENT"] = str(session_home / "venv")
+            env["UV_CACHE_DIR"] = str(session_home / "uv-cache")
+            env["UV_LINK_MODE"] = "copy"
+            if self.container_image:
+                # --cleanenv drops the host env inside the container EXCEPT
+                # APPTAINERENV_* — the key travels via env, never argv
+                for k in (self.key_env, "UV_PROJECT_ENVIRONMENT", "UV_CACHE_DIR", "UV_LINK_MODE"):
+                    env[f"APPTAINERENV_{k}"] = env[k]
             # cwd is the per-run home, NOT the workspace: --save_sample writes
             # its trajectory JSON to cwd, and artifacts must never land in the
             # clone (they would enter the diff).

--- a/src/autoresearch/panel.py
+++ b/src/autoresearch/panel.py
@@ -46,9 +46,10 @@ def parse_lenses(panel: str) -> tuple[tuple[str, str, str], ...]:
     claimed, and the climb dies at argument parsing with the claim stranded.
     Backends are peers on the panel as everywhere else; the one gate is
     CONTAINMENT on the orchestrator host (judges hold a shell and run next
-    to key files): claude and codex run inside the climb's image, hermes
-    has no container mode yet — its lens is refused until that wrapper
-    exists, never run uncontained."""
+    to key files): claude, codex, and hermes all run inside the climb's
+    image, so any backend may judge — the image is required for a
+    non-claude lens (claude's --uncontained dev concession never extends to
+    a shelled judge)."""
     entries: list[tuple[str, str, str]] = []
     for raw in panel.split(","):
         entry = raw.strip()
@@ -57,12 +58,9 @@ def parse_lenses(panel: str) -> tuple[tuple[str, str, str], ...]:
         backend = backend or "claude"
         if kind not in LENS_KINDS:
             raise ValueError(f"panel entry {entry!r}: unknown kind (use {LENS_KINDS})")
-        if backend not in ("claude", "codex"):
+        if backend not in ("claude", "codex", "hermes"):
             raise ValueError(
-                f"panel entry {entry!r}: backend {backend!r} has no container "
-                "mode on the orchestrator host yet (claude and codex run "
-                "inside the climb's image); a judge never runs uncontained "
-                "next to key files"
+                f"panel entry {entry!r}: unknown backend {backend!r} (claude, codex, hermes)"
             )
         entries.append((kind, backend, model))
     return tuple(entries)

--- a/src/autoresearch/posting.py
+++ b/src/autoresearch/posting.py
@@ -62,8 +62,12 @@ def _round_stamp(
     head = pr_data.get("head")
     head_sha = str(head.get("sha", ""))[:8] if isinstance(head, dict) else ""
     # attribution is render-side data (it can cross a job boundary in the
-    # least-token split): strip backticks/newlines, cap, never trust
-    by = " ".join(str(reviewed_by).split()).replace("`", "")[:60]
+    # least-token split): strip backticks/newlines, cap, never trust. The cap
+    # fits a panel line ("summarizer:<backend> over lens+lens+..."); a real
+    # overflow ends in an ellipsis so it never reads as a mid-word bug.
+    by = " ".join(str(reviewed_by).split()).replace("`", "")
+    if len(by) > 120:
+        by = by[:119].rstrip() + "…"
     # The round number is cosmetic: an EXPECTED failure counting prior
     # rounds must never cost the round itself. Programming errors still
     # propagate, per this module's policy.

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -321,9 +321,12 @@ def build_agent_brief(
     the workspace, so it resolves from any backend's cwd). A `lens` narrows the
     session's ATTENTION (wide first round); an unknown lens fails loudly — a
     configured lens must never silently review as the default."""
-    if lens and lens not in REVIEW_LENSES:
+    # 'general' (and "") are the full rubric with no added focus — a real
+    # value so the caller matrix can pass it straight through (no empty-string
+    # ternary, whose GitHub Actions form silently falls through)
+    if lens and lens != "general" and lens not in REVIEW_LENSES:
         raise ValueError(f"unknown review lens {lens!r} (have: {sorted(REVIEW_LENSES)})")
-    focus = f"\n\n{REVIEW_LENSES[lens]}" if lens else ""
+    focus = f"\n\n{REVIEW_LENSES[lens]}" if lens and lens != "general" else ""
     return (
         f"{SYSTEM_PROMPT}{focus}\n\n{_agent_investigation(syscall_cmd)}\n\n"
         f"{build_prompt(pr, today)}"

--- a/src/autoresearch/review_agent_cli.py
+++ b/src/autoresearch/review_agent_cli.py
@@ -169,7 +169,7 @@ def main() -> int:
     if lens:
         from autoresearch.review import REVIEW_LENSES
 
-        if lens not in REVIEW_LENSES:
+        if lens != "general" and lens not in REVIEW_LENSES:
             # a typo'd lens must be a PR-visible stub, never a silent
             # default-review (a configured lens must never quietly vanish)
             _skip_stub(

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -143,6 +143,7 @@ def build_harness(
             timeout_s=spec.budget.walltime_s,
             enabled_toolsets=enabled,
             disabled_toolsets=tuple(t for t in _HERMES_TOOLSETS if t not in enabled),
+            container_image=container_image,
         )
     if backend != "claude":
         raise ValueError(f"unknown backend: {backend!r}")

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1341,10 +1341,21 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
             FileTokenProvider(key_path).token()
             if lens_backend == "hermes":
                 repo = os.environ.get("REVIEW_HERMES_REPO", "").strip()
-                if not repo or not Path(repo).expanduser().is_dir():
+                # a REAL clone, not merely a directory: the harness executes
+                # run_agent.py from it with the panel key, so an arbitrary or
+                # empty path must fail here, never after a run is claimed
+                if not repo or not (Path(repo).expanduser() / "run_agent.py").is_file():
                     return (
                         f"a hermes panel lens needs REVIEW_HERMES_REPO pointing at "
-                        f"the pinned clone (got {repo!r})"
+                        f"the pinned clone (run_agent.py not found under {repo!r})"
+                    )
+                from autoresearch.role_runner import _HERMES_PROVIDERS
+
+                provider = os.environ.get("REVIEW_HERMES_PROVIDER", "").lower() or "openrouter"
+                if provider not in _HERMES_PROVIDERS:
+                    return (
+                        f"unknown REVIEW_HERMES_PROVIDER {provider!r} "
+                        f"(have: {sorted(_HERMES_PROVIDERS)})"
                     )
         if not any(backend == "claude" for _, backend, _ in lenses):
             return ""  # codex-only panel: the claude key checks below don't apply

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1298,38 +1298,54 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
             lenses = parse_lenses(spec.panel)
         except ValueError as exc:
             return str(exc)
-        if any(backend == "codex" for _, backend, _ in lenses):
-            # mirror the climb's rules exactly. (1) a codex judge only ever
-            # runs inside the image:
+        # non-claude (shelled) lenses: mirror the climb's rules exactly, per
+        # backend — image required, the judge's OWN key (set + absolute +
+        # neither the author's nor the claude panel key + readable), and for
+        # hermes its pinned clone.
+        shelled = {
+            "codex": "AUTORESEARCH_PANEL_CODEX_KEY_FILE",
+            "hermes": "AUTORESEARCH_PANEL_HERMES_KEY_FILE",
+        }
+        for lens_backend, key_env in shelled.items():
+            if not any(backend == lens_backend for _, backend, _ in lenses):
+                continue
             if not spec.image or not Path(spec.image).is_file():
                 return (
-                    f"a codex panel lens requires a real container image "
+                    f"a {lens_backend} panel lens requires a real container image "
                     f"(AUTORESEARCH_IMAGE={spec.image!r})"
                 )
-            # (2) a codex lens needs the JUDGE's
-            # own key, named explicitly — role separation forbids the author's
-            codex_panel_raw = os.environ.get("AUTORESEARCH_PANEL_CODEX_KEY_FILE", "").strip()
-            if not codex_panel_raw:
+            key_raw = os.environ.get(key_env, "").strip()
+            if not key_raw:
                 return (
-                    "a codex panel lens needs AUTORESEARCH_PANEL_CODEX_KEY_FILE "
+                    f"a {lens_backend} panel lens needs {key_env} "
                     "(role separation: the judge's own key, never the author's)"
                 )
-            codex_panel = Path(codex_panel_raw).expanduser()
-            if not codex_panel.is_absolute():
-                return f"codex panel key path {codex_panel} is relative; only absolute paths fly"
-            codex_author = Path(resolve_author_key_file("codex")).expanduser()
-            if codex_panel.resolve() == codex_author.resolve():
+            key_path = Path(key_raw).expanduser()
+            if not key_path.is_absolute():
                 return (
-                    f"codex panel key file {codex_panel} is the codex author key "
-                    "(role separation: the judge needs its own key)"
+                    f"{lens_backend} panel key path {key_path} is relative; only absolute paths fly"
+                )
+            author = Path(resolve_author_key_file("codex")).expanduser()
+            if key_path.resolve() == author.resolve():
+                return (
+                    f"{lens_backend} panel key file {key_path} is the codex author "
+                    "key (role separation: the judge needs its own key)"
                 )
             claude_panel = Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()
-            if codex_panel.resolve() == claude_panel.resolve():
+            if key_path.resolve() == claude_panel.resolve():
                 return (
-                    f"codex panel key file {codex_panel} is the claude panel key "
-                    "file (an anthropic key must never reach codex login)"
+                    f"{lens_backend} panel key file {key_path} is the claude panel "
+                    "key file (an anthropic key must never reach another "
+                    "provider's login)"
                 )
-            FileTokenProvider(codex_panel).token()
+            FileTokenProvider(key_path).token()
+            if lens_backend == "hermes":
+                repo = os.environ.get("REVIEW_HERMES_REPO", "").strip()
+                if not repo or not Path(repo).expanduser().is_dir():
+                    return (
+                        f"a hermes panel lens needs REVIEW_HERMES_REPO pointing at "
+                        f"the pinned clone (got {repo!r})"
+                    )
         if not any(backend == "claude" for _, backend, _ in lenses):
             return ""  # codex-only panel: the claude key checks below don't apply
         path = Path(spec.panel_key_file or PANEL_KEY_DEFAULT).expanduser()

--- a/tests/test_climb.py
+++ b/tests/test_climb.py
@@ -2839,3 +2839,45 @@ def test_codex_panel_lens_refuses_to_run_uncontained(monkeypatch, tmp_path) -> N
     )
     with pytest.raises(ValueError, match="requires --image"):
         _panel_lenses_from_args(args)
+
+
+def test_hermes_panel_lens_shares_the_judge_key_rules(monkeypatch, tmp_path) -> None:
+    # hermes joins the shelled-judge rules via the SAME helper as codex:
+    # image required, own key named, never the author's or the claude panel's
+    import argparse
+
+    import pytest
+
+    from autoresearch.climb import _panel_lenses_from_args
+
+    def args(image="/img.sif"):
+        return argparse.Namespace(
+            panel="review:hermes:gpt-5.6-terra",
+            panel_key_file="/dev/null",
+            claude_bin="claude",
+            codex_bin="codex",
+            image=image,
+        )
+
+    monkeypatch.delenv("AUTORESEARCH_PANEL_HERMES_KEY_FILE", raising=False)
+    with pytest.raises(ValueError, match="AUTORESEARCH_PANEL_HERMES_KEY_FILE"):
+        _panel_lenses_from_args(args())
+    judge = tmp_path / "panel_hermes_key"
+    judge.write_text("sk-judge")
+    judge.chmod(0o600)
+    monkeypatch.setenv("AUTORESEARCH_PANEL_HERMES_KEY_FILE", str(judge))
+    with pytest.raises(ValueError, match="requires --image"):
+        _panel_lenses_from_args(args(image=""))
+    # author-key reuse refused (the codex author key is the OpenAI author key)
+    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", str(judge))
+    with pytest.raises(ValueError, match="role separation"):
+        _panel_lenses_from_args(args())
+    monkeypatch.delenv("AUTORESEARCH_CODEX_KEY_FILE", raising=False)
+    # a properly separated key builds the contained hermes judge
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    monkeypatch.setenv("REVIEW_HERMES_REPO", str(repo))
+    lenses, secrets = _panel_lenses_from_args(args())
+    assert len(lenses) == 1 and lenses[0].kind == "review"
+    assert secrets == ("sk-judge",)
+    assert getattr(lenses[0].harness, "container_image", "") == "/img.sif"

--- a/tests/test_hermes_harness.py
+++ b/tests/test_hermes_harness.py
@@ -289,3 +289,49 @@ def test_config_write_refuses_symlink(tmp_path: Path) -> None:
     (tmp_path / "config.yaml").symlink_to(target)
     assert _write_private_fixed(tmp_path / "config.yaml", "NEW") is False  # refused
     assert target.read_text() == "ORIG"  # redirect target untouched
+
+
+def test_container_mode_jails_the_session(tmp_path, monkeypatch) -> None:
+    # container on: apptainer wraps the identical hermes argv — workspace and
+    # per-run home bound, the pinned repo read-only, key + uv vars via
+    # APPTAINERENV, never argv
+    import subprocess
+
+    from autoresearch.harness import HermesHarness
+
+    captured = {}
+
+    def fake_popen(command, cwd, env, **kw):
+        captured["command"] = command
+        captured["env"] = env
+        raise OSError("stop here")
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    repo = tmp_path / "hermes-agent"
+    repo.mkdir()
+    ws = tmp_path / "runs" / "r1" / "ws"
+    ws.mkdir(parents=True)
+    h = HermesHarness(
+        api_key="sk-h",
+        repo_dir=repo,
+        provider="openai-api",
+        container_image="/img.sif",
+    )
+    result = h.run("brief", ws)
+    assert result.is_error  # the fake Popen stopped the run
+    cmd = captured["command"]
+    assert cmd[0] == "apptainer" and "--containall" in cmd and "--cleanenv" in cmd
+    assert f"{ws.resolve()}:{ws.resolve()}" in cmd
+    assert f"{repo.resolve()}:{repo.resolve()}:ro" in cmd
+    home = (ws.parent / f"{ws.name}-home").resolve()
+    assert f"{home}:{home}" in cmd  # --home bind
+    assert "/img.sif" in cmd
+    assert "sk-h" not in " ".join(cmd)  # the key never rides argv
+    env = captured["env"]
+    assert env["APPTAINERENV_OPENROUTER_API_KEY"] == "sk-h"
+    assert env["APPTAINERENV_UV_PROJECT_ENVIRONMENT"].startswith(str(home))
+    # uncontained: same argv, no apptainer
+    captured.clear()
+    h2 = HermesHarness(api_key="sk-h", repo_dir=repo, provider="openai-api")
+    h2.run("brief", ws)
+    assert captured["command"][0] == "uv"

--- a/tests/test_panel.py
+++ b/tests/test_panel.py
@@ -125,5 +125,7 @@ def test_parse_lenses_admits_codex_and_refuses_uncontainable_backends() -> None:
         ("verify", "claude", "claude-fable-5"),
         ("review", "codex", "gpt-5.6-terra"),
     )
-    with pytest.raises(ValueError, match="no container mode"):
-        parse_lenses("review:hermes:gpt-5.6-terra")
+    # hermes is admitted now (containable); only an unknown backend refuses
+    assert parse_lenses("review:hermes:gpt-5.6-terra") == (("review", "hermes", "gpt-5.6-terra"),)
+    with pytest.raises(ValueError, match="unknown backend"):
+        parse_lenses("review:gemini")

--- a/tests/test_posting.py
+++ b/tests/test_posting.py
@@ -210,5 +210,12 @@ def test_round_stamp_fits_a_panel_attribution_without_mid_word_cut() -> None:
 
 
 def test_round_stamp_ellipsizes_a_hostile_overlong_attribution() -> None:
-    stamp, _ = posting._round_stamp(_FakeClient(), "org/repo", 1, _MARKER, {"head": {}}, "x" * 400)
+    stamp, _ = posting._round_stamp(
+        _FakeClient(),  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        _MARKER,
+        {"head": {}},
+        "x" * 400,
+    )
     assert "…" in stamp  # bounded, and legibly so

--- a/tests/test_posting.py
+++ b/tests/test_posting.py
@@ -192,3 +192,23 @@ def test_rounds_count_per_reviewer() -> None:
     # terra's next round increments ITS OWN count and sees its own same-head re-run
     stamp, label = _round_stamp(_C(), "o/r", 1, "<!-- m -->", pr_data, "hermes/terra")  # type: ignore[arg-type]
     assert "**Round 2**" in label and "(re-run on the same head)" in label
+
+
+def test_round_stamp_fits_a_panel_attribution_without_mid_word_cut() -> None:
+    # the summarizer's reviewed_by names every lens: it must render whole,
+    # not truncate mid-word (regression: a 60-char cap cut '...+de')
+    who = "summarizer:hermes/gpt-5.6-terra over general+credentials+deployment+lifecycle+coverage"
+    stamp, _ = posting._round_stamp(
+        _FakeClient(),  # type: ignore[arg-type]
+        "org/repo",
+        1,
+        _MARKER,
+        {"head": {"sha": "abc"}},
+        who,
+    )
+    assert "deployment" in stamp and "coverage" in stamp and "…" not in stamp
+
+
+def test_round_stamp_ellipsizes_a_hostile_overlong_attribution() -> None:
+    stamp, _ = posting._round_stamp(_FakeClient(), "org/repo", 1, _MARKER, {"head": {}}, "x" * 400)
+    assert "…" in stamp  # bounded, and legibly so

--- a/tests/test_review_summarize.py
+++ b/tests/test_review_summarize.py
@@ -24,6 +24,10 @@ def test_lens_narrows_attention_and_unknown_lens_fails_loudly() -> None:
     for lens, text in REVIEW_LENSES.items():
         brief = build_agent_brief(_pr(), lens=lens)
         assert text in brief and text not in plain
+    # 'general' is a REAL lens name (full rubric, no added focus) — accepted,
+    # identical to the unlensed brief (the empty-string-ternary footgun the
+    # workflow used to hit)
+    assert build_agent_brief(_pr(), lens="general") == plain
     with pytest.raises(ValueError, match="unknown review lens"):
         build_agent_brief(_pr(), lens="vibes")
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1927,7 +1927,8 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     err = _panel_preflight_error(both_wrong)
     assert "unknown kind" in err  # kind is checked before backend
     assert "claude backend" not in err
-    assert "no container mode" in _panel_preflight_error(
+    # a hermes lens preflights the shelled-judge rules (image first)
+    assert "requires a real container image" in _panel_preflight_error(
         make(panel="verify:hermes", panel_key_file=str(good))
     )
     # a codex lens preflights the image requirement too (climb parity)


### PR DESCRIPTION
Mengye's surprise ("I never knew it wasn't done on Torch") was right to be surprise: hermes was the one backend with no container mode — runnable only where an ephemeral runner was the boundary, which is why the Torch panel couldn't seat it. This closes that.

## What

- **`HermesHarness.container_image`**: apptainer `--containall --cleanenv`, workspace + per-run home bound (`--home`, so config/brief/samples/resume-transcript persist on the shared FS), the pinned hermes-agent clone bound **read-only** — the project venv + uv cache build in the per-run home (`UV_PROJECT_ENVIRONMENT`/`UV_CACHE_DIR` via `APPTAINERENV_*`), so nothing is writable-shared across sessions and the key never rides argv.
- **Panel gate lift**: `parse_lenses` admits hermes; unknown backends still refuse.
- **Shelled-judge rules unified**: the #152 checklist applies to hermes from birth through one shared helper (`_judge_lens_key`) — image required, `AUTORESEARCH_PANEL_HERMES_KEY_FILE` named explicitly, ≠ the (OpenAI) author key, ≠ the claude panel key, redaction-set membership. Tick preflight mirrors all of it plus the pinned-clone check.
- **Deployment**: new `.env` allowlist entries (`AUTORESEARCH_PANEL_HERMES_KEY_FILE`, `REVIEW_HERMES_REPO`, `REVIEW_HERMES_PROVIDER`); `scripts/install_hermes.sh` (tag-pinned, idempotent, in lockstep with the workflows' `HERMES_REF`) provisioned by the chain when the panel names hermes.

## Notes

First live wide-round test candidate — this PR itself is reviewed by the old single flow (base-branch workflow), but its sibling and the rename PR will exercise the new panel.

Perf note: the read-only repo bind means uv resolves the hermes venv per session (~a minute, cold cache in the per-run home) — deliberate isolation-over-speed; a shared writable cache would be a cross-session tampering channel.

## Tests

Container argv/env pin (binds, ro repo, APPTAINERENV key, no key in argv, uncontained unchanged); hermes lens rules via the shared helper (missing key / missing image / author-key reuse / happy path with contained judge); preflight image+clone parity; grammar admits hermes, refuses unknown. Full gate: 795 tests, ruff both, mypy — explicit exits, all 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)