### PR TITLE
docs: the README, install guide, and roadmap catch up with the running system

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,11 @@ The knobs that shape a climb, all optional:
 | `steward.allowed` | Paths a separate stewardship lane may maintain (the ruler, the harness) — never the solver |
 | `merge: manual \| auto` | Whether a gate-and-panel-clean PR waits for a human or merges itself |
 
-`gpu_hours_per_run` is metered: an author's experiment launches and its
-candidate's evals draw on it, and the author declares how long its final
-eval may run (`submit --minutes`) — compute is paid for by whoever chose to
-spend it, and never gated as the metric.
+For GPU benchmarks `gpu_hours_per_run` is metered: an author's experiment
+launches and its candidate's evals draw on it, and the author declares how
+long its final eval may run (`submit --minutes`) — compute is paid for by
+whoever chose to spend it, and never gated as the metric. CPU benchmarks
+meter nothing.
 
 ```bash
 uv run python -m autoresearch.contract_cli .autoresearch.yaml   # validate before you push

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Nothing reports back to us.
 - **Benchmark climbing** — given a contract (`.autoresearch.yaml`) declaring
   what "better" means and where the agent may write, authors propose changes
   and the orchestrator measures them itself: the base tree and the candidate
-  are evaluated on your cluster under one fresh seed, a calibrated
+  are evaluated on your cluster (under one fresh shared seed when the
+  benchmark declares `seed_env`), a calibrated
   significance floor decides whether the movement is real, a verify/review
   panel reads the claim, and only then does a PR open. Several authors can
   climb one benchmark abreast (the width dial); each author can run its own
@@ -73,7 +74,8 @@ The knobs that shape a climb, all optional:
 | `merge: manual \| auto` | Whether a gate-and-panel-clean PR waits for a human or merges itself |
 
 For GPU benchmarks `gpu_hours_per_run` is metered: an author's experiment
-launches and its candidate's evals draw on it, and the author declares how
+launches and its gate evals (baseline and candidate when paired) draw on
+it, and the author declares how
 long its final eval may run (`submit --minutes`) — compute is paid for by
 whoever chose to spend it, and never gated as the metric. CPU benchmarks
 meter nothing.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@
 An autonomous research agent you point at your own repos. It reviews pull
 requests, implements ideas, runs experiments on your compute, and opens a PR
 when a benchmark actually improves — with a readable research report, not just
-numbers. **Humans keep the merge button.**
+numbers. How much it may do on its own is a per-repo dial: PRs wait for a human
+by default, or merge themselves when the gate and the review panel are clean.
 
 Built and dogfooded by the [Agentic Learning AI Lab](https://agenticlearning.ai)
 at NYU, where it co-develops our research codebases. Designed from the start to
@@ -23,28 +24,68 @@ Nothing reports back to us.
 ## What it does
 
 - **Advisory PR reviews** — comments on pull requests with concrete findings.
-  It never approves, never blocks, and never fails your CI. This works today
-  and takes about five minutes to set up.
-- **Benchmark climbing** *(arriving — see the [roadmap](docs/roadmap.md))* —
-  given a contract (`.autoresearch.yaml`) declaring what "better" means, the
-  agent will propose changes, evaluate them on your infrastructure, and open a
-  PR only when the metric moves. Claims stay re-verifiable by your own CI
-  because benchmark commands are deterministic. The contract format and
-  validator exist today.
-- **Research reports** *(arriving)* — every run will end with a readable
-  report (hypothesis, outcome, takeaways, next steps), feeding task selection
-  for future runs.
+  It never approves, never blocks, and never fails your CI. Five minutes to
+  set up.
+- **Benchmark climbing** — given a contract (`.autoresearch.yaml`) declaring
+  what "better" means and where the agent may write, authors propose changes
+  and the orchestrator measures them itself: the base tree and the candidate
+  are evaluated on your cluster under one fresh seed, a calibrated
+  significance floor decides whether the movement is real, a verify/review
+  panel reads the claim, and only then does a PR open. Several authors can
+  climb one benchmark abreast (the width dial); each author can run its own
+  experiments outside the sandbox and sleep until they finish (the depth
+  dial). Claims stay re-verifiable by your own CI because benchmark commands
+  are deterministic.
+- **Research reports** — every attempt ends with a report (hypothesis,
+  change, outcome, takeaway, next step), including the negatives. Reports
+  are archived on a `research-log` branch of the target and pointed to from
+  a rolling issue; credited improvements update the target's ledger
+  (`BENCHMARKS.md`, `results/leader.json`).
+
+## The contract
+
+One file in the target repo. The minimum:
+
+```yaml
+benchmarks:
+  - name: my-benchmark
+    command: uv run python -m mypkg.eval --json   # prints {"success_rate": 0.42}
+    metric: success_rate
+    direction: max
+budgets:
+  gpu_hours_per_run: 8
+  runs_per_week: 10
+scope:
+  allowed: [src/]                                # the ONLY paths the agent may write
+roadmap: docs/roadmap.md
+```
+
+The knobs that shape a climb, all optional:
+
+| Knob | What it decides |
+| --- | --- |
+| `seed_env`, `min_delta` / `min_delta_rel` | Paired seeding for resampled evals, and the significance floor a delta must clear — calibrate it from seed variance, the gate enforces it |
+| `eval_minutes`, `gpus` | Evals that need their own job (and GPUs) are dispatched to the cluster rather than run in the author's job |
+| `baseline: paired \| cached` | Re-measure the base tree beside every candidate, or measure it once per base and run only candidates |
+| `depth_k`, `sleep_k` | How many experiments an author may launch and how many times it may sleep for results |
+| `max_active_attempts`, `attempt_cooldown_minutes` | Width: authors abreast on one target; pacing between attempts (0 for a hot loop) |
+| `steward.allowed` | Paths a separate stewardship lane may maintain (the ruler, the harness) — never the solver |
+| `merge: manual \| auto` | Whether a gate-and-panel-clean PR waits for a human or merges itself |
+
+`gpu_hours_per_run` is metered: an author's experiment launches and its
+candidate's evals draw on it, and the author declares how long its final
+eval may run (`submit --minutes`) — compute is paid for by whoever chose to
+spend it, and never gated as the metric.
+
+```bash
+uv run python -m autoresearch.contract_cli .autoresearch.yaml   # validate before you push
+```
 
 ## Getting started
 
 See **[docs/install.md](docs/install.md)**. Level 1 (advisory reviews) needs
 only an LLM API key and one workflow file. Level 2 (the climber) adds a bot
-account and a contract.
-
-```bash
-# validate your contract before you push it
-uv run python -m autoresearch.contract_cli .autoresearch.yaml
-```
+account, a contract, and a Slurm cluster with Apptainer.
 
 ## Design principles
 
@@ -52,12 +93,22 @@ uv run python -m autoresearch.contract_cli .autoresearch.yaml
   and committing a contract. The contract, your roadmap, and `.github/` are
   never writable by the agent, whatever the contract says.
 - **Your gates apply.** The agent is an ordinary contributor: branch
-  protection, required checks, and code owners bind it like anyone else.
-- **Untrusted by default.** PR text and diffs are data, never instructions.
-  Agent sessions run without credentials in their environment. Budgets are
-  enforced in code.
+  protection, required checks, and code owners bind it like anyone else. In
+  `merge: auto` mode your required CI with strict up-to-date checks is the
+  last word, and GitHub itself refuses a stale-base merge.
+- **Untrusted by default.** PR text, diffs, issue text, and job output are
+  data, never instructions. Authors run without credentials in their
+  environment; evals run in a jail that sees only the checked-out tree.
+  Budgets — launches, sleeps, GPU-hours, weekly runs — are enforced in code.
+- **Nothing is taken on trust.** The orchestrator measures every claim
+  itself, on committed trees, and re-verifies credited candidates before a
+  PR exists.
 - **Nothing leaves your infrastructure.** Experiments run where you say
   (Slurm is the first backend; the compute interface is small and pluggable).
+- **No resident process.** The whole system is a self-perpetuating chain of
+  short Slurm ticks with all state in records on the shared filesystem —
+  every role is its own job, and a crash anywhere heals into an honest
+  ending on the next tick.
 - **No model lock-in.** Every model call goes through the harness layer, so
   backends are swappable — Claude Code, Codex, and hermes-agent are wired today.
 
@@ -74,10 +125,10 @@ uv run pytest
 
 | Path | Purpose |
 | --- | --- |
-| `src/autoresearch/` | The library: contract, review, github, llm; harness, orchestrator, compute arriving per the roadmap |
+| `src/autoresearch/` | The kernel: contract, tick (the Slurm chain), attempt/orchestrator (the climb), measure/dispatch (evals as jobs), syscall (the author's tool), panel/verifier/review, github, harness backends |
 | `tests/` | Tiers: unit (default), `slow`, `llm`, `slurm` markers |
-| `scripts/` | Committed operational scripts |
-| `docs/` | Install guide, architecture, roadmap |
+| `scripts/` | Committed operational scripts (the tick chain, provisioning) |
+| `docs/` | Install guide, architecture and design notes, roadmap |
 
 ## License
 

--- a/docs/design/headline.md
+++ b/docs/design/headline.md
@@ -129,19 +129,21 @@ step · failure model (driver dies vs sweep heals).
    `suite_regressed` is floor-aware per sibling, same-seed paired, fails
    closed; this list previously carried a stale "to build" — Mengye caught
    it).
-3. **`merge: manual|auto` contract knob** + repo-settings runbook + the
-   publish change (merge directly when the gate CI is the sole requirement;
-   arm otherwise) — the LAST auto-mode item.
-4. **Width dial**: portfolio climbs on one benchmark (lift
-   MAX_ACTIVE_RUNS_PER_TARGET; attempt dedup/selection; merge/race policy
-   for concurrent PRs).
+3. **`merge: manual|auto` contract knob** — DONE (#171; runbook in the
+   contract's docstring; live on gpt-speedrun 2026-08-28).
+4. **Width dial** — DONE (#173, `max_active_attempts`; per-slot agent
+   identities and markers). Still open: wake-and-reintegrate for
+   superseded siblings (width-V2) before going wider than 4.
 5. **Multi-target servicing** (headline + pilot must coexist; the tick
    report fields are already shaped for it).
-6. **GPU eval jobs** + noise-floor/min_delta calibration for the speedrun
-   contract (seed-hacking defense = our private-seed re-measure).
-7. **Speedrun target repo scaffold** (contract, ruler, baseline
-   reproduction).
-8. **Grid runs + baselines**, then the write-up.
+6. **GPU eval jobs** — DONE (#174 `gpus` + GPU lane + `--nv`; #175 per-GPU
+   job sizing; #176 `--gpus-per-node`; #177 author-declared eval walltime
+   with metered GPU-hours; #178 `baseline: cached`). Calibration DONE:
+   9 runs all cross at 9472 steps → `min_delta: 256`.
+7. **Speedrun target repo scaffold** — DONE (gpt-speedrun: modded-nanogpt
+   baseline reproduced on one H200 at the public log's crossing step).
+8. **Grid runs + baselines**, then the write-up. First autonomous attempts
+   running 2026-08-28 (width 4, auto mode).
 
 Go-public gate (unchanged, tracked elsewhere): the pull_request_target
 fork-PR exfiltration gap must close before any repo flips public.

--- a/docs/install.md
+++ b/docs/install.md
@@ -139,8 +139,10 @@ The optional knobs — paired seeding and the significance floor
 `attempt_cooldown_minutes`), a stewardship scope, and `merge: manual|auto` —
 are listed in the README's contract table; the schema's own docstrings
 (`src/autoresearch/contract.py`) are the reference. A GPU benchmark needs a
-calibrated floor and a dispatched eval (the validator says so), and
-`gpu_hours_per_run` is a real meter: launches and evals draw on it.
+dispatched eval (`eval_minutes` above the in-job threshold) and a cached
+baseline needs a positive floor — the validator says so — and for GPU
+benchmarks `gpu_hours_per_run` is a real meter: launches and evals draw on
+it (CPU benchmarks meter nothing).
 
 Two things to get right:
 
@@ -192,15 +194,20 @@ Experiments run wherever your `compute` backend says. Slurm is the first
 backend; the interface is small (submit a job, poll for completion), so a CI
 runner, a cloud backend, or a hardware rig plugs in the same way.
 
-The deployment is configured by environment (the chain reads an allowlist of
-keys from `~/.config/autoresearch/.env` each tick, so most changes take effect
-at the next cadence): `AUTORESEARCH_TARGET` names the repo being climbed;
-`AUTORESEARCH_ACCOUNT`/`AUTORESEARCH_PARTITION` place the CPU jobs (ticks,
-author sessions); `AUTORESEARCH_GPU_PARTITION` (optionally
+The deployment is configured by environment. Placement and paths are set
+when the chain is started: `AUTORESEARCH_ACCOUNT`/`AUTORESEARCH_PARTITION`
+place the CPU jobs (ticks, author sessions), `AUTORESEARCH_HOME`/
+`AUTORESEARCH_ROOT` locate the checkout and the state, `AUTORESEARCH_IMAGE`
+the container. The rest is re-read from `~/.config/autoresearch/.env` each
+tick, so changes take effect at the next cadence: `AUTORESEARCH_TARGET`
+names the repo being climbed; `AUTORESEARCH_GPU_PARTITION` (optionally
 `AUTORESEARCH_GPU_ACCOUNT`) is the lane for GPU evals and launches — a
 comma-separated partition list lets Slurm start each job wherever it fits
-first; `AUTORESEARCH_PANEL` names the verify/review lenses; the author
-backend and its keys are `AUTORESEARCH_AUTHOR_*`. Evals run inside the
+first; `AUTORESEARCH_PANEL` names the verify/review lenses (with
+`AUTORESEARCH_PANEL_*_KEY_FILE` for their keys); the author backend is
+`AUTORESEARCH_AUTHOR_BACKEND`/`AUTORESEARCH_AUTHOR_MODEL`, its key file
+`AUTORESEARCH_HARNESS_KEY_FILE` (Claude) or `AUTORESEARCH_CODEX_KEY_FILE`
+(Codex). Evals run inside the
 Apptainer image at `AUTORESEARCH_IMAGE` (default
 `~/autoresearch-images/agent-py312.sif`) in a jail that binds only the
 checked-out tree — an eval that needs data must fetch it into the tree, and
@@ -232,8 +239,10 @@ unaffected — those models are not on GCP.
 
 On by default. Think hard before changing any of them:
 
-- The bot never merges and is never a code owner — your branch protection
-  applies to it like any contributor.
+- By default the bot never merges and is never a code owner — your branch
+  protection applies to it like any contributor. `merge: auto` is an explicit
+  per-repo opt-in: a gate-and-panel-clean PR merges itself, still through
+  your required checks (strict up-to-date), never around them.
 - Agent sessions run with no credentials in their environment; pushes happen
   after the session ends.
 - Only maintainer-authored issues and comments become tasks. Everything else,

--- a/docs/install.md
+++ b/docs/install.md
@@ -132,6 +132,16 @@ uv run python -m autoresearch.contract_cli .autoresearch.yaml
 
 It prints what the agent would be allowed to do, or exactly what is wrong.
 
+The optional knobs — paired seeding and the significance floor
+(`seed_env`, `min_delta`/`min_delta_rel`), dispatched and GPU evals
+(`eval_minutes`, `gpus`), `baseline: paired|cached`, the depth budgets
+(`depth_k`, `sleep_k`), width and pacing (`max_active_attempts`,
+`attempt_cooldown_minutes`), a stewardship scope, and `merge: manual|auto` —
+are listed in the README's contract table; the schema's own docstrings
+(`src/autoresearch/contract.py`) are the reference. A GPU benchmark needs a
+calibrated floor and a dispatched eval (the validator says so), and
+`gpu_hours_per_run` is a real meter: launches and evals draw on it.
+
 Two things to get right:
 
 1. Your `command` must be **deterministic and re-runnable**, and print the
@@ -161,6 +171,10 @@ A GitHub machine user in your org, with a fine-grained PAT:
   **no workflow permission**
 - Expiration: 90 days, with a rotation reminder
 
+Then **add the bot as a collaborator with write access on every target
+repo** (org members can be added directly). Without it the tick cannot even
+read the contract and idles silently on that target.
+
 Add the bot as a direct collaborator (**Write**) on each opted-in repo. Don't
 add it to a team — teams grant more than it needs and inherit future grants.
 
@@ -175,9 +189,22 @@ that can reach GitHub and your LLM provider works.
 - **A VM or workstation**: run it on a timer.
 
 Experiments run wherever your `compute` backend says. Slurm is the first
-backend (arriving per the roadmap); the interface is small (submit a job, poll
-for completion), so a CI runner, a cloud backend, or a hardware rig plugs in
-the same way.
+backend; the interface is small (submit a job, poll for completion), so a CI
+runner, a cloud backend, or a hardware rig plugs in the same way.
+
+The deployment is configured by environment (the chain reads an allowlist of
+keys from `~/.config/autoresearch/.env` each tick, so most changes take effect
+at the next cadence): `AUTORESEARCH_TARGET` names the repo being climbed;
+`AUTORESEARCH_ACCOUNT`/`AUTORESEARCH_PARTITION` place the CPU jobs (ticks,
+author sessions); `AUTORESEARCH_GPU_PARTITION` (optionally
+`AUTORESEARCH_GPU_ACCOUNT`) is the lane for GPU evals and launches — a
+comma-separated partition list lets Slurm start each job wherever it fits
+first; `AUTORESEARCH_PANEL` names the verify/review lenses; the author
+backend and its keys are `AUTORESEARCH_AUTHOR_*`. Evals run inside the
+Apptainer image at `AUTORESEARCH_IMAGE` (default
+`~/autoresearch-images/agent-py312.sif`) in a jail that binds only the
+checked-out tree — an eval that needs data must fetch it into the tree, and
+GPU jobs are requested per node (`--gpus-per-node`).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -69,11 +69,13 @@ standing instruction they supersede — a resumed agent honors stale constraints
       handoff + tick sweep + deadline floor (pending-cancel / gone-on-good-
       query / defer-on-query-failure) + `stuck` state. Session dispatch
       behind the `WakeDispatcher` seam (real dispatcher lands with phase 5)
-- [ ] Experiment/eval dispatch design: docs/design/dispatcher.md —
-      eval-as-a-job first, triggered by the 2026-08-16 steward eval-timeout
-      class. Its phase 1 supplies the first production `WakeDispatcher`
-      implementation (transaction re-entry wakes for waiting runs); session
-      -resume wakes ride the same seam in phase 2.
+- [x] Experiment/eval dispatch (docs/design/dispatcher.md): evals as their
+      own jobs with park/wake re-entry; author experiment launches and
+      sleeps (the depth dial, docs/design/research-loop.md); GPU benchmarks
+      (`gpus` + a GPU lane, per-GPU job sizing, `--gpus-per-node`); the
+      author declares its eval walltime and pays from a metered
+      `gpu_hours_per_run`; `baseline: cached` measures a base once per base
+      sha (2026-08-16 → 2026-08-28, #174–#178).
 
 - [x] The chain: `scripts/tick_chain.sbatch` — successor top-up to depth 2,
       `--dependency=singleton`, absolute `--begin` cadence grid, sbatch
@@ -132,6 +134,16 @@ the research repos' porting timelines; mistakes are free; adversarial testing
       fenced, scope/drift/re-measure on changes) → reply as bot. Tick wiring,
       issue intake, and workspace GC still pending
 - [ ] Staged injection tests against the pilot before any research target
+- [x] Autonomy and scale dials (2026-08-27/28): the gate enforces the
+      contract's calibrated floor (#169) and the panel's aggregation taste
+      (#167); `merge: manual|auto` (#171) with a repo-side runbook; pacing
+      (`attempt_cooldown_minutes`, crash tombstones, #172) and width
+      (`max_active_attempts`, per-slot identities, #173). Every attempt's
+      report — negatives included — lands on the target's `research-log`
+      branch with a pointer on a rolling issue (#170)
+- [x] First GPU target live (2026-08-28): gpt-speedrun (docs/design/headline.md)
+      — baseline reproduced on one H200 at the public log's crossing step,
+      9-run calibration → `min_delta: 256`, running at width 4 in auto mode
 
 Candidate second target (2026-08-06): a private toy-scale research repo —
 real research code, CPU-runnable, seeded, single-command evals. Two things


### PR DESCRIPTION
Docs-only. The README still said "Humans keep the merge button" and listed benchmark climbing and research reports as *arriving*; the dev table said the orchestrator and compute layer were yet to come.

- **README**: what the climb does today (measured gate + calibrated floor, panel, width/depth dials, research-log reports, ledger); a contract section with the knob table and what the metered `gpu_hours_per_run` means; merge policy as a per-repo dial; the no-resident-process principle; current layout.
- **install.md**: knob pointers; the *bot must be a collaborator on every target* step (the tick idles silently without it — cost us two ticks today); deployment env keys incl. the GPU lane and partition lists; the jail's data rule; `--gpus-per-node`.
- **roadmap.md** + **headline.md**: today's items ticked with PR refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)