### PR TITLE
fix: the gate enforces the contract's significance floor (yolo#16 audit)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- The gate now enforces the contract's declared significance floor
+  (`min_delta`/`min_delta_rel`): the decide previously applied only the
+  global relative default (0.5%), so a benchmark's calibrated noise floor
+  was consulted by the followup comparison path but never by the publish
+  gate — yolo#16 shipped at +0.0379 against a declared 0.04 floor. A delta
+  inside the floor now ends `no-improvement` with the reason on the record;
+  benchmarks that declare no floor keep today's behavior. Same-seed pairing
+  removes pool noise, not training stochasticity — which is exactly what a
+  declared floor is calibrated to. Specific no-improvement reasons now
+  survive to the record instead of being overwritten by generic framing.
+  Auto-mode prerequisite #1 (docs/design/headline.md) done.
+
 ### Added
 
 - The verify lens's rubric gains the code owner's aggregation standard

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -801,7 +801,9 @@ def measure_and_decide(
     floor = benchmark_floor(baseline, bench.min_delta, bench.min_delta_rel)
     if floor:
         delta = (candidate - baseline) if bench.direction == "max" else (baseline - candidate)
-        if delta < floor:
+        # STRICTLY greater, matching clears_min_delta: a delta exactly at the
+        # floor is indistinguishable from the noise the floor models
+        if delta <= floor:
             return AttemptResult(
                 outcome="no-improvement",
                 note=(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -791,6 +791,27 @@ def measure_and_decide(
             candidate=candidate,
             run_seed=seed,
         )
+    # The contract's OWN significance floor, when the benchmark declares one.
+    # Same-seed pairing removes pool noise but not training stochasticity —
+    # a benchmark whose eval trains models calibrates min_delta to its
+    # cross-run sd, and the gate must speak that language too (yolo#16
+    # published at +0.0379 against a declared 0.04 floor because only the
+    # followup path read it). No declared floor -> the relative default
+    # above remains the whole bar.
+    floor = benchmark_floor(baseline, bench.min_delta, bench.min_delta_rel)
+    if floor:
+        delta = (candidate - baseline) if bench.direction == "max" else (baseline - candidate)
+        if delta < floor:
+            return AttemptResult(
+                outcome="no-improvement",
+                note=(
+                    f"delta {delta:+.6g} is inside the contract's significance "
+                    f"floor ({floor:g}): real movement, not creditable progress"
+                ),
+                baseline=baseline,
+                candidate=candidate,
+                run_seed=seed,
+            )
 
     # PHASE 2 — suite gate, only for a credited candidate whose diff touched
     # shared code. A second measure set (a second park for a dispatched
@@ -921,7 +942,10 @@ def resume_attempt(
         # no-improvement the same framing the in-job path sets (a clear
         # negative is a success), so a resumed negative does not end note-less.
         note = outcome.note
-        if outcome.outcome == "no-improvement":
+        if outcome.outcome == "no-improvement" and not note:
+            # only a BARE negative gets the generic framing — a specific
+            # reason (e.g. inside the contract's significance floor) must
+            # survive to the record and report
             note = "a negative result reported clearly is a success"
         return dc_replace(outcome, session=session, note=note)
     # credited: candidate cleared the threshold and no sibling regressed. The
@@ -1367,7 +1391,10 @@ def attempt_once(
             # measured (None when it never got that far, e.g. scope-violation),
             # never overwritten with the ledger's brief number.
             note = outcome.note
-            if outcome.outcome == "no-improvement":
+            if outcome.outcome == "no-improvement" and not note:
+                # only a BARE negative gets generic framing — a specific
+                # reason (e.g. inside the contract's significance floor)
+                # must survive to the record and report
                 note = (
                     "the revision addressing panel findings lost the improvement"
                     if panel_reads

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1385,3 +1385,28 @@ def test_wake_without_a_session_id_fails_closed_to_draft(tmp_path: Path) -> None
     assert result.outcome == "improved"
     assert result.panel_blocking_open  # draft path, not a blind fresh session
     assert len(harness.resumes) == 1  # no wake attempted
+
+
+FLOOR_CONTRACT = CONTRACT.replace(
+    "    direction: min\n",
+    "    direction: min\n    min_delta: 0.5\n",
+    1,
+)
+
+
+def test_gate_enforces_the_contracts_declared_floor(tmp_path: Path) -> None:
+    """The yolo#16 class: a delta that clears the relative default but sits
+    inside the contract's declared min_delta must end no-improvement — the
+    gate speaks the contract's significance language, not only the global
+    relative default. (Same-seed pairing removes pool noise, not training
+    stochasticity — which is what a declared floor is calibrated to.)"""
+    # 13.876 -> 13.5: 2.7% relative (clears the 0.5% default) but delta
+    # 0.376 < the declared 0.5 floor
+    result, _, _ = run_climb(tmp_path, [13.876, 13.5], contract=FLOOR_CONTRACT)
+    assert result.outcome == "no-improvement"
+    assert "significance" in result.note and "floor" in result.note
+
+
+def test_gate_publishes_a_floor_clearing_delta(tmp_path: Path) -> None:
+    result, _, _ = run_climb(tmp_path, [13.876, 13.0], contract=FLOOR_CONTRACT)
+    assert result.outcome == "improved"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1410,3 +1410,10 @@ def test_gate_enforces_the_contracts_declared_floor(tmp_path: Path) -> None:
 def test_gate_publishes_a_floor_clearing_delta(tmp_path: Path) -> None:
     result, _, _ = run_climb(tmp_path, [13.876, 13.0], contract=FLOOR_CONTRACT)
     assert result.outcome == "improved"
+
+
+def test_gate_rejects_an_exact_floor_delta(tmp_path: Path) -> None:
+    # boundary matches clears_min_delta: STRICTLY greater publishes — a
+    # delta exactly at the floor is the noise the floor models (terra #169)
+    result, _, _ = run_climb(tmp_path, [13.876, 13.376], contract=FLOOR_CONTRACT)
+    assert result.outcome == "no-improvement"


### PR DESCRIPTION
The min_delta audit (auto-mode prerequisite #1) concluded: **the gate and the contract speak different threshold languages.** The publish gate applied only the global relative default (`min_relative_improvement` = 0.5%); the contract's per-benchmark `min_delta` — calibrated to measured cross-run noise (yolo: 2√2·sd) — was enforced by the followup comparison path and **never by the gate**. That's how yolo#16 published at +0.0379 against a declared 0.04 floor (+6.97% relative ≫ 0.5%).

## Fix
`measure_and_decide` now applies `benchmark_floor(baseline, min_delta, min_delta_rel)` after the relative check: a delta inside the declared floor ends `no-improvement` with the reason on the record. Benchmarks declaring no floor keep today's behavior exactly. The design rationale is stated in-code: same-seed pairing removes *pool* noise but not *training* stochasticity, and declared floors are calibrated to precisely that.

Also fixed en route: both no-improvement terminals (in-job + resumed) overwrote specific notes with the generic "a clear negative is a success" framing — they now only frame *bare* negatives, so specific reasons survive to the record and report.

Pinned on #16's shape: relative-clearing + floor-violating → rejected with reason; floor-clearing → publishes. Full gate green.

With this and #167 (aggregation taste), the remaining auto-mode prerequisite is the suite no-regression gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)