### PR TITLE
fix: a jobless checkpoint sleep gets a near-term deadline, not 12h queue slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- A submit-park wakes immediately: a waiting run whose stage carries the
+  SEALED CANDIDATE (the author's `submit` staged base+candidate and
+  hibernated) has nothing to wait on, but the sweep classified every
+  no-poll-target park as blind and rode the 12h deadline floor. Observed
+  live on the first submit-path run (2026-08-27, yolo heldout_probe): two
+  ticks swept the staged run without waking it. The sweep now wakes a
+  sealed-candidate park on sight ("sealed candidate awaiting decide");
+  genuinely blind parks keep the deadline floor.
+
 ### Removed
 
 - The review-path hermes CACHE machinery, wholesale (provision job, shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,17 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- A submit-park wakes immediately: a waiting run whose stage carries the
-  SEALED CANDIDATE (the author's `submit` staged base+candidate and
-  hibernated) has nothing to wait on, but the sweep classified every
-  no-poll-target park as blind and rode the 12h deadline floor. Observed
-  live on the first submit-path run (2026-08-27, yolo heldout_probe): two
-  ticks swept the staged run without waking it. The sweep now wakes a
-  sealed-candidate park on sight ("sealed candidate awaiting decide");
-  genuinely blind parks keep the deadline floor.
+- A jobless checkpoint sleep no longer inherits the 12h QUEUE slack: the
+  park deadline added `PARK_QUEUE_SLACK_MIN` (12h, sized to keep the sweep
+  from cancelling healthy-but-queued Slurm jobs) to every park — including
+  an author checkpoint sleep with nothing in any queue, turning "wake at
+  the first deadline pass" into a 12h coma (observed live on the yolo
+  heldout_probe run, 2026-08-27). A launch-less author-sleep park now gets
+  a near-term deadline (`CHECKPOINT_SLEEP_SLACK_MIN`, 45 min) and the
+  existing blind-park deadline branch delivers the wake; parks with queued
+  jobs keep the full queue slack, and the sweep gains no new predicate
+  (terra #166: a wake-on-sight predicate over-matched blind re-parks and
+  long sleeps).
 
 ### Removed
 

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -309,6 +309,9 @@ def _post_issue_finished(
 # healthy eval can legitimately sit queued-then-running, or `tick._sweep_one`
 # would cancel a still-queued job as "unschedulable".
 PARK_QUEUE_SLACK_MIN = 12 * 60
+# a jobless checkpoint sleep only needs to survive to the next sweep pass:
+# one cadence + coalescing headroom, not queue slack
+CHECKPOINT_SLEEP_SLACK_MIN = 45
 
 
 def _park_run(
@@ -401,7 +404,20 @@ def _park_run(
         # a submitted candidate with sibling launches waits on gate evals AND
         # launches — the floor must sit past the longest of either
         floor_minutes = max(floor_minutes, *(la.minutes for la in parked.syscall.launches), 0)
-    deadline = now + (floor_minutes + PARK_QUEUE_SLACK_MIN) * 60
+    checkpoint_sleep = (
+        parked.phase == "author-sleep"
+        and parked.syscall is not None
+        and not parked.syscall.launches
+    )
+    if checkpoint_sleep:
+        # a CHECKPOINT SLEEP has nothing in any queue, so the 12h queue slack
+        # (sized to protect queued Slurm jobs from cancel-on-pending) does not
+        # apply — the deadline needs only to reach the sweep's next pass.
+        # Observed live (yolo heldout_probe, 2026-08-27): a jobless nap
+        # inherited the queue slack and became a 12h coma.
+        deadline = now + CHECKPOINT_SLEEP_SLACK_MIN * 60
+    else:
+        deadline = now + (floor_minutes + PARK_QUEUE_SLACK_MIN) * 60
     waiting = RunRecord(
         **{
             **record.__dict__,

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -903,19 +903,13 @@ def _sweep_one(
 
         job_ids = _poll_targets(record)
         if not job_ids:
-            # No job ids to poll. A SEALED-CANDIDATE park (the author's
-            # `submit` staged base+candidate and hibernated) is not waiting
-            # on anything — the decide can start now, so wake immediately
-            # rather than ride the 12h deadline floor (observed live on the
-            # first submit-path run, 2026-08-27: two ticks swept it without
-            # waking). A BLIND PARK (the measurer could not read Slurm, so
-            # `MeasurementPending` carried no ids) still hibernated with a
-            # deadline — the deadline floor is its ONLY wake, so fire on it.
-            # A genuinely mid-write record has no deadline and is left alone.
-            stage = record.stage or {}
-            if stage.get("candidate_sha") or stage.get("candidate_ref"):
-                wake(record, "sealed candidate awaiting decide", "staged")
-                return
+            # No job ids to poll. A BLIND PARK (the measurer could not read Slurm,
+            # so `MeasurementPending` carried no ids) still hibernated with a
+            # deadline — the deadline floor is its ONLY wake, so fire on it. A
+            # genuinely mid-write record has no deadline and is left alone.
+            # (A jobless CHECKPOINT SLEEP arrives here too — its deadline is
+            # near-term by construction, attempt.py sizes it to the next sweep
+            # pass, not the 12h queue slack that protects queued jobs.)
             if record.deadline > 0 and now > record.deadline:
                 wake(record, "blind park past deadline", "deadline")
             return

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -903,10 +903,19 @@ def _sweep_one(
 
         job_ids = _poll_targets(record)
         if not job_ids:
-            # No job ids to poll. A BLIND PARK (the measurer could not read Slurm,
-            # so `MeasurementPending` carried no ids) still hibernated with a
-            # deadline — the deadline floor is its ONLY wake, so fire on it. A
-            # genuinely mid-write record has no deadline and is left alone.
+            # No job ids to poll. A SEALED-CANDIDATE park (the author's
+            # `submit` staged base+candidate and hibernated) is not waiting
+            # on anything — the decide can start now, so wake immediately
+            # rather than ride the 12h deadline floor (observed live on the
+            # first submit-path run, 2026-08-27: two ticks swept it without
+            # waking). A BLIND PARK (the measurer could not read Slurm, so
+            # `MeasurementPending` carried no ids) still hibernated with a
+            # deadline — the deadline floor is its ONLY wake, so fire on it.
+            # A genuinely mid-write record has no deadline and is left alone.
+            stage = record.stage or {}
+            if stage.get("candidate_sha") or stage.get("candidate_ref"):
+                wake(record, "sealed candidate awaiting decide", "staged")
+                return
             if record.deadline > 0 and now > record.deadline:
                 wake(record, "blind park past deadline", "deadline")
             return

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -128,8 +128,42 @@ def test_author_sleep_park_persists_the_request_and_floors_on_the_launch(tmp_pat
         {"name": "train", "minutes": 180, "artifacts": ["out/curve.json"]}
     ]
     assert r.stage["syscall_note"] == "compare to the lr sweep"
-    assert r.resume_session_id == "s9"  # the record's own field; no stage duplicate
     assert r.stage["launches_used"] == 1 and r.stage["sleeps_used"] == 1
+    assert r.resume_session_id == "s9"  # the record's own field; no stage duplicate
+
+
+def test_checkpoint_sleep_park_gets_a_near_term_deadline(tmp_path) -> None:
+    """A LAUNCH-LESS author sleep has nothing in any queue — its deadline
+    must reach only the next sweep pass (CHECKPOINT_SLEEP_SLACK_MIN), never
+    the 12h queue slack. Observed live (yolo heldout_probe, 2026-08-27): the
+    queue slack turned a checkpoint nap into a 12h coma."""
+    from autoresearch.attempt import CHECKPOINT_SLEEP_SLACK_MIN
+    from autoresearch.syscall import SyscallRequest
+
+    record = RunRecord(
+        run_id="tsp-3", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
+    )
+    parked = RunParked(
+        phase="author-sleep",
+        afterany="",
+        base_sha="b" * 40,
+        seed=7,
+        suite_seed=9,
+        candidate_sha="c" * 40,
+        session=_session("s10"),
+        syscall=SyscallRequest(launches=(), note="pausing to reread results next wake"),
+        launches_used=2,
+        sleeps_used=3,
+    )
+    _park_run(tmp_path, record, parked, "refs/dispatch/tok", eval_minutes=90, now=1000.0)
+
+    r = load_record(tmp_path, "tsp-3")
+    assert r.state == "waiting"
+    # the writer itself must produce the near-term deadline — not the queue
+    # slack, and not the benchmark eval hint (nothing was dispatched)
+    assert r.deadline == 1000.0 + CHECKPOINT_SLEEP_SLACK_MIN * 60
+    assert r.stage["syscall_launches"] == []
+    assert r.stage["launches_used"] == 2 and r.stage["sleeps_used"] == 3
 
 
 def test_park_run_redacts_the_saved_report(tmp_path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -245,25 +245,37 @@ def test_blind_park_before_its_deadline_is_left_alone(tmp_path: Path) -> None:
     assert dispatcher.dispatched == []
 
 
-def test_sealed_candidate_park_wakes_immediately(tmp_path: Path) -> None:
-    """A submit-park (candidate sealed in the stage, no jobs to wait on) is
-    not blind — the decide can start now. Observed live on the first
-    submit-path run (2026-08-27): the sweep rode the 12h deadline floor
-    instead of waking a run whose stage already carried the candidate."""
+def test_checkpoint_sleep_park_deadline_is_near_term() -> None:
+    """A jobless checkpoint sleep must not inherit the 12h QUEUE slack (it has
+    nothing in any queue) — its deadline reaches only the next sweep pass.
+    Observed live (yolo heldout_probe, 2026-08-27): a nap became a 12h coma,
+    and the existing deadline-floor branch then wakes it promptly."""
+    from autoresearch.attempt import CHECKPOINT_SLEEP_SLACK_MIN, PARK_QUEUE_SLACK_MIN
+
+    assert CHECKPOINT_SLEEP_SLACK_MIN * 60 < 3600  # near-term, sub-hour
+    assert PARK_QUEUE_SLACK_MIN == 12 * 60  # queue slack untouched
+
+
+def test_jobless_park_past_deadline_wakes_via_floor(tmp_path: Path) -> None:
+    # the sweep side of the checkpoint-sleep story: once its (now near-term)
+    # deadline passes, the existing blind-park floor delivers the wake — no
+    # special predicate that could over-match blind re-parks or long sleeps
     waiting_run(
         tmp_path,
         experiment_job_id="",
-        deadline=NOW + 10_000,  # far future: the wake must NOT need the floor
+        deadline=NOW - 1,
         stage={
             "afterany": "",
             "base_branch": "main",
             "base_sha": "b" * 40,
             "candidate_ref": "refs/autoresearch/r1",
             "candidate_sha": "c" * 40,
+            "phase": "author-sleep",
+            "syscall_launches": [],
         },
     )
     _, dispatcher = run_tick(tmp_path, FakeSlurm(states={}))
-    assert dispatcher.dispatched == [("r1", "sealed candidate awaiting decide")]
+    assert dispatcher.dispatched == [("r1", "blind park past deadline")]
 
 
 def test_multi_job_park_wakes_when_all_afterany_jobs_finish(tmp_path: Path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -245,6 +245,27 @@ def test_blind_park_before_its_deadline_is_left_alone(tmp_path: Path) -> None:
     assert dispatcher.dispatched == []
 
 
+def test_sealed_candidate_park_wakes_immediately(tmp_path: Path) -> None:
+    """A submit-park (candidate sealed in the stage, no jobs to wait on) is
+    not blind — the decide can start now. Observed live on the first
+    submit-path run (2026-08-27): the sweep rode the 12h deadline floor
+    instead of waking a run whose stage already carried the candidate."""
+    waiting_run(
+        tmp_path,
+        experiment_job_id="",
+        deadline=NOW + 10_000,  # far future: the wake must NOT need the floor
+        stage={
+            "afterany": "",
+            "base_branch": "main",
+            "base_sha": "b" * 40,
+            "candidate_ref": "refs/autoresearch/r1",
+            "candidate_sha": "c" * 40,
+        },
+    )
+    _, dispatcher = run_tick(tmp_path, FakeSlurm(states={}))
+    assert dispatcher.dispatched == [("r1", "sealed candidate awaiting decide")]
+
+
 def test_multi_job_park_wakes_when_all_afterany_jobs_finish(tmp_path: Path) -> None:
     """A multi-job park (candidate + siblings, several author launches)
     records no single experiment_job_id — the sweep polls every id in the


### PR DESCRIPTION
**Root cause (third diagnosis, this one from the live record + terra's counter-evidence):** the overnight yolo run's stall was neither a sweep bug nor a submit-park bug. The park was a launch-less **checkpoint sleep** (`syscall_launches=[]`, no submitted marker, report staged for the next wake) — and the park writer adds `PARK_QUEUE_SLACK_MIN` (**12h of queue slack**, sized to protect queued Slurm jobs from cancel-on-pending) to *every* deadline, including a park with nothing in any queue. The writer's own comment promises "floor 0 wakes it at the first deadline pass"; the queue slack made that pass 12 hours away.

**The fix (writer-side, per terra's round):** a jobless author-sleep park gets `CHECKPOINT_SLEEP_SLACK_MIN` (45 min — one cadence + coalescing headroom); parks with queued jobs keep the full queue slack. The earlier wake-on-sight sweep predicate is **reverted** — terra's two blocking findings were correct that it over-matched checkpoint sleeps and blind `MeasurementPending` re-parks (which must space retries on the floor, not burn `wake_attempts` every tick). The sweep gains no new predicate at all.

Pinned: near-term constant (sub-hour) + queue slack untouched; a jobless past-deadline park wakes via the existing floor branch; blind-re-park tests unchanged. Full gate green.

**Live-run note:** tonight's parked run persisted its 12h deadline already, so this fix helps every *future* nap; the current run wakes at ~12:18 EDT via the floor either way (or sooner by a manual wake — the proven procedure from the 08-25 validation — if we don't want to wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)