### PR TITLE
feat: attempt_cooldown_minutes — the cooldown becomes a contract dial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `attempt_cooldown_minutes` joins the contract budgets: the per-benchmark
+  self-initiated cooldown becomes a target-owner dial. Unset keeps the 6h
+  default (right for a standard research repo); an RSI/speedrun target sets
+  0 for back-to-back re-dispatch, with `runs_per_week` as the spend guard.
+  Still serial per target until the width dial lands.
+
+### Added
+
 - The merge-policy dial: a contract-level `merge: manual | auto` knob
   (default `manual`, unchanged behavior). In `auto`, a gate+panel-clean PR
   merges itself — the publish arms GitHub auto-merge, or merges directly

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -155,6 +155,13 @@ class Budgets(_StrictModel):
     session_minutes: int | None = Field(default=None, gt=0)
     attempt_job_minutes: int | None = Field(default=None, gt=0)
     followup_job_minutes: int | None = Field(default=None, gt=0)
+    # Per-benchmark self-initiated cooldown, in minutes. Default (unset) is
+    # the orchestrator's 6h — right for a standard research repo. An RSI /
+    # speedrun target sets 0: the loop re-dispatches back-to-back and
+    # `runs_per_week` becomes the spend guard (Mengye: "for the RSI
+    # experiment — no cooldown; make sure the cluster is hot"). Still
+    # SERIAL per target until the width dial lands.
+    attempt_cooldown_minutes: int | None = Field(default=None, ge=0)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1375,7 +1375,7 @@ def pick_self_initiated(
     contract: Any,
     target: str,
     now: float,
-    pending_attempt: tuple[str, float] | None = None,
+    dead_attempts: dict[str, float] | None = None,
 ) -> str | None:
     """The benchmark to climb next on `target`, or None.
 
@@ -1383,9 +1383,10 @@ def pick_self_initiated(
     to one active run per target, respect the contract's weekly budget and a
     per-benchmark cooldown, then choose the benchmark least recently
     attempted — untouched ones first. Only this target's runs count toward
-    any of it. `pending_attempt` is a (benchmark, submitted_at) from a climb
-    job that died before writing a run record — it counts toward cooldown so
-    a crash loop can't resubmit every tick.
+    any of it. `dead_attempts` maps benchmark -> submitted_at for launches
+    that died BEFORE writing a run record (per-benchmark tombstones) — each
+    counts toward cooldown with a crash-loop floor, so alternating
+    pre-record failures can't ping-pong every tick (terra #172 r2/r3).
     """
     mine = [r for r in records if r.target == target]
 
@@ -1402,8 +1403,7 @@ def pick_self_initiated(
     for r in mine:
         if r.benchmark:
             last_attempt[r.benchmark] = max(last_attempt.get(r.benchmark, 0.0), r.created)
-    if pending_attempt is not None and pending_attempt[0]:
-        bench_name, submitted_at = pending_attempt
+    for bench_name, submitted_at in (dead_attempts or {}).items():
         last_attempt[bench_name] = max(last_attempt.get(bench_name, 0.0), submitted_at)
     cooldown_min = getattr(contract.budgets, "attempt_cooldown_minutes", None)
     cooldown_s = SELF_INITIATED_COOLDOWN_S if cooldown_min is None else cooldown_min * 60
@@ -1412,18 +1412,64 @@ def pick_self_initiated(
     # guard — it keeps a floor even when the contract dials cooldown to 0
     # (terra #172: zero cooldown otherwise resubmits a crashing launch
     # every tick, uncapped).
-    dead_pending_bench = pending_attempt[0] if pending_attempt else ""
+    dead_benches = set(dead_attempts or ())
     candidates = sorted(
         contract.benchmarks,
         key=lambda b: (last_attempt.get(b.name, 0.0), b.name),
     )
     for bench in candidates:
         floor_s = cooldown_s
-        if bench.name == dead_pending_bench:
+        if bench.name in dead_benches:
             floor_s = max(cooldown_s, DEAD_LAUNCH_BACKOFF_S)
         if now - last_attempt.get(bench.name, 0.0) >= floor_s:
             return str(bench.name)
     return None
+
+
+def _tombstone_path(root: Path, target: str, benchmark: str) -> Path:
+    safe = f"{target.replace('/', '__')}__{benchmark}"
+    return root / "pending-dead" / (safe + ".json")
+
+
+def write_tombstone(root: Path, target: str, benchmark: str, submitted_at: float) -> None:
+    """Per-benchmark crash memory: a launch died before writing a record, so
+    nothing else (runs_per_week, cooldown-by-records) can see it. The
+    tombstone persists independently of the live pending marker — a second
+    benchmark's launch must not erase it (terra #172 r3)."""
+    path = _tombstone_path(root, target, benchmark)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"submitted_at": submitted_at}))
+    except OSError as exc:
+        log.warning("tombstone write failed for %s/%s: %s", target, benchmark, exc)
+
+
+def read_tombstones(root: Path, target: str, contract: Any, now: float) -> dict[str, float]:
+    """benchmark -> submitted_at for unserved crash tombstones; entries past
+    their window (the larger of the crash floor and the contract cooldown)
+    are pruned on read."""
+    cooldown_min = getattr(contract.budgets, "attempt_cooldown_minutes", None)
+    cooldown_s = SELF_INITIATED_COOLDOWN_S if cooldown_min is None else cooldown_min * 60
+    window = max(DEAD_LAUNCH_BACKOFF_S, cooldown_s)
+    out: dict[str, float] = {}
+    prefix = target.replace("/", "__") + "__"
+    dead_dir = root / "pending-dead"
+    if not dead_dir.is_dir():
+        return out
+    for path in dead_dir.glob(prefix + "*.json"):
+        bench = path.stem[len(prefix) :]
+        try:
+            submitted_at = float(json.loads(path.read_text())["submitted_at"])
+        except (OSError, ValueError, KeyError, TypeError):
+            with contextlib.suppress(OSError):
+                path.unlink()
+            continue
+        if now - submitted_at > window:
+            with contextlib.suppress(OSError):
+                path.unlink()  # backoff served
+            continue
+        out[bench] = submitted_at
+    return out
 
 
 def _pending_path(root: Path, target: str) -> Path:
@@ -1686,7 +1732,7 @@ def service_self_initiated(
     try:
         records = list_runs(root)
         pending = read_pending(root, spec.target)
-        pending_attempt: tuple[str, float] | None = None
+        # (crash memory now lives in per-benchmark tombstones, read below)
         if pending is not None:
             submitted_at = float(pending["submitted_at"])
             landed = any(
@@ -1704,22 +1750,14 @@ def service_self_initiated(
                 # Slurm can't say (a dup submit is worse than a slow retry).
                 return None
             else:
-                # Died before writing a record: the marker is the ONLY
-                # memory of the crash (no record exists for runs_per_week or
-                # cooldown to see), so it persists as a TOMBSTONE until the
-                # backoff window is served — clearing immediately made the
-                # attribution one-tick amnesia (terra #172 r2). The window is
-                # the larger of the crash floor and the contract's own
-                # cooldown, which also closes the pre-existing one-tick leak
-                # on standard repos.
-                cooldown_min = getattr(contract.budgets, "attempt_cooldown_minutes", None)
-                cooldown_s = (
-                    SELF_INITIATED_COOLDOWN_S if cooldown_min is None else cooldown_min * 60
-                )
-                if now - submitted_at > max(DEAD_LAUNCH_BACKOFF_S, cooldown_s):
-                    clear_pending(root, spec.target)  # backoff served
-                pending_attempt = (str(pending.get("benchmark", "")), submitted_at)
-        benchmark = pick_self_initiated(records, contract, spec.target, now, pending_attempt)
+                # Died before writing a record: persist the crash memory as a
+                # PER-BENCHMARK tombstone (a second benchmark's launch reuses
+                # the live marker and must not erase this — terra #172 r3),
+                # then free the live slot.
+                write_tombstone(root, spec.target, str(pending.get("benchmark", "")), submitted_at)
+                clear_pending(root, spec.target)
+        dead_attempts = read_tombstones(root, spec.target, contract, now)
+        benchmark = pick_self_initiated(records, contract, spec.target, now, dead_attempts)
         if benchmark is None:
             return None
         if getattr(contract, "merge", "manual") == "auto" and not spec.panel:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1704,9 +1704,20 @@ def service_self_initiated(
                 # Slurm can't say (a dup submit is worse than a slow retry).
                 return None
             else:
-                # Died before writing a record. Keep its cooldown so a
-                # crash-at-startup loop can't resubmit every tick.
-                clear_pending(root, spec.target)
+                # Died before writing a record: the marker is the ONLY
+                # memory of the crash (no record exists for runs_per_week or
+                # cooldown to see), so it persists as a TOMBSTONE until the
+                # backoff window is served — clearing immediately made the
+                # attribution one-tick amnesia (terra #172 r2). The window is
+                # the larger of the crash floor and the contract's own
+                # cooldown, which also closes the pre-existing one-tick leak
+                # on standard repos.
+                cooldown_min = getattr(contract.budgets, "attempt_cooldown_minutes", None)
+                cooldown_s = (
+                    SELF_INITIATED_COOLDOWN_S if cooldown_min is None else cooldown_min * 60
+                )
+                if now - submitted_at > max(DEAD_LAUNCH_BACKOFF_S, cooldown_s):
+                    clear_pending(root, spec.target)  # backoff served
                 pending_attempt = (str(pending.get("benchmark", "")), submitted_at)
         benchmark = pick_self_initiated(records, contract, spec.target, now, pending_attempt)
         if benchmark is None:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1402,12 +1402,14 @@ def pick_self_initiated(
     if pending_attempt is not None and pending_attempt[0]:
         bench_name, submitted_at = pending_attempt
         last_attempt[bench_name] = max(last_attempt.get(bench_name, 0.0), submitted_at)
+    cooldown_min = getattr(contract.budgets, "attempt_cooldown_minutes", None)
+    cooldown_s = SELF_INITIATED_COOLDOWN_S if cooldown_min is None else cooldown_min * 60
     candidates = sorted(
         contract.benchmarks,
         key=lambda b: (last_attempt.get(b.name, 0.0), b.name),
     )
     for bench in candidates:
-        if now - last_attempt.get(bench.name, 0.0) >= SELF_INITIATED_COOLDOWN_S:
+        if now - last_attempt.get(bench.name, 0.0) >= cooldown_s:
             return str(bench.name)
     return None
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1355,6 +1355,9 @@ def replace_report(
 
 MAX_ACTIVE_RUNS_PER_TARGET = 1
 SELF_INITIATED_COOLDOWN_S = 6 * 3600
+# the crash-loop floor: a launch that died pre-record backs off at least
+# this long regardless of the contract's cooldown dial
+DEAD_LAUNCH_BACKOFF_S = 30 * 60
 # An implementing run untouched for this long is a crashed climb job; it must
 # not block the lane forever, but the window must exceed the LONGEST honest
 # job — the 120-min contract ceiling plus the panel allowance the tick adds
@@ -1404,12 +1407,21 @@ def pick_self_initiated(
         last_attempt[bench_name] = max(last_attempt.get(bench_name, 0.0), submitted_at)
     cooldown_min = getattr(contract.budgets, "attempt_cooldown_minutes", None)
     cooldown_s = SELF_INITIATED_COOLDOWN_S if cooldown_min is None else cooldown_min * 60
+    # A launch that died BEFORE writing a run record is invisible to the
+    # runs_per_week cap, so its cooldown attribution is the ONLY crash-loop
+    # guard — it keeps a floor even when the contract dials cooldown to 0
+    # (terra #172: zero cooldown otherwise resubmits a crashing launch
+    # every tick, uncapped).
+    dead_pending_bench = pending_attempt[0] if pending_attempt else ""
     candidates = sorted(
         contract.benchmarks,
         key=lambda b: (last_attempt.get(b.name, 0.0), b.name),
     )
     for bench in candidates:
-        if now - last_attempt.get(bench.name, 0.0) >= cooldown_s:
+        floor_s = cooldown_s
+        if bench.name == dead_pending_bench:
+            floor_s = max(cooldown_s, DEAD_LAUNCH_BACKOFF_S)
+        if now - last_attempt.get(bench.name, 0.0) >= floor_s:
             return str(bench.name)
     return None
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -781,7 +781,7 @@ def test_self_initiated_selection_rules() -> None:
     records = [_run(f"r{i}", "tsp", NOW - i * 3600) for i in range(3)]
     assert pick(records) is None
     # a pending attempt that died pre-record still counts toward cooldown
-    assert pick([], pending_attempt=("denoise", NOW - 60)) == "reach"
+    assert pick([], dead_attempts={"denoise": NOW - 60}) == "reach"
 
 
 def test_self_initiated_scoped_to_target() -> None:
@@ -2561,49 +2561,50 @@ roadmap: docs/roadmap.md
         "o/r",
     )
     # a pre-record death 60s ago: blocked despite cooldown 0
-    assert pick_self_initiated([], hot, "o/r", NOW, ("reach", NOW - 60)) is None
+    assert pick_self_initiated([], hot, "o/r", NOW, {"reach": NOW - 60}) is None
     # past the floor: dispatches again
     assert (
-        pick_self_initiated([], hot, "o/r", NOW, ("reach", NOW - DEAD_LAUNCH_BACKOFF_S - 1))
+        pick_self_initiated([], hot, "o/r", NOW, {"reach": NOW - DEAD_LAUNCH_BACKOFF_S - 1})
         == "reach"
     )
 
 
-def test_dead_launch_tombstone_persists_across_ticks(tmp_path: Path) -> None:
-    """terra #172 r2: clearing the dead marker immediately made the backoff
-    one-tick amnesia — the tombstone persists until the window is served,
-    refusing dispatch on EVERY tick inside it."""
+def test_dead_launch_tombstones_are_per_benchmark(tmp_path: Path) -> None:
+    """terra #172 r2/r3: crash memory is a per-benchmark tombstone that a
+    SECOND benchmark's launch cannot erase, persists across ticks inside its
+    window, and prunes itself after."""
     from autoresearch.contract import load_contract
     from autoresearch.tick import (
         DEAD_LAUNCH_BACKOFF_S,
-        read_pending,
-        service_research_log,  # noqa: F401  (import side-effect free)
-        service_self_initiated,
-        write_pending,
+        pick_self_initiated,
+        read_tombstones,
+        write_tombstone,
     )
 
     hot = load_contract(
         """
 benchmarks:
   - {name: reach, command: c, metric: m, direction: max}
+  - {name: denoise, command: c, metric: m, direction: max}
 budgets: {gpu_hours_per_run: 1, runs_per_week: 500, attempt_cooldown_minutes: 0}
 scope: {allowed: [src/]}
 roadmap: docs/roadmap.md
 """,
         "o/r",
     )
-    spec = _spec(target="o/r")
-    write_pending(tmp_path, "o/r", "reach", "999", NOW - 60)  # died pre-record
-
-    class DeadSlurm:
-        def status(self, jid):
-            return "FAILED"
-
-    # two consecutive ticks inside the window: both refuse, marker survives
-    for _ in range(2):
-        assert service_self_initiated(tmp_path, DeadSlurm(), spec, hot, NOW) is None
-        assert read_pending(tmp_path, "o/r") is not None
-    # past the window: the tombstone clears (dispatch path proceeds to launch
-    # wiring, which this unit test does not exercise further)
-    service_self_initiated(tmp_path, DeadSlurm(), spec, hot, NOW + DEAD_LAUNCH_BACKOFF_S + 61)
-    assert read_pending(tmp_path, "o/r") is None
+    write_tombstone(tmp_path, "o/r", "reach", NOW - 60)
+    dead = read_tombstones(tmp_path, "o/r", hot, NOW)
+    # reach is floored; denoise still dispatches (width of the SELECTION,
+    # not an overwrite of reach's memory)
+    assert pick_self_initiated([], hot, "o/r", NOW, dead) == "denoise"
+    # denoise also crashes: BOTH tombstones coexist, nothing dispatches
+    write_tombstone(tmp_path, "o/r", "denoise", NOW - 30)
+    dead = read_tombstones(tmp_path, "o/r", hot, NOW)
+    assert pick_self_initiated([], hot, "o/r", NOW, dead) is None
+    # a second tick inside the window: same refusal (persistence)
+    dead = read_tombstones(tmp_path, "o/r", hot, NOW + 60)
+    assert pick_self_initiated([], hot, "o/r", NOW + 60, dead) is None
+    # past the window: pruned on read, dispatch resumes
+    later = NOW + DEAD_LAUNCH_BACKOFF_S + 61
+    assert read_tombstones(tmp_path, "o/r", hot, later) == {}
+    assert pick_self_initiated([], hot, "o/r", later, {}) == "denoise"

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2567,3 +2567,43 @@ roadmap: docs/roadmap.md
         pick_self_initiated([], hot, "o/r", NOW, ("reach", NOW - DEAD_LAUNCH_BACKOFF_S - 1))
         == "reach"
     )
+
+
+def test_dead_launch_tombstone_persists_across_ticks(tmp_path: Path) -> None:
+    """terra #172 r2: clearing the dead marker immediately made the backoff
+    one-tick amnesia — the tombstone persists until the window is served,
+    refusing dispatch on EVERY tick inside it."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import (
+        DEAD_LAUNCH_BACKOFF_S,
+        read_pending,
+        service_research_log,  # noqa: F401  (import side-effect free)
+        service_self_initiated,
+        write_pending,
+    )
+
+    hot = load_contract(
+        """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 500, attempt_cooldown_minutes: 0}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "o/r",
+    )
+    spec = _spec(target="o/r")
+    write_pending(tmp_path, "o/r", "reach", "999", NOW - 60)  # died pre-record
+
+    class DeadSlurm:
+        def status(self, jid):
+            return "FAILED"
+
+    # two consecutive ticks inside the window: both refuse, marker survives
+    for _ in range(2):
+        assert service_self_initiated(tmp_path, DeadSlurm(), spec, hot, NOW) is None
+        assert read_pending(tmp_path, "o/r") is not None
+    # past the window: the tombstone clears (dispatch path proceeds to launch
+    # wiring, which this unit test does not exercise further)
+    service_self_initiated(tmp_path, DeadSlurm(), spec, hot, NOW + DEAD_LAUNCH_BACKOFF_S + 61)
+    assert read_pending(tmp_path, "o/r") is None

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2513,3 +2513,31 @@ def test_research_log_lost_cache_rediscovers_instead_of_duplicating(tmp_path: Pa
     assert gh.created == []  # rediscovered via the marker, no duplicate
     assert gh.comments == [(77, gh.comments[0][1])]
     assert _ledger_issue_cache(tmp_path, "org/yolo").read_text() == "77"  # re-cached
+
+
+def test_cooldown_dial_zero_redispatches_immediately(tmp_path: Path) -> None:
+    """The RSI-era dial: attempt_cooldown_minutes: 0 re-dispatches
+    back-to-back (runs_per_week is the spend guard); unset keeps the 6h
+    default for standard research repos."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import pick_self_initiated
+
+    base = """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 500%s}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+"""
+    just_ended = RunRecord(
+        run_id="r1",
+        target="o/r",
+        task_title="t",
+        state=ENDED,
+        benchmark="reach",
+        created=NOW - 60,
+    )
+    hot = load_contract(base % ", attempt_cooldown_minutes: 0", "o/r")
+    assert pick_self_initiated([just_ended], hot, "o/r", NOW) == "reach"
+    standard = load_contract(base % "", "o/r")
+    assert pick_self_initiated([just_ended], standard, "o/r", NOW) is None  # 6h holds

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2541,3 +2541,29 @@ roadmap: docs/roadmap.md
     assert pick_self_initiated([just_ended], hot, "o/r", NOW) == "reach"
     standard = load_contract(base % "", "o/r")
     assert pick_self_initiated([just_ended], standard, "o/r", NOW) is None  # 6h holds
+
+
+def test_zero_cooldown_keeps_the_dead_launch_backoff(tmp_path: Path) -> None:
+    """terra #172: a launch that died before writing a record is invisible
+    to runs_per_week, so even a zero-cooldown contract backs it off by the
+    dead-launch floor instead of resubmitting every tick."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import DEAD_LAUNCH_BACKOFF_S, pick_self_initiated
+
+    hot = load_contract(
+        """
+benchmarks:
+  - {name: reach, command: c, metric: m, direction: max}
+budgets: {gpu_hours_per_run: 1, runs_per_week: 500, attempt_cooldown_minutes: 0}
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "o/r",
+    )
+    # a pre-record death 60s ago: blocked despite cooldown 0
+    assert pick_self_initiated([], hot, "o/r", NOW, ("reach", NOW - 60)) is None
+    # past the floor: dispatches again
+    assert (
+        pick_self_initiated([], hot, "o/r", NOW, ("reach", NOW - DEAD_LAUNCH_BACKOFF_S - 1))
+        == "reach"
+    )


### PR DESCRIPTION
Mengye's directive for the RSI era: 6h cooldown suits a standard research repo; the speedrun/RSI target needs **none** — the cluster should run hot. The dial moves to where every other pacing decision lives, the contract:

- `budgets.attempt_cooldown_minutes` — unset keeps the 6h orchestrator default (yolo unchanged); `0` re-dispatches back-to-back, with `runs_per_week` as the spend guard.
- Honest scope note: cooldown-zero makes the loop back-to-back but still **serial** per target (`MAX_ACTIVE_RUNS_PER_TARGET=1`). Full cluster-heat is the **width dial** — the headline plan's next big build (concurrent runs per target, run-keyed branches, merge/race policy).

Pinned: 0 → immediate re-dispatch after a just-ended run; unset → the 6h hold. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)