### PR TITLE
fix: the hermes clone is anonymous — a foreign-repo token 401s, not helps

### DIFF
--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -188,13 +188,6 @@ jobs:
       # Pinned artifacts, same discipline across backends: claude installer
       # pin, codex npm pin, hermes release tag. Bump deliberately.
       - name: Install the ${{ inputs.backend }} backend
-        env:
-          # authenticate the hermes clone: anonymous clones share a low
-          # per-IP limit that the wide round's fan-out trips; the job's
-          # read-only token lifts it to the authenticated tier. Passed via
-          # GIT_CONFIG_* (below), never git config --global — the token must
-          # not persist into ~/.gitconfig where the model session could read it.
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           case "$BACKEND" in
@@ -212,19 +205,15 @@ jobs:
               else
                 # cold cache, or a restore failing the sha/clean check — an
                 # unverified tree never runs with the reviewer key. Clone
-                # fresh, authenticated: the token rides GIT_CONFIG_* (not
-                # argv, not --global — it must not persist into ~/.gitconfig
-                # where the session could read it), and the authenticated
-                # tier means a concurrent cold fan-out no longer 429s.
+                # fresh, ANONYMOUSLY — deliberately: the job's GITHUB_TOKEN
+                # is a repo-scoped installation token, and git-over-HTTP
+                # 401s a foreign-repo credential outright (observed live,
+                # jepa-agent#11: "could not read Username" x6 — git tries to
+                # prompt after the reject). For a public foreign repo,
+                # anonymous succeeds where the token cannot; the cache keeps
+                # this to one clone per repo per version, and the retry
+                # rides out the anonymous rate limit on a cold fan-out.
                 rm -rf "$GITHUB_WORKSPACE/hermes-agent"
-                if [ -n "${GITHUB_TOKEN:-}" ]; then
-                  # additive-only: an EMPTY bearer header would 401 a public
-                  # clone (worse than anonymous), so auth only arms when the
-                  # token is present; without it the retry still covers us
-                  export GIT_CONFIG_COUNT=1
-                  export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
-                  export GIT_CONFIG_VALUE_0="AUTHORIZATION: Bearer ${GITHUB_TOKEN}"
-                fi
                 for i in 1 2 3 4 5 6; do
                   if git clone --depth 1 --branch "$HERMES_REF" \
                       https://github.com/NousResearch/hermes-agent \

--- a/.github/workflows/advisory-review-summarize.yml
+++ b/.github/workflows/advisory-review-summarize.yml
@@ -112,13 +112,6 @@ jobs:
           path: ${{ github.workspace }}/hermes-agent
           key: hermes-agent-${{ env.HERMES_REF }}
       - name: Install the ${{ inputs.backend }} backend
-        env:
-          # authenticate the hermes clone: anonymous clones share a low
-          # per-IP limit that the wide round's fan-out trips; the job's
-          # read-only token lifts it to the authenticated tier. Passed via
-          # GIT_CONFIG_* (below), never git config --global — the token must
-          # not persist into ~/.gitconfig where the model session could read it.
-          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           case "$BACKEND" in
@@ -136,19 +129,15 @@ jobs:
               else
                 # cold cache, or a restore failing the sha/clean check — an
                 # unverified tree never runs with the reviewer key. Clone
-                # fresh, authenticated: the token rides GIT_CONFIG_* (not
-                # argv, not --global — it must not persist into ~/.gitconfig
-                # where the session could read it), and the authenticated
-                # tier means a concurrent cold fan-out no longer 429s.
+                # fresh, ANONYMOUSLY — deliberately: the job's GITHUB_TOKEN
+                # is a repo-scoped installation token, and git-over-HTTP
+                # 401s a foreign-repo credential outright (observed live,
+                # jepa-agent#11: "could not read Username" x6 — git tries to
+                # prompt after the reject). For a public foreign repo,
+                # anonymous succeeds where the token cannot; the cache keeps
+                # this to one clone per repo per version, and the retry
+                # rides out the anonymous rate limit on a cold fan-out.
                 rm -rf "$GITHUB_WORKSPACE/hermes-agent"
-                if [ -n "${GITHUB_TOKEN:-}" ]; then
-                  # additive-only: an EMPTY bearer header would 401 a public
-                  # clone (worse than anonymous), so auth only arms when the
-                  # token is present; without it the retry still covers us
-                  export GIT_CONFIG_COUNT=1
-                  export GIT_CONFIG_KEY_0="http.https://github.com/.extraheader"
-                  export GIT_CONFIG_VALUE_0="AUTHORIZATION: Bearer ${GITHUB_TOKEN}"
-                fi
                 for i in 1 2 3 4 5 6; do
                   if git clone --depth 1 --branch "$HERMES_REF" \
                       https://github.com/NousResearch/hermes-agent \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,16 @@ Versions follow [SemVer](https://semver.org).
   wide first round fans out several hermes (terra) lens sessions at once, and
   GitHub 429s the concurrent ANONYMOUS clones of the same public repo
   (observed live: 3/5 lens sessions died at exit 128 before the model ran).
-  Fix, three layers: (1) the clone is AUTHENTICATED with the job's read-only
-  token (via `GIT_CONFIG_*`, never persisted) — the authenticated tier means
-  even concurrent cold-cache clones no longer 429; (2) the pinned clone is
-  CACHED — and because the review workflows run on `pull_request_target`,
-  every run on every PR shares the base-branch cache scope, so one round
-  populates it for all future PRs (cold = first run on a fresh tag only);
-  (3) a backoff+jitter retry remains as the last backstop. The cache is
+  Fix: (1) the pinned clone is CACHED — and because the review workflows run
+  on `pull_request_target`, every run on every PR shares the base-branch
+  cache scope, so one round populates it for all future PRs (cold = first
+  run on a fresh tag only); (2) a backoff+jitter retry rides out the
+  anonymous rate limit on a cold fan-out. The clone is deliberately
+  ANONYMOUS: the job's `GITHUB_TOKEN` is a repo-scoped installation token,
+  and git-over-HTTP rejects a foreign-repo credential outright (observed
+  live on the first post-merge run: six identical "could not read Username"
+  failures), so for a foreign public repo anonymous succeeds where the
+  token cannot. The cache is
   written by an explicit `actions/cache/save` placed BEFORE the session step
   and verified against the pinned commit sha on restore (wipe + re-clone on
   mismatch) — a post-job save would have let a prompt-injected session


### PR DESCRIPTION
The first post-merge execution of #159's provisioning chain (jepa-agent#11's terra second-opinion) validated every failure-visibility layer — 6 backoff retries, sha refusal, a posted skip-stub naming the round — and disproved the auth layer itself:

```
fatal: could not read Username for 'https://github.com': No such device or address   (x6, identical)
```

The job's `GITHUB_TOKEN` is a **repo-scoped installation token**. Git-over-HTTP doesn't ignore a credential without a grant on the target repo — it 401s, and git then dies trying to prompt headless. So authenticating the **foreign** hermes clone is strictly worse than anonymous (the same worse-than-anonymous class the empty-token guard anticipated, one ring further out). My "authenticated tier" justification was REST-API reasoning misapplied to git smart-HTTP.

## Fix
Drop the auth block + its env from both reusable workflows. What remains is what the live evidence supports:
- **Cache** (shared base-branch scope): one anonymous clone per repo per version, ever. jepa-agent/egolearn run a *single* hermes session per PR — no fan-out, so effectively no 429 exposure at all.
- **Retry with backoff**: rides out the anonymous limit on autoresearch's own 5-lens cold fan-out (proven — even the original storm landed 2/5 without retries).
- sha verify + pre-session save unchanged.

CHANGELOG's still-unreleased #159 entry is amended in place rather than stacking a contradicting entry.

## Review note
This PR **cannot get a terra round pre-merge**: reviews run main's workflow, whose clone path is the broken one, and this repo's cache was never populated (chicken-and-egg). Self-reviewed against the fix-commit checklist (both call sites, no other GIT_CONFIG references in workflows, changelog consistency); code-owner merge on green CI. After merge, re-triggering the label on jepa-agent#11 / egolearn#10 gives the sunsets their real terra rounds — and populates each repo's cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)