### PR TITLE
refactor: climb -> attempt (author-role activity); run stays the substrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Vocabulary: the author-role activity is an **attempt** (a type of run), the
+  substrate stays **run**. `climb.py`→`attempt.py`, `climb_once`→
+  `attempt_once`, `live_climb`→`live_attempt`, `resume_climb`→`resume_attempt`,
+  `ClimbResult`→`AttemptResult`, `LiveClimbOutcome`→`AttemptOutcome`; the
+  general-substrate names become `RunParked`/`RunConfig`, while `RunRecord`,
+  `run_id`, `resume_run`, and park/wake are unchanged. The `-m
+  autoresearch.attempt` CLI verb replaces `-m autoresearch.climb`. Deploy-safe:
+  the renamed module and the tick's argv land together (the tick pulls at
+  tick-start), a `load_record` shim maps a pre-rename record's `climb_job_id`
+  to `run_job_id`, and the kill-stamp reader honors a legacy
+  `climb-terminal-seen` — so an in-flight run started before the rename still
+  wakes and ends correctly.
+
 ### Added
 
 - Hermes container mode: `HermesHarness` runs under apptainer like the other

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -164,13 +164,13 @@ sha — where "the measured sha" is created if it does not exist yet: the
 candidate measure happens on a dirty workspace before anything is committed,
 so dispatch snapshots the tree first: a TEMPORARY index (`GIT_INDEX_FILE`)
 seeded with `read-tree` from the base commit — so tracked-but-ignored files
-behave exactly as they do in climb.py's populated-index fingerprint, which a
+behave exactly as they do in attempt.py's populated-index fingerprint, which a
 fresh empty index would silently drop — then add -A / write-tree /
 commit-tree parented on the base; the working index is never touched — a session that resumes later finds its
 staged state intact. (The panel's current snapshot uses the working index
 plus a reset; it should adopt the temporary index too.) The fingerprint for
 the existing drift check is the snapshot's TREE hash — `write-tree` is
-deterministic for identical trees, which is what climb.py already compares —
+deterministic for identical trees, which is what attempt.py already compares —
 while the commit wrapping it exists only so a worktree can materialize the
 tree. Suite-gate baseline jobs use real commits as today. The job runs under the SAME containment contract as
 today's in-job evaluator —

--- a/docs/design/research-loop-buildout.md
+++ b/docs/design/research-loop-buildout.md
@@ -78,7 +78,7 @@ Design rulings:
   a forced sleep. `sleep([])` — nothing to wait on — is a legitimate
   checkpoint-and-reschedule: wake in a fresh job with a fresh clock (it burns a
   sleep count like any other — the bound on living forever). This replaces the
-  self-deadline kill (climb.py's walltime alarm) with an author-managed
+  self-deadline kill (attempt.py's walltime alarm) with an author-managed
   handoff.
 
 ## Phase A — launch/sleep: suspend-on-syscall, wake-with-result

--- a/docs/validation/author-syscalls.md
+++ b/docs/validation/author-syscalls.md
@@ -22,7 +22,7 @@ Then run one climb by hand (not via the tick):
 
 ```bash
 source env.sh
-uv run python -m autoresearch.climb \
+uv run python -m autoresearch.attempt \
   --target <org/repo> --benchmark <a-cheap-benchmark> \
   --run-root <run-root> --image <image.sif> \
   <the account/partition/limit args the tick normally passes>

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1,6 +1,6 @@
-"""One live climb, end to end: clone → climb_once → commit/push/PR → report.
+"""One live climb, end to end: clone → attempt_once → commit/push/PR → report.
 
-This is the glue `orchestrator.climb_once` deliberately does not own: the git
+This is the glue `orchestrator.attempt_once` deliberately does not own: the git
 side (bot-auth clone, veto-checked commit, push, PR) and the run's durable
 record. One invocation = one run = at most one PR.
 
@@ -39,15 +39,15 @@ from autoresearch.github import (
 from autoresearch.harness import Harness, SessionResult, redact
 from autoresearch.measure import DispatchedMeasurer, DispatchSettings
 from autoresearch.orchestrator import (
-    ClimbConfig,
-    ClimbParked,
-    ClimbResult,
+    AttemptResult,
     EvalError,
     Measurer,
+    RunConfig,
+    RunParked,
     _benchmark,
-    climb_once,
+    attempt_once,
     pr_body,
-    resume_climb,
+    resume_attempt,
 )
 from autoresearch.panel import PanelLens, PanelVerdict, run_panel
 from autoresearch.progress import (
@@ -231,7 +231,7 @@ _ENDINGS_BY_OUTCOME = {
 
 
 @dataclass(frozen=True)
-class LiveClimbOutcome:
+class AttemptOutcome:
     run_id: str
     outcome: str
     pr_url: str = ""
@@ -315,7 +315,7 @@ PARK_QUEUE_SLACK_MIN = 12 * 60
 def _park_run(
     run_root: Path,
     record: RunRecord,
-    parked: ClimbParked,
+    parked: RunParked,
     candidate_ref: str,
     eval_minutes: int | None,
     now: float,
@@ -428,7 +428,7 @@ def _park_run(
 
 def _make_launcher(dispatch: DispatchSettings, run_dir: Path, workspace: Path, run_id: str):
     """The launch side of the author syscalls, shared by the first pass
-    (live_climb) and the author-sleep wake: each launch becomes a jailed job on
+    (live_attempt) and the author-sleep wake: each launch becomes a jailed job on
     the sealed snapshot (write_eval_job's copy-out handles artifacts), and a
     partially-submitted batch is reaped rather than orphaned."""
 
@@ -494,7 +494,7 @@ def _wake_author_sleep(
     contract_text: str,
     contract: Contract,
     bench: Benchmark,
-    config: ClimbConfig,
+    config: RunConfig,
     measurer: Measurer,
     harness: Harness | None,
     spec: RoleSpec | None,
@@ -502,7 +502,7 @@ def _wake_author_sleep(
     issue_number: int,
     eval_minutes: int | None,
     extra_update: str = "",
-) -> LiveClimbOutcome:
+) -> AttemptOutcome:
     """Wake a syscall park and resume the AUTHOR: deliver the launches' results
     into the sandbox, resume the SAME session through the climb's resume-entry
     with them (data-fenced), and let the climb run — it may sleep again
@@ -517,7 +517,7 @@ def _wake_author_sleep(
     from autoresearch.syscall import Launch as SyscallLaunch
     from autoresearch.syscall import gather_results, render_wake, write_budget
 
-    def _end(result: ClimbResult, drop_refs: list[str]) -> LiveClimbOutcome:
+    def _end(result: AttemptResult, drop_refs: list[str]) -> AttemptOutcome:
         # a terminal from the resumed climb: report, ending record, issue note —
         # the same ending shape every other terminal takes.
         for ref in drop_refs:
@@ -550,7 +550,7 @@ def _wake_author_sleep(
             redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
             secrets,
         )
-        return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
+        return AttemptOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
 
     # The wake NEEDS the author harness (it resumes the session). Fail as a
     # named ending, not a crash: the run cannot proceed and re-waking will not
@@ -563,7 +563,7 @@ def _wake_author_sleep(
         or not getattr(harness, "supports_resume", True)
     ):
         return _end(
-            ClimbResult(
+            AttemptResult(
                 outcome="session-error",
                 note="author-sleep wake needs the author harness/spec and a resumable session",
             ),
@@ -639,10 +639,10 @@ def _wake_author_sleep(
         else None
     )
 
-    parked: ClimbParked | None = None
+    parked: RunParked | None = None
     kept_ref = ""
     try:
-        result = climb_once(
+        result = attempt_once(
             config,
             contract_text,
             workspace,
@@ -660,7 +660,7 @@ def _wake_author_sleep(
             launches_used=launches_used,
             sleeps_used=sleeps_used,
         )
-    except ClimbParked as p:
+    except RunParked as p:
         # slept again, or the gate dispatched its measures (a candidate park the
         # existing wake path decides). Keep the NEW park's snapshot ref; the OLD
         # sleep ref is superseded once the new park persists.
@@ -684,7 +684,7 @@ def _wake_author_sleep(
             raise
         parked = p
         drop_snapshot(ws, Snapshot(commit="", tree="", ref=sleep_ref))
-        return LiveClimbOutcome(run_id=run_id, outcome="parked")
+        return AttemptOutcome(run_id=run_id, outcome="parked")
     finally:
         for snap in snapshots:
             if parked and kept_ref and snap.ref == kept_ref:
@@ -726,14 +726,14 @@ def resume_run(
     panel_lenses: tuple[PanelLens, ...] = (),
     harness: Harness | None = None,
     spec: RoleSpec | None = None,
-) -> LiveClimbOutcome:
+) -> AttemptOutcome:
     """Wake a parked dispatched climb and re-enter its decision WITHOUT the
-    session (`orchestrator.resume_climb`), from the record `_park_run` wrote.
+    session (`orchestrator.resume_attempt`), from the record `_park_run` wrote.
     The three exits:
 
     * **re-park** — the wake dispatched a measure that is not done yet (the
       suite pairs an improving candidate fans out, "another round of
-      experiments"): `resume_climb` raises `ClimbParked`, and this re-persists
+      experiments"): `resume_attempt` raises `RunParked`, and this re-persists
       the WAITING stage on the new afterany, keeping the same candidate
       snapshot;
     * **a negative terminal** (no-improvement / suite-regression / eval-error):
@@ -778,7 +778,7 @@ def resume_run(
     contract_text = ws.git("show", f"{base_sha}:.autoresearch.yaml")
     contract = load_contract(contract_text, record.target)
     bench = _benchmark(contract, record.benchmark)
-    config = ClimbConfig(target=record.target, benchmark=record.benchmark, agent_id=record.agent_id)
+    config = RunConfig(target=record.target, benchmark=record.benchmark, agent_id=record.agent_id)
     eval_minutes = next(
         (b.eval_minutes for b in contract.benchmarks if b.name == record.benchmark), None
     )
@@ -840,7 +840,7 @@ def resume_run(
         transcript_path="",
     )
     try:
-        result = resume_climb(
+        result = resume_attempt(
             contract,
             bench,
             base_sha=base_sha,
@@ -852,7 +852,7 @@ def resume_run(
             measurer=measurer,
             min_relative_improvement=config.min_relative_improvement,
         )
-    except ClimbParked as parked:
+    except RunParked as parked:
         # another measure this wake dispatched is not done — re-park on the new
         # afterany, keeping the SAME candidate snapshot the next wake reads.
         # PROGRESS only if this wake dispatched a NEW job set (e.g. the candidate
@@ -902,7 +902,7 @@ def resume_run(
             base_branch=base_branch,
             panel_reads=panel_reads,
         )
-        return LiveClimbOutcome(run_id=run_id, outcome="parked")
+        return AttemptOutcome(run_id=run_id, outcome="parked")
 
     # A SUBMITTED park (the author's `submit` syscall, buildout Phase B): gate
     # and panel results go back to the AUTHOR — it revises and resubmits, runs
@@ -917,7 +917,7 @@ def resume_run(
         and getattr(harness, "supports_resume", True)
     )
 
-    def _wake_author(extra_update: str) -> LiveClimbOutcome:
+    def _wake_author(extra_update: str) -> AttemptOutcome:
         # resume the submitted park's author with the gate/panel feedback
         # leading its wake text; the candidate ref is this park's held snapshot
         return _wake_author_sleep(
@@ -983,7 +983,7 @@ def resume_run(
                 RunRecord(**{**record.__dict__, "state": ENDED, "ending": NEGATIVE_RESULT})
             )
             _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
-            return LiveClimbOutcome(run_id=run_id, outcome="no-improvement")
+            return AttemptOutcome(run_id=run_id, outcome="no-improvement")
 
         from datetime import UTC as _UTC
         from datetime import datetime as _dt
@@ -1048,7 +1048,7 @@ def resume_run(
                 redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
                 secrets,
             )
-            return LiveClimbOutcome(
+            return AttemptOutcome(
                 run_id=run_id, outcome="improved", pr_url=pr_url, report_path=str(report_path)
             )
 
@@ -1205,7 +1205,7 @@ def resume_run(
             )
             if _best_effort("ending record", lambda: save_record(run_root, failed, now), secrets):
                 drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
-            return LiveClimbOutcome(run_id=run_id, outcome="publish-error")
+            return AttemptOutcome(run_id=run_id, outcome="publish-error")
         # PR opened. Record IN_REVIEW *before* dropping the snapshot: if the save
         # fails, the record stays `waiting` with the snapshot intact, so the run
         # is recoverable rather than an ABORTED record over a live PR.
@@ -1242,7 +1242,7 @@ def resume_run(
             redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
             secrets,
         )
-        return LiveClimbOutcome(
+        return AttemptOutcome(
             run_id=run_id, outcome="improved", pr_url=pr_url, report_path=str(report_path)
         )
 
@@ -1282,7 +1282,7 @@ def resume_run(
         redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
         secrets,
     )
-    return LiveClimbOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
+    return AttemptOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
 
 
 def _judge_lens_key(
@@ -1492,8 +1492,8 @@ def build_panel_runner(
     return runner
 
 
-def live_climb(
-    config: ClimbConfig,
+def live_attempt(
+    config: RunConfig,
     run_root: Path,
     run_id: str,
     harness: Harness,
@@ -1512,7 +1512,7 @@ def live_climb(
     panel_lenses: tuple[PanelLens, ...] = (),
     dispatch: DispatchSettings | None = None,
     eval_image: str = "",
-) -> LiveClimbOutcome:
+) -> AttemptOutcome:
     """Run one climb against the real target repo. With `panel_lenses`, the
     pre-PR verification panel gates the claim before any PR exists
     (docs/design/orchestrator-verify.md); blocking findings still open at
@@ -1537,7 +1537,7 @@ def live_climb(
         author_backend=author_backend,
         author_model=author_model,
         author_key_file=author_key_file,
-        climb_job_id=_os.environ.get("SLURM_JOB_ID", ""),
+        run_job_id=_os.environ.get("SLURM_JOB_ID", ""),
     )
     try:
         save_record(run_root, record, now)
@@ -1561,14 +1561,14 @@ def live_climb(
                 ),
                 secrets,
             )
-        return LiveClimbOutcome(run_id=run_id, outcome="climb-error")
+        return AttemptOutcome(run_id=run_id, outcome="attempt-error")
 
     try:
         ws = Workspace.clone(_target_clone_url(config.target), workspace, auth=bot_auth)
         # Build ON the requested PR base: the clone checks out the remote
         # DEFAULT branch, which need not be `base_branch` — the session must
         # edit, and the gate must measure, the tree the PR will land on.
-        # A missing base branch fails loudly as climb-error.
+        # A missing base branch fails loudly as attempt-error.
         ws.git("checkout", "-q", "-B", base_branch, f"origin/{base_branch}")
         contract_text = (workspace / ".autoresearch.yaml").read_text()
         contract = load_contract(contract_text, config.target)
@@ -1720,13 +1720,13 @@ def live_climb(
             assert dispatch is not None  # folded into author_syscalls above
             launcher = _make_launcher(dispatch, run_dir, workspace, run_id)
 
-        parked: ClimbParked | None = None
+        parked: RunParked | None = None
         kept_ref = ""  # the ONE candidate snapshot ref that must outlive a park
         try:
             # the last-known score orients the brief only; the gate re-measures
             # both sides after the session, so None (a first run) is fine.
             prior_best = load_leader(workspace).get(config.benchmark)
-            result = climb_once(
+            result = attempt_once(
                 config,
                 contract_text,
                 workspace,
@@ -1743,7 +1743,7 @@ def live_climb(
                 brief_baseline=prior_best.best if prior_best else None,
                 launcher=launcher,
             )
-        except ClimbParked as p:
+        except RunParked as p:
             # The climb dispatched its measures and hibernated. Persist the
             # re-entry stage as a WAITING record (not an error), keep the
             # candidate snapshot alive for the wake, and end. The wake re-enters
@@ -1784,7 +1784,7 @@ def live_climb(
                     dispatch.compute.cancel(job_id)
                 raise
             parked = p
-            return LiveClimbOutcome(run_id=run_id, outcome="parked")
+            return AttemptOutcome(run_id=run_id, outcome="parked")
         finally:
             for snap in snapshots:
                 # a candidate park must OUTLIVE the wake — keep the ONE recorded
@@ -1810,7 +1810,7 @@ def live_climb(
             "error report",
             lambda: report_path.write_text(
                 f"# Run report — {config.target} / {config.benchmark}\n"
-                f"Outcome: **climb-error**\n"
+                f"Outcome: **attempt-error**\n"
                 f"Note: {note}\n"
             ),
             secrets,
@@ -1825,14 +1825,14 @@ def live_climb(
                 lambda: github.comment(
                     config.target,
                     issue_number,
-                    f"Run `{run_id}` finished (climb-error): {exc_name}. "
+                    f"Run `{run_id}` finished (attempt-error): {exc_name}. "
                     f"Details are in the run's record and report on the orchestrator.",
                 ),
                 secrets,
             )
-        return LiveClimbOutcome(
+        return AttemptOutcome(
             run_id=run_id,
-            outcome="climb-error",
+            outcome="attempt-error",
             # an outcome must never point at a report that was not written
             report_path=str(report_path) if wrote else "",
         )
@@ -2011,7 +2011,7 @@ def live_climb(
             secrets,
         )
     log.info("run %s: %s %s", run_id, outcome_name, pr_url)
-    return LiveClimbOutcome(
+    return AttemptOutcome(
         run_id=run_id,
         outcome=outcome_name,
         pr_url=pr_url,
@@ -2107,7 +2107,7 @@ def main() -> int:
 
     arm_sigterm_containment()
 
-    parser = argparse.ArgumentParser(description="One live climb on one benchmark.")
+    parser = argparse.ArgumentParser(description="One live attempt on one benchmark.")
     # --target/--benchmark drive a fresh climb; they are read from the record
     # on a --resume wake instead, so they are optional (validated below).
     parser.add_argument("--target", default="")
@@ -2394,8 +2394,8 @@ def main() -> int:
         )
     try:
         try:
-            outcome = live_climb(
-                config=ClimbConfig(target=args.target, benchmark=args.benchmark),
+            outcome = live_attempt(
+                config=RunConfig(target=args.target, benchmark=args.benchmark),
                 base_branch=args.base_branch,
                 run_root=args.run_root,
                 run_id=run_id,
@@ -2438,7 +2438,7 @@ def main() -> int:
                 ),
             )
         except Terminated as exc:
-            # Fired in live_climb's microseconds-wide pre-containment window:
+            # Fired in live_attempt's microseconds-wide pre-containment window:
             # any record it saved strands and the sweep ends it from Slurm
             # truth; here we only avoid dying as an unexplained traceback.
             log.error("self-deadline fired before containment: %s", exc)

--- a/src/autoresearch/climb.py
+++ b/src/autoresearch/climb.py
@@ -1,0 +1,30 @@
+"""Back-compat shim: `climb` was renamed to `attempt` (the author-role
+activity — docs/design/research-loop-buildout.md). This module keeps
+`python -m autoresearch.climb` and `from autoresearch.climb import ...`
+working for one deprecation cycle, so a climb job SUBMITTED before the
+rename deploy — pending in the Slurm queue, its argv already fixed —
+still runs even if it lands on the post-rename tree (flight_checkout can
+fall back to the shared checkout, which after deploy is the new code).
+
+Delete once no pre-rename job can still be queued (a few tick cadences).
+"""
+
+from __future__ import annotations
+
+from autoresearch.attempt import *  # noqa: F403 — re-export the public surface
+from autoresearch.attempt import main
+
+
+def _run() -> int:
+    import logging
+
+    logging.getLogger(__name__).warning(
+        "autoresearch.climb is a compatibility shim; use autoresearch.attempt"
+    )
+    return main()
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(_run())

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -724,7 +724,7 @@ def main() -> int:
 
     from datetime import UTC, datetime
 
-    from autoresearch.climb import (
+    from autoresearch.attempt import (
         codex_author_config_error,
         resolve_author_key_file,
         resume_author,
@@ -759,7 +759,7 @@ def main() -> int:
     # ending honest (cursors un-advanced on failure -> the next tick retries).
     import signal as _signal
 
-    from autoresearch.climb import arm_self_deadline
+    from autoresearch.attempt import arm_self_deadline
     from autoresearch.role_runner import build_harness
 
     armed = arm_self_deadline(args.job_minutes)

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1,6 +1,6 @@
 """Orchestrator v1: one climb attempt on one benchmark of one target.
 
-Deliberately narrow: `climb_once` runs a single
+Deliberately narrow: `attempt_once` runs a single
 implement→evaluate→verify→PR cycle for the configured benchmark. Task
 selection across benchmarks, the planner, experiment sbatch + wakes, and
 notebook reports grow from here — each behind a seam that already exists.
@@ -89,9 +89,9 @@ class EvalError(RuntimeError):
     """The benchmark command failed or produced no readable metric."""
 
 
-class ClimbParked(Exception):
+class RunParked(Exception):
     """A dispatched climb submitted its measures and must hibernate until they
-    finish. `climb_once` raises it (a park is an exceptional exit); the caller,
+    finish. `attempt_once` raises it (a park is an exceptional exit); the caller,
     which owns the run record and git, persists the fields below as the WAITING
     stage — `afterany` among them, the dependency set the wake waits on — and
     ends the run's turn, keeping the candidate snapshot alive so the wake can
@@ -378,7 +378,7 @@ def _metric_from_output(stdout: str, metric: str) -> float | None:
 
 
 @dataclass(frozen=True)
-class ClimbConfig:
+class RunConfig:
     target: str  # owner/repo
     benchmark: str  # the ONE benchmark this loop works on
     branch_prefix: str = "feat/auto/agent-01"
@@ -405,7 +405,7 @@ class SuiteMeasurement:
 
 
 @dataclass(frozen=True)
-class ClimbResult:
+class AttemptResult:
     """What one attempt produced — the raw material of the run report."""
 
     # improved | no-improvement | session-error | session-budget |
@@ -419,7 +419,7 @@ class ClimbResult:
     measured_paths: tuple[str, ...] = ()
     # the sealed candidate snapshot this result was measured on (set on
     # `improved`); a caller can publish THIS tree (the wake path does,
-    # climb.py) and a depth loop can select the best across passes by it.
+    # attempt.py) and a depth loop can select the best across passes by it.
     # "" on non-improved outcomes.
     candidate_sha: str = ""
     session: SessionResult | None = None
@@ -442,7 +442,7 @@ class ClimbResult:
     panel_blocking_open: bool = False
     panel_degraded: bool = False
 
-    def report(self, config: ClimbConfig, redact_secrets: tuple[str, ...] = ()) -> str:
+    def report(self, config: RunConfig, redact_secrets: tuple[str, ...] = ()) -> str:
         lines = [
             f"# Run report — {config.target} / {config.benchmark}",
             f"Outcome: **{self.outcome}**",
@@ -707,7 +707,7 @@ def measure_and_decide(
     measured_paths: Sequence[str],
     measurer: Measurer,
     min_relative_improvement: float,
-) -> ClimbResult | MeasureOK:
+) -> AttemptResult | MeasureOK:
     """The post-session decision as a PURE function of committed shas and a
     `Measurer` — the re-enterable core a wake reconstructs from the record.
 
@@ -715,7 +715,7 @@ def measure_and_decide(
     common random numbers) and, when the diff touches shared code, each
     sibling's paired base/cand (on the sibling's OWN seed var, all sharing the
     single `suite_seed`), then applies the improvement threshold and the suite
-    gate. Returns a TERMINAL `ClimbResult` on any stop (scope-violation,
+    gate. Returns a TERMINAL `AttemptResult` on any stop (scope-violation,
     eval-error, no-improvement, suite-regression), or a `MeasureOK` carrying
     the credited values. No session and no git: the same shas rebuild the same
     plan and read cached results, so a wake re-enters here unchanged. A
@@ -736,7 +736,7 @@ def measure_and_decide(
     # because the out-of-scope edit could be to the ruler itself.
     violations = out_of_scope(list(measured_paths), contract)
     if violations:
-        return ClimbResult(
+        return AttemptResult(
             outcome="scope-violation",
             note=f"out-of-scope paths: {', '.join(sorted(violations)[:10])}",
             run_seed=seed,
@@ -767,18 +767,18 @@ def measure_and_decide(
 
     # PHASE 1 — baseline + candidate only. Siblings are NOT measured until the
     # candidate has cleared the threshold: a non-improving candidate must never
-    # burn the (expensive) sibling evals, matching climb_once's lazy order.
+    # burn the (expensive) sibling evals, matching attempt_once's lazy order.
     try:
         main = measurer.results(
             plan_measures(bench.command, bench.metric, base_sha, candidate_sha, seed_env, seed)
         )
     except EvalError as exc:
-        return ClimbResult(outcome="eval-error", note=str(exc), run_seed=seed)
+        return AttemptResult(outcome="eval-error", note=str(exc), run_seed=seed)
 
     baseline = main["baseline"]
     candidate = main["candidate"]
     if not improved(baseline, candidate, bench.direction, min_relative_improvement):
-        return ClimbResult(
+        return AttemptResult(
             outcome="no-improvement",
             baseline=baseline,
             candidate=candidate,
@@ -808,7 +808,7 @@ def measure_and_decide(
         vals = measurer.results(sib_plan)
     except EvalError as exc:
         # phase 1 already credited the main pair — carry it into the report.
-        return ClimbResult(
+        return AttemptResult(
             outcome="eval-error",
             baseline=baseline,
             candidate=candidate,
@@ -835,7 +835,7 @@ def measure_and_decide(
     regressed = [r for r in suite if r.regressed]
     if regressed:
         named = ", ".join(f"{r.name} {r.baseline} -> {r.candidate}" for r in regressed)
-        return ClimbResult(
+        return AttemptResult(
             outcome="suite-regression",
             baseline=baseline,
             candidate=candidate,
@@ -853,7 +853,7 @@ def measure_and_decide(
     )
 
 
-def resume_climb(
+def resume_attempt(
     contract: Contract,
     bench: Benchmark,
     *,
@@ -865,7 +865,7 @@ def resume_climb(
     session: SessionResult,
     measurer: Measurer,
     min_relative_improvement: float,
-) -> ClimbResult:
+) -> AttemptResult:
     """Re-enter a parked climb's post-session decision — the WAKE side of a
     dispatched candidate park. The candidate is already committed (its sha is in
     the record), so the session does NOT re-run: its edits are captured in
@@ -877,7 +877,7 @@ def resume_climb(
     The measurer reads the cached eval results and this returns the decision, OR
     the decision needs a measure not yet done — the suite pairs after an
     improving candidate, "another round of experiments" — and it re-parks by
-    raising `ClimbParked`, exactly as the first pass did.
+    raising `RunParked`, exactly as the first pass did.
 
     This is the re-entry seam the depth axis (docs/design/research-loop.md)
     builds on.
@@ -899,7 +899,7 @@ def resume_climb(
     except MeasurementPending as pending:
         # a measure is not done yet (the suite pairs this wake just dispatched):
         # re-park on the new afterany set, same shape as the first candidate park
-        raise ClimbParked(
+        raise RunParked(
             phase="candidate",
             afterany=pending.afterany(),
             base_sha=base_sha,
@@ -908,7 +908,7 @@ def resume_climb(
             candidate_sha=candidate_sha,
             session=session,
         ) from None
-    if isinstance(outcome, ClimbResult):
+    if isinstance(outcome, AttemptResult):
         # a terminal measurement outcome (no-improvement / suite-regression /
         # eval-error): carry the reconstructed session, and give a bare
         # no-improvement the same framing the in-job path sets (a clear
@@ -919,7 +919,7 @@ def resume_climb(
         return dc_replace(outcome, session=session, note=note)
     # credited: candidate cleared the threshold and no sibling regressed. The
     # caller sets `branch` when it opens the PR.
-    return ClimbResult(
+    return AttemptResult(
         outcome="improved",
         baseline=outcome.baseline,
         candidate=outcome.candidate,
@@ -940,8 +940,8 @@ def _merge_afterany(*parts: str) -> str:
     return "afterany:" + ":".join(ids) if ids else ""
 
 
-def climb_once(
-    config: ClimbConfig,
+def attempt_once(
+    config: RunConfig,
     contract_text: str,
     workspace: Path,
     harness: Harness,
@@ -962,7 +962,7 @@ def climb_once(
     launcher: Callable[[str, SyscallRequest], str] | None = None,
     launches_used: int = 0,
     sleeps_used: int = 0,
-) -> ClimbResult:
+) -> AttemptResult:
     """One implement→evaluate→verify cycle in an existing clean workspace.
 
     The caller owns the git side (clone before, diff/commit/push/PR after) —
@@ -994,7 +994,7 @@ def climb_once(
     session that ends having asked to launch-and-sleep parks this climb as
     `author-sleep` instead of measuring: the tree is sealed via `snapshot()`,
     the launcher submits the jobs (caller-owned — it is compute work), and the
-    ClimbParked carries the request plus the budget counts. A `submit` rides
+    RunParked carries the request plus the budget counts. A `submit` rides
     the same request: the gate (and any sibling launches) run on the sealed
     tree — a dispatched gate parks as a `candidate` with the `submitted`
     marker, an inline gate feeds back in-session. `launches_used` /
@@ -1005,7 +1005,7 @@ def climb_once(
     bench = _benchmark(contract, config.benchmark)
     spec = spec or author_spec()
     if not spec.execution.can_execute:
-        raise ValueError("climb_once runs an editing role; the spec must allow execution")
+        raise ValueError("attempt_once runs an editing role; the spec must allow execution")
     if not spec.scope:
         spec = dc_replace(spec, scope=tuple(contract.scope.allowed))
 
@@ -1102,7 +1102,7 @@ def climb_once(
             kind = "session-budget"
         else:
             kind = "session-error"
-        return ClimbResult(
+        return AttemptResult(
             outcome=kind,
             baseline=baseline,
             session=session,
@@ -1135,9 +1135,9 @@ def climb_once(
     measured: tuple[str, ...] = ()
     refused_once = False
 
-    def _resume(prompt: str) -> ClimbResult | None:
+    def _resume(prompt: str) -> AttemptResult | None:
         """Resume the author session with `prompt`: None on success (session
-        advanced), else the terminal ClimbResult for the failed resume."""
+        advanced), else the terminal AttemptResult for the failed resume."""
         nonlocal session
         wake_result = run_role(
             spec, harness, prompt, workspace, resume_session_id=session.session_id
@@ -1151,7 +1151,7 @@ def climb_once(
             kind = "session-budget"
         else:
             kind = "session-error"
-        return ClimbResult(
+        return AttemptResult(
             outcome=kind,
             baseline=baseline,
             candidate=candidate,
@@ -1189,7 +1189,7 @@ def climb_once(
                 request = read_syscall_request(workspace)
             except SyscallError as exc:
                 # loud, never silent: the author meant something by the file
-                return ClimbResult(
+                return AttemptResult(
                     outcome="session-error",
                     baseline=baseline,
                     session=session,
@@ -1222,7 +1222,7 @@ def climb_once(
                 # job. Same ending as the candidate path.
                 violations = out_of_scope(list(changed_paths()), contract)
                 if violations:
-                    return ClimbResult(
+                    return AttemptResult(
                         outcome="scope-violation",
                         baseline=baseline,
                         session=session,
@@ -1232,7 +1232,7 @@ def climb_once(
                         run_seed=run_seed,
                     )
                 sha = snapshot()
-                raise ClimbParked(
+                raise RunParked(
                     phase="author-sleep",
                     afterany=launcher(sha, request),
                     base_sha=base_sha,
@@ -1267,7 +1267,7 @@ def climb_once(
         # which re-enters it directly).
         violations = out_of_scope(list(measured), contract)
         if violations:
-            return ClimbResult(
+            return AttemptResult(
                 outcome="scope-violation",
                 baseline=baseline,
                 session=session,
@@ -1285,7 +1285,7 @@ def climb_once(
         try:
             candidate_sha = snapshot()
         except EvalError as exc:
-            return ClimbResult(
+            return AttemptResult(
                 outcome="eval-error",
                 baseline=baseline,
                 session=session,
@@ -1320,7 +1320,7 @@ def climb_once(
                 assert launcher is not None  # a submit only arrives through it
                 launch_afterany = launcher(candidate_sha, submitted)
                 launches_used += len(submitted.launches)
-            raise ClimbParked(
+            raise RunParked(
                 phase="candidate",
                 afterany=_merge_afterany(pending.afterany(), launch_afterany),
                 base_sha=base_sha,
@@ -1333,7 +1333,7 @@ def climb_once(
                 sleeps_used=sleeps_used,
                 submitted=submitted is not None,
             ) from None
-        if isinstance(outcome, ClimbResult):
+        if isinstance(outcome, AttemptResult):
             if (
                 submitted is not None
                 and outcome.outcome in ("no-improvement", "suite-regression", "eval-error")
@@ -1403,7 +1403,7 @@ def climb_once(
         panel_blocking_open = bool(verdict.blocking)
         break
 
-    return ClimbResult(
+    return AttemptResult(
         outcome="improved",
         baseline=baseline,
         candidate=candidate,
@@ -1422,8 +1422,8 @@ def climb_once(
 
 
 def pr_body(
-    result: ClimbResult,
-    config: ClimbConfig,
+    result: AttemptResult,
+    config: RunConfig,
     redact_secrets: tuple[str, ...],
     display_digits: int | None = None,
 ) -> str:

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -41,7 +41,7 @@ def author_spec(
     No output_schema: the artifact is the workspace diff plus the free-text
     research report, judged by measurement (the kernel re-runs the eval), not
     by parsing. `scope` is the contract's allowed paths; an empty tuple means
-    "filled from the contract by the kernel" (climb_once), which owns scope
+    "filled from the contract by the kernel" (attempt_once), which owns scope
     enforcement either way. Budget defaults mirror the climb CLI's.
     """
     return RoleSpec(

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -119,7 +119,7 @@ class RunRecord:
     state: str
     agent_id: str = "agent-01"
     experiment_job_id: str = ""
-    climb_job_id: str = ""  # slurm job running the climb itself; lets the
+    run_job_id: str = ""  # slurm job running the attempt itself; lets the
     # sweep end records whose job was KILLED (walltime/preemption/node
     # death) rather than crashed — signals leave no exception to contain.
     # INVARIANT: any future path that re-enters `implementing` from a NEW
@@ -202,6 +202,13 @@ def load_record(root: Path, run_id: str) -> RunRecord:
     raw = json.loads((run_dir(root, run_id) / RECORD_NAME).read_text())
     if not isinstance(raw, dict):
         raise ValueError(f"record is not a JSON object: {type(raw).__name__}")
+    # Back-compat: a record written by pre-rename code carries `climb_job_id`
+    # for what is now `run_job_id`. Map it on load so an in-flight run started
+    # before the rename still wakes/ends correctly (the deploy is atomic, but
+    # its already-parked records are not). Only when the new key is absent, so
+    # a genuine new record always wins.
+    if "climb_job_id" in raw and "run_job_id" not in raw:
+        raw["run_job_id"] = raw["climb_job_id"]
     # Ignore unknown keys: after a bad-merge revert, older code must still be
     # able to read records written by newer code — a "corrupt" verdict here
     # would blind the sweep to the whole run.

--- a/src/autoresearch/steward.py
+++ b/src/autoresearch/steward.py
@@ -26,8 +26,8 @@ from dataclasses import replace as dc_replace
 from pathlib import Path
 from typing import Any, Protocol
 
-from autoresearch.climb import (
-    LiveClimbOutcome,
+from autoresearch.attempt import (
+    AttemptOutcome,
     Terminated,
     WorkspaceDrift,
     _best_effort,
@@ -416,11 +416,11 @@ def live_steward(
     issue_number: int = 0,
     work_order: str = "",
     spec: RoleSpec | None = None,
-) -> LiveClimbOutcome:
+) -> AttemptOutcome:
     """Run one stewardship against the real target repo."""
     import os as _os
 
-    # a deployment bug is loud and immediate — same guard as climb_once
+    # a deployment bug is loud and immediate — same guard as attempt_once
     spec = spec or steward_spec()
     if not spec.execution.can_execute:
         raise ValueError("the steward is an editing role; the spec must allow execution")
@@ -438,7 +438,7 @@ def live_steward(
         agent_id=STEWARD_AGENT_ID,
         deadline=now + 24 * 3600,
         issue_number=issue_number,
-        climb_job_id=_os.environ.get("SLURM_JOB_ID", ""),
+        run_job_id=_os.environ.get("SLURM_JOB_ID", ""),
     )
     try:
         save_record(run_root, record, now)
@@ -456,7 +456,7 @@ def live_steward(
                 ),
                 secrets,
             )
-        return LiveClimbOutcome(run_id=run_id, outcome="climb-error")
+        return AttemptOutcome(run_id=run_id, outcome="attempt-error")
 
     tree_hashes: list[str] = []
     try:
@@ -540,9 +540,7 @@ def live_steward(
                     ),
                     secrets,
                 )
-            return LiveClimbOutcome(
-                run_id=run_id, outcome=outcome_name, report_path=str(report_path)
-            )
+            return AttemptOutcome(run_id=run_id, outcome=outcome_name, report_path=str(report_path))
 
         violations = steward_out_of_scope(changed, contract)
         if violations:
@@ -707,7 +705,7 @@ def live_steward(
                 lambda: github.comment(config.target, issue_number, release),
                 secrets,
             )
-        return LiveClimbOutcome(
+        return AttemptOutcome(
             run_id=run_id,
             outcome=outcome_label,
             report_path=str(report_path) if wrote else "",
@@ -736,7 +734,7 @@ def live_steward(
             secrets,
         )
     log.info("steward run %s: %s %s", run_id, outcome_name, pr_url)
-    return LiveClimbOutcome(
+    return AttemptOutcome(
         run_id=run_id, outcome=outcome_name, pr_url=pr_url, report_path=str(report_path)
     )
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -731,13 +731,21 @@ def sweep(
 
 
 def _kill_stamp(root: Path, run_id: str) -> Path:
+    # the current name; a legacy `climb-terminal-seen` from a run stamped
+    # before the rename is honored by _kill_stamp_read (a stamp only lives
+    # during a KillWait grace, so this tolerance matters for at most one
+    # in-flight run across the deploy).
+    return run_dir(root, run_id) / "attempt-terminal-seen"
+
+
+def _legacy_kill_stamp(root: Path, run_id: str) -> Path:
     return run_dir(root, run_id) / "climb-terminal-seen"
 
 
 def _sweep_implementing(root: Path, compute: SlurmCompute, now: float, grace_s: float) -> list[str]:
     """End `implementing` records whose climb job died without a verdict.
 
-    A climb that CRASHES contains its own ending (climb.py); a climb that is
+    A climb that CRASHES contains its own ending (attempt.py); a climb that is
     KILLED — walltime, preemption, scancel after the SIGTERM grace, node
     death — leaves no exception to contain, so this pass records the ending
     (the picker's stranded guard only frees the lane). Slurm truth decides:
@@ -750,9 +758,9 @@ def _sweep_implementing(root: Path, compute: SlurmCompute, now: float, grace_s: 
         if record.state != IMPLEMENTING:
             continue
         try:
-            if record.climb_job_id:
+            if record.run_job_id:
                 try:
-                    state = compute.status(record.climb_job_id)
+                    state = compute.status(record.run_job_id)
                 except SlurmQueryError:
                     continue  # Slurm outage must not read as a dead job
                 if not (is_terminal(state) or state == GONE):
@@ -767,6 +775,11 @@ def _sweep_implementing(root: Path, compute: SlurmCompute, now: float, grace_s: 
                 # concurrently written ending), and the waiting sweep's
                 # terminal_seen field stays reserved for the EXPERIMENT job.
                 stamp = _kill_stamp(root, record.run_id)
+                legacy = _legacy_kill_stamp(root, record.run_id)
+                if legacy.exists() and not stamp.exists():
+                    # a run stamped just before the rename: adopt its clock so
+                    # the KillWait grace is measured from the original sighting
+                    stamp = legacy
                 if not stamp.exists():
                     try:
                         fd = os.open(stamp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
@@ -792,7 +805,7 @@ def _sweep_implementing(root: Path, compute: SlurmCompute, now: float, grace_s: 
                         continue  # stamp vanished mid-read; next tick decides
                 if now - seen < grace_s:
                     continue
-                note = f"climb job {record.climb_job_id} ended {state} without a verdict"
+                note = f"climb job {record.run_job_id} ended {state} without a verdict"
             else:
                 # No Slurm evidence at all (legacy record, or a manual dev
                 # invocation without SLURM_JOB_ID): only the run DEADLINE —
@@ -1269,7 +1282,7 @@ def _author_config_error(spec: FollowupSpec) -> str:
     (e.g. AUTORESEARCH_AUTHOR_BACKEND=codex with no non-claude model) never
     strands a claimed intake issue. Reads the fleet author config from env — the
     same source the climb defaults from — and the image the tick already knows."""
-    from autoresearch.climb import codex_author_config_error
+    from autoresearch.attempt import codex_author_config_error
 
     backend = os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude"
     model = os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5"
@@ -1290,7 +1303,7 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
     if not spec.panel.strip():
         return ""
     try:
-        from autoresearch.climb import PANEL_KEY_DEFAULT, resolve_author_key_file
+        from autoresearch.attempt import PANEL_KEY_DEFAULT, resolve_author_key_file
         from autoresearch.github import FileTokenProvider
         from autoresearch.panel import parse_lenses
 
@@ -1538,7 +1551,7 @@ def service_self_initiated(
             "run",
             "python",
             "-m",
-            "autoresearch.climb",
+            "autoresearch.attempt",
             "--target",
             spec.target,
             "--benchmark",
@@ -1774,7 +1787,7 @@ def service_intake(
             "run",
             "python",
             "-m",
-            "autoresearch.climb",
+            "autoresearch.attempt",
             "--target",
             target,
             "--benchmark",
@@ -1858,7 +1871,7 @@ class JobWakeDispatcher:
             "run",
             "python",
             "-m",
-            "autoresearch.climb",
+            "autoresearch.attempt",
             "--resume",
             record.run_id,
             "--run-root",

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -1,4 +1,4 @@
-"""live_climb end to end: real local git repos, fake harness/evaluator/API."""
+"""live_attempt end to end: real local git repos, fake harness/evaluator/API."""
 
 from __future__ import annotations
 
@@ -9,11 +9,11 @@ from pathlib import Path
 
 import pytest
 
-from autoresearch import climb as climb_mod
-from autoresearch.climb import _park_run, live_climb, resume_run
+from autoresearch import attempt as climb_mod
+from autoresearch.attempt import _park_run, live_attempt, resume_run
 from autoresearch.dispatch import Snapshot
 from autoresearch.harness import SessionResult
-from autoresearch.orchestrator import ClimbConfig, ClimbParked
+from autoresearch.orchestrator import RunConfig, RunParked
 from autoresearch.runstate import RunRecord, load_record, save_record
 
 CONTRACT = """\
@@ -51,7 +51,7 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
         run_id="tsp-1", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
     )
     snap = Snapshot(commit="c" * 40, tree="d" * 40, ref="refs/dispatch/tok")
-    parked = ClimbParked(
+    parked = RunParked(
         phase="candidate",
         afterany="afterany:101:102",
         base_sha="b" * 40,
@@ -94,7 +94,7 @@ def test_author_sleep_park_persists_the_request_and_floors_on_the_launch(tmp_pat
     record = RunRecord(
         run_id="tsp-2", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
     )
-    parked = ClimbParked(
+    parked = RunParked(
         phase="author-sleep",
         afterany="afterany:501",
         base_sha="b" * 40,
@@ -146,7 +146,7 @@ def test_park_run_redacts_the_saved_report(tmp_path) -> None:
         final_text="used key sk-secret-123 to fetch",
         transcript_path="",
     )
-    parked = ClimbParked(
+    parked = RunParked(
         phase="candidate",
         afterany="afterany:1",
         base_sha="b" * 40,
@@ -166,7 +166,7 @@ def test_park_run_single_job_records_it_for_the_sweep(tmp_path) -> None:
     record = RunRecord(
         run_id="tsp-3", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
     )
-    parked = ClimbParked(
+    parked = RunParked(
         phase="baseline", afterany="afterany:77", base_sha="b" * 40, seed=0, suite_seed=0
     )
     _park_run(tmp_path, record, parked, "", eval_minutes=90, now=1000.0)
@@ -185,7 +185,7 @@ def test_park_resets_wake_attempts_a_productive_park_left_waiting(tmp_path) -> N
         benchmark="tsp",
         wake_attempts=2,
     )
-    parked = ClimbParked(
+    parked = RunParked(
         phase="baseline", afterany="afterany:9", base_sha="b" * 40, seed=0, suite_seed=0
     )
     _park_run(tmp_path, record, parked, "", eval_minutes=90, now=1000.0)
@@ -196,7 +196,7 @@ def test_park_run_baseline_phase_has_no_candidate_or_session(tmp_path) -> None:
     record = RunRecord(
         run_id="tsp-2", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
     )
-    parked = ClimbParked(
+    parked = RunParked(
         phase="baseline", afterany="afterany:55", base_sha="b" * 40, seed=0, suite_seed=0
     )
     _park_run(tmp_path, record, parked, "", eval_minutes=90, now=1000.0)
@@ -376,7 +376,7 @@ def _queued_local(queue):
     """Route the gate's local eval jobs through QueueCompute(queue) — the
     values feed the same list a QueueEvaluator may also pop from, so a test's
     numbers are consumed in one submit/eval order."""
-    import autoresearch.climb as _climb_mod
+    import autoresearch.attempt as _climb_mod
 
     orig = _climb_mod.LocalCompute
     _climb_mod.LocalCompute = lambda: QueueCompute(values=queue)  # type: ignore[assignment,misc]
@@ -404,8 +404,8 @@ def run_live(
     # values in call order, exactly as the old single-evaluator flow did
     queue = list(values)
     with _queued_local(queue):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id=run_id,
             harness=ScriptedHarness(edits=edits),
@@ -505,7 +505,7 @@ def test_resume_author_reproduces_the_run_not_the_fleet(monkeypatch) -> None:
     recorded key path survives (else it resolves per backend)."""
     from types import SimpleNamespace
 
-    from autoresearch.climb import resume_author
+    from autoresearch.attempt import resume_author
 
     monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", "/h")
     monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", "/c")
@@ -538,7 +538,7 @@ def test_resume_author_reproduces_the_run_not_the_fleet(monkeypatch) -> None:
 
 def test_codex_author_config_error() -> None:
     """codex needs --image and a non-claude model; claude is always fine."""
-    from autoresearch.climb import codex_author_config_error
+    from autoresearch.attempt import codex_author_config_error
 
     assert codex_author_config_error("claude", "claude-opus-5", "") == ""
     assert codex_author_config_error("codex", "gpt-5.6-terra", "img.sif") == ""
@@ -554,7 +554,7 @@ def test_resolve_author_key_file(monkeypatch) -> None:
     path wins, else the per-backend env var, else the packaged default."""
     import os
 
-    from autoresearch.climb import (
+    from autoresearch.attempt import (
         CODEX_KEY_DEFAULT,
         HARNESS_KEY_DEFAULT,
         resolve_author_key_file,
@@ -638,8 +638,8 @@ def test_session_error_aborts_cleanly(tmp_path, target_repo) -> None:
     github = FakeGitHub()
     _q = list([13.876])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-err",
             harness=DeadHarness(),
@@ -652,7 +652,7 @@ def test_session_error_aborts_cleanly(tmp_path, target_repo) -> None:
     assert github.prs == []
 
 
-def test_exhausted_live_climb_ends_budget_exhausted(tmp_path, target_repo) -> None:
+def test_exhausted_live_attempt_ends_budget_exhausted(tmp_path, target_repo) -> None:
     """The session-budget outcome flows through the ending map on a LIVE
     climb: the record says budget-exhausted with the real cause."""
 
@@ -672,8 +672,8 @@ def test_exhausted_live_climb_ends_budget_exhausted(tmp_path, target_repo) -> No
 
     _q = list([13.876])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-dry",
             harness=DryHarness(),
@@ -711,8 +711,8 @@ def test_branch_is_kept_and_recorded_after_pr_failure(tmp_path, target_repo) -> 
 
     _q = [13.876, 13.1]
     with _queued_local(_q):
-        live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-orphan",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "q=4\n"}),
@@ -807,8 +807,8 @@ def test_climb_error_still_writes_a_report(tmp_path, target_repo) -> None:
     github = FakeGitHub()
     _q = list([1.0])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="chess"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="chess"),
             run_root=tmp_path / "state",
             run_id="chess-2",
             harness=ScriptedHarness(edits={}),
@@ -817,12 +817,12 @@ def test_climb_error_still_writes_a_report(tmp_path, target_repo) -> None:
             now=1_000_000.0,
             created="t",
         )
-    assert outcome.outcome == "climb-error"
+    assert outcome.outcome == "attempt-error"
     assert Path(outcome.report_path).read_text().startswith("# Run report")
 
 
 def test_title_pair_never_renders_identical() -> None:
-    from autoresearch.climb import _title_pair
+    from autoresearch.attempt import _title_pair
 
     assert _title_pair(13.875696168157484, 10.844662077277105) == "13.88 -> 10.84"
     assert _title_pair(10.00001, 10.00002) == "10.00001 -> 10.00002"
@@ -834,8 +834,8 @@ def test_issue_run_references_issue_and_reports_back(tmp_path, target_repo) -> N
     github = CommentingGitHub()
     _q = list([13.876, 13.1])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-iss",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "i=1\n"}),
@@ -867,8 +867,8 @@ def test_clone_crash_ends_record_and_reports_to_issue(tmp_path, monkeypatch) -> 
     github = CommentingGitHub()
     _q: list = []
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-clonefail",
             harness=ScriptedHarness(edits={}),
@@ -878,11 +878,11 @@ def test_clone_crash_ends_record_and_reports_to_issue(tmp_path, monkeypatch) -> 
             created="t",
             issue_number=7,
         )
-    assert outcome.outcome == "climb-error"
+    assert outcome.outcome == "attempt-error"
     record = load_record(tmp_path / "state", "tsp-clonefail")
     assert record.state == "ended" and record.ending == "aborted"
     assert "quota" in record.ending_note
-    assert any("climb-error" in body for _, body in github.issue_comments)
+    assert any("attempt-error" in body for _, body in github.issue_comments)
     # exception DETAIL stays local: redact() only knows the secrets tuple,
     # so raw messages (paths, embedded tokens) never reach the public issue
     assert not any("quota" in body for _, body in github.issue_comments)
@@ -912,8 +912,8 @@ def test_ending_steps_degrade_independently(tmp_path, target_repo, monkeypatch) 
     github = CommentingGitHub()
     _q = list([1.0])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="chess"),  # not in contract
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="chess"),  # not in contract
             run_root=tmp_path / "state",
             run_id="chess-disk",
             harness=ScriptedHarness(edits={}),
@@ -923,9 +923,9 @@ def test_ending_steps_degrade_independently(tmp_path, target_repo, monkeypatch) 
             created="t",
             issue_number=7,
         )
-    assert outcome.outcome == "climb-error"  # returned, never raised
+    assert outcome.outcome == "attempt-error"  # returned, never raised
     # the record could not be ended (disk dead) — but the failure is VISIBLE:
-    assert any("climb-error" in body for _, body in github.issue_comments)
+    assert any("attempt-error" in body for _, body in github.issue_comments)
     assert Path(outcome.report_path).exists()
     assert not any("not in contract" in body for _, body in github.issue_comments)
 
@@ -939,8 +939,8 @@ def test_final_record_failure_does_not_lose_pr_or_issue_report(
     github = CommentingGitHub()
     _q = list([13.876, 13.1])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-finaldisk",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "z=1\n"}),
@@ -962,7 +962,7 @@ def test_final_record_failure_does_not_lose_pr_or_issue_report(
 
 def test_first_record_write_failure_is_contained(tmp_path, target_repo, monkeypatch) -> None:
     """If not even the initial record can be written, the run must not
-    proceed invisibly OR crash the caller: climb-error plus an issue post."""
+    proceed invisibly OR crash the caller: attempt-error plus an issue post."""
 
     def always_failing(root, record, now):
         raise OSError(122, "Disk quota exceeded")
@@ -971,8 +971,8 @@ def test_first_record_write_failure_is_contained(tmp_path, target_repo, monkeypa
     github = CommentingGitHub()
     _q: list = []
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-recfail",
             harness=ScriptedHarness(edits={}),
@@ -982,7 +982,7 @@ def test_first_record_write_failure_is_contained(tmp_path, target_repo, monkeypa
             created="t",
             issue_number=7,
         )
-    assert outcome.outcome == "climb-error"
+    assert outcome.outcome == "attempt-error"
     assert outcome.report_path == ""  # never point at a report that was not written
     assert any("could not start" in body for _, body in github.issue_comments)
 
@@ -1007,8 +1007,8 @@ def test_arming_failure_never_fails_the_publish(tmp_path, target_repo) -> None:
     github = FakeGitHub(arming_error="auto merge is not allowed")
     _q = list([13.876, 13.1])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-noarm",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "na=2\n"}),
@@ -1034,8 +1034,8 @@ def test_moved_base_publishes_the_sealed_candidate_without_merging(tmp_path, tar
     _q = [13.876, 13.1]
     github = FakeGitHub()
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-moved",
             harness=MovingHarness(edits={"src/pilot/solvers/tsp.py": "m=1\n"}),
@@ -1074,13 +1074,13 @@ def test_inline_publish_ships_the_sealed_sha_not_the_live_workspace(tmp_path, ta
     ws_root = tmp_path / "state" / "runs" / "tsp-seal" / "ws"
     _q = [13.876, 13.1]
     github = FakeGitHub()
-    import autoresearch.climb as _climb_mod
+    import autoresearch.attempt as _climb_mod
 
     orig = _climb_mod.LocalCompute
     _climb_mod.LocalCompute = lambda: DivergingCompute(_q, ws_root)  # type: ignore[assignment,misc]
     try:
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-seal",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "def solve(): return 7\n"}),
@@ -1128,8 +1128,8 @@ def test_non_default_base_branch_is_built_on_and_measured(tmp_path, target_repo)
     _q = [13.876, 13.1]
     github = FakeGitHub()
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-dev",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "d=1\n"}),
@@ -1163,7 +1163,7 @@ def _push_upstream(target_repo, tmp_path, rel_path: str, content: str, name: str
 def test_terminated_is_contained_like_any_crash(tmp_path, target_repo) -> None:
     """A SIGTERM surfaced as Terminated mid-session must end the run through
     the ordinary containment: record aborted, report written."""
-    from autoresearch.climb import Terminated
+    from autoresearch.attempt import Terminated
 
     @dataclass
     class KilledHarness(ScriptedHarness):
@@ -1173,8 +1173,8 @@ def test_terminated_is_contained_like_any_crash(tmp_path, target_repo) -> None:
     github = CommentingGitHub()
     _q = list([13.876])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-term",
             harness=KilledHarness(edits={}),
@@ -1184,11 +1184,11 @@ def test_terminated_is_contained_like_any_crash(tmp_path, target_repo) -> None:
             created="t",
             issue_number=7,
         )
-    assert outcome.outcome == "climb-error"
+    assert outcome.outcome == "attempt-error"
     record = load_record(tmp_path / "state", "tsp-term")
     assert record.state == "ended" and record.ending == "aborted"
     assert "SIGTERM" in record.ending_note
-    assert any("climb-error" in body for _, body in github.issue_comments)
+    assert any("attempt-error" in body for _, body in github.issue_comments)
 
 
 def test_sigterm_containment_is_one_shot() -> None:
@@ -1199,7 +1199,7 @@ def test_sigterm_containment_is_one_shot() -> None:
 
     import pytest
 
-    from autoresearch.climb import Terminated, arm_sigterm_containment
+    from autoresearch.attempt import Terminated, arm_sigterm_containment
 
     original = signal.getsignal(signal.SIGTERM)
     try:
@@ -1211,7 +1211,7 @@ def test_sigterm_containment_is_one_shot() -> None:
         signal.signal(signal.SIGTERM, original)
 
 
-def test_climb_job_id_is_stamped_from_slurm_env(tmp_path, target_repo, monkeypatch) -> None:
+def test_run_job_id_is_stamped_from_slurm_env(tmp_path, target_repo, monkeypatch) -> None:
     """The sweep's entire kill-detection keys on this field: the record must
     carry the climb's own SLURM_JOB_ID."""
     monkeypatch.setenv("SLURM_JOB_ID", "4242")
@@ -1222,7 +1222,7 @@ def test_climb_job_id_is_stamped_from_slurm_env(tmp_path, target_repo, monkeypat
         values=[13.876, 13.1],
         run_id="tsp-jid",
     )
-    assert load_record(tmp_path / "state", "tsp-jid").climb_job_id == "4242"
+    assert load_record(tmp_path / "state", "tsp-jid").run_job_id == "4242"
 
 
 def test_self_deadline_arms_before_the_walltime(monkeypatch) -> None:
@@ -1231,7 +1231,7 @@ def test_self_deadline_arms_before_the_walltime(monkeypatch) -> None:
     inside a real allocation SLURM_JOB_START_TIME would change the math."""
     import signal
 
-    from autoresearch.climb import arm_self_deadline
+    from autoresearch.attempt import arm_self_deadline
 
     monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
     original = signal.getsignal(signal.SIGALRM)
@@ -1250,7 +1250,7 @@ def test_self_deadline_anchors_on_slurm_job_start(monkeypatch) -> None:
     import signal
     import time
 
-    from autoresearch.climb import arm_self_deadline
+    from autoresearch.attempt import arm_self_deadline
 
     monkeypatch.setenv("SLURM_JOB_START_TIME", str(int(time.time()) - 600))
     original = signal.getsignal(signal.SIGALRM)
@@ -1265,7 +1265,7 @@ def test_self_deadline_anchors_on_slurm_job_start(monkeypatch) -> None:
 def test_self_deadline_margin_floor_and_off_switch(monkeypatch) -> None:
     import signal
 
-    from autoresearch.climb import MIN_ARM_S, arm_self_deadline
+    from autoresearch.attempt import MIN_ARM_S, arm_self_deadline
 
     monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
     original = signal.getsignal(signal.SIGALRM)
@@ -1285,7 +1285,7 @@ def test_self_deadline_raises_terminated_into_containment(monkeypatch) -> None:
 
     import pytest
 
-    from autoresearch.climb import Terminated, arm_self_deadline
+    from autoresearch.attempt import Terminated, arm_self_deadline
 
     monkeypatch.delenv("SLURM_JOB_START_TIME", raising=False)
     original = signal.getsignal(signal.SIGALRM)
@@ -1393,8 +1393,8 @@ def test_panel_clean_read_lands_a_normal_pr_with_transcript(tmp_path, target_rep
     github = FakeGitHub()
     _q = list([13.876, 13.1])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-panel-ok",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "p=1\n"}),
@@ -1441,8 +1441,8 @@ def test_panel_capped_blocking_opens_a_draft_and_never_arms(tmp_path, target_rep
     github = FakeGitHub()
     _q = list([13.876, 13.1, 13.05])
     with _queued_local(_q):
-        outcome = live_climb(
-            config=ClimbConfig(target="org/pilot", benchmark="tsp"),
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
             run_root=tmp_path / "state",
             run_id="tsp-panel-draft",
             harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "p=2\n"}),
@@ -1776,7 +1776,7 @@ def test_author_sleep_partial_submit_failure_cancels_earlier_jobs(
         values=[],
         dispatch=dispatch,
     )
-    assert outcome.outcome == "climb-error"
+    assert outcome.outcome == "attempt-error"
     assert cancelled == ["1000"]  # the successful submit was reaped, not orphaned
     record = load_record(tmp_path / "state", "tsp-1")
     assert record.state == "ended"
@@ -1803,7 +1803,7 @@ def test_failed_park_write_cancels_orphaned_eval_jobs(
         values=[],
         dispatch=dispatch,
     )
-    assert outcome.outcome == "climb-error"  # the failed park ends the run
+    assert outcome.outcome == "attempt-error"  # the failed park ends the run
     assert cancelled == ["1000", "1001"]  # both dispatched jobs were cancelled
 
 
@@ -1914,7 +1914,7 @@ def _write_parked_candidate(
     monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: fake)
     # the wake pushes to the canonical target URL (never the ws git config);
     # point that at this run's local bare so the improved-wake test can push.
-    monkeypatch.setattr("autoresearch.climb._target_clone_url", lambda target: str(bare))
+    monkeypatch.setattr("autoresearch.attempt._target_clone_url", lambda target: str(bare))
     return state, run_id
 
 
@@ -2156,7 +2156,7 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
     # the wake job holds the run's lease (transferred by the sweep on dispatch);
     # the --resume CLI must release it on every exit so a re-parked run is
     # immediately eligible for the next sweep, not stuck until the TTL reap.
-    from autoresearch.climb import LiveClimbOutcome, main
+    from autoresearch.attempt import AttemptOutcome, main
     from autoresearch.runstate import acquire_lease, run_dir
 
     run_id = "tsp-wake"
@@ -2174,7 +2174,7 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
     monkeypatch.setattr(
         climb_mod,
         "resume_run",
-        lambda *a, **k: LiveClimbOutcome(run_id=run_id, outcome="parked"),
+        lambda *a, **k: AttemptOutcome(run_id=run_id, outcome="parked"),
     )
     monkeypatch.setattr(
         "sys.argv",
@@ -2731,7 +2731,7 @@ def test_codex_panel_lens_requires_the_judges_own_key(monkeypatch) -> None:
 
     import pytest
 
-    from autoresearch.climb import _panel_lenses_from_args
+    from autoresearch.attempt import _panel_lenses_from_args
 
     monkeypatch.delenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", raising=False)
     args = argparse.Namespace(
@@ -2741,7 +2741,7 @@ def test_codex_panel_lens_requires_the_judges_own_key(monkeypatch) -> None:
         codex_bin="codex",
         image="/img.sif",
     )
-    monkeypatch.setattr("autoresearch.climb.role_key", lambda *a, **k: "k")
+    monkeypatch.setattr("autoresearch.attempt.role_key", lambda *a, **k: "k")
     with pytest.raises(ValueError, match="AUTORESEARCH_PANEL_CODEX_KEY_FILE"):
         _panel_lenses_from_args(args)
 
@@ -2750,7 +2750,7 @@ def test_codex_only_panel_never_reads_the_claude_key(monkeypatch, tmp_path) -> N
     # a codex-only panel must not demand the (unused) anthropic panel key
     import argparse
 
-    from autoresearch.climb import _panel_lenses_from_args
+    from autoresearch.attempt import _panel_lenses_from_args
 
     codex_key = tmp_path / "panel_codex_key"
     codex_key.write_text("sk-judge")
@@ -2775,7 +2775,7 @@ def test_codex_panel_key_must_not_be_the_author_key(monkeypatch, tmp_path) -> No
 
     import pytest
 
-    from autoresearch.climb import _panel_lenses_from_args
+    from autoresearch.attempt import _panel_lenses_from_args
 
     author_key = tmp_path / "codex_key"
     author_key.write_text("sk-author")
@@ -2800,7 +2800,7 @@ def test_codex_panel_key_must_not_be_the_claude_panel_key(monkeypatch, tmp_path)
 
     import pytest
 
-    from autoresearch.climb import _panel_lenses_from_args
+    from autoresearch.attempt import _panel_lenses_from_args
 
     shared = tmp_path / "verifier_key"
     shared.write_text("sk-ant")
@@ -2824,7 +2824,7 @@ def test_codex_panel_lens_refuses_to_run_uncontained(monkeypatch, tmp_path) -> N
 
     import pytest
 
-    from autoresearch.climb import _panel_lenses_from_args
+    from autoresearch.attempt import _panel_lenses_from_args
 
     judge_key = tmp_path / "panel_codex_key"
     judge_key.write_text("sk-judge")
@@ -2848,7 +2848,7 @@ def test_hermes_panel_lens_shares_the_judge_key_rules(monkeypatch, tmp_path) -> 
 
     import pytest
 
-    from autoresearch.climb import _panel_lenses_from_args
+    from autoresearch.attempt import _panel_lenses_from_args
 
     def args(image="/img.sif"):
         return argparse.Namespace(

--- a/tests/test_measure_and_decide.py
+++ b/tests/test_measure_and_decide.py
@@ -10,12 +10,12 @@ from autoresearch.contract import load_contract
 from autoresearch.harness import SessionResult
 from autoresearch.measure import Measure, MeasurementPending
 from autoresearch.orchestrator import (
-    ClimbParked,
     EvalError,
     MeasureOK,
+    RunParked,
     _benchmark,
     measure_and_decide,
-    resume_climb,
+    resume_attempt,
 )
 
 # main benchmark + one sibling; a `shared` scope path drives the suite gate.
@@ -258,7 +258,7 @@ def test_empty_shared_scope_does_not_require_suite_seed():
     assert isinstance(out, MeasureOK)
 
 
-# --- resume_climb: the wake side, re-entering the decision without a session ---
+# --- resume_attempt: the wake side, re-entering the decision without a session ---
 
 REPORT = "swapped the construction heuristic; tours shortened."
 
@@ -277,7 +277,7 @@ def _woke_session():
 
 def _resume(measurer, measured_paths=("src/model.py",), seed=7, suite_seed=99, text=CONTRACT):
     contract = load_contract(text, "x/y")
-    return resume_climb(
+    return resume_attempt(
         contract,
         _benchmark(contract, "main"),
         base_sha=BASE,
@@ -320,7 +320,7 @@ def test_resume_reparks_when_a_measure_is_not_done():
     # on the new afterany set, same shape as the first candidate park, carrying
     # the reconstructed session so a later wake still has the write-up.
     m = FakeMeasurer(raise_exc=MeasurementPending(("501", "502")))
-    with pytest.raises(ClimbParked) as excinfo:
+    with pytest.raises(RunParked) as excinfo:
         _resume(m)
     parked = excinfo.value
     assert parked.phase == "candidate"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -9,10 +9,10 @@ import pytest
 
 from autoresearch.harness import FakeHarness, SessionResult
 from autoresearch.orchestrator import (
-    ClimbConfig,
     EvalError,
+    RunConfig,
     _metric_from_output,
-    climb_once,
+    attempt_once,
     improved,
     pr_body,
 )
@@ -32,7 +32,7 @@ scope: {allowed: [src/pilot/solvers/]}
 roadmap: docs/roadmap.md
 """
 
-CONFIG = ClimbConfig(target="org/pilot", benchmark="tsp")
+CONFIG = RunConfig(target="org/pilot", benchmark="tsp")
 
 
 def ok_session(text: str = "Report: replaced NN with NN+2-opt.") -> SessionResult:
@@ -113,7 +113,7 @@ def run_climb(
     # usual stamp. (Callers can still override via kw.)
     if "created" not in kw and not kw.get("resume_session_id"):
         kw["created"] = "2026-08-06T00:00:00Z"
-    result = climb_once(
+    result = attempt_once(
         config,
         contract or CONTRACT,
         tmp_path,
@@ -155,7 +155,7 @@ def test_improved_result_exposes_the_candidate_sha(tmp_path: Path) -> None:
     assert result.outcome == "improved" and result.candidate_sha == "cand1"
 
 
-def test_climb_once_resume_entry_skips_the_brief(tmp_path: Path) -> None:
+def test_attempt_once_resume_entry_skips_the_brief(tmp_path: Path) -> None:
     # Phase 2a primitive: a cumulative depth pass resumes the prior session with
     # the improve prompt instead of a fresh brief (the depth loop, part 2, drives
     # this; here we verify the entry point alone).
@@ -258,14 +258,14 @@ DEEP_CONTRACT = CONTRACT.replace(
 def test_author_sleep_parks_on_a_sealed_snapshot(tmp_path: Path) -> None:
     # the author launched work and slept: the tree is sealed, the launcher is
     # handed the request, and the park carries request + budget counts.
-    from autoresearch.orchestrator import ClimbParked
+    from autoresearch.orchestrator import RunParked
 
     _write_syscall(
         tmp_path,
         {"launches": [{"name": "probe", "command": "uv run probe.py"}], "note": "check tails"},
     )
     launched: list = []
-    with pytest.raises(ClimbParked) as exc:
+    with pytest.raises(RunParked) as exc:
         run_climb(tmp_path, [], contract=DEEP_CONTRACT, launcher=_fake_launcher(launched))
     p = exc.value
     assert p.phase == "author-sleep"
@@ -278,10 +278,10 @@ def test_author_sleep_parks_on_a_sealed_snapshot(tmp_path: Path) -> None:
 
 
 def test_checkpoint_sleep_parks_with_no_dependency(tmp_path: Path) -> None:
-    from autoresearch.orchestrator import ClimbParked
+    from autoresearch.orchestrator import RunParked
 
     _write_syscall(tmp_path, {"launches": []})
-    with pytest.raises(ClimbParked) as exc:
+    with pytest.raises(RunParked) as exc:
         run_climb(tmp_path, [], contract=DEEP_CONTRACT, launcher=_fake_launcher([]))
     assert exc.value.afterany == "" and exc.value.sleeps_used == 1
     assert exc.value.launches_used == 0  # a checkpoint burns only the sleep
@@ -292,7 +292,7 @@ def test_submit_parks_the_dispatched_gate_with_the_submitted_marker(tmp_path: Pa
     # is sealed, the dispatched gate parks the run as a candidate carrying the
     # submitted marker + budget counts, and a sibling launch rides the same
     # afterany, submitted on the sealed sha.
-    from autoresearch.orchestrator import ClimbParked
+    from autoresearch.orchestrator import RunParked
 
     _write_syscall(
         tmp_path,
@@ -301,8 +301,8 @@ def test_submit_parks_the_dispatched_gate_with_the_submitted_marker(tmp_path: Pa
     launched: list = []
     harness = FakeHarness(result=ok_session())
     m = ParkingMeasurer(park_on_call=1)
-    with pytest.raises(ClimbParked) as exc:
-        climb_once(
+    with pytest.raises(RunParked) as exc:
+        attempt_once(
             CONFIG,
             DEEP_CONTRACT,
             tmp_path,
@@ -331,7 +331,7 @@ def test_failed_gate_submit_feeds_back_to_the_author(tmp_path: Path) -> None:
     harness = _SeqHarness(["the claim", "conceded"], submit_on=(1,))
     evaluator = FakeEvaluator(values=[13.9, 13.9, 13.9])
     measurer, snapshot = _wire(evaluator, tmp_path)
-    result = climb_once(
+    result = attempt_once(
         CONFIG,
         CONTRACT,
         tmp_path,
@@ -361,7 +361,7 @@ def test_inline_gate_never_dispatches_a_submits_sibling_launches(tmp_path: Path)
     harness = _SeqHarness(["the claim", "conceded"])
     evaluator = FakeEvaluator(values=[13.9, 13.9, 13.9])
     measurer, snapshot = _wire(evaluator, tmp_path)
-    result = climb_once(
+    result = attempt_once(
         CONFIG,
         CONTRACT,
         tmp_path,
@@ -449,7 +449,7 @@ def test_seeded_benchmark_measures_both_sides_under_one_fresh_seed(tmp_path: Pat
     harness = FakeHarness(result=ok_session())
     evaluator = FakeEvaluator(values=[13.876, 13.10])
     measurer, snapshot = _wire(evaluator, tmp_path)
-    result = climb_once(
+    result = attempt_once(
         CONFIG,
         SEEDED_CONTRACT,
         tmp_path,
@@ -538,12 +538,12 @@ def test_candidate_measure_parks_after_the_session(tmp_path: Path) -> None:
     # The ONLY park: the session runs (no pre-session baseline), then the gate
     # dispatches baseline+candidate together and hibernates. A dispatched climb
     # never has a baseline park.
-    from autoresearch.orchestrator import ClimbParked
+    from autoresearch.orchestrator import RunParked
 
     harness = FakeHarness(result=ok_session())
     m = ParkingMeasurer(park_on_call=1)  # the gate's first (baseline+candidate) call parks
-    with pytest.raises(ClimbParked) as exc:
-        climb_once(
+    with pytest.raises(RunParked) as exc:
+        attempt_once(
             CONFIG,
             CONTRACT,
             tmp_path,
@@ -618,7 +618,7 @@ def test_snapshot_failure_is_eval_error_not_a_crash(tmp_path: Path) -> None:
     def snapshot() -> str:
         raise EvalError("git write-tree failed")
 
-    result = climb_once(
+    result = attempt_once(
         CONFIG,
         CONTRACT,
         tmp_path,
@@ -636,7 +636,7 @@ def test_snapshot_failure_is_eval_error_not_a_crash(tmp_path: Path) -> None:
 
 def test_unknown_benchmark_raises(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="not in contract"):
-        run_climb(tmp_path, [1.0], config=ClimbConfig(target="org/pilot", benchmark="chess"))
+        run_climb(tmp_path, [1.0], config=RunConfig(target="org/pilot", benchmark="chess"))
 
 
 def test_improved_direction_semantics() -> None:
@@ -698,7 +698,7 @@ def test_out_of_scope_tree_is_rejected_before_the_snapshot(tmp_path: Path) -> No
         snapshotted.append(1)
         return "cand1"
 
-    result = climb_once(
+    result = attempt_once(
         CONFIG,
         CONTRACT,
         tmp_path,
@@ -987,7 +987,7 @@ def run_shared_climb(tmp_path, values, changed, contract=SHARED_CONTRACT, **kw):
     baseline_ws = tmp_path / "pristine"
     baseline_ws.mkdir(exist_ok=True)
     measurer, snapshot = _wire(evaluator, tmp_path, base_ws=baseline_ws)
-    result = climb_once(
+    result = attempt_once(
         CONFIG,
         contract,
         tmp_path,
@@ -1131,7 +1131,7 @@ def test_task_names_the_suite_gate_only_when_it_exists(tmp_path: Path) -> None:
     assert "suite-gated" not in ungated.done_criteria
 
 
-def test_climb_once_refuses_a_read_only_spec(tmp_path: Path) -> None:
+def test_attempt_once_refuses_a_read_only_spec(tmp_path: Path) -> None:
     # the author is an editing role; a non-executing spec here is a deployment bug
     from autoresearch.rolespec import Execution, RoleSpec, SessionBudget
 
@@ -1238,7 +1238,7 @@ def _run_panel_climb(tmp_path, values, verdicts, texts=None, supports_resume=Tru
     evaluator = FakeEvaluator(values=list(values))
     panel = _QueuedPanel(verdicts)
     measurer, snapshot = _wire(evaluator, tmp_path)
-    result = climb_once(
+    result = attempt_once(
         CONFIG,
         CONTRACT,
         tmp_path,
@@ -1363,7 +1363,7 @@ def test_wake_without_a_session_id_fails_closed_to_draft(tmp_path: Path) -> None
     evaluator = FakeEvaluator(values=[13.9, 13.1])
     panel = _QueuedPanel([_verdict(True, 1)])
     measurer, snapshot = _wire(evaluator, tmp_path)
-    result = climb_once(
+    result = attempt_once(
         CONFIG,
         CONTRACT,
         tmp_path,

--- a/tests/test_runstate.py
+++ b/tests/test_runstate.py
@@ -255,3 +255,13 @@ def test_load_record_maps_legacy_climb_job_id(tmp_path: Path) -> None:
         )
     )
     assert load_record(tmp_path, "r1").run_job_id == "new"
+
+
+def test_climb_module_is_a_compat_shim_for_attempt() -> None:
+    # a pre-rename `-m autoresearch.climb` / import must still resolve
+    from autoresearch import climb
+    from autoresearch.attempt import AttemptResult, live_attempt
+
+    assert climb.live_attempt is live_attempt
+    assert climb.AttemptResult is AttemptResult
+    assert climb.main is __import__("autoresearch.attempt", fromlist=["main"]).main

--- a/tests/test_runstate.py
+++ b/tests/test_runstate.py
@@ -217,3 +217,41 @@ def test_future_stamp_within_skew_is_active(tmp_path) -> None:
     stamp_outage(tmp_path, "credit balance", now=1000.0)
     assert outage_active(tmp_path, now=1000.0 - 60) != ""  # reader behind writer
     assert outage_active(tmp_path, now=1000.0 - MAX_CLOCK_SKEW_S - 1) == ""
+
+
+def test_load_record_maps_legacy_climb_job_id(tmp_path: Path) -> None:
+    # an in-flight record written by pre-rename code carries climb_job_id;
+    # load must map it to run_job_id so the sweep still ends a killed job
+    import json
+
+    from autoresearch.runstate import RECORD_NAME, load_record, run_dir
+
+    d = run_dir(tmp_path, "r1")
+    d.mkdir(parents=True)
+    (d / RECORD_NAME).write_text(
+        json.dumps(
+            {
+                "run_id": "r1",
+                "target": "o/r",
+                "task_title": "t",
+                "state": "implementing",
+                "climb_job_id": "16299",  # the legacy key
+            }
+        )
+    )
+    rec = load_record(tmp_path, "r1")
+    assert rec.run_job_id == "16299"
+    # a new record's run_job_id always wins over a stray legacy key
+    (d / RECORD_NAME).write_text(
+        json.dumps(
+            {
+                "run_id": "r1",
+                "target": "o/r",
+                "task_title": "t",
+                "state": "implementing",
+                "climb_job_id": "old",
+                "run_job_id": "new",
+            }
+        )
+    )
+    assert load_record(tmp_path, "r1").run_job_id == "new"

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -950,6 +950,26 @@ def test_killed_climb_is_ended_after_first_seen_grace(tmp_path: Path) -> None:
     assert "aborted" in (_run_dir(tmp_path, "r-killed") / "report.md").read_text()
 
 
+def test_legacy_kill_stamp_grace_is_honored_across_the_rename(tmp_path: Path) -> None:
+    """A run stamped just before the climb->attempt rename carries a legacy
+    `climb-terminal-seen` file. The sweep must adopt its clock so the KillWait
+    grace is measured from the ORIGINAL sighting — not restarted (which would
+    re-grace a job already past its window) or ignored."""
+    from autoresearch.tick import _kill_stamp, _legacy_kill_stamp
+
+    _implementing_run(tmp_path, "r-legacy", job_id="77", age_s=3600)
+    # a legacy stamp written a full grace ago, and NO current-name stamp
+    legacy = _legacy_kill_stamp(tmp_path, "r-legacy")
+    legacy.write_text(str(NOW - GRACE - 1))
+    assert not _kill_stamp(tmp_path, "r-legacy").exists()
+
+    report, _ = run_tick(tmp_path, FakeSlurm(states={"77": "TIMEOUT"}))
+    # the grace already elapsed by the legacy clock -> ended THIS tick, not
+    # re-stamped under the new name
+    assert report.implementing_ended == ("r-legacy",)
+    assert load_record(tmp_path, "r-legacy").state == ENDED
+
+
 def test_climb_that_lands_its_own_ending_wins_the_race(tmp_path: Path) -> None:
     """Between first-seen and grace expiry the climb's honest ending (or a
     move to waiting) must never be clobbered by the sweep."""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -919,7 +919,7 @@ def _implementing_run(root: Path, run_id: str, job_id: str = "", age_s: float = 
             task_title="t",
             benchmark="tsp",
             state=IMPLEMENTING,
-            climb_job_id=job_id,
+            run_job_id=job_id,
         ),
         now=NOW - age_s,
     )
@@ -967,7 +967,7 @@ def test_climb_that_lands_its_own_ending_wins_the_race(tmp_path: Path) -> None:
     assert load_record(tmp_path, "r-race").ending == "negative-result"
 
 
-def test_live_climb_job_is_left_alone(tmp_path: Path) -> None:
+def test_live_attempt_job_is_left_alone(tmp_path: Path) -> None:
     _implementing_run(tmp_path, "r-live", job_id="77", age_s=GRACE + 60)
     report, _ = run_tick(tmp_path, FakeSlurm(states={"77": "RUNNING"}))
     assert report.implementing_ended == ()
@@ -2120,7 +2120,7 @@ def test_job_wake_dispatcher_submits_a_resume_job_after_the_eval_jobs(tmp_path, 
     assert job_id == "9001"  # async: the wake job now owns the lease
     argv = submits[0]
     joined = " ".join(argv)
-    assert "autoresearch.climb" in joined and "--resume tsp-1" in joined
+    assert "autoresearch.attempt" in joined and "--resume tsp-1" in joined
     assert "--dependency=afterany:501:502" in argv  # runs after the eval jobs
     assert "--panel verify,review" in joined  # the wake runs the verification panel
     assert "--account=acct" in argv and "--partition=cpu_short" in argv


### PR DESCRIPTION
The vocabulary the substrate earned (research-loop-buildout.md): a **run** is the general OS unit; an **attempt** is one type of run — the author role's. So author-role names become attempt-shaped, substrate names stay run-shaped. Wide-round test #2 (a big mechanical diff — coverage/lifecycle lenses).

## Renamed
`climb.py`→`attempt.py`, `climb_once`→`attempt_once`, `live_climb`→`live_attempt`, `resume_climb`→`resume_attempt`, `ClimbResult`→`AttemptResult`, `LiveClimbOutcome`→`AttemptOutcome`, `ClimbParked`→`RunParked`, `ClimbConfig`→`RunConfig`, outcome `"climb-error"`→`"attempt-error"`, CLI `-m autoresearch.attempt`.

**Unchanged (the general substrate):** `RunRecord`, `run_id`, `resume_run`, lease, park/wake, the dispatcher.

## Deploy-safe, zero coordination
The persistence coupling the memo flagged is handled so an in-flight run parked *before* the rename still wakes/ends:
- **`climb_job_id` → `run_job_id`** with a `load_record` shim mapping the legacy key (new key always wins).
- **kill-stamp** reader honors a legacy `climb-terminal-seen` file (matters for at most one run across the deploy — a stamp lives only during KillWait grace).
- **module + tick argv land together** (`tick_chain.sbatch` is in-repo and pulls at tick-start, so `-m autoresearch.attempt` deploys atomically with `attempt.py`).

## Out of scope (a deliberate later nit)
The internal `climb_job_minutes` limits-vocab key and a few operator log strings still say "climb" — no persistence or behavior rides them; renaming the limits key threads through limits+tick and earns its own PR.

## Tests
New shim pin (legacy `climb_job_id` → `run_job_id`; new key wins). Full gate: 798 tests, ruff both, mypy — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)