### PR TITLE
feat: the author declares its eval walltime and pays for it in GPU-hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- THE AUTHOR DECLARES ITS EVAL WALLTIME, AND PAYS FOR IT: `submit --minutes
+  <N>` sizes the submit's paired gate evals (default: the contract's
+  `eval_minutes`), and `gpu_hours_per_run` is now METERED at the syscall for
+  GPU benchmarks — every launch (minutes x GPUs) and every submit (2 evals x
+  walltime x GPUs) draws on it, an over-budget request is refused with the
+  numbers, and `status`/wake text show GPU-hours remaining. The metric stays
+  steps; compute is priced by the researcher who chose to spend it, so a
+  slower-per-step candidate is no longer killed by a limit sized to the
+  baseline. The dispatcher's ceiling becomes a 24h backstop.
 - GPU BENCHMARKS: a per-benchmark contract field `gpus` (default 0) sizes
   every dispatched job of that benchmark — gate measures and author
   launches — with `--gpus-per-node=N` on the job (the per-job `--gpus` form

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -74,7 +74,20 @@ rejects a GPU benchmark whose `eval_minutes` would keep its evals in-job
 (the climb job has no allocation), and the steward lane refuses GPU
 benchmarks outright for now — a stewardship validates its rewrite in-job.
 The first target in this shape is the speedrun (`gpt-speedrun`: one H200
-per eval, ~3.5h — hence the 300-minute ceiling).
+per eval, ~3.5h).
+
+**Who decides the eval walltime.** The gate measures steps, not time, so
+walltime should bound only SPEND — and the attempt already has a spend
+budget. The contract's `eval_minutes` is the DEFAULT; the author may declare
+its own at submit (`submit --minutes <N>`, carried on the run record so a
+wake re-parks and re-floors on it), and `gpu_hours_per_run` is metered at
+the syscall for GPU benchmarks: every launch (minutes × GPUs) and every
+submit (two paired evals × walltime × GPUs) draws on it, and an over-budget
+request is refused with the numbers before anything runs. An author that
+wants a slower-per-step candidate spends more of its budget on the final
+eval and has less for experiments — compute is priced by whoever chose to
+spend it, and a legitimate win is never killed by a limit sized to the
+baseline's runtime. `EVAL_JOB_MINUTES_CEILING` is only a 24h backstop.
 
 **Interop.** The orchestrator keeps a single seam: `Evaluator` grows a
 dispatched implementation that *stages* instead of blocking. `climb_once`'s

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -655,6 +655,9 @@ def _wake_author_sleep(
         launch_budget=bench.depth_k,
         sleeps_used=sleeps_used,
         sleep_budget=bench.sleep_k,
+        gpu_hours_remaining=(
+            max(0.0, contract.budgets.gpu_hours_per_run - gpu_hours_used) if bench.gpus else None
+        ),
     )
     if extra_update:
         # a submitted park's gate/panel feedback leads; launch results follow

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -405,6 +405,11 @@ def _park_run(
         # resume_session_id, set below for every park — no stage duplicate)
         stage["launches_used"] = parked.launches_used
         stage["sleeps_used"] = parked.sleeps_used
+        stage["gpu_hours_used"] = parked.gpu_hours_used
+        if parked.eval_minutes:
+            # the author's declared eval walltime rides the park: the wake's
+            # measurer and deadline floor must use it, not the contract's
+            stage["eval_minutes"] = parked.eval_minutes
     # A single-job park records its one pollable id; a MULTI-job park records
     # none — the sweep falls back to polling every id in the stage's `afterany`
     # string and wakes only when ALL are done (tick._poll_targets).
@@ -412,7 +417,7 @@ def _park_run(
     # The deadline is a FLOOR: park time (`now` here is the park moment, passed
     # by the caller) + the eval walltime + a generous queue/grace slack, so a
     # healthy queued-then-running eval never trips the sweep's cancel-on-pending.
-    floor_minutes = effective_eval_minutes(eval_minutes)
+    floor_minutes = effective_eval_minutes(parked.eval_minutes or eval_minutes)
     if parked.phase == "author-sleep" and parked.syscall is not None:
         # an author launch's walltime is the LAUNCH's ask, not the benchmark's
         # eval hint — the floor must sit past the LONGEST launch, or the sweep
@@ -642,6 +647,7 @@ def _wake_author_sleep(
     results = gather_results(run_dir, workspace, launches)
     launches_used = int(record.stage.get("launches_used", 0))  # type: ignore[call-overload]
     sleeps_used = int(record.stage.get("sleeps_used", 0))  # type: ignore[call-overload]
+    gpu_hours_used = float(record.stage.get("gpu_hours_used", 0.0))  # type: ignore[arg-type]
     wake_text = render_wake(
         results,
         str(record.stage.get("syscall_note", "")),
@@ -659,6 +665,11 @@ def _wake_author_sleep(
             workspace,
             launches_remaining=max(0, bench.depth_k - launches_used),
             sleeps_remaining=max(0, bench.sleep_k - sleeps_used),
+            gpu_hours_remaining=(
+                max(0.0, contract.budgets.gpu_hours_per_run - gpu_hours_used)
+                if bench.gpus
+                else None
+            ),
         ),
     )
 
@@ -715,6 +726,7 @@ def _wake_author_sleep(
             launcher=_make_launcher(dispatch, run_dir, workspace, run_id, gpus=bench.gpus),
             launches_used=launches_used,
             sleeps_used=sleeps_used,
+            gpu_hours_used=gpu_hours_used,
         )
     except RunParked as p:
         # slept again, or the gate dispatched its measures (a candidate park the
@@ -838,6 +850,11 @@ def resume_run(
     eval_minutes = next(
         (b.eval_minutes for b in contract.benchmarks if b.name == record.benchmark), None
     )
+    # a submitted park carries the author's declared eval walltime: the
+    # wake's measurer (a re-dispatch) and deadline floor honor it
+    declared = int(record.stage.get("eval_minutes", 0) or 0)  # type: ignore[call-overload]
+    if declared:
+        eval_minutes = declared
     measurer = dispatch.measurer(
         run_dir, repo_root=workspace, eval_minutes=int(eval_minutes or 0), run_tag=run_id
     )
@@ -928,6 +945,8 @@ def resume_run(
             parked.submitted = True
             parked.launches_used = int(stage.get("launches_used", 0))  # type: ignore[call-overload]
             parked.sleeps_used = int(stage.get("sleeps_used", 0))  # type: ignore[call-overload]
+            parked.gpu_hours_used = float(stage.get("gpu_hours_used", 0.0))  # type: ignore[arg-type]
+            parked.eval_minutes = int(stage.get("eval_minutes", 0) or 0) or None  # type: ignore[call-overload]
             if parked.syscall is None:
                 parked.syscall = _SyscallRequest(
                     launches=tuple(
@@ -1685,6 +1704,9 @@ def live_attempt(
                 workspace,
                 launches_remaining=_bench.depth_k,
                 sleeps_remaining=_bench.sleep_k,
+                gpu_hours_remaining=(
+                    float(contract.budgets.gpu_hours_per_run) if _bench.gpus else None
+                ),
             )
 
         def changed_paths() -> list[str]:

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -76,6 +76,10 @@ class SessionBrief:
     # for this run and the brief never mentions it.
     launch_budget: int = 0
     sleep_budget: int = 0
+    # GPU benchmarks: the run's GPU-hour budget (launches + gate evals draw
+    # on it) and the contract's default eval walltime; 0 = not metered
+    gpu_hour_budget: float = 0.0
+    eval_minutes_default: int = 0
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
@@ -93,6 +97,8 @@ class SessionBrief:
             created=data["created"],
             launch_budget=data.get("launch_budget", 0),
             sleep_budget=data.get("sleep_budget", 0),
+            gpu_hour_budget=data.get("gpu_hour_budget", 0.0),
+            eval_minutes_default=data.get("eval_minutes_default", 0),
         )
 
 
@@ -108,6 +114,8 @@ class BriefInputs:
     budget: BudgetState = field(default_factory=lambda: BudgetState(0.0, 0))
     launch_budget: int = 0  # author-syscall budgets; 0 = feature off (no mention)
     sleep_budget: int = 0
+    gpu_hour_budget: float = 0.0  # GPU benchmarks only; 0 = not metered
+    eval_minutes_default: int = 0
 
 
 def _cap(text: str, limit: int) -> str:
@@ -141,6 +149,8 @@ def build_brief(inputs: BriefInputs, created: str) -> SessionBrief:
         created=created,
         launch_budget=inputs.launch_budget,
         sleep_budget=inputs.sleep_budget,
+        gpu_hour_budget=inputs.gpu_hour_budget,
+        eval_minutes_default=inputs.eval_minutes_default,
     )
 
 
@@ -235,9 +245,27 @@ def render(brief: SessionBrief) -> str:
             "",
             "    python .autoresearch/syscall launch --name <handle> "
             "--minutes <N> --artifact <repo-relative file> -- <command>",
-            "    python .autoresearch/syscall submit",
+            "    python .autoresearch/syscall submit [--minutes <N>]",
             "    python .autoresearch/syscall sleep",
             "",
+            *(
+                [
+                    "This benchmark evaluates on GPUs, so compute is metered: you have "
+                    f"{brief.gpu_hour_budget:g} GPU-hours this run, and every launch "
+                    "(minutes x GPUs) and every submit (2 paired evals x walltime x "
+                    "GPUs) draws on them. Walltime is a budget, not the metric — "
+                    "the gate scores only the contract's metric — but a candidate "
+                    "whose eval runs longer needs a longer walltime: declare it "
+                    "with `submit --minutes <N>` (default "
+                    f"{brief.eval_minutes_default} min per eval, the baseline's "
+                    "runtime with headroom); an eval that runs out of walltime is an "
+                    "eval error, not a result. Budget your experiments against the "
+                    "final eval you will need.",
+                    "",
+                ]
+                if brief.gpu_hour_budget > 0
+                else []
+            ),
             "`status` shows staged launches and remaining budget; `note ...` "
             "leaves a reminder echoed back to you on wake. `--artifact` must "
             "name a file your command actually writes (stdout/stderr are "

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -111,9 +111,9 @@ class JobSpec:
         ]
         if self.gpus:
             # per-NODE, not per-job (--gpus): every job here is single-node,
-            # and Torch's submit plugin classifies a job by its per-node
-            # GRES — the per-job form was rejected on a GPU partition as
-            # "CPU job setup is not valid"
+            # and Slurm submit plugins commonly classify a job by its
+            # per-node GRES — the per-job form has been rejected on a GPU
+            # partition as "CPU job setup is not valid"
             argv.append(f"--gpus-per-node={self.gpus}")
         if self.qos:
             argv.append(f"--qos={self.qos}")

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -167,6 +167,14 @@ class SuiteAggregate(_StrictModel):
 
 
 class Budgets(_StrictModel):
+    # The attempt's compute allowance, METERED at the syscall for GPU
+    # benchmarks: every author launch (minutes x gpus) and a submit's two
+    # paired gate evals (2 x eval walltime x gpus) draw on it, and an
+    # over-budget request is refused with the numbers. The author may
+    # declare its own eval walltime at submit (`submit --minutes`), so a
+    # candidate whose eval runs longer is paid for out of this budget rather
+    # than killed by a fixed limit — walltime is never the metric; compute
+    # is priced here. 0 for CPU benchmarks (nothing to meter).
     gpu_hours_per_run: float = Field(ge=0)
     runs_per_week: int = Field(gt=0)
     # Optional per-repo shaping of the orchestrator's session/job limits.
@@ -179,13 +187,13 @@ class Budgets(_StrictModel):
     followup_job_minutes: int | None = Field(default=None, gt=0)
     # Per-benchmark self-initiated cooldown, in minutes. Default (unset) is
     # the orchestrator's 6h — right for a standard research repo. An RSI /
-    # speedrun target sets 0: the loop re-dispatches back-to-back and
+    # hot-loop target sets 0: the loop re-dispatches back-to-back and
     # `runs_per_week` becomes the spend guard (Mengye: "for the RSI
     # experiment — no cooldown; make sure the cluster is hot"). Still
     # SERIAL per target until the width dial lands.
     attempt_cooldown_minutes: int | None = Field(default=None, ge=0)
     # THE WIDTH DIAL: concurrent self-initiated attempts per target. Default
-    # (unset) = 1, today's serial behavior. An RSI/speedrun target raises it
+    # (unset) = 1, today's serial behavior. A hot-loop target raises it
     # to run N authors abreast — each slot gets its own agent identity
     # (agent-01..agent-0N), so branches, ledger rows, and reports stay
     # distinct. runs_per_week and gpu_hours_per_run remain the spend guards.

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -50,7 +50,11 @@ _SHELL_IDENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 IN_JOB_EVAL_MINUTES = 5
 # Ceiling for the contract's eval_minutes hint: OUR spend cap, not the
 # target's to raise (same grammar as every budget ceiling).
-EVAL_JOB_MINUTES_CEILING = 300
+# A BACKSTOP, not a policy knob: the eval walltime is the contract's hint
+# or the author's own declaration at submit, and spend is metered in
+# GPU-hours against gpu_hours_per_run (syscall.budget_error). This only
+# caps a runaway value.
+EVAL_JOB_MINUTES_CEILING = 1440
 # Slack added to the job walltime beyond the eval itself: worktree
 # materialization + venv build from the lockfile on node-local scratch.
 EVAL_JOB_SETUP_MINUTES = 10

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -41,7 +41,7 @@ from autoresearch.panel import PanelVerdict
 from autoresearch.role_runner import run_role
 from autoresearch.roles import author_spec
 from autoresearch.rolespec import RoleSpec
-from autoresearch.syscall import SyscallError, SyscallRequest
+from autoresearch.syscall import SyscallError, SyscallRequest, gpu_hours_cost
 from autoresearch.syscall import budget_error as syscall_budget_error
 from autoresearch.syscall import read_request as read_syscall_request
 from autoresearch.syscall import render_refusal as render_syscall_refusal
@@ -114,6 +114,8 @@ class RunParked(Exception):
         launches_used: int = 0,
         sleeps_used: int = 0,
         submitted: bool = False,
+        gpu_hours_used: float = 0.0,
+        eval_minutes: int | None = None,
     ):
         self.phase = phase
         self.afterany = afterany
@@ -122,6 +124,11 @@ class RunParked(Exception):
         self.suite_seed = suite_seed
         self.candidate_sha = candidate_sha
         self.session = session
+        # GPU-hours drawn so far (launches + gate evals), and the eval
+        # walltime the author declared at submit — the wake re-parks and
+        # re-floors on the same numbers
+        self.gpu_hours_used = gpu_hours_used
+        self.eval_minutes = eval_minutes
         # Syscall parks (an author-sleep, or a SUBMITTED candidate — Phase B):
         # the request the wake gathers results for, and the budget counts AFTER
         # this park. `submitted` marks a candidate park raised by `submit`: the
@@ -1017,6 +1024,7 @@ def attempt_once(
     launcher: Callable[[str, SyscallRequest], str] | None = None,
     launches_used: int = 0,
     sleeps_used: int = 0,
+    gpu_hours_used: float = 0.0,
 ) -> AttemptResult:
     """One implement→evaluate→verify cycle in an existing clean workspace.
 
@@ -1140,6 +1148,13 @@ def attempt_once(
                 # (never a tool the author cannot actually call)
                 launch_budget=bench.depth_k if launcher is not None else 0,
                 sleep_budget=bench.sleep_k if launcher is not None else 0,
+                # GPU benchmarks: the compute meter the author budgets against
+                gpu_hour_budget=(
+                    contract.budgets.gpu_hours_per_run
+                    if launcher is not None and bench.gpus
+                    else 0.0
+                ),
+                eval_minutes_default=bench.eval_minutes or 0,
             ),
             created=created,
         )
@@ -1221,9 +1236,14 @@ def attempt_once(
         return bool(session.session_id) and getattr(harness, "supports_resume", True)
 
     def _budgets_line() -> str:
+        gpu = (
+            f", {max(0.0, contract.budgets.gpu_hours_per_run - gpu_hours_used):.1f} GPU-hours"
+            if bench.gpus
+            else ""
+        )
         return (
             f"Budgets: {max(0, bench.depth_k - launches_used)} launches and "
-            f"{max(0, bench.sleep_k - sleeps_used)} sleeps remaining."
+            f"{max(0, bench.sleep_k - sleeps_used)} sleeps{gpu} remaining."
         )
 
     def _not_run_note(request: SyscallRequest | None) -> str:
@@ -1258,17 +1278,31 @@ def attempt_once(
                 launch_budget=bench.depth_k,
                 sleeps_used=sleeps_used,
                 sleep_budget=bench.sleep_k,
+                gpu_hours_used=gpu_hours_used,
+                gpu_hour_budget=contract.budgets.gpu_hours_per_run,
+                gpus=bench.gpus,
+                eval_minutes_default=bench.eval_minutes or 0,
             )
             if not problem:
+                # the request's compute is charged when it is ACCEPTED: a launch
+                # park charges its launches here; a submit charges its two gate
+                # evals (plus sibling launches) here too, so the park it raises
+                # below carries the drawn total
+                gpu_hours_used += gpu_hours_cost(
+                    request, gpus=bench.gpus, eval_minutes_default=bench.eval_minutes or 0
+                )
                 if request.submit:
                     # a submit rides the measurement below on the SEALED tree —
                     # "a launch whose job is the gate" (buildout Phase B). The
                     # sleep it rides on is counted now; sibling launches are
                     # dispatched (and counted) only if the gate parks — an
                     # inline gate must never orphan launch jobs no wake would
-                    # gather.
+                    # gather. The author's declared eval walltime (its own
+                    # compute, paid from its budget) sizes the gate's jobs.
                     submitted = request
                     sleeps_used += 1
+                    if request.eval_minutes and hasattr(measurer, "eval_minutes"):
+                        measurer.eval_minutes = request.eval_minutes
                     break
                 # Scope BEFORE the snapshot, same invariant as the candidate
                 # path below: an out-of-scope tree is never snapshotted OR
@@ -1298,6 +1332,7 @@ def attempt_once(
                     syscall=request,
                     launches_used=launches_used + len(request.launches),
                     sleeps_used=sleeps_used + 1,
+                    gpu_hours_used=gpu_hours_used,
                 )
             if refused_once or not _can_resume():
                 log.warning("syscall request dropped after refusal (%s); measuring as-is", problem)
@@ -1387,6 +1422,8 @@ def attempt_once(
                 launches_used=launches_used,
                 sleeps_used=sleeps_used,
                 submitted=submitted is not None,
+                gpu_hours_used=gpu_hours_used,
+                eval_minutes=submitted.eval_minutes if submitted is not None else None,
             ) from None
         if isinstance(outcome, AttemptResult):
             if (

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -41,7 +41,12 @@ from autoresearch.panel import PanelVerdict
 from autoresearch.role_runner import run_role
 from autoresearch.roles import author_spec
 from autoresearch.rolespec import RoleSpec
-from autoresearch.syscall import SyscallError, SyscallRequest, gpu_hours_cost
+from autoresearch.syscall import (
+    SyscallError,
+    SyscallRequest,
+    evals_gpu_hours,
+    launches_gpu_hours,
+)
 from autoresearch.syscall import budget_error as syscall_budget_error
 from autoresearch.syscall import read_request as read_syscall_request
 from autoresearch.syscall import render_refusal as render_syscall_refusal
@@ -1272,6 +1277,9 @@ def attempt_once(
                 )
             if request is None:
                 break
+            # suite siblings' paired evals are charged as if measured (the
+            # suite phase decides at measurement; a budget over-charges)
+            suite_gpus = tuple(b.gpus for b in contract.benchmarks if b.name != bench.name)
             problem = syscall_budget_error(
                 request,
                 launches_used=launches_used,
@@ -1282,28 +1290,33 @@ def attempt_once(
                 gpu_hour_budget=contract.budgets.gpu_hours_per_run,
                 gpus=bench.gpus,
                 eval_minutes_default=bench.eval_minutes or 0,
+                suite_gpus=suite_gpus,
             )
             if not problem:
-                # the request's compute is charged when it is ACCEPTED: a launch
-                # park charges its launches here; a submit charges its two gate
-                # evals (plus sibling launches) here too, so the park it raises
-                # below carries the drawn total
-                gpu_hours_used += gpu_hours_cost(
-                    request, gpus=bench.gpus, eval_minutes_default=bench.eval_minutes or 0
-                )
                 if request.submit:
                     # a submit rides the measurement below on the SEALED tree —
                     # "a launch whose job is the gate" (buildout Phase B). The
                     # sleep it rides on is counted now; sibling launches are
-                    # dispatched (and counted) only if the gate parks — an
-                    # inline gate must never orphan launch jobs no wake would
-                    # gather. The author's declared eval walltime (its own
-                    # compute, paid from its budget) sizes the gate's jobs.
+                    # dispatched (and counted, and CHARGED) only if the gate
+                    # parks — an inline gate must never orphan launch jobs no
+                    # wake would gather. The gate's evals are charged here, at
+                    # the walltime THIS submit declares (else the contract's):
+                    # a resubmit without a declaration reverts to the default,
+                    # never inheriting a prior park's.
                     submitted = request
                     sleeps_used += 1
-                    if request.eval_minutes and hasattr(measurer, "eval_minutes"):
-                        measurer.eval_minutes = request.eval_minutes
+                    gpu_hours_used += evals_gpu_hours(
+                        request,
+                        gpus=bench.gpus,
+                        eval_minutes_default=bench.eval_minutes or 0,
+                        suite_gpus=suite_gpus,
+                    )
+                    if hasattr(measurer, "eval_minutes"):
+                        measurer.eval_minutes = request.eval_minutes or bench.eval_minutes or 0
                     break
+                # a launch park: its launches are dispatched right below, so
+                # they are charged now
+                gpu_hours_used += launches_gpu_hours(request, gpus=bench.gpus)
                 # Scope BEFORE the snapshot, same invariant as the candidate
                 # path below: an out-of-scope tree is never snapshotted OR
                 # executed — the out-of-scope edit could be to the ruler
@@ -1410,6 +1423,7 @@ def attempt_once(
                 assert launcher is not None  # a submit only arrives through it
                 launch_afterany = launcher(candidate_sha, submitted)
                 launches_used += len(submitted.launches)
+                gpu_hours_used += launches_gpu_hours(submitted, gpus=bench.gpus)
             raise RunParked(
                 phase="candidate",
                 afterany=_merge_afterany(pending.afterany(), launch_afterany),

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -66,6 +66,9 @@ MAX_ARTIFACTS_PER_LAUNCH = 8
 MAX_NOTE_CHARS = 2_000
 # Per-job walltime ask, clamped to the same ceiling as dispatched evals.
 MAX_LAUNCH_MINUTES = 240
+# a submit's declared eval walltime: bounded only by the GPU-hour budget the
+# author draws on, plus this backstop (the dispatcher's own ceiling matches)
+MAX_EVAL_MINUTES = 1440
 # stdout/stderr tail delivered into the wake text, per job.
 MAX_OUTPUT_CHARS = 8_000
 # Per artifact file copied back into the sandbox.
@@ -111,6 +114,12 @@ class SyscallRequest:
     # wake returns verdict + gate result to the author (published directly when
     # it clears cleanly). Costs the sleep it rides on, nothing else.
     submit: bool = False
+    # The author's declared walltime for the submit's paired gate evals
+    # (None = the contract's eval_minutes). Walltime is a budget, never the
+    # metric: compute is priced in GPU-hours against the run's budget, so a
+    # candidate whose eval runs longer is paid for here, not killed by a
+    # fixed limit.
+    eval_minutes: int | None = None
 
 
 @dataclass(frozen=True)
@@ -167,7 +176,7 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     # so anything else here (e.g. a verdict) is a wrong-type request, not a sleep.
     if data.get("type") != "sleep":
         raise SyscallError(f"expected a sleep syscall, got type {data.get('type')!r}")
-    unknown = set(data) - {"type", "launches", "note", "submit"}
+    unknown = set(data) - {"type", "launches", "note", "submit", "eval_minutes"}
     if unknown:
         raise SyscallError(f"unknown syscall keys: {sorted(unknown)}")
     note = data.get("note", "")
@@ -176,6 +185,13 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     submit = data.get("submit", False)
     if not isinstance(submit, bool):
         raise SyscallError("submit must be a boolean")
+    eval_minutes = data.get("eval_minutes")
+    if eval_minutes is not None:
+        if not isinstance(eval_minutes, int) or isinstance(eval_minutes, bool) or eval_minutes < 1:
+            raise SyscallError("eval_minutes must be a positive integer")
+        if not submit:
+            raise SyscallError("eval_minutes only applies to a submit")
+        eval_minutes = min(eval_minutes, MAX_EVAL_MINUTES)
     raw_launches = data.get("launches", [])
     if not isinstance(raw_launches, list):
         raise SyscallError("launches must be a list")
@@ -219,7 +235,22 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     # a sleep with no launches is legitimate: checkpoint-and-reschedule
     # (research-loop.md, "the session clock is visible") — it still burns a
     # sleep count, which is what bounds living forever.
-    return SyscallRequest(launches=tuple(launches), note=note, submit=submit)
+    return SyscallRequest(
+        launches=tuple(launches), note=note, submit=submit, eval_minutes=eval_minutes
+    )
+
+
+def gpu_hours_cost(request: SyscallRequest, *, gpus: int, eval_minutes_default: int) -> float:
+    """What honoring `request` draws from the run's GPU-hour budget: every
+    launch's walltime, and — for a submit — the two paired gate evals at the
+    declared (else the contract's) walltime, each times the benchmark's GPUs.
+    A CPU benchmark (gpus 0) meters nothing."""
+    if gpus <= 0:
+        return 0.0
+    minutes = sum(la.minutes for la in request.launches)
+    if request.submit:
+        minutes += 2 * (request.eval_minutes or eval_minutes_default or 0)
+    return minutes * gpus / 60.0
 
 
 def read_verdict(workspace: Path) -> dict[str, Any] | None:
@@ -377,14 +408,24 @@ def install_tool(workspace: Path) -> None:
     tool.chmod(0o755)
 
 
-def write_budget(workspace: Path, *, launches_remaining: int, sleeps_remaining: int) -> None:
+def write_budget(
+    workspace: Path,
+    *,
+    launches_remaining: int,
+    sleeps_remaining: int,
+    gpu_hours_remaining: float | None = None,
+) -> None:
     """Kernel-written budget the tool's `status` shows. Informational for the
     author's planning only — enforcement stays in `budget_error`."""
     d = workspace / SYSCALL_DIR
     d.mkdir(exist_ok=True)
-    (d / "budget.json").write_text(
-        json.dumps({"launches_remaining": launches_remaining, "sleeps_remaining": sleeps_remaining})
-    )
+    budget: dict[str, Any] = {
+        "launches_remaining": launches_remaining,
+        "sleeps_remaining": sleeps_remaining,
+    }
+    if gpu_hours_remaining is not None:
+        budget["gpu_hours_remaining"] = round(gpu_hours_remaining, 2)
+    (d / "budget.json").write_text(json.dumps(budget))
 
 
 def budget_error(
@@ -394,10 +435,16 @@ def budget_error(
     launch_budget: int,
     sleeps_used: int,
     sleep_budget: int,
+    gpu_hours_used: float = 0.0,
+    gpu_hour_budget: float | None = None,
+    gpus: int = 0,
+    eval_minutes_default: int = 0,
 ) -> str:
     """The budget check, arithmetic only ('' = within budget). The PROMPT
     carries warnings; this refuses only genuine exhaustion. The sleep being
-    requested right now counts toward the sleep budget."""
+    requested right now counts toward the sleep budget; for a GPU benchmark
+    the request's compute (launches, and a submit's two gate evals at the
+    declared walltime) must fit the run's remaining GPU-hours."""
     if sleeps_used + 1 > sleep_budget:
         return (
             f"sleep budget exhausted ({sleeps_used}/{sleep_budget} used): "
@@ -408,6 +455,14 @@ def budget_error(
             f"launch budget would be exceeded: {launches_used} used + "
             f"{len(request.launches)} requested > {launch_budget} allowed"
         )
+    if gpu_hour_budget is not None and gpus > 0:
+        cost = gpu_hours_cost(request, gpus=gpus, eval_minutes_default=eval_minutes_default)
+        if gpu_hours_used + cost > gpu_hour_budget:
+            return (
+                f"GPU-hour budget would be exceeded: {gpu_hours_used:.1f} used + "
+                f"{cost:.1f} requested > {gpu_hour_budget:g} allowed "
+                "(shorter launches, or a smaller `submit --minutes`)"
+            )
     return ""
 
 

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -240,17 +240,46 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     )
 
 
-def gpu_hours_cost(request: SyscallRequest, *, gpus: int, eval_minutes_default: int) -> float:
-    """What honoring `request` draws from the run's GPU-hour budget: every
-    launch's walltime, and — for a submit — the two paired gate evals at the
-    declared (else the contract's) walltime, each times the benchmark's GPUs.
-    A CPU benchmark (gpus 0) meters nothing."""
+def launches_gpu_hours(request: SyscallRequest, *, gpus: int) -> float:
+    """The GPU-hours of the request's launches alone (minutes x GPUs)."""
     if gpus <= 0:
         return 0.0
-    minutes = sum(la.minutes for la in request.launches)
-    if request.submit:
-        minutes += 2 * (request.eval_minutes or eval_minutes_default or 0)
-    return minutes * gpus / 60.0
+    return sum(la.minutes for la in request.launches) * gpus / 60.0
+
+
+def evals_gpu_hours(
+    request: SyscallRequest,
+    *,
+    gpus: int,
+    eval_minutes_default: int,
+    suite_gpus: tuple[int, ...] = (),
+) -> float:
+    """The GPU-hours of a submit's gate: two paired evals at the declared
+    (else the contract's) walltime times the benchmark's GPUs — plus the
+    same pair for every suite sibling (each at ITS GPU count), charged as
+    if measured: whether the suite phase runs is decided at measurement,
+    and a budget over-charges rather than under-charges. 0 when not a
+    submit."""
+    if not request.submit:
+        return 0.0
+    minutes = request.eval_minutes or eval_minutes_default or 0
+    return 2 * minutes * (max(gpus, 0) + sum(max(g, 0) for g in suite_gpus)) / 60.0
+
+
+def gpu_hours_cost(
+    request: SyscallRequest,
+    *,
+    gpus: int,
+    eval_minutes_default: int,
+    suite_gpus: tuple[int, ...] = (),
+) -> float:
+    """What honoring `request` would draw from the run's GPU-hour budget in
+    full: launches plus (for a submit) the gate. The budget check uses this
+    worst case; the orchestrator CHARGES the two parts where each actually
+    happens (evals at acceptance, sibling launches only when dispatched)."""
+    return launches_gpu_hours(request, gpus=gpus) + evals_gpu_hours(
+        request, gpus=gpus, eval_minutes_default=eval_minutes_default, suite_gpus=suite_gpus
+    )
 
 
 def read_verdict(workspace: Path) -> dict[str, Any] | None:
@@ -439,6 +468,7 @@ def budget_error(
     gpu_hour_budget: float | None = None,
     gpus: int = 0,
     eval_minutes_default: int = 0,
+    suite_gpus: tuple[int, ...] = (),
 ) -> str:
     """The budget check, arithmetic only ('' = within budget). The PROMPT
     carries warnings; this refuses only genuine exhaustion. The sleep being
@@ -455,8 +485,10 @@ def budget_error(
             f"launch budget would be exceeded: {launches_used} used + "
             f"{len(request.launches)} requested > {launch_budget} allowed"
         )
-    if gpu_hour_budget is not None and gpus > 0:
-        cost = gpu_hours_cost(request, gpus=gpus, eval_minutes_default=eval_minutes_default)
+    if gpu_hour_budget is not None and (gpus > 0 or any(g > 0 for g in suite_gpus)):
+        cost = gpu_hours_cost(
+            request, gpus=gpus, eval_minutes_default=eval_minutes_default, suite_gpus=suite_gpus
+        )
         if gpu_hours_used + cost > gpu_hour_budget:
             return (
                 f"GPU-hour budget would be exceeded: {gpu_hours_used:.1f} used + "
@@ -596,6 +628,7 @@ def render_wake(
     launch_budget: int,
     sleeps_used: int,
     sleep_budget: int,
+    gpu_hours_remaining: float | None = None,
 ) -> str:
     """The text a woken author sees: every job's results as fenced DATA, the
     author's own note echoed back, and the remaining budgets. Job output is
@@ -629,9 +662,10 @@ def render_wake(
     if note:
         fence = _fence(note)
         parts.append(f"Your note to yourself:\n{fence}\n{note}\n{fence}")
+    gpu = f", {gpu_hours_remaining:.1f} GPU-hours" if gpu_hours_remaining is not None else ""
     parts.append(
         f"Budgets: {launch_budget - launches_used} launches and "
-        f"{sleep_budget - sleeps_used} sleeps remaining."
+        f"{sleep_budget - sleeps_used} sleeps{gpu} remaining."
         + (
             " This was your LAST sleep — conclude this session with your best result."
             if sleeps_used >= sleep_budget

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -56,6 +56,8 @@ MAX_COMMAND_CHARS = 2_000
 MAX_ARTIFACTS = 8
 MAX_NOTE_CHARS = 2_000
 MAX_LAUNCH_MINUTES = 240
+# a submit's declared eval walltime (matches the kernel's backstop)
+MAX_EVAL_MINUTES = 1440
 # judge (finding/conclude) bounds
 CONFIDENCES = ("low", "medium", "high")
 KINDS = ("change", "suggestion", "question", "note")
@@ -98,6 +100,7 @@ def _load_staged(root: Path) -> dict:
         ("launches", []),
         ("note", ""),
         ("submit", False),
+        ("eval_minutes", None),
         ("findings", []),
         ("notes", ""),
     ):
@@ -112,9 +115,11 @@ def _save_staged(root: Path, data: dict) -> None:
 def _budget_line(root: Path) -> str:
     try:
         b = json.loads((root / DIR / BUDGET).read_text())
+        gpu = b.get("gpu_hours_remaining")
+        gpu_part = f", {gpu:g} GPU-hours" if isinstance(gpu, int | float) else ""
         return (
             f"budget: {b.get('launches_remaining', '?')} launches, "
-            f"{b.get('sleeps_remaining', '?')} sleeps remaining"
+            f"{b.get('sleeps_remaining', '?')} sleeps{gpu_part} remaining"
         )
     except (OSError, json.JSONDecodeError):
         return "budget: (unknown)"
@@ -168,14 +173,26 @@ def cmd_note(root: Path, args: argparse.Namespace) -> str:
     return "note saved (delivered back to you on wake)."
 
 
-def cmd_submit(root: Path, _args: argparse.Namespace) -> str:
+def cmd_submit(root: Path, args: argparse.Namespace) -> str:
     staged = _load_staged(root)
     staged["submit"] = True
+    minutes = getattr(args, "minutes", None)
+    if minutes is not None:
+        if minutes < 1:
+            raise ToolError("--minutes must be a positive integer")
+        staged["eval_minutes"] = min(minutes, MAX_EVAL_MINUTES)
     _save_staged(root, staged)
+    declared = staged.get("eval_minutes")
+    walltime = (
+        f"each paired eval gets {declared} min of walltime (your declaration; "
+        "2 evals x minutes x GPUs draws on your GPU-hour budget)"
+        if declared
+        else "each paired eval gets the contract's default walltime (declare more with --minutes)"
+    )
     return (
         "staged submit: on `sleep` your current tree is SEALED and measured "
         "against the baseline, and the review panel reads the claim; you will "
-        "be woken with the result (published if it clears cleanly). "
+        f"be woken with the result (published if it clears cleanly). {walltime}. "
         f"{_budget_line(root)}."
     )
 
@@ -189,6 +206,8 @@ def cmd_sleep(root: Path, _args: argparse.Namespace) -> str:
         "note": staged["note"],
         "submit": bool(staged["submit"]),
     }
+    if staged["submit"] and staged.get("eval_minutes"):
+        payload["eval_minutes"] = int(staged["eval_minutes"])
     (_dir(root) / ABI).write_text(json.dumps(payload))
     (root / DIR / REQUEST).unlink(missing_ok=True)
     n = len(staged["launches"])
@@ -302,9 +321,16 @@ def build_parser() -> argparse.ArgumentParser:
     la.add_argument("command", nargs=argparse.REMAINDER, help="-- then the command to run")
     no = sub.add_parser("note", help="save a note to yourself, echoed back on wake")
     no.add_argument("text")
-    sub.add_parser(
+    su = sub.add_parser(
         "submit",
         help="stage a submit: on sleep, seal this tree for the gate + review panel",
+    )
+    su.add_argument(
+        "--minutes",
+        type=int,
+        default=None,
+        help="walltime for each paired gate eval (default: the contract's; "
+        "2 evals x minutes x GPUs draws on your GPU-hour budget)",
     )
     sub.add_parser("sleep", help="commit staged launches/submit; then end your turn")
     # judge verbs

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -545,16 +545,25 @@ def test_gpu_hours_are_metered_against_the_run_budget() -> None:
     submit's two gate evals (at the declared, else default, walltime) draw on
     gpu_hours_per_run; an over-budget request is refused with the numbers.
     CPU benchmarks meter nothing."""
-    from autoresearch.syscall import gpu_hours_cost
+    from autoresearch.syscall import evals_gpu_hours, gpu_hours_cost, launches_gpu_hours
 
     launches = (_launch("a"), _launch("b"))  # 5 min each
     plain = SyscallRequest(launches=launches)
     assert gpu_hours_cost(plain, gpus=1, eval_minutes_default=240) == 10 / 60
     assert gpu_hours_cost(plain, gpus=0, eval_minutes_default=240) == 0.0
+    assert evals_gpu_hours(plain, gpus=1, eval_minutes_default=240) == 0.0  # not a submit
     sub_default = SyscallRequest(launches=(), submit=True)
     assert gpu_hours_cost(sub_default, gpus=1, eval_minutes_default=240) == 8.0
     sub_declared = SyscallRequest(launches=(), submit=True, eval_minutes=420)
     assert gpu_hours_cost(sub_declared, gpus=2, eval_minutes_default=240) == 28.0
+    # the two parts are charged where they happen: a submit's evals at
+    # acceptance, its sibling launches only when the gate parks (terra #177)
+    sub_with = SyscallRequest(launches=launches, submit=True)
+    assert launches_gpu_hours(sub_with, gpus=1) == 10 / 60
+    assert evals_gpu_hours(sub_with, gpus=1, eval_minutes_default=240) == 8.0
+    # suite siblings' paired evals are charged as if measured, each at its
+    # own GPU count (terra #177): 2 x 240 min x (1 + 1 + 0) GPUs
+    assert evals_gpu_hours(sub_default, gpus=1, eval_minutes_default=240, suite_gpus=(1, 0)) == 16.0
     # fits: 8 GPU-hours of evals into a 60-hour budget with 50 used
     ok = budget_error(
         sub_default,

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -514,3 +514,84 @@ def test_launch_job_script_copies_declared_artifacts(tmp_path: Path) -> None:
     # SYMLINK refused: the out-of-tree target was never delivered
     assert "leak.txt" in log
     assert not (ev / "artifacts" / "leak.txt").exists()
+
+
+def test_submit_carries_a_declared_eval_walltime(tmp_path: Path) -> None:
+    """`eval_minutes` is the author's walltime for the submit's paired gate
+    evals: positive, clamped to the backstop, and meaningless without a
+    submit (refused loudly rather than silently ignored)."""
+    from autoresearch.syscall import MAX_EVAL_MINUTES
+
+    write_req(tmp_path, {"launches": [], "submit": True, "eval_minutes": 420})
+    req = read_request(tmp_path)
+    assert req is not None and req.submit and req.eval_minutes == 420
+    write_req(tmp_path, {"launches": [], "submit": True, "eval_minutes": 10**6})
+    req = read_request(tmp_path)
+    assert req is not None and req.eval_minutes == MAX_EVAL_MINUTES
+    write_req(tmp_path, {"launches": [], "submit": True})
+    req = read_request(tmp_path)
+    assert req is not None and req.eval_minutes is None
+    for bad in (
+        {"launches": [], "eval_minutes": 60},
+        {"launches": [], "submit": True, "eval_minutes": 0},
+    ):
+        write_req(tmp_path, bad)
+        with pytest.raises(SyscallError):
+            read_request(tmp_path)
+
+
+def test_gpu_hours_are_metered_against_the_run_budget() -> None:
+    """Compute is priced, steps are not: launches (minutes x GPUs) and a
+    submit's two gate evals (at the declared, else default, walltime) draw on
+    gpu_hours_per_run; an over-budget request is refused with the numbers.
+    CPU benchmarks meter nothing."""
+    from autoresearch.syscall import gpu_hours_cost
+
+    launches = (_launch("a"), _launch("b"))  # 5 min each
+    plain = SyscallRequest(launches=launches)
+    assert gpu_hours_cost(plain, gpus=1, eval_minutes_default=240) == 10 / 60
+    assert gpu_hours_cost(plain, gpus=0, eval_minutes_default=240) == 0.0
+    sub_default = SyscallRequest(launches=(), submit=True)
+    assert gpu_hours_cost(sub_default, gpus=1, eval_minutes_default=240) == 8.0
+    sub_declared = SyscallRequest(launches=(), submit=True, eval_minutes=420)
+    assert gpu_hours_cost(sub_declared, gpus=2, eval_minutes_default=240) == 28.0
+    # fits: 8 GPU-hours of evals into a 60-hour budget with 50 used
+    ok = budget_error(
+        sub_default,
+        launches_used=0,
+        launch_budget=4,
+        sleeps_used=0,
+        sleep_budget=4,
+        gpu_hours_used=50.0,
+        gpu_hour_budget=60.0,
+        gpus=1,
+        eval_minutes_default=240,
+    )
+    assert ok == ""
+    # does not fit: a 14-hour eval pair on top of 50 used
+    over = budget_error(
+        sub_declared,
+        launches_used=0,
+        launch_budget=4,
+        sleeps_used=0,
+        sleep_budget=4,
+        gpu_hours_used=50.0,
+        gpu_hour_budget=60.0,
+        gpus=1,
+        eval_minutes_default=240,
+    )
+    assert "GPU-hour budget would be exceeded" in over and "60" in over
+    # a CPU benchmark never meters, whatever the numbers say
+    assert (
+        budget_error(
+            sub_declared,
+            launches_used=0,
+            launch_budget=4,
+            sleeps_used=0,
+            sleep_budget=4,
+            gpu_hours_used=999.0,
+            gpu_hour_budget=1.0,
+            gpus=0,
+        )
+        == ""
+    )


### PR DESCRIPTION
We gate the contract's metric, never time. Walltime should bound only *spend*, and the attempt already has a spend budget — `gpu_hours_per_run`, which was display-only until now.

- **`submit --minutes <N>`** (syscall `eval_minutes`, submit-only, 24h backstop) sizes the submit's two paired gate evals; the contract's `eval_minutes` is the default. The declaration rides the park, so a wake re-dispatches and re-floors on it.
- **`gpu_hours_per_run` is metered** at the syscall for GPU benchmarks: launches (minutes × GPUs) + a submit's 2 × walltime × GPUs; over-budget requests are refused with the numbers; the drawn total rides the park and shows in `status`, wake text, and the brief (worded in the contract's terms only — no target-specific metric language in the kernel).
- `EVAL_JOB_MINUTES_CEILING` 300 → 1440 (backstop, not policy).

Motivation: the first speedrun attempts produced candidates whose evals run longer than the baseline's (2× compute per step; Muon's extra matmuls), and an eval limit sized to the baseline's runtime would kill them before they could win. Now the author that wants a longer eval pays from its own GPU-hours and has less for experiments — compute priced by whoever chose to spend it.

Pinned: request parsing (submit-only, clamp), `gpu_hours_cost`, refusal arithmetic incl. CPU-benchmark no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)