### PR TITLE
refactor: de-prescriptify the author brief — orientation, not directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The author brief is de-prescriptified (Mengye, "don't dictate the
+  contract"; research-loop.md, author-directed): the Task's `expected_effect`
+  and `done_criteria` shift from directives to ORIENTATION. The metric line is
+  now a fact ("mean_tour_length (lower is better), currently 10.84" — or "no
+  score recorded yet"), not a target; the finish is stated as the AUTHOR's
+  call ("You decide when your result is worth publishing — a negative result
+  reported clearly is a success"), with the gate/suite framed as how a claim
+  is verified rather than a bar to clear. The gate itself is unchanged — it,
+  never the brief, is the real bar; naming a target in the brief only invited
+  optimizing that number. Rendered labels: "Metric:" / "Finishing:".
+
+### Changed
+
 - Vocabulary: the author-role activity is an **attempt** (a type of run), the
   substrate stays **run**. `climb.py`→`attempt.py`, `climb_once`→
   `attempt_once`, `live_climb`→`live_attempt`, `resume_climb`→`resume_attempt`,

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -48,8 +48,10 @@ class Task:
 
     hypothesis: str
     benchmark: str  # contract benchmark name this task targets
-    expected_effect: str  # e.g. "success_rate up from 0.25"
-    done_criteria: str  # what makes this attempt finished, success or not
+    # orientation, not directives (research-loop.md, author-directed): a fact
+    # about the metric + the current score, and whose call the finish is.
+    expected_effect: str  # e.g. "success_rate (higher is better), currently 0.25"
+    done_criteria: str  # who decides the finish (the author) + how a claim is verified
 
 
 @dataclass(frozen=True)
@@ -189,8 +191,8 @@ def render(brief: SessionBrief) -> str:
         "# Task",
         f"Hypothesis: {brief.task.hypothesis}",
         f"Benchmark: {brief.task.benchmark}",
-        f"Expected effect: {brief.task.expected_effect}",
-        f"Done when: {brief.task.done_criteria}",
+        f"Metric: {brief.task.expected_effect}",
+        f"Finishing: {brief.task.done_criteria}",
         "",
         "# Contract (.autoresearch.yaml — the scope and budget rules that bind you)",
         brief.contract_text,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -666,7 +666,8 @@ def make_task(
         done_criteria=(
             "You decide when your result is worth publishing — and a negative "
             "result reported clearly is a success. The orchestrator re-measures "
-            f"`{bench.command}` and runs the repository tests to verify any claim"
+            f"`{bench.command}` on a private seed to verify any improvement "
+            "claim, and the PR's CI runs the repository tests"
             + (
                 "; changes touching shared paths are suite-gated, so no sibling "
                 "benchmark may regress beyond its floor"

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -643,13 +643,15 @@ def make_task(
     contract: Contract, benchmark_name: str, baseline: float | None, hypothesis: str = ""
 ) -> Task:
     bench = _benchmark(contract, benchmark_name)
-    better = "up" if bench.direction == "max" else "down"
+    better = "lower" if bench.direction == "min" else "higher"
     suite_gated = bool(contract.scope.shared) and len(contract.benchmarks) > 1
-    # `baseline` orients the brief only (the last-known score from the ledger);
-    # the GATE re-measures both sides after the session, so a missing baseline
-    # (a benchmark's first run) just drops the reference number, never the gate.
-    versus = f" from {baseline}" if baseline is not None else ""
-    against = f" versus {baseline}" if baseline is not None else ""
+    # ORIENTATION, not direction: the brief states the current score and how
+    # the metric reads as FACTS, and leaves the goal and the finish to the
+    # author (research-loop.md, author-directed). The GATE — never the brief —
+    # is the real bar: it re-measures both sides after the session, so a
+    # missing baseline (a benchmark's first run) just drops the reference
+    # number. Naming a target here would only invite optimizing that number.
+    current = f"currently {baseline}" if baseline is not None else "no score recorded yet"
     return Task(
         hypothesis=hypothesis
         or (
@@ -658,16 +660,20 @@ def make_task(
             f"for why it underperforms, and implement it."
         ),
         benchmark=bench.name,
-        expected_effect=f"{bench.metric} {better}{versus}",
+        # a fact about the metric, not a target to chase
+        expected_effect=f"{bench.metric} ({better} is better), {current}",
+        # the finish is the AUTHOR's call; the gate decides what publishes
         done_criteria=(
-            f"`{bench.command}` runs clean and {bench.metric} moves {better}"
-            f"{against}; repository tests pass"
+            "You decide when your result is worth publishing — and a negative "
+            "result reported clearly is a success. The orchestrator re-measures "
+            f"`{bench.command}` and runs the repository tests to verify any claim"
             + (
-                "; a change touching shared paths is suite-gated — no sibling "
+                "; changes touching shared paths are suite-gated, so no sibling "
                 "benchmark may regress beyond its floor"
                 if suite_gated
                 else ""
             )
+            + "."
         ),
     )
 

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -140,3 +140,21 @@ def test_wake_prompt_is_bounded_and_asks_for_conclusion() -> None:
     huge = render_wake("x" * 100_000, budget)
     assert len(huge) < MAX_WAKE_CHARS + 600
     assert "[truncated" in huge
+
+
+
+def test_render_uses_orientation_labels_not_directives() -> None:
+    # the de-prescriptified brief labels the metric/finish as context
+    from autoresearch.brief import BriefInputs, BudgetState, Task, build_brief, render
+
+    t = Task(
+        hypothesis="h",
+        benchmark="tsp",
+        expected_effect="mean_tour_length (lower is better), currently 10.84",
+        done_criteria="You decide when your result is worth publishing; CI runs the tests.",
+    )
+    text = render(build_brief(BriefInputs(task=t, contract_text="c", ruler="r"), created="t"))
+    assert "Metric: mean_tour_length (lower is better), currently 10.84" in text
+    assert "Finishing: You decide" in text
+    # the retired directive labels are gone
+    assert "Expected effect:" not in text and "Done when:" not in text

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -142,10 +142,9 @@ def test_wake_prompt_is_bounded_and_asks_for_conclusion() -> None:
     assert "[truncated" in huge
 
 
-
 def test_render_uses_orientation_labels_not_directives() -> None:
     # the de-prescriptified brief labels the metric/finish as context
-    from autoresearch.brief import BriefInputs, BudgetState, Task, build_brief, render
+    from autoresearch.brief import BriefInputs, Task, build_brief, render
 
     t = Task(
         hypothesis="h",

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -139,7 +139,11 @@ def test_improvement_end_to_end(tmp_path: Path) -> None:
     # the brief carried the ledger baseline and the contract verbatim
     brief_text = harness.calls[0][0]
     assert "13.876" in brief_text
-    assert "mean_tour_length down from 13.876" in brief_text
+    # the score is stated as a FACT (currently X), never as a target to hit,
+    # and the finish is the author's call — the de-prescriptified brief
+    assert "currently 13.876" in brief_text
+    assert "lower is better" in brief_text  # metric direction as context
+    assert "You decide when your result is worth publishing" in brief_text
     assert "src/pilot/solvers/" in brief_text
     # eval ran twice (baseline + candidate) with the contract's command
     assert (
@@ -220,7 +224,9 @@ def test_first_run_brief_has_no_baseline_number(tmp_path: Path) -> None:
     result, harness, _ = run_climb(tmp_path, [13.876, 13.10])  # brief_baseline defaults None
     assert result.outcome == "improved" and result.baseline == 13.876
     brief_text = harness.calls[0][0]
-    assert "mean_tour_length down" in brief_text and "down from" not in brief_text
+    assert "no score recorded yet" in brief_text  # no reference number
+    assert "currently" not in brief_text  # and no fabricated baseline
+    assert "lower is better" in brief_text  # the metric context still orients
 
 
 def test_direction_min_regression_is_no_improvement(tmp_path: Path) -> None:


### PR DESCRIPTION
The last backlog item, and a research-design choice Mengye picked (soften to context, not remove): the author brief stops *dictating* the shape of success and instead *orients*.

## Before → after (rendered)

```
Expected effect: mean_tour_length down from 10.84      ->  Metric: mean_tour_length (lower is better), currently 10.84
Done when: `uv run eval` runs clean and                ->  Finishing: You decide when your result is worth publishing
  mean_tour_length moves down; tests pass                   — and a negative result reported clearly is a success. The
                                                            orchestrator re-measures `uv run eval` and runs the tests
                                                            to verify any claim; shared-path changes are suite-gated.
```

## Why

The gate — never the brief — is the real bar (it re-measures both sides on a private seed). A prescriptive `done_criteria` ("the metric must move down") added nothing the gate doesn't enforce, and *did* nudge the author toward optimizing the one named metric — the benchmark-gaming failure mode from the closed yolo-jepa attempts. The metric direction and current score stay as **context** (useful orientation), not a **target**.

## Scope

`hypothesis` (the seed prompt) unchanged. Task fields and schema unchanged — only wording + two render labels (`Metric:` / `Finishing:`) move, so the change is tightly bounded. Tests updated to pin the de-prescriptification (score stated as fact, not target; finish is the author's call; first-run has no fabricated baseline).

Full gate: 800 tests, ruff both, mypy — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)