### PR TITLE
Parks arm their own wake, depending on the jobs they wait on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
-- Parks arm their own wake: a run that parks on eval or experiment jobs submits its wake job at once, depending on those jobs (`afterany`), so it fires the moment they finish instead of a sweep cadence plus grace later (~30 min per gate decision). Same job and lease as a sweep-delivered wake; the sweep stays the backup, and now also cancels and redelivers an armed wake Slurm will never start. A lease whose holder Slurm reports alive is no longer reaped by age.
+- A park now submits its own wake job, which waits on the park's jobs and
+  starts the moment they finish (previously: the next sweep, a grace
+  window, and another sweep — about 30 minutes). The sweep remains the
+  fallback, and it replaces a wake job Slurm can never start. A lease held
+  by a live Slurm job is no longer reaped by age.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Parks arm their own wake: a run that parks on eval or experiment jobs submits its wake job at once, depending on those jobs (`afterany`), so it fires the moment they finish instead of a sweep cadence plus grace later (~30 min per gate decision). Same job and lease as a sweep-delivered wake; the sweep stays the backup, and now also cancels and redelivers an armed wake Slurm will never start. A lease whose holder Slurm reports alive is no longer reaped by age.
+
 ### Fixed
 
 - A tree the gate already turned down in this attempt is never measured again: when the woken author concludes (or resubmits untouched), that verdict stands and the attempt ends on it — no second eval pair, no GPU-hours. An errored eval is still retried.

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -345,6 +345,7 @@ def _park_run(
     keep_wake_attempts: bool = False,
     base_branch: str = "main",
     panel_reads: int = 0,
+    dispatch: DispatchSettings | None = None,
 ) -> None:
     """Persist a dispatched climb's re-entry point as a WAITING record: the
     committed shas, drawn seeds, candidate snapshot ref, and afterany set a
@@ -479,6 +480,42 @@ def _park_run(
         }
     )
     save_record(run_root, waiting, now)
+    if dispatch is not None:
+        _arm_park_wake(run_root, record.run_id, now, dispatch)
+
+
+def _arm_park_wake(run_root: Path, run_id: str, now: float, dispatch: DispatchSettings) -> str:
+    """Submit the parked run's wake right away, depending on the jobs it
+    waits on (tick.arm_wake), when the tick has published its wake recipe.
+    Without the recipe — dispatched wakes not armed, or a local compute —
+    the sweep delivers as before."""
+    from autoresearch.compute import SlurmCompute
+    from autoresearch.tick import JobWakeDispatcher, arm_wake, load_wake_spec
+
+    spec = load_wake_spec(run_root)
+    if spec is None or not isinstance(dispatch.compute, SlurmCompute):
+        return ""
+    try:
+        record = load_record(run_root, run_id)
+        dispatcher = JobWakeDispatcher(dispatch.compute, spec, now)
+        return arm_wake(
+            run_root, record, dispatcher, now, holder_job_id=os.environ.get("SLURM_JOB_ID", "")
+        )
+    except Exception as exc:
+        log.warning("park-time wake not armed for %s: %s: %s", run_id, type(exc).__name__, exc)
+        return ""
+
+
+def _release_own_lease(run_root: Path, run_id: str) -> None:
+    """Release the run's lease only while this job still holds it: a park
+    hands the lease to the wake it arms, and that wake must keep it."""
+    from autoresearch.runstate import read_lease, release_lease
+
+    lease = read_lease(run_root, run_id)
+    mine = os.environ.get("SLURM_JOB_ID", "")
+    if lease is not None and lease.holder_job_id and mine and lease.holder_job_id != mine:
+        return
+    release_lease(run_root, run_id)
 
 
 def _dispatch_settings(args: argparse.Namespace) -> DispatchSettings:
@@ -772,6 +809,7 @@ def _wake_author_sleep(
                 eval_minutes,
                 time.time(),
                 secrets,
+                dispatch=dispatch,
                 base_branch=base_branch,
             )
         except Exception:
@@ -1023,6 +1061,7 @@ def resume_run(
             eval_minutes,
             now,
             secrets,
+            dispatch=dispatch,
             keep_wake_attempts=not made_progress,
             base_branch=base_branch,
             panel_reads=panel_reads,
@@ -1926,6 +1965,7 @@ def live_attempt(
                     eval_minutes,
                     time.time(),
                     secrets,
+                    dispatch=dispatch,
                     base_branch=base_branch,
                 )
             except Exception:
@@ -2407,7 +2447,7 @@ def main() -> int:
                 "--resume needs the cluster triple (--account/--partition/--image) "
                 "to rebuild the dispatched measurer"
             )
-        from autoresearch.runstate import load_record, release_lease
+        from autoresearch.runstate import load_record
 
         # Reproduce the PARKED run's author, not the current fleet default: the
         # (backend, model) PAIR is persisted on the record — a fleet flip must not
@@ -2429,7 +2469,7 @@ def main() -> int:
             # this wake job HOLDS the run's lease (transferred on dispatch); release
             # it before exiting so a misconfig doesn't strand the run until the TTL
             # reap (the resume_run finally below only runs once we reach it)
-            release_lease(args.run_root, args.resume)
+            _release_own_lease(args.run_root, args.resume)
             parser.error(f"parked run {args.resume}: {_err}")
         # the wake runs the SAME verification panel as a fresh climb, so a
         # dispatched improvement is not published unverified.
@@ -2483,7 +2523,7 @@ def main() -> int:
             # dispatch); release it on every exit so a re-parked run is
             # immediately eligible for the next sweep instead of waiting out the
             # TTL reap. Idempotent (no-op if no lease file).
-            release_lease(args.run_root, args.resume)
+            _release_own_lease(args.run_root, args.resume)
         print(f"outcome={resumed.outcome} pr={resumed.pr_url or '-'} report={resumed.report_path}")
         return 0
 

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -490,8 +490,10 @@ def _arm_park_wake(run_root: Path, run_id: str, now: float, dispatch: DispatchSe
     Without the recipe — dispatched wakes not armed, or a local compute —
     the sweep delivers as before."""
     from autoresearch.compute import SlurmCompute
-    from autoresearch.tick import JobWakeDispatcher, arm_wake, load_wake_spec
+    from autoresearch.tick import JobWakeDispatcher, arm_wake, dispatch_wake_armed, load_wake_spec
 
+    if not dispatch_wake_armed(run_root):
+        return ""  # disarmed: a recipe the tick has not yet removed is not used
     spec = load_wake_spec(run_root)
     if spec is None or not isinstance(dispatch.compute, SlurmCompute):
         return ""
@@ -506,14 +508,25 @@ def _arm_park_wake(run_root: Path, run_id: str, now: float, dispatch: DispatchSe
         return ""
 
 
-def _release_own_lease(run_root: Path, run_id: str) -> None:
-    """Release the run's lease only while this job still holds it: a park
-    hands the lease to the wake it arms, and that wake must keep it."""
-    from autoresearch.runstate import read_lease, release_lease
+def _lease_held_by_another_job(run_root: Path, run_id: str) -> str:
+    """The job id of a wake that holds this run's lease and is not us, or "".
+    A resume with no job id of its own (a manual run) never counts as the
+    holder of a job-held lease."""
+    from autoresearch.runstate import read_lease
 
     lease = read_lease(run_root, run_id)
     mine = os.environ.get("SLURM_JOB_ID", "")
-    if lease is not None and lease.holder_job_id and mine and lease.holder_job_id != mine:
+    if lease is not None and lease.holder_job_id and lease.holder_job_id != mine:
+        return lease.holder_job_id
+    return ""
+
+
+def _release_own_lease(run_root: Path, run_id: str) -> None:
+    """Release the run's lease only while this job still holds it: a park
+    hands the lease to the wake it arms, and that wake must keep it."""
+    from autoresearch.runstate import release_lease
+
+    if _lease_held_by_another_job(run_root, run_id):
         return
     release_lease(run_root, run_id)
 
@@ -2448,6 +2461,14 @@ def main() -> int:
                 "to rebuild the dispatched measurer"
             )
         from autoresearch.runstate import load_record
+
+        # a wake that is not the lease holder is a straggler (a replacement was
+        # dispatched after it was cancelled, or it was armed and then lost):
+        # it must not touch the run beside the holder
+        other = _lease_held_by_another_job(args.run_root, args.resume)
+        if other:
+            print(f"run {args.resume}: wake job {other} holds the lease; this one exits")
+            return 0
 
         # Reproduce the PARKED run's author, not the current fleet default: the
         # (backend, model) PAIR is persisted on the record — a fleet flip must not

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -176,6 +176,20 @@ class SlurmCompute:
         state = result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
         return state if state else GONE
 
+    def pending_reason(self, job_id: str) -> str:
+        """Why a PENDING job is pending — Slurm's reason (`Dependency`,
+        `DependencyNeverSatisfied`, `Priority`, ...), or "" when squeue no
+        longer lists it. Raises SlurmQueryError when the query itself fails."""
+        if not job_id.isdigit():
+            raise ValueError(f"not a job id: {job_id!r}")
+        try:
+            result = self.runner(["squeue", "-j", job_id, "-h", "-o", "%r"], self.command_timeout_s)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SlurmQueryError(f"squeue did not run: {exc}") from exc
+        if result.returncode != 0:
+            return ""  # squeue errors for a job it no longer knows; sacct is the record
+        return result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
+
     def active_job_names(self) -> list[str]:
         """The names of this user's PENDING and RUNNING jobs. Names, not
         commands: squeue's Command field is not guaranteed to carry --wrap

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -187,7 +187,7 @@ class SlurmCompute:
         except (OSError, subprocess.TimeoutExpired) as exc:
             raise SlurmQueryError(f"squeue did not run: {exc}") from exc
         if result.returncode != 0:
-            return ""  # squeue errors for a job it no longer knows; sacct is the record
+            raise SlurmQueryError(f"squeue failed ({result.returncode}): {result.stderr.strip()}")
         return result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
 
     def active_job_names(self) -> list[str]:

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -334,7 +334,10 @@ def reap_lease(root: Path, run_id: str, reaper: str, expected: Lease) -> bool:
 
 
 def lease_is_stale(lease: Lease, now: float, ttl_s: float, holder_alive: bool | None) -> bool:
-    """A lease is stale when its holder is known-dead, or too old.
+    """A lease is stale when its holder is known-dead, or — when Slurm cannot
+    say — too old. A holder Slurm reports alive is never stale by age: a wake
+    armed at park time waits in the queue for as long as the evals run, and
+    its walltime bounds it once it starts.
 
     `holder_alive` is None when Slurm could not answer (query failure) — in
     that case only the TTL can prove staleness, never the holder check:
@@ -342,4 +345,6 @@ def lease_is_stale(lease: Lease, now: float, ttl_s: float, holder_alive: bool | 
     """
     if holder_alive is False:
         return True
+    if holder_alive is True:
+        return False
     return (now - lease.acquired) > ttl_s

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -22,7 +22,7 @@ import re
 import socket
 import subprocess
 from collections.abc import Sequence
-from dataclasses import dataclass, field, replace
+from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any, Protocol
 from uuid import uuid4
@@ -48,6 +48,7 @@ from autoresearch.runstate import (
     MAX_WAKE_ATTEMPTS,
     STUCK,
     WAITING,
+    Lease,
     RunRecord,
     acquire_lease,
     lease_is_stale,
@@ -702,6 +703,120 @@ def _wake(
     return True
 
 
+WAKE_SPEC_NAME = "wake-spec.json"
+
+
+def write_wake_spec(root: Path, spec: FollowupSpec) -> None:
+    """Publish the tick's wake recipe for the jobs that park runs: a park
+    submits its own wake (`arm_wake`) with exactly the tick's settings, so
+    dispatched wakes stay one recipe with one owner."""
+    data = {k: (str(v) if isinstance(v, Path) else v) for k, v in asdict(spec).items()}
+    tmp = root / f".{WAKE_SPEC_NAME}.{os.getpid()}.tmp"
+    tmp.write_text(json.dumps(data))
+    os.replace(tmp, root / WAKE_SPEC_NAME)
+
+
+def remove_wake_spec(root: Path) -> None:
+    with contextlib.suppress(FileNotFoundError):
+        (root / WAKE_SPEC_NAME).unlink()
+
+
+def load_wake_spec(root: Path) -> FollowupSpec | None:
+    """The published wake recipe, or None when dispatched wakes are not armed
+    (or the file is unreadable — the sweep still delivers)."""
+    try:
+        data = json.loads((root / WAKE_SPEC_NAME).read_text())
+    except (OSError, ValueError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    names = {f.name for f in FollowupSpec.__dataclass_fields__.values()}
+    kwargs: dict[str, Any] = {
+        k: (Path(v) if k in ("run_root", "home") else v) for k, v in data.items() if k in names
+    }
+    try:
+        return FollowupSpec(**kwargs)
+    except TypeError:
+        return None
+
+
+def arm_wake(
+    root: Path, record: RunRecord, dispatcher: WakeDispatcher, now: float, *, holder_job_id: str
+) -> str:
+    """Submit a parked run's wake NOW, depending on the jobs it waits on, so
+    it fires the moment they finish instead of a sweep cadence (plus grace)
+    later. The same job and lease as a sweep-delivered wake: a wake job that
+    parks again hands its own lease to the wake it arms; any other holder (a
+    tick mid-delivery) keeps it and the sweep delivers as before. Arming is
+    not a redelivery, so it leaves `wake_attempts` — the sweep's stuck
+    counter — alone: an eval requeued by preemption fires the afterany
+    early, the wake re-parks, and that must not count toward STUCK. Returns
+    the wake job id, or "" when nothing was armed."""
+    lease = read_lease(root, record.run_id)
+    if lease is not None:
+        if not holder_job_id or lease.holder_job_id != holder_job_id:
+            return ""
+    elif not acquire_lease(
+        root, record.run_id, f"park:{holder_job_id or os.getpid()}", holder_job_id="", now=now
+    ):
+        return ""
+    if record.deadline <= 0:  # a waiting record always carries a deadline
+        record = replace(record, deadline=now)
+        save_record(root, record, now)
+    try:
+        job = dispatcher.dispatch(record, "parked")
+    except Exception as exc:
+        log.warning("arming the wake failed for %s: %s: %s", record.run_id, type(exc).__name__, exc)
+        job = ""
+    if job:
+        update_lease_holder(root, record.run_id, f"wake-job:{job}", job, now)
+    elif lease is None:
+        release_lease(root, record.run_id)
+    return job
+
+
+def _armed_wake_lost(
+    root: Path,
+    compute: SlurmCompute,
+    record: RunRecord,
+    lease: Lease,
+    now: float,
+    grace_s: float,
+    dry_run: bool,
+) -> bool:
+    """An armed wake that is still PENDING on its dependency after every job
+    it waits on has been terminal for a full grace window is not coming
+    (Slurm reports the dependency as never satisfiable, or the afterany was
+    lost). Cancel it so the sweep redelivers; the lease is then reaped."""
+    if not lease.holder_job_id:
+        return False
+    job_ids = _poll_targets(record)
+    if not job_ids:
+        return False
+    try:
+        holder_state = compute.status(lease.holder_job_id)
+        if not is_pending(holder_state):
+            return False
+        reason = compute.pending_reason(lease.holder_job_id)
+        states = [compute.status(jid) for jid in job_ids]
+    except SlurmQueryError:
+        return False
+    if reason == "DependencyNeverSatisfied":
+        pass
+    elif reason != "Dependency" or not all(is_terminal(s) for s in states):
+        return False
+    elif record.terminal_seen <= 0:
+        if not dry_run:
+            save_record(root, replace(record, terminal_seen=now), now)
+        return False
+    elif now - record.terminal_seen < grace_s:
+        return False
+    if not dry_run:
+        with contextlib.suppress(Exception):
+            compute.cancel(lease.holder_job_id)
+    return True
+
+
 def sweep(
     root: Path,
     compute: SlurmCompute,
@@ -1086,7 +1201,9 @@ def _sweep_one(
         if lease is not None:
             alive = _holder_alive(compute, lease.holder_job_id)
             if not lease_is_stale(lease, now, lease_ttl_s, alive):
-                return
+                if not _armed_wake_lost(root, compute, record, lease, now, grace_s, dry_run):
+                    return
+                record = load_record(root, record.run_id)
             if dry_run:
                 reaped.append(record.run_id)
                 return
@@ -2562,6 +2679,11 @@ def main() -> int:
     compute = SlurmCompute()
     now = time.time()
     dispatcher, wake_live = _wake_dispatcher_from_env(compute, followup_spec, now, args.root)
+    # parks arm their own wake from this recipe; without it the sweep delivers
+    if wake_live and followup_spec is not None:
+        write_wake_spec(args.root, followup_spec)
+    else:
+        remove_wake_spec(args.root)
 
     report = tick(
         args.root,

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -706,6 +706,16 @@ def _wake(
 WAKE_SPEC_NAME = "wake-spec.json"
 
 
+def dispatch_wake_armed(root: Path) -> bool:
+    """The operator's on-switch for dispatched wakes: the env var, or the
+    sentinel file (touch/rm, no chain restart). Read by the tick and by every
+    park, so a disarm takes effect at once."""
+    return (
+        bool(os.environ.get("AUTORESEARCH_DISPATCH_WAKE", "").strip())
+        or (root / DISPATCH_WAKE_SENTINEL).exists()
+    )
+
+
 def write_wake_spec(root: Path, spec: FollowupSpec) -> None:
     """Publish the tick's wake recipe for the jobs that park runs: a park
     submits its own wake (`arm_wake`) with exactly the tick's settings, so
@@ -751,7 +761,11 @@ def arm_wake(
     not a redelivery, so it leaves `wake_attempts` — the sweep's stuck
     counter — alone: an eval requeued by preemption fires the afterany
     early, the wake re-parks, and that must not count toward STUCK. Returns
-    the wake job id, or "" when nothing was armed."""
+    the wake job id, or "" when nothing was armed. A park with nothing to
+    depend on (a checkpoint sleep, a blind park) is not armed: it rides the
+    deadline floor, as before."""
+    if not _poll_targets(record):
+        return ""
     lease = read_lease(root, record.run_id)
     if lease is not None:
         if not holder_job_id or lease.holder_job_id != holder_job_id:
@@ -811,10 +825,15 @@ def _armed_wake_lost(
         return False
     elif now - record.terminal_seen < grace_s:
         return False
-    if not dry_run:
-        with contextlib.suppress(Exception):
-            compute.cancel(lease.holder_job_id)
-    return True
+    if dry_run:
+        return True
+    try:
+        compute.cancel(lease.holder_job_id)
+        # only a cancellation Slurm confirms lets the sweep redeliver: a
+        # still-pending wake would otherwise run beside its replacement
+        return not is_pending(compute.status(lease.holder_job_id))
+    except Exception:
+        return False
 
 
 def sweep(
@@ -2501,11 +2520,7 @@ def _wake_dispatcher_from_env(
     chain restart. So dispatched climbing is turned on deliberately, and a
     half-configured environment fails safe to dry rather than to a wake job
     that cannot run."""
-    armed = (
-        bool(os.environ.get("AUTORESEARCH_DISPATCH_WAKE", "").strip())
-        or (root / DISPATCH_WAKE_SENTINEL).exists()
-    )
-    if not armed:
+    if not dispatch_wake_armed(root):
         return LoggingDispatcher(), False
     if followup_spec is None:
         log.warning("dispatch-wake armed but the chain env is incomplete; wake stays dry")

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -84,6 +84,62 @@ def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> No
     assert r.stage["session_cost_usd"] == 1.0 and r.stage["session_turns"] == 5
 
 
+def test_park_arms_its_own_wake_when_the_tick_published_the_recipe(tmp_path, monkeypatch) -> None:
+    """With dispatched wakes on (the tick publishes wake-spec.json), a park
+    submits its wake immediately and the wake job holds the lease; without
+    the recipe nothing is armed and the sweep delivers as before."""
+    from autoresearch.runstate import read_lease
+    from autoresearch.tick import FollowupSpec, write_wake_spec
+
+    monkeypatch.setattr(
+        "autoresearch.tick._flight_command", lambda home, name, now, argv: " ".join(argv)
+    )
+
+    def park(run_id: str) -> None:
+        record = RunRecord(
+            run_id=run_id, target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
+        )
+        parked = RunParked(
+            phase="candidate",
+            afterany="afterany:501:502",
+            base_sha="b" * 40,
+            seed=7,
+            suite_seed=9,
+            candidate_sha="c" * 40,
+            session=_session("s9"),
+        )
+        _park_run(
+            tmp_path, record, parked, "refs/dispatch/tok", None, 1000.0, dispatch=_fake_dispatch()
+        )
+
+    park("tsp-quiet")
+    assert read_lease(tmp_path, "tsp-quiet") is None
+    assert load_record(tmp_path, "tsp-quiet").wake_attempts == 0
+
+    spec = FollowupSpec(
+        account="a", partition="cpu", run_root=tmp_path, image="/img.sif", home=tmp_path
+    )
+    write_wake_spec(tmp_path, spec)
+    park("tsp-armed")
+    lease = read_lease(tmp_path, "tsp-armed")
+    assert lease is not None and lease.holder == "wake-job:1000"
+    r = load_record(tmp_path, "tsp-armed")
+    assert r.state == "waiting" and r.wake_attempts == 0  # arming is not a redelivery
+
+
+def test_release_own_lease_keeps_a_lease_handed_to_the_armed_wake(tmp_path, monkeypatch) -> None:
+    from autoresearch.attempt import _release_own_lease
+    from autoresearch.runstate import acquire_lease, read_lease
+
+    acquire_lease(tmp_path, "r", "wake-job:9001", "9001", now=1.0)
+    monkeypatch.setenv("SLURM_JOB_ID", "55")  # the wake job that armed 9001, exiting
+    _release_own_lease(tmp_path, "r")
+    assert read_lease(tmp_path, "r") is not None
+    monkeypatch.setenv("SLURM_JOB_ID", "9001")
+    _release_own_lease(tmp_path, "r")
+    assert read_lease(tmp_path, "r") is None
+
+
 def test_author_sleep_park_carries_the_gate_verdict(tmp_path) -> None:
     """A gate negative the author answered by launching more work rides the
     park, so the wake that ends on the same tree reuses it (review #182)."""

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -112,6 +112,7 @@ def test_park_arms_its_own_wake_when_the_tick_published_the_recipe(tmp_path, mon
             tmp_path, record, parked, "refs/dispatch/tok", None, 1000.0, dispatch=_fake_dispatch()
         )
 
+    monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
     park("tsp-quiet")
     assert read_lease(tmp_path, "tsp-quiet") is None
     assert load_record(tmp_path, "tsp-quiet").wake_attempts == 0
@@ -120,6 +121,9 @@ def test_park_arms_its_own_wake_when_the_tick_published_the_recipe(tmp_path, mon
         account="a", partition="cpu", run_root=tmp_path, image="/img.sif", home=tmp_path
     )
     write_wake_spec(tmp_path, spec)
+    park("tsp-disarmed")  # a recipe left behind after a disarm is not used
+    assert read_lease(tmp_path, "tsp-disarmed") is None
+    (tmp_path / "DISPATCH_WAKE").touch()
     park("tsp-armed")
     lease = read_lease(tmp_path, "tsp-armed")
     assert lease is not None and lease.holder == "wake-job:1000"
@@ -128,14 +132,27 @@ def test_park_arms_its_own_wake_when_the_tick_published_the_recipe(tmp_path, mon
 
 
 def test_release_own_lease_keeps_a_lease_handed_to_the_armed_wake(tmp_path, monkeypatch) -> None:
-    from autoresearch.attempt import _release_own_lease
-    from autoresearch.runstate import acquire_lease, read_lease
+    from autoresearch.attempt import _lease_held_by_another_job, _release_own_lease
+    from autoresearch.runstate import acquire_lease, read_lease, release_lease
 
     acquire_lease(tmp_path, "r", "wake-job:9001", "9001", now=1.0)
     monkeypatch.setenv("SLURM_JOB_ID", "55")  # the wake job that armed 9001, exiting
+    assert _lease_held_by_another_job(tmp_path, "r") == "9001"
+    _release_own_lease(tmp_path, "r")
+    assert read_lease(tmp_path, "r") is not None
+    monkeypatch.delenv("SLURM_JOB_ID")  # a manual resume never owns a job-held lease
+    assert _lease_held_by_another_job(tmp_path, "r") == "9001"
     _release_own_lease(tmp_path, "r")
     assert read_lease(tmp_path, "r") is not None
     monkeypatch.setenv("SLURM_JOB_ID", "9001")
+    assert _lease_held_by_another_job(tmp_path, "r") == ""
+    _release_own_lease(tmp_path, "r")
+    assert read_lease(tmp_path, "r") is None
+    # a lease with no job id (a tick's, mid-delivery) is the caller's to release
+    release_lease(tmp_path, "r")
+    acquire_lease(tmp_path, "r", "park:1", "", now=1.0)
+    monkeypatch.delenv("SLURM_JOB_ID")
+    assert _lease_held_by_another_job(tmp_path, "r") == ""
     _release_own_lease(tmp_path, "r")
     assert read_lease(tmp_path, "r") is None
 
@@ -2318,6 +2335,7 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
     # always read it and failed).
     assert acquire_lease(tmp_path, run_id, "wake-job:1", "1", 1_000.0)
     assert (run_dir(tmp_path, run_id) / "lease.json").exists()
+    monkeypatch.setenv("SLURM_JOB_ID", "1")  # this process IS the wake job that holds it
 
     monkeypatch.setattr(climb_mod, "arm_sigterm_containment", lambda: None)
     monkeypatch.setattr(

--- a/tests/test_runstate.py
+++ b/tests/test_runstate.py
@@ -108,7 +108,8 @@ def test_lease_staleness_rules(tmp_path: Path) -> None:
     assert not lease_is_stale(lease, now=1001.0, ttl_s=3600, holder_alive=None)
     assert lease_is_stale(lease, now=1000.0 + 3601, ttl_s=3600, holder_alive=None)
     # live holder but ancient → stale (TTL wins: sessions are bounded)
-    assert lease_is_stale(lease, now=1000.0 + 3601, ttl_s=3600, holder_alive=True)
+    # a holder Slurm reports alive is never stale by age (walltime bounds it)
+    assert not lease_is_stale(lease, now=1000.0 + 3601, ttl_s=3600, holder_alive=True)
 
 
 def test_reap_lease_exactly_one_reaper_wins(tmp_path: Path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -42,6 +42,7 @@ class FakeSlurm:
     states: dict[str, str] = field(default_factory=dict)
     cancelled: list[str] = field(default_factory=list)
     reasons: dict[str, str] = field(default_factory=dict)  # squeue %r by job id
+    cancel_sticks: bool = True  # scancel moves the job to CANCELLED, like Slurm
 
     def _runner(self, argv, timeout_s):
         if argv[0] == "sacct":
@@ -52,6 +53,8 @@ class FakeSlurm:
             return CommandResult(0, state + "\n" if state else "", "")
         if argv[0] == "scancel":
             self.cancelled.append(argv[1])
+            if self.cancel_sticks:
+                self.states[argv[1]] = "CANCELLED"
             return CommandResult(0, "", "")
         if argv[0] == "squeue":
             if "-j" in argv:
@@ -3131,3 +3134,57 @@ def test_wake_spec_round_trips_and_is_absent_when_wakes_are_dry(tmp_path: Path) 
     assert load_wake_spec(tmp_path) is None
     (tmp_path / "wake-spec.json").write_text("not json")
     assert load_wake_spec(tmp_path) is None
+
+
+def test_arm_wake_skips_a_park_with_nothing_to_depend_on(tmp_path: Path, monkeypatch) -> None:
+    """A checkpoint sleep or blind park has no jobs: an armed wake would run
+    at once instead of at the deadline floor, so nothing is armed."""
+    from autoresearch.tick import JobWakeDispatcher, arm_wake
+
+    monkeypatch.setattr(
+        "autoresearch.tick._flight_command", lambda home, name, now, argv: " ".join(argv)
+    )
+    record = waiting_run(tmp_path, experiment_job_id="", stage={"afterany": ""})
+    submits, compute = _sbatch_capture()
+    dispatcher = JobWakeDispatcher(compute, _wake_spec(tmp_path), NOW)
+    assert arm_wake(tmp_path, record, dispatcher, NOW, holder_job_id="") == ""
+    assert submits == [] and read_lease(tmp_path, "r1") is None
+
+
+def test_sweep_keeps_a_wake_it_could_not_cancel(tmp_path: Path) -> None:
+    """Redelivery waits for a cancellation Slurm confirms: a wake still pending
+    after scancel would otherwise run beside its replacement."""
+    waiting_run(tmp_path)
+    acquire_lease(tmp_path, "r1", "wake-job:55", "55", now=NOW - 60)
+    slurm = FakeSlurm(
+        states={"100": "COMPLETED", "55": "PENDING"},
+        reasons={"55": "DependencyNeverSatisfied"},
+        cancel_sticks=False,
+    )
+    report, dispatcher = run_tick(tmp_path, slurm)
+    assert slurm.cancelled == ["55"]
+    assert report.reaped_leases == () and dispatcher.dispatched == []
+
+
+def test_pending_reason_query_failure_is_an_error_not_a_reason() -> None:
+    import pytest
+
+    from autoresearch.compute import SlurmQueryError
+
+    def runner(argv, timeout_s):
+        return CommandResult(1, "", "slurmctld down")
+
+    with pytest.raises(SlurmQueryError):
+        SlurmCompute(runner=runner).pending_reason("55")
+
+
+def test_dispatch_wake_switch_reads_env_or_sentinel(tmp_path: Path, monkeypatch) -> None:
+    from autoresearch.tick import dispatch_wake_armed
+
+    monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
+    assert not dispatch_wake_armed(tmp_path)
+    (tmp_path / "DISPATCH_WAKE").touch()
+    assert dispatch_wake_armed(tmp_path)
+    (tmp_path / "DISPATCH_WAKE").unlink()
+    monkeypatch.setenv("AUTORESEARCH_DISPATCH_WAKE", "1")
+    assert dispatch_wake_armed(tmp_path)

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -41,6 +41,7 @@ class FakeSlurm:
 
     states: dict[str, str] = field(default_factory=dict)
     cancelled: list[str] = field(default_factory=list)
+    reasons: dict[str, str] = field(default_factory=dict)  # squeue %r by job id
 
     def _runner(self, argv, timeout_s):
         if argv[0] == "sacct":
@@ -53,6 +54,9 @@ class FakeSlurm:
             self.cancelled.append(argv[1])
             return CommandResult(0, "", "")
         if argv[0] == "squeue":
+            if "-j" in argv:
+                reason = self.reasons.get(argv[argv.index("-j") + 1], "")
+                return CommandResult(0, reason + "\n" if reason else "", "")
             return CommandResult(0, "", "")  # no live jobs
         raise AssertionError(f"unexpected command {argv}")
 
@@ -3002,3 +3006,128 @@ roadmap: docs/roadmap.md
 
     assert "speedrun" in _gpu_lane_error(contract, "tsp", spec(""))
     assert _gpu_lane_error(contract, "tsp", spec("h200")) == ""
+
+
+def _wake_spec(tmp_path: Path):
+    from autoresearch.tick import FollowupSpec
+
+    return FollowupSpec(
+        account="acct", partition="cpu_short", run_root=tmp_path, image="/img/a.sif", home=tmp_path
+    )
+
+
+def _sbatch_capture():
+    submits: list[list[str]] = []
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            submits.append(list(argv))
+            return CommandResult(0, f"{9000 + len(submits)}\n", "")
+        raise AssertionError(argv)
+
+    return submits, SlurmCompute(runner=runner)
+
+
+def test_arm_wake_submits_the_dependent_wake_and_hands_it_the_lease(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A park submits its own wake at once, depending on the jobs it waits
+    on — the same job and lease the sweep would use, only ~30 minutes
+    (cadence + grace + cadence) earlier; arming is not a redelivery, so the
+    stuck counter does not move."""
+    from autoresearch.tick import JobWakeDispatcher, arm_wake
+
+    monkeypatch.setattr(
+        "autoresearch.tick._flight_command", lambda home, name, now, argv: " ".join(argv)
+    )
+    record = waiting_run(tmp_path, experiment_job_id="", stage={"afterany": "afterany:501:502"})
+    submits, compute = _sbatch_capture()
+    dispatcher = JobWakeDispatcher(compute, _wake_spec(tmp_path), NOW)
+    job = arm_wake(tmp_path, record, dispatcher, NOW, holder_job_id="")
+    assert job == "9001"
+    assert "--dependency=afterany:501:502" in submits[0]
+    lease = read_lease(tmp_path, "r1")
+    assert lease is not None and lease.holder == "wake-job:9001" and lease.holder_job_id == "9001"
+    assert load_record(tmp_path, "r1").wake_attempts == 0
+
+
+def test_arm_wake_hands_over_its_own_lease_and_leaves_another_holder_alone(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from autoresearch.tick import JobWakeDispatcher, arm_wake
+
+    monkeypatch.setattr(
+        "autoresearch.tick._flight_command", lambda home, name, now, argv: " ".join(argv)
+    )
+    submits, compute = _sbatch_capture()
+    dispatcher = JobWakeDispatcher(compute, _wake_spec(tmp_path), NOW)
+    # a wake job (55) re-parks: its own lease passes to the wake it arms
+    record = waiting_run(tmp_path, experiment_job_id="", stage={"afterany": "afterany:601"})
+    acquire_lease(tmp_path, "r1", "wake-job:55", "55", now=NOW - 60)
+    assert arm_wake(tmp_path, record, dispatcher, NOW, holder_job_id="55") == "9001"
+    lease = read_lease(tmp_path, "r1")
+    assert lease is not None and lease.holder_job_id == "9001"
+    # a lease held by someone else (a tick mid-delivery) is respected: nothing armed
+    other = waiting_run(
+        tmp_path, run_id="r2", experiment_job_id="", stage={"afterany": "afterany:7"}
+    )
+    acquire_lease(tmp_path, "r2", "tick:host:1", "", now=NOW - 5)
+    assert arm_wake(tmp_path, other, dispatcher, NOW, holder_job_id="55") == ""
+    assert len(submits) == 1
+    assert load_record(tmp_path, "r2").wake_attempts == 0
+
+
+def test_sweep_leaves_an_armed_pending_wake_alone_however_old(tmp_path: Path) -> None:
+    """A wake armed at park time waits in the queue as long as the evals run;
+    an alive holder is never reaped by age."""
+    waiting_run(tmp_path)
+    acquire_lease(tmp_path, "r1", "wake-job:55", "55", now=NOW - 3 * 3600)
+    slurm = FakeSlurm(states={"100": "RUNNING", "55": "PENDING"}, reasons={"55": "Dependency"})
+    report, dispatcher = run_tick(tmp_path, slurm)
+    assert dispatcher.dispatched == [] and report.reaped_leases == ()
+
+
+def test_sweep_reaps_an_armed_wake_slurm_will_never_start(tmp_path: Path) -> None:
+    """Torch does not kill jobs whose dependency can never be satisfied: such a
+    wake would hold the lease forever. The sweep cancels it, reaps the lease,
+    and redelivers — in the same tick."""
+    waiting_run(tmp_path)
+    acquire_lease(tmp_path, "r1", "wake-job:55", "55", now=NOW - 60)
+    slurm = FakeSlurm(
+        states={"100": "COMPLETED", "55": "PENDING"}, reasons={"55": "DependencyNeverSatisfied"}
+    )
+    report, dispatcher = run_tick(tmp_path, slurm)
+    assert slurm.cancelled == ["55"]
+    assert report.reaped_leases == ("r1",)
+    assert dispatcher.dispatched == [("r1", "experiment COMPLETED")]
+
+
+def test_sweep_gives_a_dependency_pending_wake_the_grace_window(tmp_path: Path) -> None:
+    """Dependencies all terminal but the wake still pending on them: the grace
+    window runs from when the sweep first saw that, then it is redelivered."""
+    from autoresearch.tick import tick as tick_fn
+
+    waiting_run(tmp_path, terminal_seen=0.0)
+    acquire_lease(tmp_path, "r1", "wake-job:55", "55", now=NOW - 60)
+    slurm = FakeSlurm(states={"100": "COMPLETED", "55": "PENDING"}, reasons={"55": "Dependency"})
+    from autoresearch.tick import RecordingDispatcher as RD
+
+    d = RD()
+    tick_fn(tmp_path, slurm.compute(), d, now=NOW, min_tick_s=0)
+    assert d.dispatched == [] and slurm.cancelled == []
+    assert load_record(tmp_path, "r1").terminal_seen == NOW
+    tick_fn(tmp_path, slurm.compute(), d, now=NOW + GRACE + 1, min_tick_s=0)
+    assert slurm.cancelled == ["55"] and d.dispatched == [("r1", "experiment COMPLETED")]
+
+
+def test_wake_spec_round_trips_and_is_absent_when_wakes_are_dry(tmp_path: Path) -> None:
+    from autoresearch.tick import load_wake_spec, remove_wake_spec, write_wake_spec
+
+    assert load_wake_spec(tmp_path) is None
+    spec = _wake_spec(tmp_path)
+    write_wake_spec(tmp_path, spec)
+    assert load_wake_spec(tmp_path) == spec
+    remove_wake_spec(tmp_path)
+    assert load_wake_spec(tmp_path) is None
+    (tmp_path / "wake-spec.json").write_text("not json")
+    assert load_wake_spec(tmp_path) is None


### PR DESCRIPTION
## Summary

Every gate decision on the speedrun fleet waited ~30 minutes after the evals finished (tick cadence + 15-minute grace + cadence), because nobody submitted the wake job until the sweep did. The park now submits its own wake with `--dependency=afterany:<job ids>`, so it starts the moment the jobs finish.

No bypass of the orchestrator:
- **Same job, same lease.** The park calls the tick's own `JobWakeDispatcher` (recipe published by the tick as `<root>/wake-spec.json`, only while dispatched wakes are armed) and hands the lease to the submitted wake job. A wake job that parks again hands its *own* lease over and no longer releases it on exit (`_release_own_lease`).
- **The sweep keeps its authority.** A lease held by a live (pending or running) wake job stands — `lease_is_stale` no longer reaps an alive holder by age, since Slurm's walltime bounds it; a dead holder is reaped and redelivered as before; and an armed wake Slurm will never start (`DependencyNeverSatisfied`, or still `Dependency`-pending a full grace window after every dependency is terminal — Torch does not kill such jobs) is cancelled, reaped and redelivered in the same tick.
- **Arming is not a redelivery**: `wake_attempts` (the stuck counter, max 3) is untouched, so an eval requeued by preemption that fires the afterany early just re-parks.
- Without the recipe (dispatched wakes not armed, or `LocalCompute`) a park is silent and everything behaves exactly as today.

## Test plan

- [x] `ruff check`, `ruff format --check`, `mypy`, `pytest` (862 passed)
- [x] `arm_wake`: submits with the dependency and hands the lease to the job; a wake job's own lease is handed over; another holder's lease is respected (nothing armed)
- [x] Sweep: an armed pending wake is left alone however old; a `DependencyNeverSatisfied` wake is cancelled + reaped + redelivered; a `Dependency`-pending wake with terminal deps gets the grace window, then redelivery
- [x] `_park_run` arms only when the recipe exists; `_release_own_lease` keeps a handed-over lease; wake-spec round-trip
- [ ] Review rounds; then watch one live park on Torch arm its wake

🤖 Generated with [Claude Code](https://claude.com/claude-code)
