### PR TITLE
feat: baseline: cached — measure the base tree once per base, run only candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `baseline: cached` (per benchmark; default `paired`): the base tree is
+  measured once per (benchmark, base sha) into a target-wide cache and reused
+  by every attempt on that base, so a gate runs only the candidate — half the
+  eval spend for a benchmark whose baseline is effectively deterministic. The
+  comparison is unpaired, so the contract must declare a calibrated floor
+  (the loader insists), and a credited result says which cached measurement
+  (and seed) its delta was taken against.
 - THE AUTHOR DECLARES ITS EVAL WALLTIME, AND PAYS FOR IT: `submit --minutes
   <N>` sizes the submit's paired gate evals (default: the contract's
   `eval_minutes`), and `gpu_hours_per_run` is now METERED at the syscall for

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -89,6 +89,19 @@ eval and has less for experiments — compute is priced by whoever chose to
 spend it, and a legitimate win is never killed by a limit sized to the
 baseline's runtime. `EVAL_JOB_MINUTES_CEILING` is only a 24h backstop.
 
+**Paired or cached baseline.** By default every gate re-measures the base
+tree beside the candidate under one fresh seed (common random numbers): the
+noise-minimal comparison, at two evals per attempt. A benchmark whose
+baseline is effectively deterministic — the speedrun's calibration put nine
+seeds on the same step count — can declare `baseline: cached`: the base
+tree is measured once per (benchmark, base sha) into a target-wide cache
+beside the run dirs, every attempt on that base reuses it, and only the
+candidate runs. The comparison is then unpaired, so the loader requires a
+calibrated floor (`min_delta`/`min_delta_rel`), and the credited result says
+which cached measurement (and seed) the delta was taken against. Two width
+slots that miss the cache at once both measure and both write; last writer
+wins and both values are real.
+
 **Interop.** The orchestrator keeps a single seam: `Evaluator` grows a
 dispatched implementation that *stages* instead of blocking. `climb_once`'s
 transaction (session -> measure -> gates -> panel -> publish) becomes

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1799,6 +1799,8 @@ def live_attempt(
                 partition="",
                 eval_minutes=int(eval_minutes or 0),
                 run_tag=run_id,
+                # an inline gate shares the same target-wide baseline cache
+                baseline_cache=run_dir.parent / "baselines",
             )
         snapshots: list[Snapshot] = []
 

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -150,13 +150,15 @@ class Benchmark(_StrictModel):
                 f"benchmark {self.name!r} asks for {self.gpus} GPU(s) but its evals "
                 "would run in-job: set eval_minutes above the in-job threshold so they dispatch"
             )
-        if self.baseline == "cached" and self.min_delta is None and self.min_delta_rel is None:
+        floor_set = (self.min_delta or 0) > 0 or (self.min_delta_rel or 0) > 0
+        if self.baseline == "cached" and not floor_set:
             # an unpaired comparison has no built-in noise cancellation: the
             # floor is the only thing standing between seed luck and a record
+            # — and benchmark_floor treats 0 as "no floor", so it must be > 0
             raise ValueError(
                 f"benchmark {self.name!r} uses a cached baseline (unpaired comparison) "
-                "but declares no significance floor: set min_delta or min_delta_rel "
-                "from a seed-variance calibration"
+                "but declares no positive significance floor: set min_delta or "
+                "min_delta_rel (> 0) from a seed-variance calibration"
             )
         return self
 

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -99,6 +99,17 @@ class Benchmark(_StrictModel):
     # attempts on it rather than queue evals that can never run. Bounded at
     # one node's worth: multi-node evals are not a shape the jail supports.
     gpus: int = Field(default=0, ge=0, le=8)
+    # How the gate obtains the baseline number it compares a candidate to.
+    #   paired (default): re-measure the base tree next to every candidate,
+    #     both under one fresh seed (common random numbers) — the noise-
+    #     minimal comparison, at two evals per attempt.
+    #   cached: measure the base tree ONCE per (benchmark, base sha) into a
+    #     cache shared by every attempt on that base, then run only the
+    #     candidate at a fresh seed. Halves eval spend; the comparison is
+    #     unpaired, so the contract's min_delta must cover cross-seed noise
+    #     on its own (calibrate it). The ledger row says which baseline
+    #     measurement (and seed) a credited delta was taken against.
+    baseline: Literal["paired", "cached"] = "paired"
     # Depth budget (docs/design/research-loop.md, "one syscall, author-directed"):
     # how many external experiment jobs the author may LAUNCH within one attempt.
     # A generous meter on actions, not a loop the kernel drives — the author
@@ -138,6 +149,14 @@ class Benchmark(_StrictModel):
             raise ValueError(
                 f"benchmark {self.name!r} asks for {self.gpus} GPU(s) but its evals "
                 "would run in-job: set eval_minutes above the in-job threshold so they dispatch"
+            )
+        if self.baseline == "cached" and self.min_delta is None and self.min_delta_rel is None:
+            # an unpaired comparison has no built-in noise cancellation: the
+            # floor is the only thing standing between seed luck and a record
+            raise ValueError(
+                f"benchmark {self.name!r} uses a cached baseline (unpaired comparison) "
+                "but declares no significance floor: set min_delta or min_delta_rel "
+                "from a seed-variance calibration"
             )
         return self
 

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -18,9 +18,11 @@ phase flows straight through to the decision.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from autoresearch.compute import Compute, JobSpec, is_terminal
 from autoresearch.dispatch import (
@@ -142,6 +144,41 @@ def plan_measures(
     return plan
 
 
+def _baseline_cache_path(cache_dir: Path, benchmark: str, base_sha: str) -> Path:
+    return cache_dir / f"{benchmark}@{base_sha}.json"
+
+
+def read_baseline_cache(cache_dir: Path, benchmark: str, base_sha: str) -> dict[str, Any] | None:
+    """The cached base-tree measurement for (benchmark, base sha), or None.
+    A cache entry is only ever written from an orchestrator-measured value
+    (below), never from anything an author produced."""
+    try:
+        data = json.loads(_baseline_cache_path(cache_dir, benchmark, base_sha).read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict) or "value" not in data:
+        return None
+    try:
+        float(data["value"])
+    except (TypeError, ValueError):
+        return None
+    return data
+
+
+def write_baseline_cache(
+    cache_dir: Path, benchmark: str, base_sha: str, *, value: float, seed: int, run_tag: str
+) -> None:
+    """Record an orchestrator-measured baseline for every later attempt on
+    this base. Atomic (tmp + replace): two width slots measuring the same
+    base concurrently both write a valid file; last writer wins, and both
+    values are real measurements."""
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    path = _baseline_cache_path(cache_dir, benchmark, base_sha)
+    tmp = path.with_suffix(f".{run_tag[:20] or 'tmp'}.tmp")
+    tmp.write_text(json.dumps({"value": value, "seed": seed, "run": run_tag, "base_sha": base_sha}))
+    tmp.replace(path)
+
+
 @dataclass
 class DispatchedMeasurer:
     """Submits and reads a climb's measures as jobs on any `Compute` backend.
@@ -164,6 +201,9 @@ class DispatchedMeasurer:
     # benchmark), everything else on account/partition
     gpu_partition: str = ""
     gpu_account: str = ""
+    # where a `baseline: cached` benchmark's base-tree measurements live
+    # (target-wide); None = no cache, every gate measures its own baseline
+    baseline_cache: Path | None = None
 
     def _placement(self, m: Measure) -> tuple[str, str]:
         if m.gpus <= 0:
@@ -362,4 +402,7 @@ class DispatchSettings:
             run_tag=run_tag,
             gpu_partition=self.gpu_partition,
             gpu_account=self.gpu_account,
+            # target-wide, beside the run dirs: every attempt on one base
+            # shares its cached baseline measurement (Benchmark.baseline)
+            baseline_cache=run_dir.parent / "baselines",
         )

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -156,11 +156,16 @@ def read_baseline_cache(
     image: str = "",
     command: str = "",
     metric: str = "",
+    seed_env: str = "",
+    gpus: int = 0,
 ) -> dict[str, Any] | None:
     """The cached base-tree measurement for (benchmark, base sha), or None.
     The entry must have been measured under the SAME determinants the
-    candidate will be — eval image, contract command, metric key — or it is stale
-    (terra #178): a comparison across images is not a comparison. A cache
+    candidate will be — eval image, contract command, metric key, seed
+    variable, GPU count: everything the measurer's own eval identity
+    carries except the tree sha (the key) and the seed VALUE (fresh per
+    attempt by design) — or it is stale (terra #178): a comparison across
+    determinants is not a comparison. A cache
     entry is only ever written from an orchestrator-measured value (below),
     never from anything an author produced."""
     try:
@@ -177,6 +182,8 @@ def read_baseline_cache(
         data.get("image", "") != image
         or data.get("command", "") != command
         or data.get("metric", "") != metric
+        or data.get("seed_env", "") != seed_env
+        or int(data.get("gpus", 0) or 0) != gpus
     ):
         return None
     return data
@@ -193,6 +200,8 @@ def write_baseline_cache(
     image: str = "",
     command: str = "",
     metric: str = "",
+    seed_env: str = "",
+    gpus: int = 0,
 ) -> None:
     """Record an orchestrator-measured baseline for every later attempt on
     this base, with the determinants it was measured under. Atomic (a
@@ -215,6 +224,8 @@ def write_baseline_cache(
                 "image": image,
                 "command": command,
                 "metric": metric,
+                "seed_env": seed_env,
+                "gpus": gpus,
             },
             fh,
         )

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -149,11 +149,17 @@ def _baseline_cache_path(cache_dir: Path, benchmark: str, base_sha: str) -> Path
 
 
 def read_baseline_cache(
-    cache_dir: Path, benchmark: str, base_sha: str, *, image: str = "", command: str = ""
+    cache_dir: Path,
+    benchmark: str,
+    base_sha: str,
+    *,
+    image: str = "",
+    command: str = "",
+    metric: str = "",
 ) -> dict[str, Any] | None:
     """The cached base-tree measurement for (benchmark, base sha), or None.
     The entry must have been measured under the SAME determinants the
-    candidate will be — eval image and contract command — or it is stale
+    candidate will be — eval image, contract command, metric key — or it is stale
     (terra #178): a comparison across images is not a comparison. A cache
     entry is only ever written from an orchestrator-measured value (below),
     never from anything an author produced."""
@@ -167,7 +173,11 @@ def read_baseline_cache(
         float(data["value"])
     except (TypeError, ValueError):
         return None
-    if data.get("image", "") != image or data.get("command", "") != command:
+    if (
+        data.get("image", "") != image
+        or data.get("command", "") != command
+        or data.get("metric", "") != metric
+    ):
         return None
     return data
 
@@ -182,6 +192,7 @@ def write_baseline_cache(
     run_tag: str,
     image: str = "",
     command: str = "",
+    metric: str = "",
 ) -> None:
     """Record an orchestrator-measured baseline for every later attempt on
     this base, with the determinants it was measured under. Atomic (a
@@ -203,6 +214,7 @@ def write_baseline_cache(
                 "base_sha": base_sha,
                 "image": image,
                 "command": command,
+                "metric": metric,
             },
             fh,
         )

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -148,10 +148,15 @@ def _baseline_cache_path(cache_dir: Path, benchmark: str, base_sha: str) -> Path
     return cache_dir / f"{benchmark}@{base_sha}.json"
 
 
-def read_baseline_cache(cache_dir: Path, benchmark: str, base_sha: str) -> dict[str, Any] | None:
+def read_baseline_cache(
+    cache_dir: Path, benchmark: str, base_sha: str, *, image: str = "", command: str = ""
+) -> dict[str, Any] | None:
     """The cached base-tree measurement for (benchmark, base sha), or None.
-    A cache entry is only ever written from an orchestrator-measured value
-    (below), never from anything an author produced."""
+    The entry must have been measured under the SAME determinants the
+    candidate will be — eval image and contract command — or it is stale
+    (terra #178): a comparison across images is not a comparison. A cache
+    entry is only ever written from an orchestrator-measured value (below),
+    never from anything an author produced."""
     try:
         data = json.loads(_baseline_cache_path(cache_dir, benchmark, base_sha).read_text())
     except (OSError, ValueError):
@@ -162,21 +167,46 @@ def read_baseline_cache(cache_dir: Path, benchmark: str, base_sha: str) -> dict[
         float(data["value"])
     except (TypeError, ValueError):
         return None
+    if data.get("image", "") != image or data.get("command", "") != command:
+        return None
     return data
 
 
 def write_baseline_cache(
-    cache_dir: Path, benchmark: str, base_sha: str, *, value: float, seed: int, run_tag: str
+    cache_dir: Path,
+    benchmark: str,
+    base_sha: str,
+    *,
+    value: float,
+    seed: int,
+    run_tag: str,
+    image: str = "",
+    command: str = "",
 ) -> None:
     """Record an orchestrator-measured baseline for every later attempt on
-    this base. Atomic (tmp + replace): two width slots measuring the same
-    base concurrently both write a valid file; last writer wins, and both
+    this base, with the determinants it was measured under. Atomic (a
+    unique tmp per writer + replace): two width slots measuring the same
+    base concurrently both land a valid file; last writer wins, and both
     values are real measurements."""
+    import os
+    import tempfile
+
     cache_dir.mkdir(parents=True, exist_ok=True)
     path = _baseline_cache_path(cache_dir, benchmark, base_sha)
-    tmp = path.with_suffix(f".{run_tag[:20] or 'tmp'}.tmp")
-    tmp.write_text(json.dumps({"value": value, "seed": seed, "run": run_tag, "base_sha": base_sha}))
-    tmp.replace(path)
+    fd, tmp_name = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=cache_dir)
+    with os.fdopen(fd, "w") as fh:
+        json.dump(
+            {
+                "value": value,
+                "seed": seed,
+                "run": run_tag,
+                "base_sha": base_sha,
+                "image": image,
+                "command": command,
+            },
+            fh,
+        )
+    Path(tmp_name).replace(path)
 
 
 @dataclass

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1249,6 +1249,7 @@ def attempt_once(
     candidate: float | None = baseline
     suite: tuple[SuiteMeasurement, ...] = ()
     suite_seed_ran = 0
+    baseline_note = ""
     measured: tuple[str, ...] = ()
     refused_once = False
 
@@ -1546,6 +1547,7 @@ def attempt_once(
         candidate = outcome.candidate
         suite = outcome.suite
         suite_seed_ran = outcome.suite_seed
+        baseline_note = outcome.baseline_note  # cached-baseline provenance, to the report
 
         if panel_runner is None:
             break
@@ -1582,6 +1584,7 @@ def attempt_once(
         run_seed=run_seed,
         suite=suite,
         suite_seed=suite_seed_ran,
+        note=baseline_note,
         panel_transcript="\n\n".join(panel_sections),
         panel_rounds=panel_reads,
         panel_blocking_open=panel_blocking_open,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -713,6 +713,9 @@ class MeasureOK:
     candidate: float
     suite: tuple[SuiteMeasurement, ...] = ()
     suite_seed: int = 0
+    # how the baseline number was obtained when it was NOT measured beside
+    # this candidate (`baseline: cached`) — surfaces on the credited result
+    baseline_note: str = ""
 
 
 def measure_and_decide(
@@ -749,7 +752,12 @@ def measure_and_decide(
     # deferred like contract.py's managed_eval_env import: measure -> dispatch
     # -> orchestrator for the eval primitives, so orchestrator imports measure
     # at call time to keep the module graph acyclic.
-    from autoresearch.measure import SiblingSpec, plan_measures
+    from autoresearch.measure import (
+        SiblingSpec,
+        plan_measures,
+        read_baseline_cache,
+        write_baseline_cache,
+    )
 
     # Scope BEFORE measurement: an out-of-scope tree is never evaluated,
     # because the out-of-scope edit could be to the ruler itself.
@@ -787,22 +795,51 @@ def measure_and_decide(
     # PHASE 1 — baseline + candidate only. Siblings are NOT measured until the
     # candidate has cleared the threshold: a non-improving candidate must never
     # burn the (expensive) sibling evals, matching attempt_once's lazy order.
+    # `baseline: cached` — the base tree is measured ONCE per (benchmark, base
+    # sha) into the target's cache and reused by every attempt on that base;
+    # only the candidate runs. Unpaired, so the contract's floor carries the
+    # cross-seed noise (the loader requires one). A miss measures both and
+    # records the baseline for the next attempt.
+    cache_dir = getattr(measurer, "baseline_cache", None)
+    cached = (
+        read_baseline_cache(cache_dir, bench.name, base_sha)
+        if bench.baseline == "cached" and cache_dir is not None
+        else None
+    )
+    plan = plan_measures(
+        bench.command,
+        bench.metric,
+        base_sha,
+        candidate_sha,
+        seed_env,
+        seed,
+        gpus=bench.gpus,
+    )
+    if cached is not None:
+        plan = [m for m in plan if m.name != "baseline"]
     try:
-        main = measurer.results(
-            plan_measures(
-                bench.command,
-                bench.metric,
-                base_sha,
-                candidate_sha,
-                seed_env,
-                seed,
-                gpus=bench.gpus,
-            )
-        )
+        main = measurer.results(plan)
     except EvalError as exc:
         return AttemptResult(outcome="eval-error", note=str(exc), run_seed=seed)
 
-    baseline = main["baseline"]
+    baseline_note = ""
+    if cached is not None:
+        baseline = float(cached["value"])
+        baseline_note = (
+            f"baseline {baseline} reused from the cache (measured at seed "
+            f"{cached.get('seed')} by run {cached.get('run')}); candidate at seed {seed}"
+        )
+    else:
+        baseline = main["baseline"]
+        if bench.baseline == "cached" and cache_dir is not None:
+            write_baseline_cache(
+                cache_dir,
+                bench.name,
+                base_sha,
+                value=baseline,
+                seed=seed,
+                run_tag=str(getattr(measurer, "run_tag", "")),
+            )
     candidate = main["candidate"]
     if not improved(baseline, candidate, bench.direction, min_relative_improvement):
         return AttemptResult(
@@ -839,7 +876,7 @@ def measure_and_decide(
     # shared code. A second measure set (a second park for a dispatched
     # backend): an extra CPU wake, never a wasted GPU sibling eval.
     if not (siblings and shared_touched(measured_paths, contract)):
-        return MeasureOK(baseline=baseline, candidate=candidate)
+        return MeasureOK(baseline=baseline, candidate=candidate, baseline_note=baseline_note)
 
     # every seeded sibling runs its pair under the ONE suite_seed, read through
     # its own seed var (mirrors the in-job gate).
@@ -914,6 +951,7 @@ def measure_and_decide(
         candidate=candidate,
         suite=suite,
         suite_seed=suite_seed,  # reached only on the suite path
+        baseline_note=baseline_note,
     )
 
 
@@ -996,6 +1034,7 @@ def resume_attempt(
         suite=outcome.suite,
         suite_seed=outcome.suite_seed,
         candidate_sha=candidate_sha,
+        note=outcome.baseline_note,
     )
 
 

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -810,6 +810,8 @@ def measure_and_decide(
             image=image,
             command=bench.command,
             metric=bench.metric,
+            seed_env=bench.seed_env or "",
+            gpus=bench.gpus,
         )
         if bench.baseline == "cached" and cache_dir is not None
         else None
@@ -850,6 +852,8 @@ def measure_and_decide(
                 image=image,
                 command=bench.command,
                 metric=bench.metric,
+                seed_env=bench.seed_env or "",
+                gpus=bench.gpus,
             )
     candidate = main["candidate"]
     if not improved(baseline, candidate, bench.direction, min_relative_improvement):
@@ -1345,6 +1349,8 @@ def attempt_once(
                     image=str(getattr(measurer, "image", "")),
                     command=bench.command,
                     metric=bench.metric,
+                    seed_env=bench.seed_env or "",
+                    gpus=bench.gpus,
                 ):
                     main_evals = 1
             problem = syscall_budget_error(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -801,8 +801,9 @@ def measure_and_decide(
     # cross-seed noise (the loader requires one). A miss measures both and
     # records the baseline for the next attempt.
     cache_dir = getattr(measurer, "baseline_cache", None)
+    image = str(getattr(measurer, "image", ""))
     cached = (
-        read_baseline_cache(cache_dir, bench.name, base_sha)
+        read_baseline_cache(cache_dir, bench.name, base_sha, image=image, command=bench.command)
         if bench.baseline == "cached" and cache_dir is not None
         else None
     )
@@ -839,6 +840,8 @@ def measure_and_decide(
                 value=baseline,
                 seed=seed,
                 run_tag=str(getattr(measurer, "run_tag", "")),
+                image=image,
+                command=bench.command,
             )
     candidate = main["candidate"]
     if not improved(baseline, candidate, bench.direction, min_relative_improvement):
@@ -1319,6 +1322,21 @@ def attempt_once(
             # suite siblings' paired evals are charged as if measured (the
             # suite phase decides at measurement; a budget over-charges)
             suite_gpus = tuple(b.gpus for b in contract.benchmarks if b.name != bench.name)
+            # a `baseline: cached` gate with a warm cache runs ONE main eval
+            # (the candidate); charge what will actually run (terra #178)
+            main_evals = 2
+            if request.submit and bench.baseline == "cached":
+                from autoresearch.measure import read_baseline_cache
+
+                cache_dir = getattr(measurer, "baseline_cache", None)
+                if cache_dir is not None and read_baseline_cache(
+                    cache_dir,
+                    bench.name,
+                    base_sha,
+                    image=str(getattr(measurer, "image", "")),
+                    command=bench.command,
+                ):
+                    main_evals = 1
             problem = syscall_budget_error(
                 request,
                 launches_used=launches_used,
@@ -1330,6 +1348,7 @@ def attempt_once(
                 gpus=bench.gpus,
                 eval_minutes_default=bench.eval_minutes or 0,
                 suite_gpus=suite_gpus,
+                main_evals=main_evals,
             )
             if not problem:
                 if request.submit:
@@ -1349,6 +1368,7 @@ def attempt_once(
                         gpus=bench.gpus,
                         eval_minutes_default=bench.eval_minutes or 0,
                         suite_gpus=suite_gpus,
+                        main_evals=main_evals,
                     )
                     if hasattr(measurer, "eval_minutes"):
                         measurer.eval_minutes = request.eval_minutes or bench.eval_minutes or 0

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -803,7 +803,14 @@ def measure_and_decide(
     cache_dir = getattr(measurer, "baseline_cache", None)
     image = str(getattr(measurer, "image", ""))
     cached = (
-        read_baseline_cache(cache_dir, bench.name, base_sha, image=image, command=bench.command)
+        read_baseline_cache(
+            cache_dir,
+            bench.name,
+            base_sha,
+            image=image,
+            command=bench.command,
+            metric=bench.metric,
+        )
         if bench.baseline == "cached" and cache_dir is not None
         else None
     )
@@ -842,6 +849,7 @@ def measure_and_decide(
                 run_tag=str(getattr(measurer, "run_tag", "")),
                 image=image,
                 command=bench.command,
+                metric=bench.metric,
             )
     candidate = main["candidate"]
     if not improved(baseline, candidate, bench.direction, min_relative_improvement):
@@ -1336,6 +1344,7 @@ def attempt_once(
                     base_sha,
                     image=str(getattr(measurer, "image", "")),
                     command=bench.command,
+                    metric=bench.metric,
                 ):
                     main_evals = 1
             problem = syscall_budget_error(

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -253,17 +253,20 @@ def evals_gpu_hours(
     gpus: int,
     eval_minutes_default: int,
     suite_gpus: tuple[int, ...] = (),
+    main_evals: int = 2,
 ) -> float:
-    """The GPU-hours of a submit's gate: two paired evals at the declared
-    (else the contract's) walltime times the benchmark's GPUs — plus the
-    same pair for every suite sibling (each at ITS GPU count), charged as
-    if measured: whether the suite phase runs is decided at measurement,
-    and a budget over-charges rather than under-charges. 0 when not a
-    submit."""
+    """The GPU-hours of a submit's gate: `main_evals` evals of the climbed
+    benchmark at the declared (else the contract's) walltime times its GPUs
+    (two when paired; one when a cached baseline is warm) — plus a paired
+    pair for every suite sibling (each at ITS GPU count), charged as if
+    measured: whether the suite phase runs is decided at measurement, and a
+    budget over-charges rather than under-charges. 0 when not a submit."""
     if not request.submit:
         return 0.0
     minutes = request.eval_minutes or eval_minutes_default or 0
-    return 2 * minutes * (max(gpus, 0) + sum(max(g, 0) for g in suite_gpus)) / 60.0
+    main = max(main_evals, 0) * max(gpus, 0)
+    suite = 2 * sum(max(g, 0) for g in suite_gpus)
+    return minutes * (main + suite) / 60.0
 
 
 def gpu_hours_cost(
@@ -272,13 +275,18 @@ def gpu_hours_cost(
     gpus: int,
     eval_minutes_default: int,
     suite_gpus: tuple[int, ...] = (),
+    main_evals: int = 2,
 ) -> float:
     """What honoring `request` would draw from the run's GPU-hour budget in
     full: launches plus (for a submit) the gate. The budget check uses this
     worst case; the orchestrator CHARGES the two parts where each actually
     happens (evals at acceptance, sibling launches only when dispatched)."""
     return launches_gpu_hours(request, gpus=gpus) + evals_gpu_hours(
-        request, gpus=gpus, eval_minutes_default=eval_minutes_default, suite_gpus=suite_gpus
+        request,
+        gpus=gpus,
+        eval_minutes_default=eval_minutes_default,
+        suite_gpus=suite_gpus,
+        main_evals=main_evals,
     )
 
 
@@ -469,6 +477,7 @@ def budget_error(
     gpus: int = 0,
     eval_minutes_default: int = 0,
     suite_gpus: tuple[int, ...] = (),
+    main_evals: int = 2,
 ) -> str:
     """The budget check, arithmetic only ('' = within budget). The PROMPT
     carries warnings; this refuses only genuine exhaustion. The sleep being
@@ -487,7 +496,11 @@ def budget_error(
         )
     if gpu_hour_budget is not None and (gpus > 0 or any(g > 0 for g in suite_gpus)):
         cost = gpu_hours_cost(
-            request, gpus=gpus, eval_minutes_default=eval_minutes_default, suite_gpus=suite_gpus
+            request,
+            gpus=gpus,
+            eval_minutes_default=eval_minutes_default,
+            suite_gpus=suite_gpus,
+            main_evals=main_evals,
         )
         if gpu_hours_used + cost > gpu_hour_budget:
             return (

--- a/tests/test_measure_and_decide.py
+++ b/tests/test_measure_and_decide.py
@@ -385,7 +385,9 @@ def test_cached_baseline_measures_the_base_once_then_only_candidates(tmp_path):
     out = decide(first)
     assert isinstance(out, MeasureOK) and out.baseline == 0.50 and out.baseline_note == ""
     assert first.per_call == [["baseline", "candidate"]]
-    entry = read_baseline_cache(tmp_path / "baselines", "main", BASE, command="run main")
+    entry = read_baseline_cache(
+        tmp_path / "baselines", "main", BASE, command="run main", metric="score"
+    )
     assert entry and entry["value"] == 0.50 and entry["seed"] == 7 and entry["run"] == "run-1"
 
     second = FakeMeasurer({"candidate": 0.61})  # no baseline value: it must not be asked for
@@ -428,6 +430,9 @@ def test_cached_baseline_is_keyed_by_image_and_command(tmp_path):
     assert read_baseline_cache(d, "main", BASE, image="/a.sif", command="run main")
     assert read_baseline_cache(d, "main", BASE, image="/b.sif", command="run main") is None
     assert read_baseline_cache(d, "main", BASE, image="/a.sif", command="run other") is None
+    assert (
+        read_baseline_cache(d, "main", BASE, image="/a.sif", command="run main", metric="x") is None
+    )
     # two concurrent writers of the same entry: unique tmp files, last wins, no crash
     write_baseline_cache(
         d, "main", BASE, value=0.6, seed=4, run_tag="r", image="/a.sif", command="run main"

--- a/tests/test_measure_and_decide.py
+++ b/tests/test_measure_and_decide.py
@@ -385,7 +385,7 @@ def test_cached_baseline_measures_the_base_once_then_only_candidates(tmp_path):
     out = decide(first)
     assert isinstance(out, MeasureOK) and out.baseline == 0.50 and out.baseline_note == ""
     assert first.per_call == [["baseline", "candidate"]]
-    entry = read_baseline_cache(tmp_path / "baselines", "main", BASE)
+    entry = read_baseline_cache(tmp_path / "baselines", "main", BASE, command="run main")
     assert entry and entry["value"] == 0.50 and entry["seed"] == 7 and entry["run"] == "run-1"
 
     second = FakeMeasurer({"candidate": 0.61})  # no baseline value: it must not be asked for
@@ -414,3 +414,23 @@ def test_paired_default_never_touches_the_cache(tmp_path):
 def test_cached_baseline_requires_a_floor():
     with pytest.raises(ValueError, match="floor"):
         load_contract(CACHED_CONTRACT.replace("    min_delta: 0.02\n", ""), "x/y")
+
+
+def test_cached_baseline_is_keyed_by_image_and_command(tmp_path):
+    """A cache entry measured under another eval image or contract command
+    is stale, not a baseline (terra #178): the gate misses and re-measures."""
+    from autoresearch.measure import read_baseline_cache, write_baseline_cache
+
+    d = tmp_path / "baselines"
+    write_baseline_cache(
+        d, "main", BASE, value=0.5, seed=3, run_tag="r", image="/a.sif", command="run main"
+    )
+    assert read_baseline_cache(d, "main", BASE, image="/a.sif", command="run main")
+    assert read_baseline_cache(d, "main", BASE, image="/b.sif", command="run main") is None
+    assert read_baseline_cache(d, "main", BASE, image="/a.sif", command="run other") is None
+    # two concurrent writers of the same entry: unique tmp files, last wins, no crash
+    write_baseline_cache(
+        d, "main", BASE, value=0.6, seed=4, run_tag="r", image="/a.sif", command="run main"
+    )
+    got = read_baseline_cache(d, "main", BASE, image="/a.sif", command="run main")
+    assert got and got["value"] == 0.6 and not list(d.glob("*.tmp"))

--- a/tests/test_measure_and_decide.py
+++ b/tests/test_measure_and_decide.py
@@ -4,6 +4,8 @@ session, no git, no cluster."""
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from autoresearch.contract import load_contract
@@ -65,6 +67,9 @@ class FakeMeasurer:
         self.seen: list[Measure] = []
         self.per_call: list[list[str]] = []  # measure names, one entry per call
         self.calls = 0
+        # the cached-baseline seam measure_and_decide reads off a measurer
+        self.baseline_cache: Path | None = None
+        self.run_tag = ""
 
     def results(self, measures: list[Measure]) -> dict[str, float]:
         self.calls += 1
@@ -334,3 +339,78 @@ def test_resume_eval_error_is_terminal():
     out = _resume(FakeMeasurer(raise_exc=EvalError("candidate: no readable r2")))
     assert out.outcome == "eval-error"
     assert "no readable r2" in out.note
+
+
+CACHED_CONTRACT = """
+benchmarks:
+  - name: main
+    command: run main
+    metric: score
+    direction: max
+    baseline: cached
+    min_delta: 0.02
+budgets: {gpu_hours_per_run: 1, runs_per_week: 5}
+scope:
+  allowed: [src/]
+roadmap: docs/roadmap.md
+"""
+
+
+def test_cached_baseline_measures_the_base_once_then_only_candidates(tmp_path):
+    """`baseline: cached`: the first attempt on a base measures both and
+    records the baseline; the next attempt on the same base measures ONLY its
+    candidate and compares against the cache, saying so on the credited
+    result. A different base misses the cache."""
+    from autoresearch.measure import read_baseline_cache
+
+    contract = load_contract(CACHED_CONTRACT, "x/y")
+    bench = _benchmark(contract, "main")
+
+    def decide(m, base=BASE, seed=7):
+        return measure_and_decide(
+            contract,
+            bench,
+            base_sha=base,
+            candidate_sha=CAND,
+            seed=seed,
+            suite_seed=0,
+            measured_paths=("src/model.py",),
+            measurer=m,
+            min_relative_improvement=0.005,
+        )
+
+    first = FakeMeasurer({"baseline": 0.50, "candidate": 0.60})
+    first.baseline_cache = tmp_path / "baselines"
+    first.run_tag = "run-1"
+    out = decide(first)
+    assert isinstance(out, MeasureOK) and out.baseline == 0.50 and out.baseline_note == ""
+    assert first.per_call == [["baseline", "candidate"]]
+    entry = read_baseline_cache(tmp_path / "baselines", "main", BASE)
+    assert entry and entry["value"] == 0.50 and entry["seed"] == 7 and entry["run"] == "run-1"
+
+    second = FakeMeasurer({"candidate": 0.61})  # no baseline value: it must not be asked for
+    second.baseline_cache = tmp_path / "baselines"
+    second.run_tag = "run-2"
+    out2 = decide(second, seed=8)
+    assert isinstance(out2, MeasureOK) and out2.baseline == 0.50 and out2.candidate == 0.61
+    assert second.per_call == [["candidate"]]
+    assert "reused from the cache" in out2.baseline_note and "seed 7" in out2.baseline_note
+
+    other = FakeMeasurer({"baseline": 0.55, "candidate": 0.58})
+    other.baseline_cache = tmp_path / "baselines"
+    other.run_tag = "run-3"
+    decide(other, base="c" * 40)
+    assert other.per_call == [["baseline", "candidate"]]  # a new base: measured again
+
+
+def test_paired_default_never_touches_the_cache(tmp_path):
+    m = FakeMeasurer({"baseline": 0.50, "candidate": 0.60})
+    m.baseline_cache = tmp_path / "baselines"
+    out = _decide(m)
+    assert isinstance(out, MeasureOK) and out.baseline_note == ""
+    assert not (tmp_path / "baselines").exists()
+
+
+def test_cached_baseline_requires_a_floor():
+    with pytest.raises(ValueError, match="floor"):
+        load_contract(CACHED_CONTRACT.replace("    min_delta: 0.02\n", ""), "x/y")

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -604,3 +604,16 @@ def test_gpu_hours_are_metered_against_the_run_budget() -> None:
         )
         == ""
     )
+
+
+def test_cached_gate_is_charged_one_main_eval() -> None:
+    """A `baseline: cached` submit with a warm cache runs only the candidate:
+    the gate charges one main eval, not two (terra #178); siblings stay paired."""
+    from autoresearch.syscall import evals_gpu_hours
+
+    sub = SyscallRequest(launches=(), submit=True, eval_minutes=240)
+    assert evals_gpu_hours(sub, gpus=1, eval_minutes_default=0, main_evals=2) == 8.0
+    assert evals_gpu_hours(sub, gpus=1, eval_minutes_default=0, main_evals=1) == 4.0
+    assert (
+        evals_gpu_hours(sub, gpus=1, eval_minutes_default=0, main_evals=1, suite_gpus=(1,)) == 12.0
+    )


### PR DESCRIPTION
Stacked on #177 (retargets to `main` when that merges).

Every gate re-measures the base tree beside the candidate — paired, common random numbers, the noise-minimal comparison. For a benchmark whose baseline is effectively deterministic that doubles eval spend for nothing: the speedrun's calibration put nine seeds on the same step count, and today's width-4 gate runs eight H200s where four would do.

- **`Benchmark.baseline: paired | cached`** (default `paired`, unchanged). `cached`: the base tree is measured once per (benchmark, base sha) into a target-wide cache beside the run dirs; later attempts on that base run **only their candidate** at a fresh seed.
- Unpaired ⇒ the floor carries the cross-seed noise: the loader rejects `cached` without `min_delta`/`min_delta_rel`.
- A credited result says which cached measurement (and seed) its delta was taken against (`MeasureOK.baseline_note` → the run report).
- Concurrency: two width slots missing the cache at once both measure and both write (atomic tmp+replace); last writer wins, both values are real.

Pinned: first attempt measures both and records; second measures only its candidate and reports the reuse; a new base misses; paired never touches the cache; loader floor requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)