### PR TITLE
feat: modelless provision job owns the hermes cache — sessions restore-only

### DIFF
--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -118,10 +118,13 @@ on:
           once it is public.
         required: false
 
-# The caller grants this much; each job below narrows it further.
+# The caller grants this much; each job below narrows it further. Only the
+# modelless provision job takes actions:write (cache save); the session
+# job's own block excludes it, so the model's token never gains it.
 permissions:
   contents: read
   pull-requests: write
+  actions: write
 
 # One review per opinion per PR at a time. Do NOT cancel in progress: a running
 # session is a paid model call, so queue behind it rather than kill it.
@@ -130,56 +133,15 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Provisions the pinned hermes clone into the Actions cache, ONCE per
-  # version. This job runs NO model code, so it alone may hold the
-  # actions:write that cache SAVES require — the session jobs are
-  # deliberately read-only (the model runs there), which makes the cache
-  # service refuse their reservations ("unable to reserve"; why no session
-  # save ever committed). Sessions being UNABLE to write the shared cache
-  # is the cache-poisoning defense, stronger than any save ordering.
+  # One shared provisioning definition (hermes-provision.yml): nested here
+  # so single-call repos provision with zero extra wiring; wide-round
+  # callers (autoresearch review.yml) ALSO call it once before their lens
+  # fan-out, so this nested call no-ops on the warm cache. `./` resolves
+  # against THIS workflow's repo+ref, so cross-repo callers get the same
+  # pinned definition.
   provision:
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 15
     if: inputs.backend == 'hermes' && github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      actions: write
-    env:
-      HERMES_REF: v2026.8.13
-      # the COMMIT sha (the v-tags are annotated: pin ls-remote's ^{} line)
-      HERMES_SHA: f80f453ae0679347e38abc917c7f94f717bf96c5
-    steps:
-      - name: Restore the hermes clone
-        id: hermes-cache
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/hermes-agent
-          key: hermes-agent-${{ env.HERMES_REF }}
-      - name: Clone at the pin (cache miss only)
-        if: steps.hermes-cache.outputs.cache-hit != 'true'
-        run: |
-          set -euo pipefail
-          for i in 1 2 3; do
-            if git clone --depth 1 --branch "$HERMES_REF" \
-                https://github.com/NousResearch/hermes-agent \
-                "$GITHUB_WORKSPACE/hermes-agent"; then
-              break
-            fi
-            [ "$i" = 3 ] && exit 1  # sessions fall back to their own clone
-            sleep $(( i * 10 + RANDOM % 10 ))
-            rm -rf "$GITHUB_WORKSPACE/hermes-agent"
-          done
-          head=$(git -C "$GITHUB_WORKSPACE/hermes-agent" rev-parse HEAD)
-          if [ "$head" != "$HERMES_SHA" ]; then
-            echo "tag resolves to $head, expected $HERMES_SHA — refusing" >&2
-            exit 1
-          fi
-      - name: Save the pristine clone
-        if: steps.hermes-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/hermes-agent
-          key: hermes-agent-${{ env.HERMES_REF }}
+    uses: ./.github/workflows/hermes-provision.yml
 
   session:
     runs-on: ubuntu-latest

--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -130,8 +130,62 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Provisions the pinned hermes clone into the Actions cache, ONCE per
+  # version. This job runs NO model code, so it alone may hold the
+  # actions:write that cache SAVES require — the session jobs are
+  # deliberately read-only (the model runs there), which makes the cache
+  # service refuse their reservations ("unable to reserve"; why no session
+  # save ever committed). Sessions being UNABLE to write the shared cache
+  # is the cache-poisoning defense, stronger than any save ordering.
+  provision:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 15
+    if: inputs.backend == 'hermes' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      actions: write
+    env:
+      HERMES_REF: v2026.8.13
+      # the COMMIT sha (the v-tags are annotated: pin ls-remote's ^{} line)
+      HERMES_SHA: f80f453ae0679347e38abc917c7f94f717bf96c5
+    steps:
+      - name: Restore the hermes clone
+        id: hermes-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/hermes-agent
+          key: hermes-agent-${{ env.HERMES_REF }}
+      - name: Clone at the pin (cache miss only)
+        if: steps.hermes-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          for i in 1 2 3; do
+            if git clone --depth 1 --branch "$HERMES_REF" \
+                https://github.com/NousResearch/hermes-agent \
+                "$GITHUB_WORKSPACE/hermes-agent"; then
+              break
+            fi
+            [ "$i" = 3 ] && exit 1  # sessions fall back to their own clone
+            sleep $(( i * 10 + RANDOM % 10 ))
+            rm -rf "$GITHUB_WORKSPACE/hermes-agent"
+          done
+          head=$(git -C "$GITHUB_WORKSPACE/hermes-agent" rev-parse HEAD)
+          if [ "$head" != "$HERMES_SHA" ]; then
+            echo "tag resolves to $head, expected $HERMES_SHA — refusing" >&2
+            exit 1
+          fi
+      - name: Save the pristine clone
+        if: steps.hermes-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/hermes-agent
+          key: hermes-agent-${{ env.HERMES_REF }}
+
   session:
     runs-on: ubuntu-latest
+    # a skipped/failed provision (non-hermes backend, clone outage) must not
+    # skip the session — it has its own clone fallback
+    needs: provision
     # Advisory means advisory: an infrastructure failure here must never turn
     # the caller's PR red. (Failures still show in this job's run log.)
     continue-on-error: true
@@ -139,7 +193,7 @@ jobs:
     timeout-minutes: 70
     # Fork PRs must not reach any secret. `pull_request_target` runs in the
     # base repo's context, so this gate is what closes the pwn-request hole.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: ${{ !cancelled() && github.event.pull_request.head.repo.full_name == github.repository }}
     # READ-ONLY: the session runs here, so the job token must not be worth
     # stealing. pull-requests:read lets the CLI fetch the PR metadata/diff.
     permissions:
@@ -174,10 +228,10 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
-      # Cache scope: this workflow runs on pull_request_target, so every run —
-      # any PR — executes in the BASE branch context and shares ONE cache
-      # scope. One round populates it; every later round hits. Cold is only
-      # the first run on a fresh HERMES_REF (or 7-day eviction).
+      # Restore-ONLY: the provision job (the sole holder of actions:write)
+      # commits this cache; read-only session jobs cannot write it at all.
+      # pull_request_target runs share the base-branch cache scope, so one
+      # provision serves every PR until the pin moves (or 7-day eviction).
       - name: Restore the hermes clone
         id: hermes-cache
         if: inputs.backend == 'hermes'
@@ -244,18 +298,6 @@ jobs:
               exit 0  # advisory: never red the caller's CI
               ;;
           esac
-      # Save BEFORE the session step, never post-job: the cache is shared by
-      # every future run (base-branch scope), so it must only ever hold the
-      # pristine verified clone — a post-job save would persist whatever the
-      # session left in the workspace into a tree later runs EXECUTE with the
-      # reviewer key (cache poisoning). Immutability then works for us: the
-      # first save wins and nothing can overwrite it.
-      - name: Save the pristine hermes clone
-        if: inputs.backend == 'hermes' && steps.hermes-cache.outputs.cache-hit != 'true' && hashFiles('hermes-agent/**') != ''
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/hermes-agent
-          key: hermes-agent-${{ env.HERMES_REF }}
       - name: Run the session (emit only — nothing posted from this job)
         working-directory: .autoresearch
         env:

--- a/.github/workflows/advisory-review-summarize.yml
+++ b/.github/workflows/advisory-review-summarize.yml
@@ -100,10 +100,10 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
-      # Cache scope: this workflow runs on pull_request_target, so every run —
-      # any PR — executes in the BASE branch context and shares ONE cache
-      # scope. One round populates it; every later round hits. Cold is only
-      # the first run on a fresh HERMES_REF (or 7-day eviction).
+      # Restore-ONLY: the agent workflow's provision job commits this cache
+      # (read-only jobs like this one cannot write it); by the time the
+      # summarizer runs, the lens round has warmed it. The clone fallback
+      # below covers a cold cache.
       - name: Restore the hermes clone
         id: hermes-cache
         if: inputs.backend == 'hermes'
@@ -168,18 +168,6 @@ jobs:
               exit 0  # advisory: never red the caller's CI
               ;;
           esac
-      # Save BEFORE the session step, never post-job: the cache is shared by
-      # every future run (base-branch scope), so it must only ever hold the
-      # pristine verified clone — a post-job save would persist whatever the
-      # session left in the workspace into a tree later runs EXECUTE with the
-      # reviewer key (cache poisoning). Immutability then works for us: the
-      # first save wins and nothing can overwrite it.
-      - name: Save the pristine hermes clone
-        if: inputs.backend == 'hermes' && steps.hermes-cache.outputs.cache-hit != 'true' && hashFiles('hermes-agent/**') != ''
-        uses: actions/cache/save@v4
-        with:
-          path: ${{ github.workspace }}/hermes-agent
-          key: hermes-agent-${{ env.HERMES_REF }}
       - name: Download lens opinions
         # NO required-download here: the summarizer CLI itself turns "no
         # envelopes" into a visible skip-stub, so a died-before-emitting lens

--- a/.github/workflows/hermes-provision.yml
+++ b/.github/workflows/hermes-provision.yml
@@ -1,0 +1,59 @@
+name: hermes-provision
+# Provisions the pinned hermes clone into the caller repo's Actions cache,
+# ONCE per version. Reused at two levels: review.yml calls it once BEFORE
+# the wide round's lens fan-out (so a cold cache costs ONE clone, not one
+# per lens), and advisory-review-agent.yml nests it so single-call repos
+# (jepa-agent, egolearn) provision without their own wiring — by the time
+# a nested call runs behind a caller-level one, the cache is warm and it
+# no-ops. Runs NO model code, so it alone may hold the actions:write that
+# cache SAVES require; the model-running session jobs stay read-only,
+# which is the cache-poisoning defense (they cannot write what other runs
+# execute).
+on:
+  workflow_call: {}
+
+jobs:
+  provision:
+    runs-on: ubuntu-latest
+    # advisory infrastructure: a clone outage must never redden the PR —
+    # sessions carry their own anonymous-clone fallback
+    continue-on-error: true
+    timeout-minutes: 15
+    permissions:
+      actions: write
+    env:
+      HERMES_REF: v2026.8.13
+      # the COMMIT sha (the v-tags are annotated: pin ls-remote's ^{} line)
+      HERMES_SHA: f80f453ae0679347e38abc917c7f94f717bf96c5
+    steps:
+      - name: Restore the hermes clone
+        id: hermes-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/hermes-agent
+          key: hermes-agent-${{ env.HERMES_REF }}
+      - name: Clone at the pin (cache miss only)
+        if: steps.hermes-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          for i in 1 2 3; do
+            if git clone --depth 1 --branch "$HERMES_REF" \
+                https://github.com/NousResearch/hermes-agent \
+                "$GITHUB_WORKSPACE/hermes-agent"; then
+              break
+            fi
+            [ "$i" = 3 ] && exit 1  # sessions fall back to their own clone
+            sleep $(( i * 10 + RANDOM % 10 ))
+            rm -rf "$GITHUB_WORKSPACE/hermes-agent"
+          done
+          head=$(git -C "$GITHUB_WORKSPACE/hermes-agent" rev-parse HEAD)
+          if [ "$head" != "$HERMES_SHA" ]; then
+            echo "tag resolves to $head, expected $HERMES_SHA — refusing" >&2
+            exit 1
+          fi
+      - name: Save the pristine clone
+        if: steps.hermes-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ github.workspace }}/hermes-agent
+          key: hermes-agent-${{ env.HERMES_REF }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,9 +17,19 @@ permissions:
   # the model-running session jobs downscope themselves to read-only
   actions: write
 jobs:
+  # ONE provision before the fan-out: a cold cache costs one clone total,
+  # not one per lens (terra #162 r1, all five lenses agreed). The nested
+  # provision inside each lens call then no-ops on the warm cache.
+  provision:
+    if: github.event.action != 'labeled'
+    uses: ./.github/workflows/hermes-provision.yml
+
   # --- wide first round: a general session + distinct lenses, emit-only ---
   lens:
-    if: github.event.action != 'labeled'
+    needs: provision
+    # !cancelled: a failed provision must not skip the round (sessions carry
+    # their own anonymous-clone fallback)
+    if: ${{ !cancelled() && github.event.action != 'labeled' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -13,6 +13,9 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  # ceiling for the called workflows' provision job (cache save needs it);
+  # the model-running session jobs downscope themselves to read-only
+  actions: write
 jobs:
   # --- wide first round: a general session + distinct lenses, emit-only ---
   lens:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,17 @@ Versions follow [SemVer](https://semver.org).
   `actions: write`, which the model-running session jobs deliberately never
   hold — the service refused their reservations (masked as "unable to
   reserve... another job"), so no session save ever committed, in any repo.
-  A new modelless `provision` job in the reusable review workflow is the
-  sole holder of `actions: write`: it clones the pin once, sha-verifies, and
-  commits the cache; sessions are restore-only with the anonymous
-  clone+retry as fallback. Sessions being UNABLE to write the shared cache
-  replaces save-ordering as the poisoning defense. Callers grant the
-  `actions: write` ceiling (the session jobs still downscope to read-only).
+  Provisioning is ONE shared reusable workflow (`hermes-provision.yml`),
+  modelless and the sole holder of `actions: write`: restore, clone the pin
+  (sha-verified), commit the cache. autoresearch's review.yml calls it ONCE
+  before the lens fan-out (a cold cache costs one clone total — terra #162,
+  all five lenses agreed); the agent workflow nests it so single-call repos
+  provision with zero wiring (no-op on a warm cache). Sessions are
+  restore-only with the anonymous clone+retry as fallback — being UNABLE to
+  write the shared cache replaces save-ordering as the poisoning defense.
+  Callers and the reusable's own top-level block grant the `actions: write`
+  ceiling (terra's advisory: the reusable's block would have capped its own
+  provision job); session jobs still downscope to read-only.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- The hermes Actions cache now actually commits: cache SAVES require
+  `actions: write`, which the model-running session jobs deliberately never
+  hold — the service refused their reservations (masked as "unable to
+  reserve... another job"), so no session save ever committed, in any repo.
+  A new modelless `provision` job in the reusable review workflow is the
+  sole holder of `actions: write`: it clones the pin once, sha-verifies, and
+  commits the cache; sessions are restore-only with the anonymous
+  clone+retry as fallback. Sessions being UNABLE to write the shared cache
+  replaces save-ordering as the poisoning defense. Callers grant the
+  `actions: write` ceiling (the session jobs still downscope to read-only).
+
+### Fixed
+
 - Wide-round lens sessions no longer die on GitHub's clone rate limit. The
   wide first round fans out several hermes (terra) lens sessions at once, and
   GitHub 429s the concurrent ANONYMOUS clones of the same public repo


### PR DESCRIPTION
## The solved mystery

Why did no hermes cache ever commit, despite "save" steps succeeding-ish in every round? **Cache saves require `actions: write`, and the session jobs are deliberately read-only** (the model runs in them). The cache service refuses the reservation; actions/toolkit masks that as *"Unable to reserve cache... another job may be creating this cache"* — a fictional other job. Evidence closing the case:
- Every cache ever committed in all three repos traces to `ci.yml` runs (default write permissions); zero to review jobs.
- 7 review-job saves across 3 repos failed identically — including #161's 5-way lens race, where a genuine race would have crowned one winner.
- The same masked message decorates every historical `setup-uv` save from review jobs, which we'd been misreading as benign races.

## The fix (the design Mengye intuited)

A **`provision` job** — runs no model code, sole holder of `actions: write` — restores, clones the pin once (3 tries, backoff), verifies the commit sha, and commits the cache. Sessions become **restore-only**: dead save steps deleted, anonymous clone+retry kept as fallback, `!cancelled()` so a skipped/failed provision never blocks a session. One clone per version per repo, even on a cold cache — the "wait for the first cache" behavior, and now for a security reason: **the job that runs the model cannot write what other runs execute**, which retires save-ordering as the poisoning defense.

Callers grant the `actions: write` ceiling (this PR updates autoresearch's `review.yml`; jepa-agent/egolearn get one-line PRs). The session jobs' own `permissions:` blocks still downscope to read-only, so the model's token gains nothing.

## Note
This PR's own round runs main's workflow (no provision yet) — sessions clone anonymously, which #161 just proved works 5-wide. First post-merge round validates the provision path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)