### PR TITLE
Every jailed job gets /tmp on node-local scratch

### DIFF
--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -316,7 +316,7 @@ def write_eval_job(
         # the wake needs only stdout/exit-code, which stay in $EV
         'SCRATCH="${SLURM_TMPDIR:-${TMPDIR:-/tmp}}/dispatch-eval-$$"',
         'TREE="$SCRATCH/tree"',
-        'mkdir -p "$SCRATCH/cache" "$SCRATCH/home" "$TREE"',
+        'mkdir -p "$SCRATCH/cache" "$SCRATCH/home" "$SCRATCH/work" "$TREE"',
         # trap FIRST, before anything that can exit, so $SCRATCH never leaks.
         # prune reaps the stale worktree admin entry in $REPO/.git/worktrees
         # left when we deleted $TREE/.git (worktree remove can't run without it)
@@ -368,6 +368,11 @@ def write_eval_job(
             + ("--nv " if gpus > 0 else "")
             + '--bind "$TREE:$TREE" --home "$SCRATCH/home:$SCRATCH/home" '
             '--bind "$SCRATCH/cache:$SCRATCH/cache" --pwd "$TREE" '
+            # /tmp and /var/tmp inside the jail live on node-local scratch,
+            # not apptainer's small tmpfs: a command that writes compile caches
+            # or checkpoints to /tmp (any training script that was not told
+            # otherwise) must not die on a temp-disk limit
+            '--workdir "$SCRATCH/work" '
             f"{shlex.quote(image)} "
             'sh -c "$(cat "$EV/command.txt")" '
             '> "$EV/stdout" 2> "$EV/stderr"',

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -245,6 +245,8 @@ class SubprocessEvaluator:
         import signal
 
         if self.container_image:
+            workdir = cache_dir.parent / "work"
+            workdir.mkdir(parents=True, exist_ok=True)
             argv = [
                 self.apptainer_binary,
                 "exec",
@@ -260,6 +262,10 @@ class SubprocessEvaluator:
                 f"{cache_dir}:{cache_dir}",
                 "--pwd",
                 str(workspace),
+                # /tmp on the same scratch as the cache, not apptainer's tmpfs
+                # (the dispatched job script does the same with --workdir)
+                "--workdir",
+                str(workdir),
                 self.container_image,
                 "sh",
                 "-c",

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -245,7 +245,8 @@ class SubprocessEvaluator:
         import signal
 
         if self.container_image:
-            workdir = cache_dir.parent / "work"
+            # per evaluation, and gone with the cache dir the caller removes
+            workdir = cache_dir / "work"
             workdir.mkdir(parents=True, exist_ok=True)
             argv = [
                 self.apptainer_binary,
@@ -262,8 +263,8 @@ class SubprocessEvaluator:
                 f"{cache_dir}:{cache_dir}",
                 "--pwd",
                 str(workspace),
-                # /tmp on the same scratch as the cache, not apptainer's tmpfs
-                # (the dispatched job script does the same with --workdir)
+                # /tmp inside the jail on this evaluation's own scratch, not
+                # apptainer's tmpfs (the dispatched job script does the same)
                 "--workdir",
                 str(workdir),
                 self.container_image,

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -443,3 +443,20 @@ def test_gpu_evals_are_sized_per_gpu(tmp_path):
             script, job_name="e", account="a", partition="p", eval_minutes=60, gpus=1, mem=mem
         )
         assert spec.mem == expect, mem
+
+
+def test_job_tmp_lives_on_node_local_scratch(tmp_path: Path) -> None:
+    """Inside the jail /tmp is apptainer's small tmpfs unless --workdir moves
+    it: an author's sweep that wrote compile caches to /tmp died on a
+    temp-disk limit (2026-08-29). Every job gets --workdir on $SCRATCH."""
+    script = write_eval_job(
+        tmp_path,
+        "tmp-check",
+        repo_root=tmp_path / "repo",
+        snapshot_sha="a" * 40,
+        command="python train.py",
+        image="/img.sif",
+    )
+    text = Path(script).read_text()
+    assert '--workdir "$SCRATCH/work"' in text
+    assert 'mkdir -p "$SCRATCH/cache" "$SCRATCH/home" "$SCRATCH/work"' in text

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -963,6 +963,13 @@ def test_subprocess_evaluator_container_wrapping(tmp_path: Path) -> None:
     # a real-disk home: apptainer's tmpfs home is size-capped and uv blows it
     assert "--home " in argv and "ws-eval-home-" in argv
     assert "/img/pilot.sif sh -c run-the-eval" in argv
+    # /tmp inside the jail is a per-evaluation directory under this eval's
+    # own cache dir — created for the run, removed with it (never a shared,
+    # surviving $TMPDIR/work)
+    tokens = argv.split()
+    workdir = Path(tokens[tokens.index("--workdir") + 1])
+    assert workdir.name == "work" and "uv-cache-" in workdir.parent.name
+    assert not workdir.exists()
 
 
 def test_pr_body_refuses_non_improved_results(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Seen live (agent-03, 2026-08-29): a launched sweep ran `train.py` directly, wrote its compile caches to `/tmp`, and died on a temp-disk limit — inside the jail `/tmp` is apptainer's small tmpfs. `bench_eval.py` only survives because it sets its own cache paths under the tree.

- The dispatched job script passes `--workdir "$SCRATCH/work"` (node-local scratch, dies with the job), so `/tmp` and `/var/tmp` inside the container are real disk.
- The in-job evaluator (`SubprocessEvaluator._run`) does the same next to its cache dir, keeping the two jails identical.

## Test plan

- [x] ruff, format, mypy, pytest (875 passed)
- [x] New test: the job script carries `--workdir` and creates the dir
- [ ] Review round; then watch a launched job on Torch write to /tmp freely

🤖 Generated with [Claude Code](https://claude.com/claude-code)