### PR TITLE
Launch GPU-hours are reconciled with what the jobs actually ran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- GPU-hours for an author's launches are charged at the declared walltime when dispatched and reconciled when the wake gathers them: unused walltime is refunded (a sweep that dies in its first minutes no longer costs its full declared hours).
 - An author that concludes after an errored gate eval ends the attempt on that error; only a resubmit runs the eval again.
 - A tree the gate already turned down in this attempt is never measured again: when the woken author concludes (or resubmits untouched), that verdict stands and the attempt ends on it — no second eval pair, no GPU-hours. An errored eval is still retried.
 

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -363,6 +363,7 @@ def _park_run(
         "seed": parked.seed,
         "suite_seed": parked.suite_seed,
         "afterany": parked.afterany,
+        "launch_afterany": parked.launch_afterany,
         # the branch the run targets, so a wake opens its PR against the SAME
         # branch a non-default `--base-branch` selected — the wake CLI otherwise
         # defaults to main and would mis-target.
@@ -720,16 +721,7 @@ def _wake_author_sleep(
     results = gather_results(run_dir, workspace, launches)
     launches_used = int(record.stage.get("launches_used", 0))  # type: ignore[call-overload]
     sleeps_used = int(record.stage.get("sleeps_used", 0))  # type: ignore[call-overload]
-    gpu_hours_used = float(record.stage.get("gpu_hours_used", 0.0))  # type: ignore[arg-type]
-    if bench.gpus:
-        # the launches were charged at their declared walltime; now that they
-        # have run, hand back what they did not use
-        refund = _launch_refund(
-            dispatch, launches, afterany_ids(str(record.stage.get("afterany", ""))), bench.gpus
-        )
-        if refund > 0:
-            log.info("%s: refunding %.2f GPU-hours of unused launch walltime", run_id, refund)
-            gpu_hours_used = max(0.0, gpu_hours_used - refund)
+    gpu_hours_used = _reconcile_launch_hours(record, dispatch, bench.gpus, launches)
     wake_text = render_wake(
         results,
         str(record.stage.get("syscall_note", "")),
@@ -871,6 +863,54 @@ def _stage_judged(record: RunRecord) -> tuple[str, AttemptResult] | None:
             note=str(j.get("note") or ""),
         ),
     )
+
+
+def _stage_syscall_launches(record: RunRecord) -> tuple:
+    """The park's launches as `Launch` values (command elided: they ran)."""
+    from autoresearch.syscall import Launch
+
+    return tuple(
+        Launch(
+            name=str(item.get("name", "")),
+            command="(ran)",
+            minutes=int(item.get("minutes") or 1),
+            artifacts=tuple(str(a) for a in item.get("artifacts", [])),
+            array=int(item.get("array") or 1),
+        )
+        for item in _stage_launches(record)
+    )
+
+
+def _stage_launch_job_ids(record: RunRecord) -> list[str]:
+    """The park's launch jobs: `launch_afterany` when the park recorded it;
+    for an older author-sleep park every waited job was a launch; for an
+    older candidate park the gate's evals are mixed in, so none."""
+    stage = record.stage or {}
+    if "launch_afterany" in stage:
+        return afterany_ids(str(stage.get("launch_afterany") or ""))
+    if stage.get("phase") == "author-sleep":
+        return afterany_ids(str(stage.get("afterany") or ""))
+    return []
+
+
+def _reconcile_launch_hours(
+    record: RunRecord, dispatch: DispatchSettings, gpus: int, launches: tuple
+) -> float:
+    """The run's GPU-hours after handing back the unused walltime of the
+    park's launch jobs — once: the stage remembers the refund, so a wake
+    that follows a gate decision on the same park does not refund twice.
+    Returns the (possibly corrected) `gpu_hours_used`."""
+    stage = record.stage or {}
+    used = float(stage.get("gpu_hours_used", 0.0))  # type: ignore[arg-type]
+    if not gpus or stage.get("launch_hours_refunded"):
+        return used
+    refund = _launch_refund(dispatch, launches, _stage_launch_job_ids(record), gpus)
+    if refund > 0:
+        log.info("%s: refunding %.2f GPU-hours of unused launch walltime", record.run_id, refund)
+        used = max(0.0, used - refund)
+        stage["gpu_hours_used"] = used
+    stage["launch_hours_refunded"] = True
+    return used
 
 
 def _launch_refund(
@@ -1075,6 +1115,7 @@ def resume_run(
             parked.gpu_hours_used = float(stage.get("gpu_hours_used", 0.0))  # type: ignore[arg-type]
             parked.eval_minutes = int(stage.get("eval_minutes", 0) or 0) or None  # type: ignore[call-overload]
             parked.judged = parked.judged or _stage_judged(record)
+            parked.launch_afterany = parked.launch_afterany or str(stage.get("launch_afterany", ""))
             if parked.syscall is None:
                 parked.syscall = _SyscallRequest(
                     launches=tuple(
@@ -1121,6 +1162,11 @@ def resume_run(
         and bool(record.resume_session_id)
         and getattr(harness, "supports_resume", True)
     )
+
+    # the park's sibling launches are done too: settle their charge before
+    # any path — publish or hand back to the author — reads the budget
+    if _stage_launches(record):
+        _reconcile_launch_hours(record, dispatch, bench.gpus, _stage_syscall_launches(record))
 
     def _wake_author(
         extra_update: str, judged: tuple[str, AttemptResult] | None = None

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -721,6 +721,15 @@ def _wake_author_sleep(
     launches_used = int(record.stage.get("launches_used", 0))  # type: ignore[call-overload]
     sleeps_used = int(record.stage.get("sleeps_used", 0))  # type: ignore[call-overload]
     gpu_hours_used = float(record.stage.get("gpu_hours_used", 0.0))  # type: ignore[arg-type]
+    if bench.gpus:
+        # the launches were charged at their declared walltime; now that they
+        # have run, hand back what they did not use
+        refund = _launch_refund(
+            dispatch, launches, afterany_ids(str(record.stage.get("afterany", ""))), bench.gpus
+        )
+        if refund > 0:
+            log.info("%s: refunding %.2f GPU-hours of unused launch walltime", run_id, refund)
+            gpu_hours_used = max(0.0, gpu_hours_used - refund)
     wake_text = render_wake(
         results,
         str(record.stage.get("syscall_note", "")),
@@ -862,6 +871,25 @@ def _stage_judged(record: RunRecord) -> tuple[str, AttemptResult] | None:
             note=str(j.get("note") or ""),
         ),
     )
+
+
+def _launch_refund(
+    dispatch: DispatchSettings, launches: tuple, job_ids: list[str], gpus: int
+) -> float:
+    """The unused walltime of a park's launch jobs, in GPU-hours, or 0 when
+    the compute cannot say how long they ran (nothing is refunded on a
+    guess)."""
+    from autoresearch.syscall import launch_hours_refund
+
+    query = getattr(dispatch.compute, "elapsed_seconds", None)
+    if query is None or not job_ids:
+        return 0.0
+    try:
+        elapsed = [query(jid) for jid in job_ids]
+    except Exception as exc:
+        log.warning("launch walltime unknown (%s: %s); nothing refunded", type(exc).__name__, exc)
+        return 0.0
+    return launch_hours_refund(launches, elapsed, gpus=gpus)
 
 
 def _stage_launches(record: RunRecord) -> list[dict]:

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -176,6 +176,23 @@ class SlurmCompute:
         state = result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
         return state if state else GONE
 
+    def elapsed_seconds(self, job_id: str) -> int | None:
+        """How long the job actually ran (sacct Elapsed), or None when sacct
+        has no record. Raises SlurmQueryError when the query itself fails."""
+        if not job_id.isdigit():
+            raise ValueError(f"not a job id: {job_id!r}")
+        try:
+            result = self.runner(
+                ["sacct", "-j", job_id, "--parsable2", "--noheader", "-X", "-o", "Elapsed"],
+                self.command_timeout_s,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SlurmQueryError(f"sacct did not run: {exc}") from exc
+        if result.returncode != 0:
+            raise SlurmQueryError(f"sacct failed ({result.returncode}): {result.stderr.strip()}")
+        text = result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
+        return parse_elapsed(text) if text else None
+
     def pending_reason(self, job_id: str) -> str:
         """Why a PENDING job is pending — Slurm's reason (`Dependency`,
         `DependencyNeverSatisfied`, `Priority`, ...), or "" when squeue no
@@ -329,6 +346,25 @@ class LocalCompute:
         if not job_id.isdigit():
             raise ValueError(f"not a job id: {job_id!r}")
         # already terminal; cancelling a finished job is not an error
+
+
+def parse_elapsed(text: str) -> int | None:
+    """Seconds in a sacct Elapsed field: `MM:SS`, `HH:MM:SS` or `D-HH:MM:SS`.
+    None for anything else (an unknown field never becomes a refund)."""
+    days = 0
+    if "-" in text:
+        day_part, _, text = text.partition("-")
+        if not day_part.isdigit():
+            return None
+        days = int(day_part)
+    parts = text.split(":")
+    if not parts or not all(p.isdigit() for p in parts) or len(parts) > 3:
+        return None
+    nums = [int(p) for p in parts]
+    while len(nums) < 3:
+        nums.insert(0, 0)
+    hours, minutes, seconds = nums
+    return days * 86400 + hours * 3600 + minutes * 60 + seconds
 
 
 def is_terminal(state: str) -> bool:

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -122,8 +122,12 @@ class RunParked(Exception):
         gpu_hours_used: float = 0.0,
         eval_minutes: int | None = None,
         judged: tuple[str, AttemptResult] | None = None,
+        launch_afterany: str = "",
     ):
         self.phase = phase
+        # the author's launch jobs alone (a candidate park's `afterany` also
+        # carries the gate's evals): the wake reconciles their charge
+        self.launch_afterany = launch_afterany
         # the gate's last negative and the tree it judged, carried across an
         # author-sleep so a wake ending on that tree reuses the verdict
         self.judged = judged
@@ -1461,10 +1465,12 @@ def attempt_once(
                         run_seed=run_seed,
                     )
                 sha = snapshot()
+                launch_afterany = launcher(sha, request)
                 raise RunParked(
                     phase="author-sleep",
                     judged=failed_gate,
-                    afterany=launcher(sha, request),
+                    afterany=launch_afterany,
+                    launch_afterany=launch_afterany,
                     base_sha=base_sha,
                     seed=run_seed,
                     suite_seed=suite_seed,
@@ -1569,6 +1575,7 @@ def attempt_once(
             raise RunParked(
                 phase="candidate",
                 afterany=_merge_afterany(pending.afterany(), launch_afterany),
+                launch_afterany=launch_afterany,
                 base_sha=base_sha,
                 seed=run_seed,
                 suite_seed=suite_seed,

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import contextlib
 import json
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -268,6 +269,25 @@ def launches_gpu_hours(request: SyscallRequest, *, gpus: int) -> float:
     if gpus <= 0:
         return 0.0
     return sum(la.minutes * max(la.array, 1) for la in request.launches) * gpus / 60.0
+
+
+def launch_hours_refund(
+    launches: Iterable[Launch], elapsed_seconds: Iterable[int | None], *, gpus: int
+) -> float:
+    """GPU-hours to hand back once a park's launch jobs are done: they were
+    charged at their declared walltime when dispatched, and a job that died
+    in its first minutes (a bad command, a missing path) must not cost the
+    author the four hours it asked for. The refund is the declared charge
+    minus what the jobs actually ran, never below zero, and zero when any
+    job's elapsed time is unknown (a refund is never guessed)."""
+    if gpus <= 0:
+        return 0.0
+    elapsed = list(elapsed_seconds)
+    if not elapsed or any(e is None for e in elapsed):
+        return 0.0
+    declared = sum(la.minutes * max(la.array, 1) for la in launches) * gpus / 60.0
+    actual = sum(int(e) for e in elapsed if e is not None) * gpus / 3600.0
+    return max(0.0, declared - actual)
 
 
 def evals_gpu_hours(

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -157,6 +157,70 @@ def test_release_own_lease_keeps_a_lease_handed_to_the_armed_wake(tmp_path, monk
     assert read_lease(tmp_path, "r") is None
 
 
+def test_launch_hours_are_reconciled_once_from_the_parks_launch_jobs(tmp_path, monkeypatch) -> None:
+    """A park remembers which of its jobs were the author's launches
+    (`launch_afterany`); the refund reads those jobs' elapsed time — never the
+    gate's evals mixed into a candidate park's `afterany` — and happens once
+    per park, however many wakes read the budget afterwards."""
+    from dataclasses import dataclass
+
+    from autoresearch.attempt import _reconcile_launch_hours, _stage_launch_job_ids
+    from autoresearch.syscall import Launch
+
+    @dataclass
+    class Elapsed:
+        seconds: dict
+
+        def elapsed_seconds(self, job_id: str) -> int | None:
+            return self.seconds.get(job_id)
+
+    @dataclass
+    class D:
+        compute: object
+
+    sweep = (Launch(name="sweep", command="x", minutes=240, array=2),)
+    # a candidate park: gate evals 601/602 waited on too, launches 701/702
+    rec = RunRecord(
+        run_id="r",
+        target="o/p",
+        task_title="t",
+        state="waiting",
+        stage={
+            "phase": "candidate",
+            "afterany": "afterany:601:602:701:702",
+            "launch_afterany": "afterany:701:702",
+            "syscall_launches": [{"name": "sweep", "minutes": 240, "array": 2}],
+            "gpu_hours_used": 16.0,
+        },
+    )
+    assert _stage_launch_job_ids(rec) == ["701", "702"]
+    d = D(Elapsed({"601": 12000, "602": 12000, "701": 300, "702": 300}))
+    used = _reconcile_launch_hours(rec, d, 1, sweep)  # type: ignore[arg-type]
+    assert abs(used - (16.0 - (8.0 - 600 / 3600))) < 1e-9
+    assert rec.stage["launch_hours_refunded"] is True
+    assert _reconcile_launch_hours(rec, d, 1, sweep) == used  # type: ignore[arg-type]
+    # older parks: an author-sleep park's jobs were all launches; a candidate
+    # park without the field has the gate mixed in, so nothing is refunded
+    old_sleep = RunRecord(
+        run_id="s",
+        target="o/p",
+        task_title="t",
+        state="waiting",
+        stage={"phase": "author-sleep", "afterany": "afterany:701:702"},
+    )
+    assert _stage_launch_job_ids(old_sleep) == ["701", "702"]
+    old_cand = RunRecord(
+        run_id="c",
+        target="o/p",
+        task_title="t",
+        state="waiting",
+        stage={"phase": "candidate", "afterany": "afterany:601:701"},
+    )
+    assert _stage_launch_job_ids(old_cand) == []
+    # no GPUs: nothing is metered, nothing refunded
+    assert _reconcile_launch_hours(old_sleep, d, 0, sweep) == 0.0  # type: ignore[arg-type]
+
+
 def test_author_sleep_park_carries_the_gate_verdict(tmp_path) -> None:
     """A gate negative the author answered by launching more work rides the
     park, so the wake that ends on the same tree reuses it (review #182)."""
@@ -180,6 +244,7 @@ def test_author_sleep_park_carries_the_gate_verdict(tmp_path) -> None:
         session=_session("s9"),
         syscall=SyscallRequest(launches=(Launch(name="probe", command="x", minutes=5),)),
         judged=("d" * 40, verdict),
+        launch_afterany="afterany:501",
     )
     _park_run(tmp_path, record, parked, "refs/dispatch/tok", eval_minutes=None, now=1000.0)
     r = load_record(tmp_path, "tsp-3")
@@ -191,6 +256,7 @@ def test_author_sleep_park_carries_the_gate_verdict(tmp_path) -> None:
         "note": "inside the floor",
     }
     assert _stage_judged(r) == ("d" * 40, verdict)
+    assert r.stage["launch_afterany"] == "afterany:501"
     bare = RunRecord(run_id="x", target="o/p", task_title="t", state="waiting")
     assert _stage_judged(bare) is None
 

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -680,3 +680,31 @@ def test_array_launch_fans_out_and_gathers_per_index(tmp_path: Path) -> None:
     again = gather_results(run_dir, ws, (Launch(name="sweep", command="x", minutes=10, array=2),))
     assert again[0].delivered == (".autoresearch/results/sweep/0/out/curve.json",)
     assert first.read_text() == "[0]"
+
+
+def test_launch_hours_refund_hands_back_unused_declared_walltime() -> None:
+    """A sweep charged 8 x 240 min at dispatch that died after 5 minutes per
+    job is refunded almost all of it; a job that ran its full walltime is
+    refunded nothing; an unknown elapsed time refunds nothing at all."""
+    from autoresearch.syscall import Launch, launch_hours_refund
+
+    sweep = (Launch(name="sweep", command="x", minutes=240, array=8),)
+    assert launch_hours_refund(sweep, [300] * 8, gpus=1) == 32.0 - 8 * 300 / 3600
+    assert launch_hours_refund(sweep, [240 * 60] * 8, gpus=1) == 0.0
+    assert launch_hours_refund(sweep, [250 * 60] * 8, gpus=1) == 0.0  # overran: never negative
+    assert launch_hours_refund(sweep, [300] * 7 + [None], gpus=1) == 0.0
+    assert launch_hours_refund(sweep, [], gpus=1) == 0.0
+    assert launch_hours_refund(sweep, [300] * 8, gpus=0) == 0.0
+    two = (Launch(name="a", command="x", minutes=60), Launch(name="b", command="x", minutes=30))
+    assert launch_hours_refund(two, [1800, 1800], gpus=2) == (90 * 2 / 60) - (3600 * 2 / 3600)
+
+
+def test_parse_elapsed_reads_sacct_fields() -> None:
+    from autoresearch.compute import parse_elapsed
+
+    assert parse_elapsed("00:05:00") == 300
+    assert parse_elapsed("04:10:05") == 4 * 3600 + 605
+    assert parse_elapsed("1-02:00:00") == 86400 + 7200
+    assert parse_elapsed("05:00") == 300
+    assert parse_elapsed("") is None and parse_elapsed("INVALID") is None
+    assert parse_elapsed("x-01:00:00") is None


### PR DESCRIPTION
## Summary

Seen live (agent-03, 2026-08-29): four early-dying submissions of an 8-wide, 240-minute sweep were each charged their declared 32 GPU-hours — 128 of the attempt's 400 for roughly one hour of real compute. The declared charge is right for the budget check at dispatch; once the jobs have run, the wake now reconciles.

- `SlurmCompute.elapsed_seconds` (sacct Elapsed; `parse_elapsed` handles `MM:SS`, `HH:MM:SS`, `D-HH:MM:SS`).
- `launch_hours_refund`: declared minus actual, never below zero (an overrun is not charged extra), zero when any job's elapsed time is unknown — a refund is never guessed.
- `_wake_author_sleep` applies it after gathering the park's launches, before the wake text and budget file are written, so the author sees the corrected remainder. Composes with `LocalCompute`/fakes (no `elapsed_seconds` → no refund).

Not in scope: gate evals (declared 240 min vs ~210 actual) — small and constant; can follow the same helper later.

## Test plan

- [x] ruff, format, mypy, pytest
- [x] Refund arithmetic (sweep dying early, full walltime, overrun, unknown elapsed, no GPUs, mixed launches); sacct Elapsed parsing
- [ ] Review round; then watch agent-03's next wake refund on Torch

🤖 Generated with [Claude Code](https://claude.com/claude-code)