### PR TITLE
Brief: launch artifacts live under the repo tree, never in .autoresearch/

### DIFF
--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -268,8 +268,10 @@ def render(brief: SessionBrief) -> str:
             ),
             "`status` shows staged launches and remaining budget; `note ...` "
             "leaves a reminder echoed back to you on wake. `--artifact` must "
-            "name a file your command actually writes (stdout/stderr are "
-            "captured regardless). Bad arguments fail "
+            "name a file your command actually writes, anywhere under the repo "
+            "tree — the `.autoresearch/` channel does not exist in the job, so "
+            "never write there (stdout/stderr are captured regardless). Bad "
+            "arguments fail "
             "immediately — fix and retry before sleeping. You may launch "
             "several jobs before one sleep, and after a wake you can launch "
             "more, revise, or finish. `--array K` runs one command as K jobs "

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -90,6 +90,18 @@ def test_render_has_every_section_in_order() -> None:
     assert "13.876" in text
 
 
+def test_render_tells_launches_where_artifacts_live() -> None:
+    """An author once wrote its experiment log into .autoresearch/results/,
+    which does not exist in the jailed job, and paid a full walltime for a
+    launch that died on its first line. The brief pins the rule; without a
+    launch budget the paragraph is absent."""
+    text = render(build_brief(make_inputs(launch_budget=3, sleep_budget=2), created="t"))
+    assert "anywhere under the repo tree" in text
+    assert "`.autoresearch/` channel does not exist in the job" in text
+    off = render(build_brief(make_inputs(), created="t"))
+    assert "--artifact" not in off
+
+
 def test_render_omits_empty_memory_sections() -> None:
     text = render(build_brief(make_inputs(lessons="", recent_reports=()), created="t"))
     assert "# Lessons" not in text


### PR DESCRIPTION
## Summary

Seen live (agent-02, 2026-08-28): the author wrote its experiment log to `.autoresearch/results/<name>.log`, which does not exist in the jailed job tree, so the launch failed on its first line after paying its declared walltime. The brief now says artifacts go anywhere under the repo tree and never into `.autoresearch/`.

## Test plan

- [x] ruff, format, brief tests
- [ ] review round

🤖 Generated with [Claude Code](https://claude.com/claude-code)