### PR TITLE
fix: GPU jobs request --gpus-per-node, not --gpus (Torch rejects the per-job form)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Versions follow [SemVer](https://semver.org).
 
 - GPU BENCHMARKS: a per-benchmark contract field `gpus` (default 0) sizes
   every dispatched job of that benchmark — gate measures and author
-  launches — with `--gpus=N` on the job and `--nv` on the jail. GPU jobs go
+  launches — with `--gpus-per-node=N` on the job (the per-job `--gpus` form
+  is rejected by Torch's submit plugin as a "CPU job" on a GPU partition —
+  the first fleet speedrun attempt aborted on it) and `--nv` on the jail. GPU jobs go
   to a dedicated lane (`AUTORESEARCH_GPU_PARTITION`, optional
   `AUTORESEARCH_GPU_ACCOUNT`); a `gpus > 0` benchmark on a deployment with no
   lane is refused at launch rather than queued into evals that can never

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -110,7 +110,11 @@ class JobSpec:
             f"--output={self.output}",
         ]
         if self.gpus:
-            argv.append(f"--gpus={self.gpus}")
+            # per-NODE, not per-job (--gpus): every job here is single-node,
+            # and Torch's submit plugin classifies a job by its per-node
+            # GRES — the per-job form was rejected on a GPU partition as
+            # "CPU job setup is not valid"
+            argv.append(f"--gpus-per-node={self.gpus}")
         if self.qos:
             argv.append(f"--qos={self.qos}")
         if self.dependency:

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -392,7 +392,11 @@ def test_gpu_jobs_get_nv_and_gpus(tmp_path):
     spec = eval_job_spec(
         script, job_name="e", account="a", partition="h200", eval_minutes=240, gpus=1
     )
-    assert spec.gpus == 1 and "--gpus=1" in spec.to_argv()
+    # --gpus-per-node, not --gpus: Torch's submit plugin classifies a job by
+    # its per-node GRES and rejects a per-job --gpus on a GPU partition as
+    # "CPU job setup is not valid" (the first fleet speedrun attempt died there)
+    assert spec.gpus == 1 and "--gpus-per-node=1" in spec.to_argv()
+    assert not any(a.startswith("--gpus=") for a in spec.to_argv())
     assert spec.time_minutes == 250  # a 4h GPU eval fits under the raised ceiling
 
 

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -380,9 +380,10 @@ def test_mixed_suite_places_each_measure_on_its_own_lane(tmp_path):
     assert len(cpu_jobs) == 2 and len(gpu_jobs) == 2
     for argv in cpu_jobs:
         assert "--partition=cpu" in argv and "--account=acct" in argv
-        assert not any(a.startswith("--gpus=") for a in argv)
+        assert not any(a.startswith("--gpus") for a in argv)
     for argv in gpu_jobs:
-        assert "--partition=h200" in argv and "--account=gpu-acct" in argv and "--gpus=1" in argv
+        assert "--partition=h200" in argv and "--account=gpu-acct" in argv
+        assert "--gpus-per-node=1" in argv
     # the GPU measures' job scripts carry --nv; the CPU ones do not
     scripts = {n: Path(a[-1]).read_text() for n, a in by_job.items()}
     for n, text in scripts.items():


### PR DESCRIPTION
First fleet speedrun attempt (run `speedrun-20260828-124540-agent-01`) aborted at its baseline eval:

```
sbatch: error: *** Error partition 'h200_courant' is not valid for this job
sbatch: error: *** Error: CPU job setup is not valid
```

Torch's submit plugin classifies a job by its **per-node** GRES: `--gpus=N` (per-job TRES) reads as a CPU job and is refused on a GPU partition; `--gpus-per-node=N` and `--gres=gpu:N` are accepted (verified with `sbatch --test-only` on `h200_courant`). Every job the kernel submits is single-node, so `JobSpec` now emits the per-node form. Tests pin it; relaunches on the target are paused (temporary cooldown) until this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)