### PR TITLE
fix: fully qualify the nested provision reference — cross-repo callers broke

### DIFF
--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -141,7 +141,12 @@ jobs:
   # pinned definition.
   provision:
     if: inputs.backend == 'hermes' && github.event.pull_request.head.repo.full_name == github.repository
-    uses: ./.github/workflows/hermes-provision.yml
+    # FULLY QUALIFIED, not `./`: a local path inside a workflow that was
+    # itself called cross-repo does not resolve for the caller (observed
+    # live 2026-08-27: every jepa-agent/egolearn review died at
+    # startup_failure the moment the nested provision landed; this repo's
+    # own calls resolved it fine, which hid the breakage here).
+    uses: agentic-learning-ai-lab/autoresearch/.github/workflows/hermes-provision.yml@main
 
   session:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- Cross-repo review callers (jepa-agent, egolearn) died at
+  `startup_failure` the moment the nested provision job landed: a
+  `uses: ./...` local reference inside a workflow that was itself called
+  cross-repo does not resolve for the caller. The nested
+  `hermes-provision.yml` reference is now fully qualified (`@main`).
+  autoresearch's own rounds resolved the local path fine, which hid the
+  breakage from this repo's reviews.
+
+### Fixed
+
 - `AUTORESEARCH_TARGET` joins the tick chain's `.env` allowlist, making the
   launch target a LIVE knob like its siblings. It was only ever inherited
   from the chain-start environment, so a `.env` edit could not retarget the


### PR DESCRIPTION
Answering "why hasn't jepa#10's autoreview responded": every jepa-agent/egolearn review run since #162 merged dies at **startup_failure** — a nested `uses: ./.github/workflows/hermes-provision.yml` inside `advisory-review-agent.yml` does not resolve when the workflow is itself called **cross-repo**. autoresearch's own rounds resolved the local path fine (all provision jobs green on #163's wide round), which is exactly why this repo's reviews never surfaced it.

One line: the nested reference becomes fully qualified (`agentic-learning-ai-lab/autoresearch/.github/workflows/hermes-provision.yml@main`), matching how every caller already references the agent workflow itself. review.yml's own caller-level `./` reference is fine (it is a top-level workflow, not a called one) and unchanged.

On merge, jepa#10's label re-request works again with no change in jepa/egolearn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)