### PR TITLE
An eval killed at its walltime says so in the note

### DIFF
--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -511,13 +511,6 @@ def read_eval_result(run_dir: Path, name: str, metric: str) -> float:
         tail = ""
         with contextlib.suppress(OSError, ValueError):
             tail = (ev / "stderr").read_text(errors="replace")[-300:]
-        if code == 143:
-            # the job script traps Slurm's SIGTERM and records 143: the eval
-            # was killed at its walltime, and the author must hear that
-            raise EvalError(
-                f"dispatched eval {name} was killed at its walltime (exit 143, SIGTERM); "
-                f"a slower run needs more minutes than were declared for its eval: {tail}"
-            )
         raise EvalError(f"dispatched eval {name} failed ({code}): {tail}")
     value = _metric_from_output(stdout, metric)
     if value is None:

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -511,6 +511,13 @@ def read_eval_result(run_dir: Path, name: str, metric: str) -> float:
         tail = ""
         with contextlib.suppress(OSError, ValueError):
             tail = (ev / "stderr").read_text(errors="replace")[-300:]
+        if code == 143:
+            # the job script traps Slurm's SIGTERM and records 143: the eval
+            # was killed at its walltime, and the author must hear that
+            raise EvalError(
+                f"dispatched eval {name} was killed at its walltime (exit 143, SIGTERM); "
+                f"a slower run needs more minutes than were declared for its eval: {tail}"
+            )
         raise EvalError(f"dispatched eval {name} failed ({code}): {tail}")
     value = _metric_from_output(stdout, metric)
     if value is None:

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from autoresearch.compute import Compute, JobSpec, is_terminal
+from autoresearch.compute import GONE, Compute, JobSpec, is_terminal
 from autoresearch.dispatch import (
     eval_job_spec,
     read_eval_result,
@@ -315,6 +315,25 @@ class DispatchedMeasurer:
     def _done(self, m: Measure) -> bool:
         return (self._ev(m) / "exit-code").exists()
 
+    def _ended_without_result(self, m: Measure) -> str:
+        """Why a dispatched job left no result, as far as Slurm can say. A
+        TIMEOUT is the walltime the submit declared (or the contract's
+        default): the author reading the note must learn that a slower run
+        needs more minutes, not that the measurement broke."""
+        job_id = self._marker(m)
+        try:
+            state = self.compute.status(job_id) if job_id.isdigit() else ""
+        except Exception:
+            state = ""
+        if state.startswith("TIMEOUT"):
+            return (
+                f"job {job_id} hit its walltime (TIMEOUT) before producing a result; "
+                "a slower run needs more minutes than were declared for its eval"
+            )
+        if state and state != GONE and is_terminal(state):
+            return f"job {job_id} ended {state} without a result"
+        return "dispatched job vanished without a result"
+
     def _marker(self, m: Measure) -> str:
         f = self._ev(m) / "submitted"
         return f.read_text().strip() if f.exists() else ""
@@ -377,7 +396,7 @@ class DispatchedMeasurer:
                 continue
             if self._marker(m):
                 # was dispatched, not live, no result -> died before result
-                raise EvalError(f"measure {m.name}: dispatched job vanished without a result")
+                raise EvalError(f"measure {m.name}: {self._ended_without_result(m)}")
             # No marker, not live, no result -> never dispatched -> dispatch.
             # RESIDUAL (bounded, accepted): if a prior process died in the
             # microsecond gap between sbatch returning and _dispatch writing

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -425,7 +425,42 @@ class DispatchedMeasurer:
             pending.append(job_id)
         if pending or blind:
             raise MeasurementPending(tuple(pending))
-        return {m.name: read_eval_result(self.run_dir, self._slot(m), m.metric) for m in measures}
+        out: dict[str, float] = {}
+        for m in measures:
+            try:
+                out[m.name] = read_eval_result(self.run_dir, self._slot(m), m.metric)
+            except EvalError as exc:
+                raise EvalError(self._explain_signal_exit(m, str(exc))) from None
+        return out
+
+    def _explain_signal_exit(self, m: Measure, message: str) -> str:
+        """Exit 143 is the job script's record of a TERM: Slurm sends one at
+        the walltime, on scancel, and on preemption alike, so only its end
+        state for the job says which. The walltime case is the author's to
+        fix (more minutes); the others are the cluster's."""
+        try:
+            code = (self._ev(m) / "exit-code").read_text().strip()
+        except OSError:
+            return message
+        if code != "143":
+            return message
+        job_id = self._marker(m)
+        try:
+            state = self.compute.status(job_id) if job_id.isdigit() else ""
+        except Exception:
+            state = ""
+        if state.startswith("TIMEOUT"):
+            why = (
+                "was killed at its walltime (exit 143); a slower run needs more minutes "
+                "than were declared for its eval"
+            )
+        elif state.startswith("CANCELLED"):
+            why = "was cancelled (exit 143)"
+        elif state.startswith("PREEMPTED"):
+            why = "was preempted (exit 143); nothing about the tree is known"
+        else:
+            why = "was killed by a signal (exit 143)"
+        return f"measure {m.name} {why}; {message}"
 
 
 @dataclass(frozen=True)

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -148,6 +148,20 @@ def _baseline_cache_path(cache_dir: Path, benchmark: str, base_sha: str) -> Path
     return cache_dir / f"{benchmark}@{base_sha}.json"
 
 
+def _no_result_note(job_id: str, state: str) -> str:
+    """The note for a job that ended with no result. A TIMEOUT is the walltime
+    the submit declared (or the contract's default), and the author must
+    hear that a slower run needs more minutes — not that measurement broke."""
+    if state.startswith("TIMEOUT"):
+        return (
+            f"job {job_id} hit its walltime (TIMEOUT) before producing a result; "
+            "a slower run needs more minutes than were declared for its eval"
+        )
+    if state and state != GONE and is_terminal(state):
+        return f"job {job_id} ended {state} without a result"
+    return "dispatched job vanished without a result"
+
+
 def read_baseline_cache(
     cache_dir: Path,
     benchmark: str,
@@ -316,23 +330,14 @@ class DispatchedMeasurer:
         return (self._ev(m) / "exit-code").exists()
 
     def _ended_without_result(self, m: Measure) -> str:
-        """Why a dispatched job left no result, as far as Slurm can say. A
-        TIMEOUT is the walltime the submit declared (or the contract's
-        default): the author reading the note must learn that a slower run
-        needs more minutes, not that the measurement broke."""
+        """Why a dispatched job produced no result; a TIMEOUT means the eval
+        needs more walltime."""
         job_id = self._marker(m)
         try:
             state = self.compute.status(job_id) if job_id.isdigit() else ""
         except Exception:
             state = ""
-        if state.startswith("TIMEOUT"):
-            return (
-                f"job {job_id} hit its walltime (TIMEOUT) before producing a result; "
-                "a slower run needs more minutes than were declared for its eval"
-            )
-        if state and state != GONE and is_terminal(state):
-            return f"job {job_id} ended {state} without a result"
-        return "dispatched job vanished without a result"
+        return _no_result_note(job_id, state)
 
     def _marker(self, m: Measure) -> str:
         f = self._ev(m) / "submitted"
@@ -416,7 +421,7 @@ class DispatchedMeasurer:
                 # the job already ENDED without writing a result (a local
                 # timeout, an instant cluster failure): parking would wait on
                 # a job that will never deliver — fail like a vanished job
-                raise EvalError(f"measure {m.name}: job {job_id} ended {state} without a result")
+                raise EvalError(f"measure {m.name}: {_no_result_note(job_id, state)}")
             pending.append(job_id)
         if pending or blind:
             raise MeasurementPending(tuple(pending))

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -208,7 +208,7 @@ def test_job_terminal_without_a_result_fails_instead_of_parking(tmp_path: Path) 
         run_tag="t",
     )
     plan = plan_measures(command="true", metric="s", base_sha=base, candidate_sha=cand)
-    with pytest.raises(EvalError, match="without a result"):
+    with pytest.raises(EvalError, match=r"hit its walltime|without a result"):
         m.results(plan)
 
 

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -140,15 +140,34 @@ def test_walltime_kill_is_named_in_the_error(tmp_path):
     assert submitted == []
 
 
-def test_walltime_kill_recorded_by_the_job_script_is_named_too(tmp_path):
-    """The job script traps SIGTERM and writes exit-code 143 before Slurm's
-    TIMEOUT lands: that path must carry the same walltime wording."""
+def test_exit_143_is_explained_by_the_jobs_slurm_end_state(tmp_path):
+    """The job script writes exit-code 143 on any TERM — Slurm's walltime,
+    scancel, and preemption alike — so only the job's end state says which.
+    A walltime kill tells the author to declare more minutes; a cancellation
+    or preemption must not be blamed on the tree."""
+
+    def failing(states):
+        m = _measurer(tmp_path, [], states=states)
+        base, cand = _measures()
+        _land(m, base, 0.50)
+        _land(m, cand, code="143", job="102")
+        return m
+
+    with pytest.raises(EvalError, match=r"killed at its walltime \(exit 143\).*more minutes"):
+        failing({"102": "TIMEOUT"}).results(_measures())
+    with pytest.raises(EvalError, match=r"was cancelled \(exit 143\)"):
+        failing({"102": "CANCELLED by 1"}).results(_measures())
+    with pytest.raises(EvalError, match=r"was preempted \(exit 143\)"):
+        failing({"102": "PREEMPTED"}).results(_measures())
+    with pytest.raises(EvalError, match=r"killed by a signal \(exit 143\)"):
+        failing({"102": "GONE"}).results(_measures())
     m = _measurer(tmp_path, [])
     base, cand = _measures()
     _land(m, base, 0.50)
-    _land(m, cand, code="143")
-    with pytest.raises(EvalError, match=r"killed at its walltime \(exit 143, SIGTERM\)"):
+    _land(m, cand, code="97")
+    with pytest.raises(EvalError, match=r"failed \(97\)") as exc:
         m.results(_measures())
+    assert "143" not in str(exc.value)
 
 
 def test_timeout_right_after_submit_is_named(tmp_path):

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -20,10 +20,16 @@ from autoresearch.orchestrator import EvalError
 
 
 def _measurer(
-    tmp_path: Path, submitted: list, live: dict | None = None, squeue_fails: bool = False
+    tmp_path: Path,
+    submitted: list,
+    live: dict | None = None,
+    squeue_fails: bool = False,
+    states: dict | None = None,
 ) -> DispatchedMeasurer:
-    """`live` maps job-name -> id for jobs squeue should report as running."""
+    """`live` maps job-name -> id for jobs squeue should report as running;
+    `states` maps job id -> the sacct state to report (default PENDING)."""
     live = live or {}
+    states = states or {}
 
     def runner(argv, timeout_s):
         if argv and argv[0] == "sbatch":
@@ -36,6 +42,8 @@ def _measurer(
             return CommandResult(0, (live.get(name, "") + "\n") if live.get(name) else "", "")
         # sacct on a just-submitted job: PENDING, like a real queue (a fake
         # that said COMPLETED would trip the terminal-without-result check)
+        if argv and argv[0] == "sacct" and "-j" in argv:
+            return CommandResult(0, states.get(argv[argv.index("-j") + 1], "PENDING") + "\n", "")
         return CommandResult(0, "PENDING\n", "")
 
     return DispatchedMeasurer(
@@ -114,6 +122,20 @@ def test_dispatched_but_vanished_fails_not_resubmits(tmp_path):
     _land(m, base, 0.50)
     _dispatched(m, cand, job="102")  # marker, not live, no result
     with pytest.raises(EvalError, match="vanished"):
+        m.results(_measures())
+    assert submitted == []
+
+
+def test_walltime_kill_is_named_in_the_error(tmp_path):
+    """An eval killed at its walltime leaves no result; the note must say
+    TIMEOUT and what it means (an author read "vanished" as broken
+    infrastructure and resubmitted the same tree with the same walltime)."""
+    submitted: list = []
+    m = _measurer(tmp_path, submitted, live={}, states={"102": "TIMEOUT"})
+    base, cand = _measures()
+    _land(m, base, 0.50)
+    _dispatched(m, cand, job="102")
+    with pytest.raises(EvalError, match=r"hit its walltime \(TIMEOUT\).*more minutes"):
         m.results(_measures())
     assert submitted == []
 

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -140,6 +140,28 @@ def test_walltime_kill_is_named_in_the_error(tmp_path):
     assert submitted == []
 
 
+def test_walltime_kill_recorded_by_the_job_script_is_named_too(tmp_path):
+    """The job script traps SIGTERM and writes exit-code 143 before Slurm's
+    TIMEOUT lands: that path must carry the same walltime wording."""
+    m = _measurer(tmp_path, [])
+    base, cand = _measures()
+    _land(m, base, 0.50)
+    _land(m, cand, code="143")
+    with pytest.raises(EvalError, match=r"killed at its walltime \(exit 143, SIGTERM\)"):
+        m.results(_measures())
+
+
+def test_timeout_right_after_submit_is_named(tmp_path):
+    """A job that is already TIMEOUT when the post-submit status check runs
+    (a local compute's walltime) gets the walltime wording, not the generic
+    ended-state error."""
+    submitted: list = []
+    m = _measurer(tmp_path, submitted, states={"101": "TIMEOUT"})
+    with pytest.raises(EvalError, match=r"hit its walltime \(TIMEOUT\).*more minutes"):
+        m.results(_measures())
+    assert len(submitted) == 1
+
+
 def test_nonzero_exit_raises(tmp_path):
     m = _measurer(tmp_path, [])
     base, cand = _measures()


### PR DESCRIPTION
## Summary

Seen live (agent-03, 2026-08-28): its candidate eval hit the 4-hour walltime; the wake note said \"dispatched job vanished without a result\", the author read that as broken measurement and resubmitted the unchanged tree with the same walltime — which will time out again. The note now names the terminal Slurm state of the job (from sacct), and for a TIMEOUT says a slower run needs more minutes than were declared for its eval. GONE, unknown, or non-terminal states keep the old wording.

## Test plan

- [x] ruff, format, mypy, pytest (855 passed)
- [x] New test: a TIMEOUT-ended eval raises with the walltime wording; no resubmit
- [ ] Review round

🤖 Generated with [Claude Code](https://claude.com/claude-code)