### PR TITLE
feat: the judge's taste learns the aggregation standard (yolo#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- The verify lens's rubric gains the code owner's aggregation standard
+  (set closing yolo-jepa#16): a delta that clears the significance floor
+  only as a MIXTURE of individually sub-floor tweaks is a finding — a
+  publishable improvement needs an identifiable mechanism that clears the
+  floor on its own. New `aggregation` category in the verify taxonomy.
+
 ### Removed
 
 - The review-path hermes CACHE machinery, wholesale (provision job, shared

--- a/src/autoresearch/verifier.py
+++ b/src/autoresearch/verifier.py
@@ -118,6 +118,7 @@ CATEGORIES = (
     "overfitting",
     "unsupported-claim",
     "measurement-gap",
+    "aggregation",
     "other",
 )
 
@@ -151,6 +152,13 @@ measured:
   mechanism) that the provided evidence does not back
 - measurement-gap: noise floors, seeds, or protocol issues that make the
   claimed delta unconvincing at its size
+- aggregation: the delta clears the significance floor only as a MIXTURE
+  of several individually sub-floor tweaks. The code owner's standard
+  (set closing yolo-jepa#16): a publishable improvement needs an
+  identifiable mechanism whose effect clears the floor ON ITS OWN — an
+  even blend of small terms buys a number while losing clarity on what
+  actually works. Check the ablations: if no single component carries the
+  win, say so
 
 Use the contract (the rules), the ruler source (how the eval actually
 works), the claimed numbers, and the agent's own report. The report's

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -249,3 +249,13 @@ def test_gather_thread_gates_by_standing_and_orders_chronologically() -> None:
     # drive-by, and the forger who copied the marker without the posting identity.
     assert authors == ["maint", BOT, "github-actions[bot]"]
     assert "drive-by" not in authors and "forger" not in authors
+
+
+def test_aggregation_is_a_first_class_verify_category() -> None:
+    # the code owner's standard from yolo-jepa#16: a mixture must not clear
+    # the floor by aggregation — the judge's taste names it, the syscall
+    # clamp keeps it (a taxonomy miss would silently demote it to 'other')
+    from autoresearch.verifier import CATEGORIES, VERIFY_SYSTEM_PROMPT
+
+    assert "aggregation" in CATEGORIES
+    assert "clears the floor ON ITS OWN" in VERIFY_SYSTEM_PROMPT


### PR DESCRIPTION
Codifies Mengye's closing reason on yolo-jepa#16 into the **verify lens's rubric** — the panel judge that grades climb candidates pre-PR — so the standard is enforced by the gate rather than only at the human merge:

> a delta that clears the significance floor only as a **mixture** of individually sub-floor tweaks buys a number while losing clarity on what actually works; a publishable improvement needs an **identifiable mechanism whose effect clears the floor on its own**.

The rubric bullet tells the judge to check the ablations for which component carries the win; `aggregation` joins the verify category taxonomy (without it, the syscall finding clamp would silently demote such findings to `other`). Pinned: category present + rubric line present. Full gate green.

This is also a prerequisite on the auto-merge path for the speedrun era: once the human checkpoint is removed, every taste standard has to live in the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)