### PR TITLE
feat: the width dial — max_active_attempts runs N authors abreast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- THE WIDTH DIAL: `budgets.max_active_attempts` runs N self-initiated
+  attempts abreast on one target (default 1 — today's serial behavior).
+  Each slot gets its own agent identity (`agent-01..agent-0N`) threaded
+  via `--agent-id`, keeping branches, ledger rows, and reports distinct;
+  pending markers become per-slot (the legacy un-suffixed marker from a
+  pre-width deploy is still read and attributed); live markers and
+  non-stranded active records both occupy slots; resumed runs inherit
+  identity from their record. With `attempt_cooldown_minutes: 0` this is
+  the RSI-era "cluster hot" configuration — `runs_per_week` and
+  `gpu_hours_per_run` remain the spend guards.
+
+### Added
+
 - `attempt_cooldown_minutes` joins the contract budgets: the per-benchmark
   self-initiated cooldown becomes a target-owner dial. Unset keeps the 6h
   default (right for a standard research repo); an RSI/speedrun target sets

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -2397,7 +2397,9 @@ def main() -> int:
     # file is tolerated only when Vertex (ADC) covers the claude backend.
     api_key = role_key(args.key_file, args.author_backend)
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
-    run_id = f"{args.benchmark}-{stamp}"
+    # the agent id keeps concurrent same-benchmark slots (the width dial's
+    # portfolio case) from minting one run directory in the same second
+    run_id = f"{args.benchmark}-{stamp}-{args.agent_id}"
 
     # Disk preflight BEFORE any run state exists: a session started on a
     # full filesystem dies mid-flight in ways that lose its own evidence

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -2169,6 +2169,10 @@ def main() -> int:
     # on a --resume wake instead, so they are optional (validated below).
     parser.add_argument("--target", default="")
     parser.add_argument("--benchmark", default="")
+    # WIDTH: the tick assigns each concurrent slot its own agent identity;
+    # branches, ledger rows, and reports key on it. Resumed runs inherit
+    # the identity from their record instead.
+    parser.add_argument("--agent-id", default="agent-01")
     parser.add_argument("--run-root", required=True, type=Path)
     parser.add_argument(
         "--resume",
@@ -2452,7 +2456,9 @@ def main() -> int:
     try:
         try:
             outcome = live_attempt(
-                config=RunConfig(target=args.target, benchmark=args.benchmark),
+                config=RunConfig(
+                    target=args.target, benchmark=args.benchmark, agent_id=args.agent_id
+                ),
                 base_branch=args.base_branch,
                 run_root=args.run_root,
                 run_id=run_id,

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -162,6 +162,12 @@ class Budgets(_StrictModel):
     # experiment — no cooldown; make sure the cluster is hot"). Still
     # SERIAL per target until the width dial lands.
     attempt_cooldown_minutes: int | None = Field(default=None, ge=0)
+    # THE WIDTH DIAL: concurrent self-initiated attempts per target. Default
+    # (unset) = 1, today's serial behavior. An RSI/speedrun target raises it
+    # to run N authors abreast — each slot gets its own agent identity
+    # (agent-01..agent-0N), so branches, ledger rows, and reports stay
+    # distinct. runs_per_week and gpu_hours_per_run remain the spend guards.
+    max_active_attempts: int | None = Field(default=None, ge=1)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1394,7 +1394,7 @@ def pick_self_initiated(
         return r.state == IMPLEMENTING and now - max(r.updated, r.created) > STRANDED_IMPLEMENTING_S
 
     active = [r for r in mine if r.state != ENDED and not stranded(r)]
-    if len(active) >= MAX_ACTIVE_RUNS_PER_TARGET:
+    if len(active) >= _attempt_width(contract):
         return None
     week_ago = now - 7 * 24 * 3600
     if sum(1 for r in mine if r.created >= week_ago) >= contract.budgets.runs_per_week:
@@ -1472,13 +1472,16 @@ def read_tombstones(root: Path, target: str, contract: Any, now: float) -> dict[
     return out
 
 
-def _pending_path(root: Path, target: str) -> Path:
-    return root / "pending" / (target.replace("/", "__") + ".json")
+def _pending_path(root: Path, target: str, agent: str = "") -> Path:
+    # agent "" is the legacy single-slot name, still read for back-compat
+    # with a marker written before the width dial deployed
+    suffix = f"__{agent}" if agent else ""
+    return root / "pending" / (target.replace("/", "__") + suffix + ".json")
 
 
-def read_pending(root: Path, target: str) -> dict[str, Any] | None:
+def read_pending(root: Path, target: str, agent: str = "") -> dict[str, Any] | None:
     """The submit-time marker for a climb whose run record may not exist yet."""
-    path = _pending_path(root, target)
+    path = _pending_path(root, target, agent)
     try:
         data = json.loads(path.read_text())
     except (OSError, ValueError):
@@ -1486,16 +1489,56 @@ def read_pending(root: Path, target: str) -> dict[str, Any] | None:
     return data if isinstance(data, dict) and "submitted_at" in data else None
 
 
-def write_pending(root: Path, target: str, benchmark: str, job_id: str, now: float) -> None:
-    path = _pending_path(root, target)
+def list_pendings(root: Path, target: str) -> list[tuple[str, dict[str, Any]]]:
+    """(agent, marker) for every live pending marker of `target` — one per
+    WIDTH slot, plus the legacy un-suffixed marker from a pre-width deploy
+    (attributed to agent-01)."""
+    out: list[tuple[str, dict[str, Any]]] = []
+    stem = target.replace("/", "__")
+    pending_dir = root / "pending"
+    if not pending_dir.is_dir():
+        return out
+    for path in sorted(pending_dir.glob(stem + "*.json")):
+        name = path.stem
+        agent = name[len(stem) + 2 :] if name.startswith(stem + "__") else ""
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, ValueError):
+            continue
+        if isinstance(data, dict) and "submitted_at" in data:
+            out.append((agent or str(data.get("agent_id") or "agent-01"), data))
+    return out
+
+
+def write_pending(
+    root: Path, target: str, benchmark: str, job_id: str, now: float, agent: str = ""
+) -> None:
+    path = _pending_path(root, target, agent)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps({"benchmark": benchmark, "job_id": job_id, "submitted_at": now}))
+    tmp.write_text(
+        json.dumps(
+            {"benchmark": benchmark, "job_id": job_id, "submitted_at": now, "agent_id": agent}
+        )
+    )
     os.replace(tmp, path)
 
 
-def clear_pending(root: Path, target: str) -> None:
-    _pending_path(root, target).unlink(missing_ok=True)
+def clear_pending(root: Path, target: str, agent: str = "") -> None:
+    _pending_path(root, target, agent).unlink(missing_ok=True)
+
+
+def _attempt_width(contract: Any) -> int:
+    width = getattr(getattr(contract, "budgets", None), "max_active_attempts", None)
+    return int(width) if width else MAX_ACTIVE_RUNS_PER_TARGET
+
+
+def _free_agent_slot(occupied: set[str], width: int) -> str | None:
+    for i in range(1, width + 1):
+        agent = f"agent-{i:02d}"
+        if agent not in occupied:
+            return agent
+    return None
 
 
 def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
@@ -1731,31 +1774,44 @@ def service_self_initiated(
         return None
     try:
         records = list_runs(root)
-        pending = read_pending(root, spec.target)
-        # (crash memory now lives in per-benchmark tombstones, read below)
-        if pending is not None:
+        width = _attempt_width(contract)
+        # WIDTH: every live pending marker occupies a slot; landed ones
+        # clear; dead ones become per-benchmark tombstones and free theirs.
+        occupied: set[str] = set()
+        for agent, pending in list_pendings(root, spec.target):
+            marker_agent = "" if not pending.get("agent_id") else agent
             submitted_at = float(pending["submitted_at"])
             landed = any(
                 r.target == spec.target and r.created >= submitted_at - 60 for r in records
             )
             expired = now - submitted_at > PENDING_TTL_S
             if landed:
-                clear_pending(root, spec.target)  # the run record carries it now
+                clear_pending(root, spec.target, marker_agent)
             elif (alive := _holder_alive(compute, str(pending.get("job_id", "")))) is True or (
                 not expired and alive is not False
             ):
                 # climb queued or starting; its record isn't written yet. A
-                # provably-alive job waits regardless of the marker's TTL —
-                # queue wait can exceed it — the TTL only breaks ties when
-                # Slurm can't say (a dup submit is worse than a slow retry).
-                return None
+                # provably-alive job holds its SLOT regardless of the
+                # marker's TTL — queue wait can exceed it — the TTL only
+                # breaks ties when Slurm can't say.
+                occupied.add(agent)
             else:
                 # Died before writing a record: persist the crash memory as a
-                # PER-BENCHMARK tombstone (a second benchmark's launch reuses
-                # the live marker and must not erase this — terra #172 r3),
-                # then free the live slot.
+                # PER-BENCHMARK tombstone (a sibling launch must not erase
+                # this — terra #172 r3), then free the slot.
                 write_tombstone(root, spec.target, str(pending.get("benchmark", "")), submitted_at)
-                clear_pending(root, spec.target)
+                clear_pending(root, spec.target, marker_agent)
+        stranded_cutoff = now - STRANDED_IMPLEMENTING_S
+        for r in records:
+            if r.target == spec.target and r.state != ENDED:
+                if r.state == IMPLEMENTING and max(r.updated, r.created) <= stranded_cutoff:
+                    continue  # stranded: pick ignores it, so must occupancy
+                occupied.add(r.agent_id)
+        if len(occupied) >= width:
+            return None
+        slot_agent = _free_agent_slot(occupied, width)
+        if slot_agent is None:
+            return None
         dead_attempts = read_tombstones(root, spec.target, contract, now)
         benchmark = pick_self_initiated(records, contract, spec.target, now, dead_attempts)
         if benchmark is None:
@@ -1806,6 +1862,8 @@ def service_self_initiated(
             str(spec.run_root),
             "--image",
             spec.image,
+            "--agent-id",
+            slot_agent,
             *_climb_limit_argv(limits, job_minutes),
             *_climb_panel_argv(spec),
         ]
@@ -1816,16 +1874,18 @@ def service_self_initiated(
         # neither the backend nor its key — a new backend needs zero tick change.
         job_id = compute.submit(
             JobSpec(
-                job_name=f"climb-{benchmark}"[:60],
+                job_name=f"climb-{benchmark}-{slot_agent}"[:60],
                 account=spec.account,
                 partition=spec.job_partition or spec.partition,
                 time_minutes=job_minutes,
-                command=_flight_command(spec.home, f"climb-{benchmark}"[:60], now, argv),
+                command=_flight_command(
+                    spec.home, f"climb-{benchmark}-{slot_agent}"[:60], now, argv
+                ),
                 cpus=4,
                 mem="8G",
             )
         )
-        write_pending(root, spec.target, benchmark, job_id, now)
+        write_pending(root, spec.target, benchmark, job_id, now, agent=slot_agent)
         log.info("self-initiated climb on %s: job %s", benchmark, job_id)
         return (benchmark, job_id)
     except Exception as exc:  # one bad pass must not break the tick

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1376,6 +1376,7 @@ def pick_self_initiated(
     target: str,
     now: float,
     dead_attempts: dict[str, float] | None = None,
+    live_pendings: list[tuple[str, float]] | None = None,
 ) -> str | None:
     """The benchmark to climb next on `target`, or None.
 
@@ -1397,7 +1398,12 @@ def pick_self_initiated(
     if len(active) >= _attempt_width(contract):
         return None
     week_ago = now - 7 * 24 * 3600
-    if sum(1 for r in mine if r.created >= week_ago) >= contract.budgets.runs_per_week:
+    # queued slots count toward the weekly budget BEFORE their records
+    # exist, or a width-N target with one run left could submit N (terra
+    # #173 r2); when a marker lands, the service clears it before calling
+    # here, so a run is never counted twice
+    queued = sum(1 for _, submitted_at in live_pendings or [] if submitted_at >= week_ago)
+    if sum(1 for r in mine if r.created >= week_ago) + queued >= contract.budgets.runs_per_week:
         return None
     last_attempt: dict[str, float] = {}
     for r in mine:
@@ -1405,6 +1411,12 @@ def pick_self_initiated(
             last_attempt[r.benchmark] = max(last_attempt.get(r.benchmark, 0.0), r.created)
     for bench_name, submitted_at in (dead_attempts or {}).items():
         last_attempt[bench_name] = max(last_attempt.get(bench_name, 0.0), submitted_at)
+    for bench_name, submitted_at in live_pendings or []:
+        # a queued sibling starts its benchmark's cooldown clock too:
+        # width spreads across benchmarks first, and re-picking the same
+        # one needs the contract to have set cooldown to 0 (portfolio)
+        if bench_name:
+            last_attempt[bench_name] = max(last_attempt.get(bench_name, 0.0), submitted_at)
     cooldown_min = getattr(contract.budgets, "attempt_cooldown_minutes", None)
     cooldown_s = SELF_INITIATED_COOLDOWN_S if cooldown_min is None else cooldown_min * 60
     # A launch that died BEFORE writing a run record is invisible to the
@@ -1481,8 +1493,12 @@ _SLOT_AGENT_RE = re.compile(r"agent-\d+")
 
 def _pending_path(root: Path, target: str, agent: str = "") -> Path:
     # agent "" is the legacy single-slot name, still read for back-compat
-    # with a marker written before the width dial deployed
-    suffix = f"__{agent}" if agent else ""
+    # with a marker written before the width dial deployed. The slot
+    # separator is "@" because it CANNOT appear in a GitHub owner/repo
+    # name — any character legal in repo names ("_", ".", "-") would make
+    # org/pilot's slot file collide with some other target's legacy file
+    # (org/pilot__agent-01 is a valid repo).
+    suffix = f"@{agent}" if agent else ""
     return root / "pending" / (target.replace("/", "__") + suffix + ".json")
 
 
@@ -1509,8 +1525,8 @@ def list_pendings(root: Path, target: str) -> list[tuple[str, dict[str, Any]]]:
         name = path.stem
         if name == stem:
             agent = ""
-        elif name.startswith(stem + "__") and _SLOT_AGENT_RE.fullmatch(name[len(stem) + 2 :]):
-            agent = name[len(stem) + 2 :]
+        elif name.startswith(stem + "@") and _SLOT_AGENT_RE.fullmatch(name[len(stem) + 1 :]):
+            agent = name[len(stem) + 1 :]
         else:
             continue  # a longer target sharing this prefix (org/foo vs org/foobar)
         try:
@@ -1790,6 +1806,7 @@ def service_self_initiated(
         # WIDTH: every live pending marker occupies a slot; landed ones
         # clear; dead ones become per-benchmark tombstones and free theirs.
         occupied: set[str] = set()
+        live_pendings: list[tuple[str, float]] = []
         nonslot_busy = False
         for agent, pending in list_pendings(root, spec.target):
             marker_agent = "" if not pending.get("agent_id") else agent
@@ -1815,6 +1832,7 @@ def service_self_initiated(
                 # marker's TTL — queue wait can exceed it — the TTL only
                 # breaks ties when Slurm can't say.
                 occupied.add(agent)
+                live_pendings.append((str(pending.get("benchmark", "")), submitted_at))
                 if not marker_agent:
                     # a live un-slotted marker is another lane's submit
                     # (steward/intake, or a pre-width deploy): serial
@@ -1844,7 +1862,9 @@ def service_self_initiated(
         if slot_agent is None:
             return None
         dead_attempts = read_tombstones(root, spec.target, contract, now)
-        benchmark = pick_self_initiated(records, contract, spec.target, now, dead_attempts)
+        benchmark = pick_self_initiated(
+            records, contract, spec.target, now, dead_attempts, live_pendings
+        )
         if benchmark is None:
             return None
         if getattr(contract, "merge", "manual") == "auto" and not spec.panel:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1472,6 +1472,13 @@ def read_tombstones(root: Path, target: str, contract: Any, now: float) -> dict[
     return out
 
 
+# WIDTH slots are the only suffixed marker names; the pattern also fences
+# list_pendings against a longer target that shares this one's file-name
+# prefix (org/foo vs org/foobar — "/" encodes as "__", so glob alone is
+# ambiguous)
+_SLOT_AGENT_RE = re.compile(r"agent-\d+")
+
+
 def _pending_path(root: Path, target: str, agent: str = "") -> Path:
     # agent "" is the legacy single-slot name, still read for back-compat
     # with a marker written before the width dial deployed
@@ -1500,7 +1507,12 @@ def list_pendings(root: Path, target: str) -> list[tuple[str, dict[str, Any]]]:
         return out
     for path in sorted(pending_dir.glob(stem + "*.json")):
         name = path.stem
-        agent = name[len(stem) + 2 :] if name.startswith(stem + "__") else ""
+        if name == stem:
+            agent = ""
+        elif name.startswith(stem + "__") and _SLOT_AGENT_RE.fullmatch(name[len(stem) + 2 :]):
+            agent = name[len(stem) + 2 :]
+        else:
+            continue  # a longer target sharing this prefix (org/foo vs org/foobar)
         try:
             data = json.loads(path.read_text())
         except (OSError, ValueError):
@@ -1778,11 +1790,19 @@ def service_self_initiated(
         # WIDTH: every live pending marker occupies a slot; landed ones
         # clear; dead ones become per-benchmark tombstones and free theirs.
         occupied: set[str] = set()
+        nonslot_busy = False
         for agent, pending in list_pendings(root, spec.target):
             marker_agent = "" if not pending.get("agent_id") else agent
             submitted_at = float(pending["submitted_at"])
+            # A slotted marker lands only when ITS OWN record appears —
+            # matching on target+time alone would let a sibling slot's
+            # record clear a still-live marker (terra #173). A legacy
+            # marker names no slot, so it keeps the lax match.
             landed = any(
-                r.target == spec.target and r.created >= submitted_at - 60 for r in records
+                r.target == spec.target
+                and r.created >= submitted_at - 60
+                and (not marker_agent or r.agent_id == marker_agent)
+                for r in records
             )
             expired = now - submitted_at > PENDING_TTL_S
             if landed:
@@ -1795,6 +1815,10 @@ def service_self_initiated(
                 # marker's TTL — queue wait can exceed it — the TTL only
                 # breaks ties when Slurm can't say.
                 occupied.add(agent)
+                if not marker_agent:
+                    # a live un-slotted marker is another lane's submit
+                    # (steward/intake, or a pre-width deploy): serial
+                    nonslot_busy = True
             else:
                 # Died before writing a record: persist the crash memory as a
                 # PER-BENCHMARK tombstone (a sibling launch must not erase
@@ -1807,6 +1831,13 @@ def service_self_initiated(
                 if r.state == IMPLEMENTING and max(r.updated, r.created) <= stranded_cutoff:
                     continue  # stranded: pick ignores it, so must occupancy
                 occupied.add(r.agent_id)
+                if not _SLOT_AGENT_RE.fullmatch(r.agent_id):
+                    nonslot_busy = True
+        if nonslot_busy:
+            # steward and intake keep their pre-width one-run-per-target
+            # exclusivity: width applies AMONG self-initiated slots, it
+            # does not license launching beside another lane (terra #173)
+            return None
         if len(occupied) >= width:
             return None
         slot_agent = _free_agent_slot(occupied, width)
@@ -1932,16 +1963,22 @@ def service_steward(
         if any(r.target == target and r.state != ENDED for r in records):
             return None
         # The queue window (submit -> job writes its record) is bridged by
-        # the SAME per-target pending marker the self-initiated lane uses:
-        # while a submitted job is alive without a record, no lane launches.
-        pending = read_pending(root, target)
-        if pending is not None:
+        # the SAME per-target pending markers the self-initiated lane uses
+        # — ALL of them, slotted included: a width slot queued without a
+        # record yet must block a stewardship the same way an active run
+        # does. Liveness first, TTL only breaks unknown ties (queue wait
+        # can outlive the TTL).
+        for slot, pending in list_pendings(root, target):
+            marker_agent = "" if not pending.get("agent_id") else slot
             submitted_at = float(pending.get("submitted_at", 0.0))
-            landed = any(r.target == target and r.created >= submitted_at - 60 for r in records)
+            landed = any(
+                r.target == target
+                and r.created >= submitted_at - 60
+                and (not marker_agent or r.agent_id == marker_agent)
+                for r in records
+            )
             expired = now - submitted_at > PENDING_TTL_S
             alive = _holder_alive(compute, str(pending.get("job_id", "")))
-            # liveness first, TTL only breaks unknown ties — same rule as
-            # the self-initiated lane (queue wait can outlive the TTL)
             if not landed and (alive is True or (not expired and alive is not False)):
                 return None
         task = pick_steward_issue(github, target, contract, spec.bot_login)

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2681,3 +2681,123 @@ roadmap: docs/roadmap.md
     )
     assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 300) == ("tsp", "103")
     assert "--agent-id agent-01" in submitted[2]
+    # the landed check is SLOT-SCOPED: agent-01's record must not have
+    # cleared agent-02's still-live marker (terra #173 r1)
+    from autoresearch.tick import read_pending
+
+    assert read_pending(tmp_path, "org/pilot", "agent-02") is not None
+
+
+def test_list_pendings_is_delimited_by_target(tmp_path: Path) -> None:
+    """org/pilot's marker scan must not absorb org/pilotx's markers ("/"
+    encodes as "__" so a bare glob is prefix-ambiguous), nor any suffixed
+    file that isn't a width-slot name (terra #173 r1)."""
+    from autoresearch.tick import list_pendings, write_pending
+
+    write_pending(tmp_path, "org/pilot", "tsp", "1", NOW, agent="agent-01")
+    write_pending(tmp_path, "org/pilotx", "tsp", "2", NOW)
+    write_pending(tmp_path, "org/pilotx", "tsp", "3", NOW, agent="agent-01")
+    write_pending(tmp_path, "org/pilot", "tsp", "4", NOW, agent="not-a-slot")
+    got = [(agent, p["job_id"]) for agent, p in list_pendings(tmp_path, "org/pilot")]
+    assert got == [("agent-01", "1")]
+
+
+def test_width_never_launches_beside_a_steward_run(tmp_path: Path) -> None:
+    """Width applies AMONG self-initiated slots; an active stewardship keeps
+    its pre-width one-run-per-target exclusivity (terra #173 r1)."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import FollowupSpec, service_self_initiated
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets:
+  gpu_hours_per_run: 1
+  runs_per_week: 500
+  max_active_attempts: 2
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="acct",
+        partition="part",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+        bot_login="bot",
+    )
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="stew",
+            target="org/pilot",
+            task_title="t",
+            state="implementing",
+            agent_id="steward-01",
+        ),
+        now=NOW - 100,
+    )
+    compute = SlurmCompute(runner=lambda argv, timeout_s: CommandResult(0, "RUNNING\n", ""))
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW) is None
+
+
+def test_steward_waits_for_a_queued_width_slot(tmp_path: Path) -> None:
+    """A slotted pending marker (width launch queued, record not written yet)
+    blocks the steward lane the same way an active run does (terra #173 r1
+    parity: the lane used to read only the legacy un-suffixed marker)."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import FollowupSpec, effective_limits, service_steward, write_pending
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets: {gpu_hours_per_run: 0, runs_per_week: 20}
+scope: {allowed: [src/pilot/solvers/]}
+steward: {allowed: [src/pilot/instances.py]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    limits = effective_limits(contract.budgets)
+
+    class G:
+        def __init__(self):
+            self.comments_posted = []
+
+        def list_open_issues(self, repo, max_pages: int = 3):
+            return [
+                {
+                    "number": 21,
+                    "title": "re-base the tsp pool",
+                    "body": "",
+                    "user": {"login": "renmengye"},
+                    "author_association": "OWNER",
+                    "labels": [{"name": "autoresearch:steward"}],
+                }
+            ]
+
+        def list_comments(self, repo, number, max_pages: int = 20):
+            return []
+
+        def comment(self, repo, number, body):
+            self.comments_posted.append((number, body))
+
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="a",
+        partition="p",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+        steward_key_file="/k",
+    )
+    write_pending(tmp_path, "org/pilot", "tsp", "777", NOW, agent="agent-02")
+    compute = SlurmCompute(runner=lambda argv, timeout_s: CommandResult(0, "RUNNING\n", ""))
+    github = G()
+    assert service_steward(tmp_path, github, compute, spec, NOW + 60, contract, limits) is None
+    assert github.comments_posted == []

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -842,7 +842,7 @@ def test_self_initiated_pending_marker_blocks_duplicates(tmp_path: Path) -> None
     compute = SlurmCompute(runner=runner)
     out = service_self_initiated(tmp_path, compute, spec, contract, NOW)
     assert out == ("denoise", "123")
-    marker = read_pending(tmp_path, "org/pilot")
+    marker = read_pending(tmp_path, "org/pilot", "agent-01")
     assert marker is not None and marker["benchmark"] == "denoise"
     # next tick, record not yet written, job alive -> NO duplicate submit
     assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 1800) is None
@@ -855,7 +855,7 @@ def test_self_initiated_pending_marker_blocks_duplicates(tmp_path: Path) -> None
         now=NOW + 1900,
     )
     assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 3600) is None
-    assert read_pending(tmp_path, "org/pilot") is None
+    assert read_pending(tmp_path, "org/pilot", "agent-01") is None
     assert len(submitted) == 1
 
 
@@ -1701,7 +1701,7 @@ roadmap: docs/roadmap.md
     # the queue window is bridged: pending marker written, second pass no-ops
     from autoresearch.tick import read_pending
 
-    marker = read_pending(tmp_path, "org/pilot")
+    marker = read_pending(tmp_path, "org/pilot")  # steward lane: legacy marker
     assert marker is not None and marker["benchmark"] == "steward:tsp"
     assert (
         service_steward(tmp_path, G(), compute, spec("/k"), NOW + 60, with_steward, limits) is None
@@ -2078,6 +2078,7 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     from autoresearch.tick import clear_pending
 
     clear_pending(tmp_path, "org/pilot")
+    clear_pending(tmp_path, "org/pilot", "agent-01")
     out_low = service_self_initiated(
         tmp_path, SlurmCompute(runner=runner_low), low, contract, NOW + 4000
     )
@@ -2087,6 +2088,7 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     # clamp): 60-min job - 20-min overhead, never the full 90-min default
     assert "--session-minutes 40" in submitted_low[0]
     clear_pending(tmp_path, "org/pilot")
+    clear_pending(tmp_path, "org/pilot", "agent-01")
 
     ok2 = make(panel_key_file=str(good))
     from autoresearch.contract import load_contract
@@ -2608,3 +2610,74 @@ roadmap: docs/roadmap.md
     later = NOW + DEAD_LAUNCH_BACKOFF_S + 61
     assert read_tombstones(tmp_path, "o/r", hot, later) == {}
     assert pick_self_initiated([], hot, "o/r", later, {}) == "denoise"
+
+
+def test_width_dial_runs_two_slots_and_caps(tmp_path: Path) -> None:
+    """WIDTH-V1: max_active_attempts: 2 dispatches two concurrent attempts
+    with distinct agent identities (branch/ledger uniqueness), refuses a
+    third while both slots are occupied, and frees slots as runs land+end."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import FollowupSpec, service_self_initiated
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets:
+  gpu_hours_per_run: 1
+  runs_per_week: 500
+  attempt_cooldown_minutes: 0
+  max_active_attempts: 2
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    panel_key = tmp_path / "vkey"
+    panel_key.write_text("k")
+    panel_key.chmod(0o600)
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="acct",
+        partition="part",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+        bot_login="bot",
+        panel_key_file=str(panel_key),
+    )
+    submitted: list[str] = []
+    job_ids = iter(["101", "102", "103"])
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            submitted.append(" ".join(argv))
+            return CommandResult(0, next(job_ids) + "\n", "")
+        return CommandResult(0, "RUNNING\n", "")  # both holders alive
+
+    compute = SlurmCompute(runner=runner)
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW) == ("tsp", "101")
+    assert "--agent-id agent-01" in submitted[0]
+    # slot 2: dispatches concurrently with a DISTINCT identity
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 60) == ("tsp", "102")
+    assert "--agent-id agent-02" in submitted[1]
+    # both slots occupied: the third asks is refused
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 120) is None
+    assert len(submitted) == 2
+    # slot 1 lands and ends -> a slot frees, dispatch resumes as agent-01
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="w1",
+            target="org/pilot",
+            task_title="t",
+            state=ENDED,
+            ending="negative-result",
+            benchmark="tsp",
+            agent_id="agent-01",
+            created=NOW + 61,
+        ),
+        NOW + 200,
+    )
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 300) == ("tsp", "103")
+    assert "--agent-id agent-01" in submitted[2]

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -2691,15 +2691,66 @@ roadmap: docs/roadmap.md
 def test_list_pendings_is_delimited_by_target(tmp_path: Path) -> None:
     """org/pilot's marker scan must not absorb org/pilotx's markers ("/"
     encodes as "__" so a bare glob is prefix-ambiguous), nor any suffixed
-    file that isn't a width-slot name (terra #173 r1)."""
-    from autoresearch.tick import list_pendings, write_pending
+    file that isn't a width-slot name (terra #173 r1), nor the LEGACY
+    marker of a repo literally named pilot__agent-01 — "_" is legal in
+    repo names, which is why the slot separator is "@" (terra #173 r2)."""
+    from autoresearch.tick import list_pendings, read_pending, write_pending
 
     write_pending(tmp_path, "org/pilot", "tsp", "1", NOW, agent="agent-01")
     write_pending(tmp_path, "org/pilotx", "tsp", "2", NOW)
     write_pending(tmp_path, "org/pilotx", "tsp", "3", NOW, agent="agent-01")
     write_pending(tmp_path, "org/pilot", "tsp", "4", NOW, agent="not-a-slot")
+    write_pending(tmp_path, "org/pilot__agent-01", "tsp", "5", NOW)
     got = [(agent, p["job_id"]) for agent, p in list_pendings(tmp_path, "org/pilot")]
     assert got == [("agent-01", "1")]
+    marker = read_pending(tmp_path, "org/pilot__agent-01")
+    assert marker is not None and marker["job_id"] == "5"
+
+
+def test_width_queued_slots_count_toward_weekly_budget(tmp_path: Path) -> None:
+    """With one run left in runs_per_week, a width-2 target must not submit
+    two attempts in the pre-record queue window (terra #173 r2)."""
+    from autoresearch.contract import load_contract
+    from autoresearch.tick import FollowupSpec, service_self_initiated
+
+    contract = load_contract(
+        """
+benchmarks:
+  - {name: tsp, command: c, metric: m, direction: min}
+budgets:
+  gpu_hours_per_run: 1
+  runs_per_week: 1
+  attempt_cooldown_minutes: 0
+  max_active_attempts: 2
+scope: {allowed: [src/]}
+roadmap: docs/roadmap.md
+""",
+        "org/pilot",
+    )
+    panel_key = tmp_path / "vkey"
+    panel_key.write_text("k")
+    panel_key.chmod(0o600)
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="acct",
+        partition="part",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+        bot_login="bot",
+        panel_key_file=str(panel_key),
+    )
+    job_ids = iter(["101", "102"])
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            return CommandResult(0, next(job_ids) + "\n", "")
+        return CommandResult(0, "RUNNING\n", "")
+
+    compute = SlurmCompute(runner=runner)
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW) == ("tsp", "101")
+    # slot 2 is free, but the queued slot already spent the last weekly run
+    assert service_self_initiated(tmp_path, compute, spec, contract, NOW + 60) is None
 
 
 def test_width_never_launches_beside_a_steward_run(tmp_path: Path) -> None:


### PR DESCRIPTION
The last substrate item before the Outerloop speedrun scaffold — Mengye's "make sure the cluster is hot with agents," second half (the cooldown dial #172 was the first).

- **`budgets.max_active_attempts`** (default 1 = today's serial behavior): N concurrent self-initiated attempts per target.
- **Per-slot agent identities** (`agent-01..agent-0N`, new `--agent-id` flag): branches, ledger rows, queue names, and reports stay distinct — and the scaling study speaks "authors," not threads. Resumed runs inherit identity from their record (already true).
- **Per-slot pending markers**; the legacy un-suffixed marker (pre-width deploys, and the intake/steward lanes which deliberately stay single) is still read and attributed.
- **Occupancy** = live markers + non-stranded active records; first free slot dispatches; full slots refuse; #172's per-benchmark crash tombstones compose unchanged.
- V2 (deferred, per the agreed split): superseded-losers handling for auto-mode PR races.

Hot-loop config for the RSI target: `max_active_attempts: N` + `attempt_cooldown_minutes: 0`, with `runs_per_week`/`gpu_hours_per_run` as spend guards.

Pinned end-to-end: width-2 double-dispatch with distinct identities, third refused, slot freed and reused after a run ends. 825 tests, all gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)