### PR TITLE
refactor: finish climb->attempt in the limits/contract vocab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Completed the climb->attempt vocabulary in the limits/contract surface:
+  `climb_job_minutes`->`attempt_job_minutes` (contract budget field),
+  `CLIMB_JOB_MINUTES_FLOOR`/`CLIMB_OVERHEAD_MINUTES`/`MAX_CLIMB_JOB_MINUTES`
+  ->`ATTEMPT_*`, and the `EffectiveLimits` field + `_BOUNDS` key. The old
+  contract field name is accepted as a TRANSITIONAL pydantic alias so the two
+  live contracts (pilot, yolo-jepa) migrate at leisure; the alias drops once
+  they have.
+
+### Changed
+
 - Vocabulary: the author-role activity is an **attempt** (a type of run), the
   substrate stays **run**. `climb.py`→`attempt.py`, `climb_once`→
   `attempt_once`, `live_climb`→`live_attempt`, `resume_climb`→`resume_attempt`,

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -18,7 +18,7 @@ from pathlib import PurePosixPath
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 SELF_REPO = "agentic-learning-ai-lab/autoresearch"
 ALWAYS_FORBIDDEN: tuple[str, ...] = (".github", ".autoresearch.yaml")
@@ -153,7 +153,14 @@ class Budgets(_StrictModel):
     # spend less of us, never more. Absent = orchestrator defaults.
     session_max_turns: int | None = Field(default=None, gt=0)
     session_minutes: int | None = Field(default=None, gt=0)
-    climb_job_minutes: int | None = Field(default=None, gt=0)
+    # `attempt_job_minutes` is the current name; `attempt_job_minutes` is
+    # accepted as a TRANSITIONAL alias so the (two) live contracts migrate
+    # at leisure — drop the alias once they have.
+    attempt_job_minutes: int | None = Field(
+        default=None,
+        gt=0,
+        validation_alias=AliasChoices("attempt_job_minutes", "climb_job_minutes"),
+    )
     followup_job_minutes: int | None = Field(default=None, gt=0)
 
 

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -18,7 +18,7 @@ from pathlib import PurePosixPath
 from typing import Any, Literal
 
 import yaml
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 SELF_REPO = "agentic-learning-ai-lab/autoresearch"
 ALWAYS_FORBIDDEN: tuple[str, ...] = (".github", ".autoresearch.yaml")
@@ -153,15 +153,21 @@ class Budgets(_StrictModel):
     # spend less of us, never more. Absent = orchestrator defaults.
     session_max_turns: int | None = Field(default=None, gt=0)
     session_minutes: int | None = Field(default=None, gt=0)
-    # `attempt_job_minutes` is the current name; `attempt_job_minutes` is
-    # accepted as a TRANSITIONAL alias so the (two) live contracts migrate
-    # at leisure — drop the alias once they have.
-    attempt_job_minutes: int | None = Field(
-        default=None,
-        gt=0,
-        validation_alias=AliasChoices("attempt_job_minutes", "climb_job_minutes"),
-    )
+    attempt_job_minutes: int | None = Field(default=None, gt=0)
     followup_job_minutes: int | None = Field(default=None, gt=0)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_legacy_climb_job_minutes(cls, data: Any) -> Any:
+        # TRANSITIONAL: the field was `climb_job_minutes`. Map the legacy key
+        # to the new name before validation (new name wins if BOTH appear, so
+        # a mid-migration contract never fails), and consume it so extra=forbid
+        # does not reject it. Drop this once the (two) live contracts migrate.
+        if isinstance(data, dict) and "climb_job_minutes" in data:
+            data = dict(data)
+            legacy = data.pop("climb_job_minutes")
+            data.setdefault("attempt_job_minutes", legacy)
+        return data
 
 
 class Scope(_StrictModel):

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -46,7 +46,7 @@ log = logging.getLogger(__name__)
 _SHELL_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 # In-job evals must fit the climb job's overhead runway (a few minutes each,
-# see limits.CLIMB_OVERHEAD_MINUTES); anything longer is dispatched.
+# see limits.ATTEMPT_OVERHEAD_MINUTES); anything longer is dispatched.
 IN_JOB_EVAL_MINUTES = 5
 # Ceiling for the contract's eval_minutes hint: OUR spend cap, not the
 # target's to raise (same grammar as every budget ceiling).

--- a/src/autoresearch/limits.py
+++ b/src/autoresearch/limits.py
@@ -27,7 +27,7 @@ from typing import Any
 # floor = session floor + overhead + self-deadline margin: even at the
 # floors, a session must fit inside its job with the ending's runway.
 # Public: the tick's AUTORESEARCH_MAX_JOB_MINUTES knob floors here too.
-CLIMB_JOB_MINUTES_FLOOR = 40
+ATTEMPT_JOB_MINUTES_FLOOR = 40
 
 # Public: the tick shrinks a capped job's session with the same floor the
 # contract clamp uses.
@@ -36,21 +36,21 @@ SESSION_MINUTES_FLOOR = 10
 _BOUNDS: dict[str, tuple[int, int, int]] = {
     "session_max_turns": (120, 10, 120),
     "session_minutes": (90, SESSION_MINUTES_FLOOR, 90),
-    "climb_job_minutes": (120, CLIMB_JOB_MINUTES_FLOOR, 120),
+    "attempt_job_minutes": (120, ATTEMPT_JOB_MINUTES_FLOOR, 120),
     "followup_job_minutes": (90, 20, 90),
 }
 
 # A climb job must outlive its session long enough for the orchestrator's
 # own work around it (clone, two evals, publish, ending writes). Public:
 # the tick's cap warning uses it as the no-runway threshold too.
-CLIMB_OVERHEAD_MINUTES = 20
+ATTEMPT_OVERHEAD_MINUTES = 20
 
 
 @dataclass(frozen=True)
 class EffectiveLimits:
     session_max_turns: int
     session_minutes: int
-    climb_job_minutes: int
+    attempt_job_minutes: int
     followup_job_minutes: int
 
 
@@ -73,7 +73,7 @@ def effective_limits(budgets: Any = None) -> EffectiveLimits:
         name: _clamp(name, getattr(budgets, name, None) if budgets is not None else None)
         for name in _BOUNDS
     }
-    max_session = values["climb_job_minutes"] - CLIMB_OVERHEAD_MINUTES
+    max_session = values["attempt_job_minutes"] - ATTEMPT_OVERHEAD_MINUTES
     if values["session_minutes"] > max_session:
         floor = _BOUNDS["session_minutes"][1]
         values["session_minutes"] = max(floor, max_session)

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -149,7 +149,7 @@ class TickReport:
 # longer than 10 h need that window made spec-aware first (named gap). The
 # self-deadline arms at the CLAMPED value, so a job that wanted more time
 # fails safe mid-panel instead of never starting.
-MAX_CLIMB_JOB_MINUTES = 6 * 60
+MAX_ATTEMPT_JOB_MINUTES = 6 * 60
 MAX_JOB_MINUTES_CEILING = 10 * 60
 
 
@@ -187,8 +187,8 @@ class FollowupSpec:
     # scheduling priority, so the two deserve independent placement.
     job_partition: str = ""
     # Partition MaxTime for work jobs — the panel-augmented walltime clamps
-    # here (see MAX_CLIMB_JOB_MINUTES). Raise together with job_partition.
-    max_job_minutes: int = MAX_CLIMB_JOB_MINUTES
+    # here (see MAX_ATTEMPT_JOB_MINUTES). Raise together with job_partition.
+    max_job_minutes: int = MAX_ATTEMPT_JOB_MINUTES
 
 
 # Generous vs the ~2 h job walltimes plus queue wait, tight enough that
@@ -1407,15 +1407,15 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
         return f"{type(exc).__name__}: {exc}"
 
 
-def _climb_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
+def _attempt_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
     """The submitted climb walltime: contract budget + panel allowance,
     clamped at the partition cap. Warns when the cap cuts below the session
     budget — the self-deadline would then fire before the author's own
     clock, and that must be a visible operator choice, never a silent
     surprise."""
-    from autoresearch.limits import CLIMB_OVERHEAD_MINUTES
+    from autoresearch.limits import ATTEMPT_OVERHEAD_MINUTES
 
-    wanted = limits.climb_job_minutes + _panel_job_minutes(spec, limits)
+    wanted = limits.attempt_job_minutes + _panel_job_minutes(spec, limits)
     job = min(wanted, spec.max_job_minutes)
     if job < wanted:
         log.info(
@@ -1424,14 +1424,14 @@ def _climb_job_minutes(spec: FollowupSpec, limits: EffectiveLimits) -> int:
             job,
             wanted,
         )
-    if job < limits.session_minutes + CLIMB_OVERHEAD_MINUTES:
+    if job < limits.session_minutes + ATTEMPT_OVERHEAD_MINUTES:
         log.warning(
             "work-job cap %d min leaves no runway around the %d-min session "
             "(the orchestrator needs ~%d min); sessions or endings will be "
             "cut short by the self-deadline",
             job,
             limits.session_minutes,
-            CLIMB_OVERHEAD_MINUTES,
+            ATTEMPT_OVERHEAD_MINUTES,
         )
     return job
 
@@ -1463,9 +1463,9 @@ def _climb_limit_argv(limits: EffectiveLimits, job_minutes: int) -> list[str]:
     CAPPED job with the same rule limits.effective_limits applies to
     contract values — better a short session that ends cleanly than a full
     one the self-deadline kills mid-flight."""
-    from autoresearch.limits import CLIMB_OVERHEAD_MINUTES, SESSION_MINUTES_FLOOR
+    from autoresearch.limits import ATTEMPT_OVERHEAD_MINUTES, SESSION_MINUTES_FLOOR
 
-    session = min(limits.session_minutes, job_minutes - CLIMB_OVERHEAD_MINUTES)
+    session = min(limits.session_minutes, job_minutes - ATTEMPT_OVERHEAD_MINUTES)
     return [
         "--max-turns",
         str(limits.session_max_turns),
@@ -1545,7 +1545,7 @@ def service_self_initiated(
             return None
         if dry_run:
             return (benchmark, "dry-run")
-        job_minutes = _climb_job_minutes(spec, limits)
+        job_minutes = _attempt_job_minutes(spec, limits)
         argv = [
             "uv",
             "run",
@@ -1676,7 +1676,7 @@ def service_steward(
             spec.steward_key_file,
             # the SAME clamped walltime the JobSpec requests, so the
             # self-deadline arms against the real clock
-            *_climb_limit_argv(limits, min(limits.climb_job_minutes, spec.max_job_minutes)),
+            *_climb_limit_argv(limits, min(limits.attempt_job_minutes, spec.max_job_minutes)),
         ]
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
@@ -1686,7 +1686,7 @@ def service_steward(
                     job_name=f"steward-issue-{task.number}",
                     account=spec.account,
                     partition=spec.job_partition or spec.partition,
-                    time_minutes=min(limits.climb_job_minutes, spec.max_job_minutes),
+                    time_minutes=min(limits.attempt_job_minutes, spec.max_job_minutes),
                     command=_flight_command(spec.home, f"steward-issue-{task.number}", now, argv),
                     cpus=4,
                     mem="8G",
@@ -1768,7 +1768,7 @@ def service_intake(
             return None
         if dry_run:
             return (f"issue-{task.number}", "dry-run")
-        job_minutes = _climb_job_minutes(spec, limits)
+        job_minutes = _attempt_job_minutes(spec, limits)
         # claim BEFORE submit: Slurm queueing can take minutes, and the next
         # tick must not re-claim the same issue in that window
         from autoresearch.intake import CLAIM_MARKER, MAX_INTAKE_ATTEMPTS, RELEASE_MARKER
@@ -1897,13 +1897,13 @@ class JobWakeDispatcher:
         # budget + overhead and pass --session-minutes so the in-job
         # self-deadline fires BEFORE Slurm's walltime. A candidate wake keeps
         # the short budget (read results + panel).
-        from autoresearch.limits import CLIMB_OVERHEAD_MINUTES
+        from autoresearch.limits import ATTEMPT_OVERHEAD_MINUTES
         from autoresearch.roles import author_spec
 
         if record.stage.get("phase") == "author-sleep":
             session_minutes = author_spec().budget.walltime_s // 60
             argv += ["--session-minutes", str(session_minutes)]
-            job_minutes = min(session_minutes + CLIMB_OVERHEAD_MINUTES, self.spec.max_job_minutes)
+            job_minutes = min(session_minutes + ATTEMPT_OVERHEAD_MINUTES, self.spec.max_job_minutes)
         else:
             job_minutes = self.wake_minutes + _wake_panel_minutes(self.spec)
         if self.spec.pat_file:
@@ -1979,17 +1979,17 @@ def _max_job_minutes_from_env() -> int:
     rejected), at most the ceiling the stranded window allows. A clamped
     value logs — a silently-changed cap would read as the partition
     rejecting jobs for no reason."""
-    from autoresearch.limits import CLIMB_JOB_MINUTES_FLOOR
+    from autoresearch.limits import ATTEMPT_JOB_MINUTES_FLOOR
 
     raw = os.environ.get("AUTORESEARCH_MAX_JOB_MINUTES", "").strip()
     if not raw:
-        return MAX_CLIMB_JOB_MINUTES
+        return MAX_ATTEMPT_JOB_MINUTES
     try:
         value = int(raw)
     except ValueError:
         log.warning("AUTORESEARCH_MAX_JOB_MINUTES=%r is not an integer; using default", raw)
-        return MAX_CLIMB_JOB_MINUTES
-    clamped = max(CLIMB_JOB_MINUTES_FLOOR, min(value, MAX_JOB_MINUTES_CEILING))
+        return MAX_ATTEMPT_JOB_MINUTES
+    clamped = max(ATTEMPT_JOB_MINUTES_FLOOR, min(value, MAX_JOB_MINUTES_CEILING))
     if clamped != value:
         log.warning("AUTORESEARCH_MAX_JOB_MINUTES=%d clamped to %d", value, clamped)
     return clamped

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -274,3 +274,18 @@ def test_benchmark_name_must_be_a_slug() -> None:
     bad = PILOT_CONTRACT.replace("name: tsp", "name: ../tsp evil")
     with pytest.raises(ValidationError):
         load_contract(bad, "org/pilot")
+
+
+def test_climb_job_minutes_is_a_transitional_alias_for_attempt_job_minutes() -> None:
+    from autoresearch.contract import load_contract
+
+    base = """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3, %s: 180}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    # the new name and the legacy alias both populate the same field
+    assert load_contract(base % "attempt_job_minutes", "o/r").budgets.attempt_job_minutes == 180
+    assert load_contract(base % "climb_job_minutes", "o/r").budgets.attempt_job_minutes == 180

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -289,3 +289,13 @@ roadmap: docs/roadmap.md
     # the new name and the legacy alias both populate the same field
     assert load_contract(base % "attempt_job_minutes", "o/r").budgets.attempt_job_minutes == 180
     assert load_contract(base % "climb_job_minutes", "o/r").budgets.attempt_job_minutes == 180
+    # a mid-migration contract with BOTH keys does not fail — the new name
+    # wins (terra #158 r1: the old alias must not read as an extra field)
+    both = """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 3, attempt_job_minutes: 120, climb_job_minutes: 180}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    assert load_contract(both, "o/r").budgets.attempt_job_minutes == 120

--- a/tests/test_limits.py
+++ b/tests/test_limits.py
@@ -22,17 +22,17 @@ def test_absent_knobs_yield_the_standing_defaults() -> None:
     assert _limits() == EffectiveLimits(
         session_max_turns=120,
         session_minutes=90,
-        climb_job_minutes=120,
+        attempt_job_minutes=120,
         followup_job_minutes=90,
     )
     assert effective_limits(None) == _limits()  # no contract at all
 
 
 def test_contract_shapes_spend_downward() -> None:
-    lim = _limits(", session_max_turns: 20, session_minutes: 15, climb_job_minutes: 40")
+    lim = _limits(", session_max_turns: 20, session_minutes: 15, attempt_job_minutes: 40")
     assert lim.session_max_turns == 20
     assert lim.session_minutes == 15
-    assert lim.climb_job_minutes == 40
+    assert lim.attempt_job_minutes == 40
 
 
 def test_ceilings_cannot_be_raised_by_a_contract() -> None:
@@ -41,25 +41,25 @@ def test_ceilings_cannot_be_raised_by_a_contract() -> None:
     on every knob."""
     lim = _limits(
         ", session_max_turns: 100000, session_minutes: 100000"
-        ", climb_job_minutes: 100000, followup_job_minutes: 100000"
+        ", attempt_job_minutes: 100000, followup_job_minutes: 100000"
     )
     assert lim == effective_limits(None)  # identical to no knobs at all
 
 
 def test_floors_defeat_starvation() -> None:
-    lim = _limits(", session_max_turns: 1, session_minutes: 1, climb_job_minutes: 1")
+    lim = _limits(", session_max_turns: 1, session_minutes: 1, attempt_job_minutes: 1")
     assert lim.session_max_turns == 10
     assert lim.session_minutes == 10
     # floor 40 = session floor (10) + orchestrator overhead (20) + runway:
     # even the floor combination keeps the session inside the job
-    assert lim.climb_job_minutes == 40
-    assert lim.session_minutes <= lim.climb_job_minutes - 20
+    assert lim.attempt_job_minutes == 40
+    assert lim.session_minutes <= lim.attempt_job_minutes - 20
 
 
 def test_session_is_shrunk_to_fit_inside_the_job() -> None:
     """A session that outlives its job ends as a kill, not a report."""
-    lim = _limits(", session_minutes: 60, climb_job_minutes: 60")
-    assert lim.climb_job_minutes == 60
+    lim = _limits(", session_minutes: 60, attempt_job_minutes: 60")
+    assert lim.attempt_job_minutes == 60
     assert lim.session_minutes == 40  # 60 - 20 overhead
 
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1032,7 +1032,7 @@ def test_legacy_record_without_job_id_ends_only_past_deadline(tmp_path: Path) ->
 
 def test_self_initiated_carries_contract_limits_into_the_job(tmp_path: Path) -> None:
     """The submitted climb job wears the contract's (clamped) limits: Slurm
-    walltime from climb_job_minutes, and the climb argv carries the session
+    walltime from attempt_job_minutes, and the climb argv carries the session
     knobs plus its own walltime for the self-deadline."""
     from autoresearch.contract import load_contract
     from autoresearch.tick import FollowupSpec, service_self_initiated
@@ -1046,7 +1046,7 @@ budgets:
   runs_per_week: 3
   session_max_turns: 30
   session_minutes: 25
-  climb_job_minutes: 100000
+  attempt_job_minutes: 100000
 scope: {allowed: [src/]}
 roadmap: docs/roadmap.md
 """,
@@ -2041,14 +2041,14 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     # panel-augmented total clamps at the 6h partition cap (sbatch would
     # REJECT a longer request outright, grounding every climb)
     from autoresearch.limits import effective_limits
-    from autoresearch.tick import MAX_CLIMB_JOB_MINUTES, _panel_job_minutes
+    from autoresearch.tick import MAX_ATTEMPT_JOB_MINUTES, _panel_job_minutes
 
     limits = effective_limits()  # defaults: 120-min job, 90-min session
     assert _panel_job_minutes(make(panel=""), limits) == 0
-    wanted = limits.climb_job_minutes + _panel_job_minutes(make(), limits)
+    wanted = limits.attempt_job_minutes + _panel_job_minutes(make(), limits)
     # the default path NEEDS the clamp (spec.max_job_minutes defaults to
-    # MAX_CLIMB_JOB_MINUTES = cpu_short's 6h MaxTime)
-    assert wanted > MAX_CLIMB_JOB_MINUTES
+    # MAX_ATTEMPT_JOB_MINUTES = cpu_short's 6h MaxTime)
+    assert wanted > MAX_ATTEMPT_JOB_MINUTES
     submitted2: list[str] = []
 
     def runner2(argv, timeout_s):
@@ -2095,8 +2095,8 @@ roadmap: docs/roadmap.md
         tmp_path, SlurmCompute(runner=runner2), ok2, default_contract, NOW + 9000
     )
     assert out2 is not None
-    assert f"--time={MAX_CLIMB_JOB_MINUTES}" in submitted2[0]
-    assert f"--job-minutes {MAX_CLIMB_JOB_MINUTES}" in submitted2[0]
+    assert f"--time={MAX_ATTEMPT_JOB_MINUTES}" in submitted2[0]
+    assert f"--job-minutes {MAX_ATTEMPT_JOB_MINUTES}" in submitted2[0]
 
 
 def test_job_wake_dispatcher_submits_a_resume_job_after_the_eval_jobs(tmp_path, monkeypatch):
@@ -2226,7 +2226,7 @@ def test_author_sleep_wake_gets_a_full_session_walltime(tmp_path, monkeypatch):
     # an author-sleep wake resumes a FULL author session, so its Slurm job must
     # fit the session (+ overhead) and pass --session-minutes, not the short
     # candidate-wake budget (terra #135 r3).
-    from autoresearch.limits import CLIMB_OVERHEAD_MINUTES
+    from autoresearch.limits import ATTEMPT_OVERHEAD_MINUTES
     from autoresearch.roles import author_spec
     from autoresearch.runstate import RunRecord
     from autoresearch.tick import FollowupSpec, JobWakeDispatcher
@@ -2259,6 +2259,6 @@ def test_author_sleep_wake_gets_a_full_session_walltime(tmp_path, monkeypatch):
     )
     JobWakeDispatcher(SlurmCompute(runner=runner), spec, now=NOW).dispatch(sleep_rec, "x")
     session_minutes = author_spec().budget.walltime_s // 60
-    assert times[0] == session_minutes + CLIMB_OVERHEAD_MINUTES  # fits the session
+    assert times[0] == session_minutes + ATTEMPT_OVERHEAD_MINUTES  # fits the session
     assert times[0] > 20  # far more than a candidate wake's base
     assert f"--session-minutes {session_minutes}" in joined_argv[0]  # self-deadline set


### PR DESCRIPTION
Completes the `climb → attempt` rename in the limits/contract surface the main rename (#156) left as a deferred nit — cheap now that only pilot + yolo-jepa are live (Mengye).

## Renamed
- `climb_job_minutes` → `attempt_job_minutes` (contract `budgets` field)
- `CLIMB_JOB_MINUTES_FLOOR` / `CLIMB_OVERHEAD_MINUTES` / `MAX_CLIMB_JOB_MINUTES` → `ATTEMPT_*`
- `EffectiveLimits.climb_job_minutes` + the `_BOUNDS` dict key + the `_climb_job_minutes` tick helper

## Back-compat
The contract field is public API (a target's `.autoresearch.yaml` may declare it), so the old name is a **transitional** pydantic `AliasChoices` alias — existing contracts load unchanged. Drop the alias in a follow-up once pilot + yolo-jepa have migrated to `attempt_job_minutes` (I couldn't inspect them this session — VPN down — so the alias is the safe path). Pinned: both names populate the field.

Full gate: 801 tests, ruff both, mypy — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)