### PR TITLE
A tree the gate already turned down is not measured again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- A tree the gate already turned down in this attempt is never measured again: when the woken author concludes (or resubmits untouched), that verdict stands and the attempt ends on it — no second eval pair, no GPU-hours. An errored eval is still retried.
+
 ### Added
 
 - `baseline: cached` (per benchmark; default `paired`): the base tree is

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -563,6 +563,7 @@ def _wake_author_sleep(
     issue_number: int,
     eval_minutes: int | None,
     extra_update: str = "",
+    judged: tuple[str, AttemptResult] | None = None,
 ) -> AttemptOutcome:
     """Wake a syscall park and resume the AUTHOR: deliver the launches' results
     into the sandbox, resume the SAME session through the climb's resume-entry
@@ -727,6 +728,8 @@ def _wake_author_sleep(
             resume_session_id=record.resume_session_id,
             improve_prompt=wake_text,
             launcher=_make_launcher(dispatch, run_dir, workspace, run_id, gpus=bench.gpus),
+            tree_of=lambda sha: ws.git("rev-parse", f"{sha}^{{tree}}").strip(),
+            judged=judged,
             launches_used=launches_used,
             sleeps_used=sleeps_used,
             gpu_hours_used=gpu_hours_used,
@@ -995,7 +998,9 @@ def resume_run(
         and getattr(harness, "supports_resume", True)
     )
 
-    def _wake_author(extra_update: str) -> AttemptOutcome:
+    def _wake_author(
+        extra_update: str, judged: tuple[str, AttemptResult] | None = None
+    ) -> AttemptOutcome:
         # resume the submitted park's author with the gate/panel feedback
         # leading its wake text; the candidate ref is this park's held snapshot
         return _wake_author_sleep(
@@ -1023,6 +1028,7 @@ def resume_run(
             issue_number=issue_number,
             eval_minutes=eval_minutes,
             extra_update=extra_update,
+            judged=judged,
         )
 
     if (
@@ -1038,7 +1044,11 @@ def resume_run(
             f"{result.note or result.outcome} "
             f"(baseline {result.baseline}, candidate {result.candidate}). "
             "Revise and submit again, run more experiments, or finish with an "
-            "honest negative report."
+            "honest negative report.",
+            # the verdict rides the resume: the same tree, sealed again after
+            # the author concludes or resubmits untouched, is not measured
+            # twice (an errored eval is retried, so it is not carried)
+            judged=(candidate_sha, result) if result.outcome != "eval-error" else None,
         )
 
     if result.outcome == "improved":
@@ -1843,6 +1853,7 @@ def live_attempt(
                 panel_runner=panel_runner,
                 brief_baseline=prior_best.best if prior_best else None,
                 launcher=launcher,
+                tree_of=lambda sha: ws.git("rev-parse", f"{sha}^{{tree}}").strip(),
             )
         except RunParked as p:
             # The climb dispatched its measures and hibernated. Persist the

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -406,6 +406,17 @@ def _park_run(
         stage["launches_used"] = parked.launches_used
         stage["sleeps_used"] = parked.sleeps_used
         stage["gpu_hours_used"] = parked.gpu_hours_used
+        if parked.judged is not None:
+            # the gate's last negative rides the park: a wake that ends on the
+            # same tree reuses it instead of measuring again
+            judged_sha, verdict = parked.judged
+            stage["judged"] = {
+                "sha": judged_sha,
+                "outcome": verdict.outcome,
+                "baseline": verdict.baseline,
+                "candidate": verdict.candidate,
+                "note": redact(verdict.note, secrets),
+            }
         if parked.eval_minutes:
             # the author's declared eval walltime rides the park: the wake's
             # measurer and deadline floor must use it, not the contract's
@@ -729,7 +740,7 @@ def _wake_author_sleep(
             improve_prompt=wake_text,
             launcher=_make_launcher(dispatch, run_dir, workspace, run_id, gpus=bench.gpus),
             tree_of=lambda sha: ws.git("rev-parse", f"{sha}^{{tree}}").strip(),
-            judged=judged,
+            judged=judged or _stage_judged(record),
             launches_used=launches_used,
             sleeps_used=sleeps_used,
             gpu_hours_used=gpu_hours_used,
@@ -769,6 +780,26 @@ def _wake_author_sleep(
     # scope-violation, eval-error; a dispatched gate never returns improved
     # inline): end the run and release the sleep snapshot.
     return _end(result, drop_refs=[sleep_ref])
+
+
+def _stage_judged(record: RunRecord) -> tuple[str, AttemptResult] | None:
+    """The gate verdict a park carried (written by `_park_run`), or None."""
+    j = (record.stage or {}).get("judged")
+    if not isinstance(j, dict) or not j.get("sha"):
+        return None
+
+    def num(v: object) -> float | None:
+        return float(v) if isinstance(v, int | float) and not isinstance(v, bool) else None
+
+    return (
+        str(j["sha"]),
+        AttemptResult(
+            outcome=str(j.get("outcome") or "no-improvement"),
+            baseline=num(j.get("baseline")),
+            candidate=num(j.get("candidate")),
+            note=str(j.get("note") or ""),
+        ),
+    )
 
 
 def _stage_launches(record: RunRecord) -> list[dict]:
@@ -953,6 +984,7 @@ def resume_run(
             parked.sleeps_used = int(stage.get("sleeps_used", 0))  # type: ignore[call-overload]
             parked.gpu_hours_used = float(stage.get("gpu_hours_used", 0.0))  # type: ignore[arg-type]
             parked.eval_minutes = int(stage.get("eval_minutes", 0) or 0) or None  # type: ignore[call-overload]
+            parked.judged = parked.judged or _stage_judged(record)
             if parked.syscall is None:
                 parked.syscall = _SyscallRequest(
                     launches=tuple(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -121,8 +121,12 @@ class RunParked(Exception):
         submitted: bool = False,
         gpu_hours_used: float = 0.0,
         eval_minutes: int | None = None,
+        judged: tuple[str, AttemptResult] | None = None,
     ):
         self.phase = phase
+        # the gate's last negative and the tree it judged, carried across an
+        # author-sleep so a wake ending on that tree reuses the verdict
+        self.judged = judged
         self.afterany = afterany
         self.base_sha = base_sha
         self.seed = seed
@@ -1328,6 +1332,7 @@ def attempt_once(
         # the syscall request the session's last leg left, if any
         submitted: SyscallRequest | None = None
         evals_charge = 0.0  # GPU-hours this pass took for gate evals
+        presealed = ""  # a seal taken early to compare against the judged tree
         while launcher is not None:
             try:
                 request = read_syscall_request(workspace)
@@ -1362,6 +1367,15 @@ def attempt_once(
                     gpus=bench.gpus,
                 ):
                     main_evals = 1
+            if request.submit and failed_gate is not None:
+                # a resubmit of the tree the gate already turned down: nothing
+                # to budget or charge — the verdict is reused below (the sleep
+                # still counts, so unchanged resubmits stay bounded)
+                presealed = snapshot()
+                if tree(failed_gate[0]) == tree(presealed):
+                    submitted = request
+                    sleeps_used += 1
+                    break
             problem = syscall_budget_error(
                 request,
                 launches_used=launches_used,
@@ -1421,6 +1435,7 @@ def attempt_once(
                 sha = snapshot()
                 raise RunParked(
                     phase="author-sleep",
+                    judged=failed_gate,
                     afterany=launcher(sha, request),
                     base_sha=base_sha,
                     seed=run_seed,
@@ -1438,6 +1453,7 @@ def attempt_once(
             # the refusal burns no count (nothing was launched, nothing woke a
             # job); the refused_once bound is what stops a refuse/re-ask loop.
             refused_once = True
+            presealed = ""  # the refused author may edit the tree again
             failed = _resume(
                 render_syscall_refusal(
                     problem,
@@ -1471,7 +1487,7 @@ def attempt_once(
         # could not be captured), not a climb crash — same as a candidate eval
         # that raises.
         try:
-            candidate_sha = snapshot()
+            candidate_sha = presealed or snapshot()
         except EvalError as exc:
             return AttemptResult(
                 outcome="eval-error",
@@ -1535,6 +1551,7 @@ def attempt_once(
                 submitted is not None
                 and outcome.outcome in ("no-improvement", "suite-regression", "eval-error")
                 and _can_resume()
+                and not (unchanged and sleeps_used > bench.sleep_k)
             ):
                 # a submitted candidate that failed the gate — including an
                 # eval that errored — is FEEDBACK to the author: it revises and

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1084,6 +1084,8 @@ def attempt_once(
     launches_used: int = 0,
     sleeps_used: int = 0,
     gpu_hours_used: float = 0.0,
+    tree_of: Callable[[str], str] | None = None,
+    judged: tuple[str, AttemptResult] | None = None,
 ) -> AttemptResult:
     """One implement→evaluate→verify cycle in an existing clean workspace.
 
@@ -1264,6 +1266,12 @@ def attempt_once(
     baseline_note = ""
     measured: tuple[str, ...] = ()
     refused_once = False
+    # the gate's last negative and the sealed tree it judged: sealing the same
+    # content again (the author concluded, or resubmitted untouched) reuses
+    # that verdict rather than paying for a second, identical measurement
+    # (`judged` is the wake's: the parked candidate the gate turned down)
+    failed_gate: tuple[str, AttemptResult] | None = judged
+    tree = tree_of or (lambda sha: sha)
 
     def _resume(prompt: str) -> AttemptResult | None:
         """Resume the author session with `prompt`: None on success (session
@@ -1319,6 +1327,7 @@ def attempt_once(
     while True:
         # the syscall request the session's last leg left, if any
         submitted: SyscallRequest | None = None
+        evals_charge = 0.0  # GPU-hours this pass took for gate evals
         while launcher is not None:
             try:
                 request = read_syscall_request(workspace)
@@ -1379,13 +1388,14 @@ def attempt_once(
                     # never inheriting a prior park's.
                     submitted = request
                     sleeps_used += 1
-                    gpu_hours_used += evals_gpu_hours(
+                    evals_charge = evals_gpu_hours(
                         request,
                         gpus=bench.gpus,
                         eval_minutes_default=bench.eval_minutes or 0,
                         suite_gpus=suite_gpus,
                         main_evals=main_evals,
                     )
+                    gpu_hours_used += evals_charge
                     if hasattr(measurer, "eval_minutes"):
                         measurer.eval_minutes = request.eval_minutes or bench.eval_minutes or 0
                     break
@@ -1472,18 +1482,24 @@ def attempt_once(
                 panel_transcript="\n\n".join(panel_sections),
                 panel_rounds=panel_reads,
             )
+        unchanged = failed_gate is not None and tree(failed_gate[0]) == tree(candidate_sha)
         try:
-            outcome = measure_and_decide(
-                contract,
-                bench,
-                base_sha=base_sha,
-                candidate_sha=candidate_sha,
-                seed=run_seed,
-                suite_seed=suite_seed,
-                measured_paths=measured,
-                measurer=measurer,
-                min_relative_improvement=config.min_relative_improvement,
-            )
+            if unchanged:
+                assert failed_gate is not None
+                gpu_hours_used -= evals_charge  # nothing ran
+                outcome: AttemptResult | MeasureOK = failed_gate[1]
+            else:
+                outcome = measure_and_decide(
+                    contract,
+                    bench,
+                    base_sha=base_sha,
+                    candidate_sha=candidate_sha,
+                    seed=run_seed,
+                    suite_seed=suite_seed,
+                    measured_paths=measured,
+                    measurer=measurer,
+                    min_relative_improvement=config.min_relative_improvement,
+                )
         except MeasurementPending as pending:
             # PARK 2 (dispatched candidate/suite, after the session): the wake
             # reads the cached results and decides — or, on a SUBMITTED park,
@@ -1524,11 +1540,22 @@ def attempt_once(
                 # eval that errored — is FEEDBACK to the author: it revises and
                 # resubmits, or concludes honestly (buildout Phase B) — never a
                 # silent terminal. Rounds stay bounded by sleep_k.
-                failed = _resume(
-                    "Your `submit` did NOT clear the gate: "
+                if outcome.outcome != "eval-error":
+                    failed_gate = (candidate_sha, outcome)
+                verdict_text = (
                     f"{outcome.note or outcome.outcome} "
-                    f"(baseline {outcome.baseline}, candidate {outcome.candidate}). "
-                    f"{_not_run_note(submitted)}{_budgets_line()} "
+                    f"(baseline {outcome.baseline}, candidate {outcome.candidate})."
+                )
+                if unchanged:
+                    lead = (
+                        "Your `submit` sealed a tree identical to the candidate the gate "
+                        "already measured, so nothing was run or paid; that verdict "
+                        f"stands: {verdict_text} "
+                    )
+                else:
+                    lead = f"Your `submit` did NOT clear the gate: {verdict_text} "
+                failed = _resume(
+                    f"{lead}{_not_run_note(submitted)}{_budgets_line()} "
                     "Revise and submit again, run more "
                     "experiments, or finish with an honest negative report."
                 )

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -84,6 +84,44 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
     assert r.stage["session_cost_usd"] == 1.0 and r.stage["session_turns"] == 5
 
 
+def test_author_sleep_park_carries_the_gate_verdict(tmp_path) -> None:
+    """A gate negative the author answered by launching more work rides the
+    park, so the wake that ends on the same tree reuses it (review #182)."""
+    from autoresearch.attempt import _stage_judged
+    from autoresearch.orchestrator import AttemptResult
+    from autoresearch.syscall import Launch, SyscallRequest
+
+    record = RunRecord(
+        run_id="tsp-3", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
+    )
+    verdict = AttemptResult(
+        outcome="no-improvement", baseline=13.0, candidate=13.0, note="inside the floor"
+    )
+    parked = RunParked(
+        phase="author-sleep",
+        afterany="afterany:501",
+        base_sha="b" * 40,
+        seed=7,
+        suite_seed=9,
+        candidate_sha="c" * 40,
+        session=_session("s9"),
+        syscall=SyscallRequest(launches=(Launch(name="probe", command="x", minutes=5),)),
+        judged=("d" * 40, verdict),
+    )
+    _park_run(tmp_path, record, parked, "refs/dispatch/tok", eval_minutes=None, now=1000.0)
+    r = load_record(tmp_path, "tsp-3")
+    assert r.stage["judged"] == {
+        "sha": "d" * 40,
+        "outcome": "no-improvement",
+        "baseline": 13.0,
+        "candidate": 13.0,
+        "note": "inside the floor",
+    }
+    assert _stage_judged(r) == ("d" * 40, verdict)
+    bare = RunRecord(run_id="x", target="o/p", task_title="t", state="waiting")
+    assert _stage_judged(bare) is None
+
+
 def test_author_sleep_park_persists_the_request_and_floors_on_the_launch(tmp_path) -> None:
     # Phase A (research-loop-buildout.md): an author-sleep park carries the
     # launch names/artifacts, note, session id, and budget counts the wake

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -2496,6 +2496,73 @@ def test_resume_blocking_panel_on_a_submitted_park_wakes_the_author(tmp_path, mo
     assert str(rec.stage["candidate_sha"]) in kept and str(old) not in kept
 
 
+def test_gate_negative_wake_with_an_unchanged_tree_ends_without_a_second_gate(
+    tmp_path, monkeypatch
+) -> None:
+    """A submitted candidate fails the gate; the woken author concludes with an
+    honest negative and leaves the tree as it was. The attempt ends on that
+    verdict — the identical tree is NOT sealed and dispatched to the gate a
+    second time (the speedrun fleet paid a second 8 GPU-hour eval pair for a
+    byte-identical tree, 2026-08-28)."""
+    from dataclasses import dataclass
+
+    from autoresearch.measure import DispatchSettings
+    from autoresearch.orchestrator import author_spec
+    from autoresearch.syscall import ensure_excluded
+
+    @dataclass
+    class ConcedingHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            assert "did NOT clear the gate" in brief_text
+            return SessionResult(
+                stop_reason="end_turn",
+                is_error=False,
+                cost_usd=0.2,
+                num_turns=2,
+                session_id="s1",
+                final_text="Negative result: the change did not help.",
+                transcript_path="",
+            )
+
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    rec = load_record(state, run_id)
+    rec.stage["submitted"] = True
+    save_record(state, rec, 1_000_050.0)
+    ensure_excluded(state / "runs" / run_id / "ws")
+    # the fixture's eval cruft is for the finish path; here the tree must be
+    # exactly the candidate's
+    (state / "runs" / run_id / "ws" / "eval-cache.tmp").unlink()
+
+    class _Once:
+        def __init__(self):
+            self.calls = 0
+
+        def results(self, measures):
+            self.calls += 1
+            assert self.calls == 1, "the same tree was measured twice"
+            return {"baseline": 13.0, "candidate": 13.0}
+
+    once = _Once()
+    monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: once)
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        harness=ConcedingHarness(),
+        spec=author_spec(),
+    )
+    assert outcome.outcome == "no-improvement"
+    assert github.prs == []
+    assert once.calls == 1
+    assert load_record(state, run_id).state != "waiting"
+
+
 def test_resume_blocking_panel_on_a_plain_finish_drafts(tmp_path, monkeypatch) -> None:
     # a candidate park WITHOUT a submit gets no author loop: blocking findings
     # DRAFT the PR for a human (the policy-driven revision loop is retired —

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -352,6 +352,50 @@ def test_failed_gate_submit_feeds_back_to_the_author(tmp_path: Path) -> None:
     )
     assert result.outcome == "no-improvement"
     assert harness.resumes == [None, "s1"]  # the author heard the gate result
+    assert len(evaluator.calls) == 3  # the concluding tree differed, so it was measured
+
+
+def _gate_negative_attempt(tmp_path: Path, harness, evaluator):
+    measurer, snapshot = _wire(evaluator, tmp_path)
+    return attempt_once(
+        CONFIG,
+        CONTRACT,
+        tmp_path,
+        harness,
+        measurer,
+        "base",
+        snapshot,
+        ruler="r",
+        changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+        created="t",
+        launcher=lambda sha, req: "",
+        tree_of=lambda sha: "same-tree",  # every seal has the same content
+    )
+
+
+def test_unchanged_tree_after_a_gate_negative_is_not_measured_again(tmp_path: Path) -> None:
+    """The author hears the gate's negative and concludes without touching the
+    tree: that verdict stands, and the identical tree is not sealed and
+    measured a second time (the speedrun fleet paid a second 8 GPU-hour gate
+    for an identical tree, 2026-08-28)."""
+    harness = _SeqHarness(["the claim", "conceded"], submit_on=(1,))
+    evaluator = FakeEvaluator(values=[13.9, 13.9])  # a third eval would empty the queue
+    result = _gate_negative_attempt(tmp_path, harness, evaluator)
+    assert result.outcome == "no-improvement"
+    assert harness.resumes == [None, "s1"]
+    assert len(evaluator.calls) == 2
+
+
+def test_identical_resubmit_is_told_so_without_a_second_gate(tmp_path: Path) -> None:
+    """A resubmit of the tree the gate already judged runs nothing: the author
+    is told the verdict stands and decides again (bounded by sleep_k)."""
+    harness = _SeqHarness(["the claim", "again", "conceded"], submit_on=(1, 2))
+    evaluator = FakeEvaluator(values=[13.9, 13.9])
+    result = _gate_negative_attempt(tmp_path, harness, evaluator)
+    assert result.outcome == "no-improvement"
+    assert harness.resumes == [None, "s1", "s2"]
+    assert len(evaluator.calls) == 2
+    assert "identical to the candidate the gate already measured" in harness.prompts[2]
 
 
 def test_inline_gate_never_dispatches_a_submits_sibling_launches(tmp_path: Path) -> None:
@@ -1176,11 +1220,13 @@ class _SeqHarness:
     ) -> None:
         self._texts = list(texts)
         self.resumes: list[str | None] = []
+        self.prompts: list[str] = []
         self.supports_resume = supports_resume
         self.submit_on = set(submit_on)
 
     def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
         self.resumes.append(resume_session_id)
+        self.prompts.append(brief_text)
         if len(self.resumes) in self.submit_on:
             import json as _json
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -355,11 +355,11 @@ def test_failed_gate_submit_feeds_back_to_the_author(tmp_path: Path) -> None:
     assert len(evaluator.calls) == 3  # the concluding tree differed, so it was measured
 
 
-def _gate_negative_attempt(tmp_path: Path, harness, evaluator):
+def _gate_negative_attempt(tmp_path: Path, harness, evaluator, contract: str = CONTRACT):
     measurer, snapshot = _wire(evaluator, tmp_path)
     return attempt_once(
         CONFIG,
-        CONTRACT,
+        contract,
         tmp_path,
         harness,
         measurer,
@@ -396,6 +396,19 @@ def test_identical_resubmit_is_told_so_without_a_second_gate(tmp_path: Path) -> 
     assert harness.resumes == [None, "s1", "s2"]
     assert len(evaluator.calls) == 2
     assert "identical to the candidate the gate already measured" in harness.prompts[2]
+
+
+def test_identical_resubmit_past_the_sleep_budget_ends_on_the_verdict(tmp_path: Path) -> None:
+    """The unchanged-tree reuse runs BEFORE the budget check, so an author out
+    of sleeps (or GPU-hours) is not refused a gate it would never run; past
+    the sleep budget the attempt simply ends on the standing verdict."""
+    one_sleep = CONTRACT.replace("    direction: min\n", "    direction: min\n    sleep_k: 1\n", 1)
+    harness = _SeqHarness(["the claim", "again", "never reached"], submit_on=(1, 2))
+    evaluator = FakeEvaluator(values=[13.9, 13.9])
+    result = _gate_negative_attempt(tmp_path, harness, evaluator, contract=one_sleep)
+    assert result.outcome == "no-improvement"
+    assert harness.resumes == [None, "s1"]  # the second resubmit was the last word
+    assert len(evaluator.calls) == 2
 
 
 def test_inline_gate_never_dispatches_a_submits_sibling_launches(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Seen live on the speedrun fleet (agent-01, 2026-08-28): the Muon candidate failed the gate (DNF vs baseline 9472), the woken author wrote an honest negative report and ended its session without touching the tree — and the kernel sealed the identical tree and dispatched a second baseline+candidate eval pair (8 GPU-hours, 3.5 h) before it could end the attempt.

- `attempt_once` now remembers the gate's last negative and the sealed tree it judged (`judged` rides the wake's resume; `tree_of` compares tree ids, so a fresh seal of the same content matches).
- Same content sealed again → the verdict is reused: the attempt ends on it when the author concluded; a resubmit of the untouched tree tells the author once that nothing was run, with the evals' GPU-hours refunded.
- An errored eval is not carried, so it is still retried on resubmit.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest` (848 passed)
- [x] Orchestrator: unchanged tree after a gate negative is not measured again; an identical resubmit is told so without a second gate; a changed tree is still measured
- [x] Wake path (`resume_run`): a submitted park's gate negative + a conceding author ends the run with one measurement, no second dispatch
- [ ] Review rounds converge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
