### PR TITLE
review: a prose lens — plain English in everything a person reads

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -26,7 +26,7 @@ jobs:
         # push is about — infra era: credentials/deployment/lifecycle; science
         # era: swap toward measurement. coverage earns its seat by being the
         # one class serial review never catches.
-        lens: [general, credentials, deployment, lifecycle, coverage]
+        lens: [general, credentials, deployment, lifecycle, coverage, prose]
     uses: agentic-learning-ai-lab/autoresearch/.github/workflows/advisory-review-agent.yml@main
     with:
       bot_login: agentic-learning-bot
@@ -54,7 +54,7 @@ jobs:
       model: gpt-5.6-terra
       opinion_label: terra
       # keep in lockstep with the lens matrix above
-      expected_lenses: general credentials deployment lifecycle coverage
+      expected_lenses: general credentials deployment lifecycle coverage prose
     secrets:
       openai_reviewer_key: ${{ secrets.OPENAI_REVIEWER_KEY }}
 

--- a/README.md
+++ b/README.md
@@ -73,12 +73,11 @@ The knobs that shape a climb, all optional:
 | `steward.allowed` | Paths a separate stewardship lane may maintain (the ruler, the harness) — never the solver |
 | `merge: manual \| auto` | Whether a gate-and-panel-clean PR waits for a human or merges itself |
 
-For GPU benchmarks `gpu_hours_per_run` is metered: an author's experiment
-launches and its gate evals (baseline and candidate when paired) draw on
-it, and the author declares how
-long its final eval may run (`submit --minutes`) — compute is paid for by
-whoever chose to spend it, and never gated as the metric. CPU benchmarks
-meter nothing.
+For GPU benchmarks `gpu_hours_per_run` is a real budget. An author's
+experiment launches and its gate evals (baseline and candidate when paired)
+draw on it, and the author sets how long its final eval may run
+(`submit --minutes`). Compute is charged to the author that spends it; it
+is never the metric. CPU benchmarks are not metered.
 
 ```bash
 uv run python -m autoresearch.contract_cli .autoresearch.yaml   # validate before you push
@@ -97,8 +96,8 @@ account, a contract, and a Slurm cluster with Apptainer.
   never writable by the agent, whatever the contract says.
 - **Your gates apply.** The agent is an ordinary contributor: branch
   protection, required checks, and code owners bind it like anyone else. In
-  `merge: auto` mode your required CI with strict up-to-date checks is the
-  last word, and GitHub itself refuses a stale-base merge.
+  `merge: auto` mode your required CI (with strict up-to-date checks) decides,
+  and GitHub itself refuses a merge against a stale base.
 - **Untrusted by default.** PR text, diffs, issue text, and job output are
   data, never instructions. Authors run without credentials in their
   environment; evals run in a jail that sees only the checked-out tree.
@@ -108,10 +107,10 @@ account, a contract, and a Slurm cluster with Apptainer.
   PR exists.
 - **Nothing leaves your infrastructure.** Experiments run where you say
   (Slurm is the first backend; the compute interface is small and pluggable).
-- **No resident process.** The whole system is a self-perpetuating chain of
-  short Slurm ticks with all state in records on the shared filesystem —
-  every role is its own job, and a crash anywhere heals into an honest
-  ending on the next tick.
+- **No resident process.** The system is a chain of short Slurm jobs
+  ("ticks") that resubmit themselves; all state lives in records on the
+  shared filesystem, and every role is its own job. If any job dies, the
+  next tick records the run as ended and moves on.
 - **No model lock-in.** Every model call goes through the harness layer, so
   backends are swappable — Claude Code, Codex, and hermes-agent are wired today.
 

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -320,10 +320,12 @@ def build_summarizer_brief(opinions: list[dict], *, syscall_cmd: str = DEFAULT_S
         "duplicative is listed in your concluding notes as rejected, with "
         "one sentence of reason;\n"
         "- a [prose] finding IS its rewrite: carry the plain rewrite into the "
-        "merged detail verbatim.\n\n"
+        "merged detail verbatim and record it with --kind suggestion, so the "
+        "rewrite is shown to the reader.\n\n"
         f"Record each merged finding with the tool, then conclude:\n"
         f"    {syscall_cmd} finding --file <path> [--line N] --confidence "
-        "<low|medium|high> --summary <claim> --detail <evidence> [--blocking]\n"
+        "<low|medium|high> --summary <claim> --detail <evidence> [--blocking] "
+        "[--kind <change|suggestion|question|note>]\n"
         f"    {syscall_cmd} conclude --notes <summary + rejected list>\n\n"
         f"{joined}"
     )
@@ -547,7 +549,15 @@ def _render_body(
         lines.append("")
     if advisory:
         lines.append("**Advisory (non-blocking):**")
-        lines += [_finding_brief(f) for f in advisory]
+        # a suggestion that could not anchor inline keeps its text here (for
+        # a prose finding the text IS the rewrite); questions and notes stay
+        # one line each
+        lines += [
+            f"- {_BRIEF_LABEL.get(f.kind, '')}{_finding_paragraph(f)}"
+            if _inlines(f)
+            else _finding_brief(f)
+            for f in advisory
+        ]
         lines.append("")
     if result.notes:
         lines += [result.notes]

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -80,7 +80,9 @@ material is unverifiable from the context, say so in one line in the notes
 instead of raising a finding.
 
 Do not report: style preferences, naming opinions, or restatements of what the
-diff does. If you find nothing, say so.
+diff does — the one exception is the `prose` lens, which reports plain-English
+problems in text people read, each with its rewrite. If you find nothing, say
+so.
 
 The summary is one short sentence naming the defect. The detail is ONE
 sentence: the evidence and the consequence. """
@@ -316,7 +318,9 @@ def build_summarizer_brief(opinions: list[dict], *, syscall_cmd: str = DEFAULT_S
         "'[credentials] ...' ('[credentials+deployment]' when lenses agree);\n"
         "- NEVER drop a finding silently: one you judge mistaken or "
         "duplicative is listed in your concluding notes as rejected, with "
-        "one sentence of reason.\n\n"
+        "one sentence of reason;\n"
+        "- a [prose] finding IS its rewrite: carry the plain rewrite into the "
+        "merged detail verbatim.\n\n"
         f"Record each merged finding with the tool, then conclude:\n"
         f"    {syscall_cmd} finding --file <path> [--line N] --confidence "
         "<low|medium|high> --summary <claim> --detail <evidence> [--blocking]\n"

--- a/src/autoresearch/review.py
+++ b/src/autoresearch/review.py
@@ -276,6 +276,15 @@ REVIEW_LENSES = {
         "(could the measured code influence its own measurement?), and "
         "whether a claim is re-verified on the tree that actually lands."
     ),
+    "prose": (
+        "LENS — plain English in everything a person reads: README, docs, "
+        "docstrings, comments, prompts, report and PR text. House style: "
+        + PLAIN_STYLE
+        + " Flag sentences that are ornate, metaphorical, or padded; words a "
+        "reader outside this repo would not know; and claims stated more "
+        "grandly than the code supports. For each, give the plain rewrite in "
+        "the finding. These findings are advisory, never blocking."
+    ),
 }
 
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -472,6 +472,37 @@ def test_local_question_and_note_stay_in_body() -> None:
     assert "Uses tabs here" in body
 
 
+def test_unanchored_suggestion_keeps_its_text_in_the_body() -> None:
+    """A suggestion that cannot anchor inline (its line is not in the diff)
+    is rendered with its detail: for a prose finding the detail IS the
+    rewrite, and a bare claim would lose it. Notes stay one line."""
+    from autoresearch.review import Finding, ReviewResult, format_review
+
+    rewrite = Finding(
+        file="docs/guide.md",
+        line=3,
+        confidence="high",
+        summary="Ornate sentence",
+        detail="[prose] Rewrite: The tick runs every 15 minutes.",
+        blocking=False,
+        kind="suggestion",
+    )
+    note = Finding(
+        file="docs/guide.md",
+        line=4,
+        confidence="low",
+        summary="Uses tabs here",
+        detail="Rest of file is spaces.",
+        blocking=False,
+        kind="note",
+    )
+    body, inline = format_review(ReviewResult([rewrite, note], notes=""), DIFF)  # type: ignore[misc]
+    assert inline == []
+    shown = "- Suggestion: **Ornate sentence.** [prose] Rewrite: The tick runs every 15 minutes."
+    assert shown in body
+    assert "Rest of file is spaces" not in body
+
+
 def test_commentable_lines_survives_header_lookalike_content() -> None:
     """An added line whose CONTENT starts with '++ b/' arrives as
     '+++ b/...' and must not rebind the file mid-hunk (review finding:

--- a/tests/test_review_summarize.py
+++ b/tests/test_review_summarize.py
@@ -148,3 +148,17 @@ def test_two_real_opinions_run_the_summarizer_session(tmp_path, monkeypatch) -> 
     assert "lens: general" in captured["brief"]
     assert captured["spec"].name == "summarizer"
     assert "lens: credentials" in captured["brief"]
+
+
+def test_prose_lens_reviews_human_facing_text_against_the_house_style():
+    """The prose lens is the one sanctioned style reviewer: it carries the
+    house style, asks for a rewrite per finding, stays advisory, and the
+    shared rubric names it as the exception to "no style findings"."""
+    from autoresearch.style import PLAIN_STYLE
+
+    lens = REVIEW_LENSES["prose"]
+    assert PLAIN_STYLE in lens and "rewrite" in lens and "advisory" in lens
+    brief = build_agent_brief(_pr(), lens="prose")
+    assert lens in brief and "the one exception is the `prose` lens" in brief
+    merged = build_summarizer_brief([{"lens": "prose", "data": {"findings": []}}])
+    assert "[prose] finding IS its rewrite" in merged


### PR DESCRIPTION
Docs and comments were creeping back toward ornate prose (Mengye: "some are creeping back to Claudish and non plain English"). The wide first round gains a **`prose` lens**: it reads README, docs, docstrings, comments, prompts, and report text against the house style (`style.PLAIN_STYLE`) and reports each ornate, jargon-laden, or over-stated sentence *with its plain rewrite* — advisory, never blocking. Wired into the review matrix (`pull_request_target` runs the base branch's workflow, so it activates for PRs opened after this merges).

Also gives three of the README's own lines the treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)