### PR TITLE
feat: size GPU eval jobs per GPU (8 cores, 64 GB each)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Versions follow [SemVer](https://semver.org).
   `eval_minutes`), and stewardships on them are refused for now (their
   validation runs in-job). The dispatched-eval ceiling rises from 240 to
   300 minutes for the ~3.5h single-GPU evals of the speedrun target.
+- GPU evals are sized per GPU (8 cores, 64 GB each) — a training eval's
+  data loading and torch.compile workers do not fit the CPU eval's 4 cores /
+  8 GB; explicit larger requests are never shrunk.
 
 - THE WIDTH DIAL: `budgets.max_active_attempts` runs N self-initiated
   attempts abreast on one target (default 1 — today's serial behavior).

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -456,7 +456,11 @@ def eval_job_spec(
     torch.compile workers do not fit the CPU eval's 4 cores / 8 GB)."""
     if gpus > 0:
         cpus = max(cpus, EVAL_CPUS_PER_GPU * gpus)
-        mem = f"{max(_mem_gb(mem), EVAL_MEM_GB_PER_GPU * gpus)}G"
+        given = _mem_gb(mem)
+        # an explicit request is never SHRUNK: only a parseable value below
+        # the per-GPU floor is raised; anything unparseable passes through
+        if given is not None and given < EVAL_MEM_GB_PER_GPU * gpus:
+            mem = f"{EVAL_MEM_GB_PER_GPU * gpus}G"
     return JobSpec(
         job_name=job_name[:60],
         account=account,
@@ -469,18 +473,18 @@ def eval_job_spec(
     )
 
 
-def _mem_gb(mem: str) -> int:
-    """A Slurm --mem value ("8G", "512M", "16") in whole GB, rounded down;
-    unparseable -> 0 so the per-GPU floor wins."""
+def _mem_gb(mem: str) -> int | None:
+    """A Slurm --mem value ("8G", "512M", "1T", "16") in whole GB, rounded
+    down; None when unparseable (the caller then leaves it alone)."""
     text = mem.strip().upper()
+    scale = {"K": 1 / (1024 * 1024), "M": 1 / 1024, "G": 1.0, "T": 1024.0}
+    unit = text[-1:] if text[-1:] in scale else ""
+    number = text[:-1] if unit else text
     try:
-        if text.endswith("G"):
-            return int(float(text[:-1]))
-        if text.endswith("M"):
-            return int(float(text[:-1])) // 1024
-        return int(float(text)) // 1024  # bare Slurm --mem is MB
+        value = float(number)
     except ValueError:
-        return 0
+        return None
+    return int(value * (scale[unit] if unit else 1 / 1024))  # bare Slurm --mem is MB
 
 
 def read_eval_result(run_dir: Path, name: str, metric: str) -> float:

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -484,6 +484,8 @@ def _mem_gb(mem: str) -> int | None:
         value = float(number)
     except ValueError:
         return None
+    if not math.isfinite(value) or value < 0:
+        return None  # "nanG"/"infG": not a size — pass it through untouched
     return int(value * (scale[unit] if unit else 1 / 1024))  # bare Slurm --mem is MB
 
 

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -54,6 +54,10 @@ EVAL_JOB_MINUTES_CEILING = 300
 # Slack added to the job walltime beyond the eval itself: worktree
 # materialization + venv build from the lockfile on node-local scratch.
 EVAL_JOB_SETUP_MINUTES = 10
+# a GPU eval trains: data loading + torch.compile workers need real cores
+# and host RAM; sized per GPU so an 8-GPU eval scales the same way
+EVAL_CPUS_PER_GPU = 8
+EVAL_MEM_GB_PER_GPU = 64
 
 
 def effective_eval_minutes(eval_minutes: int | None) -> int:
@@ -446,7 +450,13 @@ def eval_job_spec(
     plus setup slack — a contract value above EVAL_JOB_MINUTES_CEILING must
     not create a longer Slurm job than the ceiling allows. `gpus` is the
     benchmark's contract field; the caller has already placed the job on
-    the GPU lane (DispatchSettings.placement) when it is nonzero."""
+    the GPU lane (DispatchSettings.placement) when it is nonzero, and the
+    job is sized for it: a GPU eval gets at least EVAL_CPUS_PER_GPU cores
+    and EVAL_MEM_GB_PER_GPU GB per GPU (a training eval's data loading and
+    torch.compile workers do not fit the CPU eval's 4 cores / 8 GB)."""
+    if gpus > 0:
+        cpus = max(cpus, EVAL_CPUS_PER_GPU * gpus)
+        mem = f"{max(_mem_gb(mem), EVAL_MEM_GB_PER_GPU * gpus)}G"
     return JobSpec(
         job_name=job_name[:60],
         account=account,
@@ -457,6 +467,20 @@ def eval_job_spec(
         mem=mem,
         gpus=gpus,
     )
+
+
+def _mem_gb(mem: str) -> int:
+    """A Slurm --mem value ("8G", "512M", "16") in whole GB, rounded down;
+    unparseable -> 0 so the per-GPU floor wins."""
+    text = mem.strip().upper()
+    try:
+        if text.endswith("G"):
+            return int(float(text[:-1]))
+        if text.endswith("M"):
+            return int(float(text[:-1])) // 1024
+        return int(float(text)) // 1024  # bare Slurm --mem is MB
+    except ValueError:
+        return 0
 
 
 def read_eval_result(run_dir: Path, name: str, metric: str) -> float:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -426,7 +426,15 @@ def test_gpu_evals_are_sized_per_gpu(tmp_path):
     # every Slurm suffix is understood, and an explicit value is never
     # shrunk — a terabyte request stays a terabyte (terra #175 r1); a
     # value we cannot parse passes through untouched
-    for mem, expect in (("1T", "1T"), ("2048M", "64G"), ("70000", "70000"), ("weird", "weird")):
+    cases = (
+        ("1T", "1T"),
+        ("2048M", "64G"),
+        ("70000", "70000"),
+        ("weird", "weird"),
+        ("nanG", "nanG"),  # non-finite: never a crash, passes through (terra #175 r2)
+        ("infG", "infG"),
+    )
+    for mem, expect in cases:
         spec = eval_job_spec(
             script, job_name="e", account="a", partition="p", eval_minutes=60, gpus=1, mem=mem
         )

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -423,3 +423,11 @@ def test_gpu_evals_are_sized_per_gpu(tmp_path):
         mem="256G",
     )
     assert (big.cpus, big.mem) == (32, "256G")
+    # every Slurm suffix is understood, and an explicit value is never
+    # shrunk — a terabyte request stays a terabyte (terra #175 r1); a
+    # value we cannot parse passes through untouched
+    for mem, expect in (("1T", "1T"), ("2048M", "64G"), ("70000", "70000"), ("weird", "weird")):
+        spec = eval_job_spec(
+            script, job_name="e", account="a", partition="p", eval_minutes=60, gpus=1, mem=mem
+        )
+        assert spec.mem == expect, mem

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -394,3 +394,32 @@ def test_gpu_jobs_get_nv_and_gpus(tmp_path):
     )
     assert spec.gpus == 1 and "--gpus=1" in spec.to_argv()
     assert spec.time_minutes == 250  # a 4h GPU eval fits under the raised ceiling
+
+
+def test_gpu_evals_are_sized_per_gpu(tmp_path):
+    """A GPU eval trains: it gets cores and host RAM per GPU (compile workers
+    and data loading OOM-kill at the CPU eval's 4 cores / 8 GB); CPU evals
+    keep the small defaults; an explicit larger request is never shrunk."""
+    from autoresearch.dispatch import EVAL_CPUS_PER_GPU, EVAL_MEM_GB_PER_GPU
+
+    script = tmp_path / "job.sh"
+    script.write_text("#!/bin/sh\n")
+    cpu = eval_job_spec(script, job_name="e", account="a", partition="p", eval_minutes=30)
+    assert (cpu.cpus, cpu.mem) == (4, "8G")
+    one = eval_job_spec(
+        script, job_name="e", account="a", partition="h200", eval_minutes=240, gpus=1
+    )
+    assert (one.cpus, one.mem) == (EVAL_CPUS_PER_GPU, f"{EVAL_MEM_GB_PER_GPU}G")
+    eight = eval_job_spec(script, job_name="e", account="a", partition="p", eval_minutes=60, gpus=8)
+    assert (eight.cpus, eight.mem) == (8 * EVAL_CPUS_PER_GPU, f"{8 * EVAL_MEM_GB_PER_GPU}G")
+    big = eval_job_spec(
+        script,
+        job_name="e",
+        account="a",
+        partition="p",
+        eval_minutes=60,
+        gpus=1,
+        cpus=32,
+        mem="256G",
+    )
+    assert (big.cpus, big.mem) == (32, "256G")


### PR DESCRIPTION
Follow-up to #174, found walking the first speedrun eval through the fleet's jail: a dispatched eval job defaults to 4 cores / 8 GB, which a training eval (data loading + `torch.compile` workers) would OOM-kill in. `eval_job_spec` now floors GPU jobs at 8 cores and 64 GB **per GPU**; CPU evals unchanged; explicit larger requests never shrunk. Pinned for 0/1/8 GPUs and the explicit case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)