### PR TITLE
An author that concludes after an errored eval ends the attempt; only a resubmit retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- An author that concludes after an errored gate eval ends the attempt on that error; only a resubmit runs the eval again.
 - A tree the gate already turned down in this attempt is never measured again: when the woken author concludes (or resubmits untouched), that verdict stands and the attempt ends on it — no second eval pair, no GPU-hours. An errored eval is still retried.
 
 ### Added

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1142,8 +1142,8 @@ def resume_run(
             "Revise and submit again, run more experiments, or finish with an "
             "honest negative report.",
             # the verdict rides the resume: the same tree, sealed again after
-            # the author concludes or resubmits untouched, is not measured
-            # twice (an errored eval is retried, so it is not carried)
+            # the author concludes, is not measured twice; only an explicit
+            # resubmit runs an errored eval again
             judged=(candidate_sha, result),
         )
 

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1144,7 +1144,7 @@ def resume_run(
             # the verdict rides the resume: the same tree, sealed again after
             # the author concludes or resubmits untouched, is not measured
             # twice (an errored eval is retried, so it is not carried)
-            judged=(candidate_sha, result) if result.outcome != "eval-error" else None,
+            judged=(candidate_sha, result),
         )
 
     if result.outcome == "improved":

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1370,9 +1370,13 @@ def attempt_once(
             if request.submit and failed_gate is not None:
                 # a resubmit of the tree the gate already turned down: nothing
                 # to budget or charge — the verdict is reused below (the sleep
-                # still counts, so unchanged resubmits stay bounded)
+                # still counts, so unchanged resubmits stay bounded). An eval
+                # that ERRORED is the exception: resubmitting is how the author
+                # retries it (with more minutes, say), so that one runs.
                 presealed = snapshot()
-                if tree(failed_gate[0]) == tree(presealed):
+                if failed_gate[1].outcome != "eval-error" and tree(failed_gate[0]) == tree(
+                    presealed
+                ):
                     submitted = request
                     sleeps_used += 1
                     break
@@ -1498,7 +1502,14 @@ def attempt_once(
                 panel_transcript="\n\n".join(panel_sections),
                 panel_rounds=panel_reads,
             )
-        unchanged = failed_gate is not None and tree(failed_gate[0]) == tree(candidate_sha)
+        # the tree the gate already judged, sealed again: the verdict stands
+        # when the author concluded, or resubmitted an unchanged tree after a
+        # real negative. After an ERRORED eval only a resubmit runs it again.
+        unchanged = (
+            failed_gate is not None
+            and tree(failed_gate[0]) == tree(candidate_sha)
+            and not (failed_gate[1].outcome == "eval-error" and submitted is not None)
+        )
         try:
             if unchanged:
                 assert failed_gate is not None
@@ -1557,8 +1568,7 @@ def attempt_once(
                 # eval that errored — is FEEDBACK to the author: it revises and
                 # resubmits, or concludes honestly (buildout Phase B) — never a
                 # silent terminal. Rounds stay bounded by sleep_k.
-                if outcome.outcome != "eval-error":
-                    failed_gate = (candidate_sha, outcome)
+                failed_gate = (candidate_sha, outcome)
                 verdict_text = (
                     f"{outcome.note or outcome.outcome} "
                     f"(baseline {outcome.baseline}, candidate {outcome.candidate})."

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1372,8 +1372,32 @@ def attempt_once(
                 # to budget or charge — the verdict is reused below (the sleep
                 # still counts, so unchanged resubmits stay bounded). An eval
                 # that ERRORED is the exception: resubmitting is how the author
-                # retries it (with more minutes, say), so that one runs.
-                presealed = snapshot()
+                # retries it (with more minutes, say), so that one runs. The
+                # early seal keeps the later seal's guards: scope first, and a
+                # failed snapshot is the eval error it always was.
+                violations = out_of_scope(list(changed_paths()), contract)
+                if violations:
+                    return AttemptResult(
+                        outcome="scope-violation",
+                        baseline=baseline,
+                        session=session,
+                        note=f"out-of-scope paths: {', '.join(sorted(violations)[:10])}",
+                        run_seed=run_seed,
+                        panel_transcript="\n\n".join(panel_sections),
+                        panel_rounds=panel_reads,
+                    )
+                try:
+                    presealed = snapshot()
+                except EvalError as exc:
+                    return AttemptResult(
+                        outcome="eval-error",
+                        baseline=baseline,
+                        session=session,
+                        note=f"snapshot: {exc}",
+                        run_seed=run_seed,
+                        panel_transcript="\n\n".join(panel_sections),
+                        panel_rounds=panel_reads,
+                    )
                 if failed_gate[1].outcome != "eval-error" and tree(failed_gate[0]) == tree(
                     presealed
                 ):

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -2717,6 +2717,67 @@ def test_gate_negative_wake_with_an_unchanged_tree_ends_without_a_second_gate(
     assert load_record(state, run_id).state != "waiting"
 
 
+def test_errored_gate_wake_with_a_conceding_author_ends_without_a_retry(
+    tmp_path, monkeypatch
+) -> None:
+    """A submitted candidate's gate eval errored (a walltime kill); the woken
+    author concludes with the tree untouched. The attempt ends on that error
+    — nothing is dispatched again (only a resubmit is a retry)."""
+    from dataclasses import dataclass
+
+    from autoresearch.measure import DispatchSettings
+    from autoresearch.orchestrator import EvalError, author_spec
+    from autoresearch.syscall import ensure_excluded
+
+    @dataclass
+    class ConcedingHarness:
+        def run(self, brief_text, workspace, resume_session_id=None) -> SessionResult:
+            assert "did NOT clear the gate" in brief_text and "walltime" in brief_text
+            return SessionResult(
+                stop_reason="end_turn",
+                is_error=False,
+                cost_usd=0.2,
+                num_turns=2,
+                session_id="s1",
+                final_text="Negative result: the run could not be measured in its walltime.",
+                transcript_path="",
+            )
+
+    state, run_id = _write_parked_candidate(tmp_path, monkeypatch, values={"baseline": 13.0})
+    rec = load_record(state, run_id)
+    rec.stage["submitted"] = True
+    save_record(state, rec, 1_000_050.0)
+    ensure_excluded(state / "runs" / run_id / "ws")
+    (state / "runs" / run_id / "ws" / "eval-cache.tmp").unlink()
+
+    class _Once:
+        def __init__(self):
+            self.calls = 0
+
+        def results(self, measures):
+            self.calls += 1
+            assert self.calls == 1, "the same tree was sent to the gate again"
+            raise EvalError("job 102 hit its walltime (TIMEOUT) before producing a result")
+
+    once = _Once()
+    monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: once)
+    github = FakeGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+        harness=ConcedingHarness(),
+        spec=author_spec(),
+    )
+    assert outcome.outcome == "eval-error"
+    assert github.prs == []
+    assert once.calls == 1
+    assert load_record(state, run_id).state != "waiting"
+
+
 def test_resume_blocking_panel_on_a_plain_finish_drafts(tmp_path, monkeypatch) -> None:
     # a candidate park WITHOUT a submit gets no author loop: blocking findings
     # DRAFT the PR for a human (the policy-driven revision loop is retired —

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -398,6 +398,36 @@ def test_identical_resubmit_is_told_so_without_a_second_gate(tmp_path: Path) -> 
     assert "identical to the candidate the gate already measured" in harness.prompts[2]
 
 
+def test_conceding_after_an_errored_eval_ends_without_another_gate(tmp_path: Path) -> None:
+    """The gate's eval errored (a walltime kill, say); the author read the
+    note and concluded without touching the tree. The attempt ends on that
+    error — the identical tree is not sent to the gate a third time (the
+    speedrun fleet paid a third 8 GPU-hour pair this way, 2026-08-28)."""
+    from autoresearch.orchestrator import EvalError
+
+    harness = _SeqHarness(["the claim", "conceded"], submit_on=(1,))
+    evaluator = FakeEvaluator(values=[13.9, EvalError("job hit its walltime (TIMEOUT)")])  # type: ignore[list-item]
+    result = _gate_negative_attempt(tmp_path, harness, evaluator)
+    assert result.outcome == "eval-error"
+    assert "walltime" in result.note
+    assert harness.resumes == [None, "s1"]
+    assert len(evaluator.calls) == 2
+
+
+def test_resubmitting_after_an_errored_eval_runs_it_again(tmp_path: Path) -> None:
+    """After an errored eval a resubmit of the same tree is the retry (more
+    minutes declared, say): it is measured again, not answered from memory."""
+    from autoresearch.orchestrator import EvalError
+
+    harness = _SeqHarness(["the claim", "again", "conceded"], submit_on=(1, 2))
+    evaluator = FakeEvaluator(values=[13.9, EvalError("job hit its walltime (TIMEOUT)"), 13.9])  # type: ignore[list-item]
+    result = _gate_negative_attempt(tmp_path, harness, evaluator)
+    assert result.outcome == "no-improvement"
+    assert harness.resumes == [None, "s1", "s2"]
+    assert len(evaluator.calls) == 3
+    assert "identical" not in harness.prompts[2]  # the retry ran; it was not refused
+
+
 def test_identical_resubmit_past_the_sleep_budget_ends_on_the_verdict(tmp_path: Path) -> None:
     """The unchanged-tree reuse runs BEFORE the budget check, so an author out
     of sleeps (or GPU-hours) is not refused a gate it would never run; past

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -399,10 +399,9 @@ def test_identical_resubmit_is_told_so_without_a_second_gate(tmp_path: Path) -> 
 
 
 def test_conceding_after_an_errored_eval_ends_without_another_gate(tmp_path: Path) -> None:
-    """The gate's eval errored (a walltime kill, say); the author read the
-    note and concluded without touching the tree. The attempt ends on that
-    error — the identical tree is not sent to the gate a third time (the
-    speedrun fleet paid a third 8 GPU-hour pair this way, 2026-08-28)."""
+    """The gate's eval errored; the author read the note and concluded
+    without touching the tree. The attempt ends on that error — the
+    identical tree is not evaluated again."""
     from autoresearch.orchestrator import EvalError
 
     harness = _SeqHarness(["the claim", "conceded"], submit_on=(1,))
@@ -426,6 +425,61 @@ def test_resubmitting_after_an_errored_eval_runs_it_again(tmp_path: Path) -> Non
     assert harness.resumes == [None, "s1", "s2"]
     assert len(evaluator.calls) == 3
     assert "identical" not in harness.prompts[2]  # the retry ran; it was not refused
+
+
+def test_resubmit_after_a_gate_verdict_keeps_scope_and_snapshot_guards(tmp_path: Path) -> None:
+    """The early seal of a resubmit runs behind the same guards as the late
+    one: an out-of-scope edit is a scope violation before anything is
+    snapshotted, and a failed snapshot is the eval error it always was."""
+    from autoresearch.orchestrator import EvalError
+
+    harness = _SeqHarness(["the claim", "again"], submit_on=(1, 2))
+    evaluator = FakeEvaluator(values=[13.9, 13.9])
+    measurer, _snapshot = _wire(evaluator, tmp_path)
+    seals = {"n": 0}
+
+    def snapshot() -> str:
+        seals["n"] += 1
+        if seals["n"] > 1:
+            raise EvalError("git objects unwritable")
+        return f"cand{seals['n']}"
+
+    result = attempt_once(
+        CONFIG,
+        CONTRACT,
+        tmp_path,
+        harness,
+        measurer,
+        "base",
+        snapshot,
+        ruler="r",
+        changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+        created="t",
+        launcher=lambda sha, req: "",
+        tree_of=lambda sha: "same-tree",
+    )
+    assert result.outcome == "eval-error" and "snapshot" in result.note
+    assert seals["n"] == 2
+
+    harness = _SeqHarness(["the claim", "again"], submit_on=(1, 2))
+    evaluator = FakeEvaluator(values=[13.9, 13.9])
+    measurer, snapshot2 = _wire(evaluator, tmp_path)
+    paths = iter([["src/pilot/solvers/tsp.py"], ["src/pilot/solvers/tsp.py", "docs/roadmap.md"]])
+    result = attempt_once(
+        CONFIG,
+        CONTRACT,
+        tmp_path,
+        harness,
+        measurer,
+        "base",
+        snapshot2,
+        ruler="r",
+        changed_paths=lambda: next(paths),
+        created="t",
+        launcher=lambda sha, req: "",
+        tree_of=lambda sha: "same-tree",
+    )
+    assert result.outcome == "scope-violation" and "docs/roadmap.md" in result.note
 
 
 def test_identical_resubmit_past_the_sleep_budget_ends_on_the_verdict(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Seen live (agent-03, 2026-08-28): its gate evals kept timing out; after the second, the author read the note, wrote an honest negative and ended its session — and the kernel sealed the unchanged tree and dispatched a third 8 GPU-hour eval pair. #182 deliberately did not carry an errored-eval verdict so the author could retry it; that left the concluding case open.

- The verdict now rides the resume for every gate outcome (`judged` is set for eval-error too).
- An unchanged tree ends the attempt on the carried verdict when the author concludes — for an errored eval the attempt ends as that error, with the author's report.
- After an errored eval, a resubmit of the same tree is the retry: it is measured again and goes through the normal budget check (the early reuse branch skips it).

## Test plan

- [x] ruff, format, mypy, pytest (872 passed)
- [x] Conclude after an errored eval → `eval-error` terminal, evaluator not called again
- [x] Resubmit after an errored eval → measured again; the retry is not refused as "identical"
- [ ] Review round

🤖 Generated with [Claude Code](https://claude.com/claude-code)