### PR TITLE
Every role can search and read the web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Every role can search and read the web (Claude: WebSearch/WebFetch; Codex: `--search`; hermes: the `web` and `search` toolsets) — literature and documentation are part of research.
 - A park now submits its own wake job, which waits on the park's jobs and
   starts the moment they finish (previously: the next sweep, a grace
   window, and another sweep — about 30 minutes). The sweep remains the

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ account, a contract, and a Slurm cluster with Apptainer.
   data, never instructions. Authors run without credentials in their
   environment; evals run in a jail that sees only the checked-out tree.
   Budgets — launches, sleeps, GPU-hours, weekly runs — are enforced in code.
+  Every role can search and read the web (literature, documentation); what
+  it reads there is data too.
 - **Nothing is taken on trust.** The orchestrator measures every claim
   itself, on committed trees, and re-verifies credited candidates before a
   PR exists.

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -36,7 +36,9 @@ log = logging.getLogger(__name__)
 # Native Claude Code tool names a spec may grant. A spec's other tools
 # (pr-context-read, retriever) are harness-provided MCP tools, wired
 # separately — never passed as native CLI tools.
-_NATIVE_TOOLS = frozenset({"Read", "Grep", "Glob", "Write", "Edit", "Bash"})
+_NATIVE_TOOLS = frozenset(
+    {"Read", "Grep", "Glob", "Write", "Edit", "Bash", "WebSearch", "WebFetch"}
+)
 
 # hermes names capabilities as toolsets: `file` is the read/edit surface,
 # `terminal` the shell. Everything else stays disabled for parity with the
@@ -113,6 +115,8 @@ def build_harness(
     the ephemeral boundary (CI). The tokenless split keeps credentials out of
     the session either way."""
     if backend == "codex":
+        # the web: codex's native web_search tool, on when the spec grants it
+        web = ("--search",) if "WebSearch" in spec.tools else ()
         return CodexHarness(
             api_key=api_key,
             binary=binary or "codex",
@@ -120,7 +124,7 @@ def build_harness(
             sandbox="danger-full-access",
             timeout_s=spec.budget.walltime_s,
             container_image=container_image,
-            extra_args=codex_extra_args,
+            extra_args=(*codex_extra_args, *web),
         )
     if backend == "hermes":
         if hermes_repo is None:
@@ -133,6 +137,8 @@ def build_harness(
         # gives a role the same shell/no-shell whether or not those two ever
         # diverge for a future spec.
         enabled = ("file", "terminal") if "Bash" in spec.tools else ("file",)
+        if "WebSearch" in spec.tools:
+            enabled = (*enabled, "web", "search")
         return HermesHarness(
             api_key=api_key,
             key_env=key_env,

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -120,7 +120,7 @@ def summarizer_spec(
             "its `conclude` command and end your turn."
         ),
         key="reviewer",
-        tools=("Bash",),
+        tools=("Bash", *_WEB_TOOLS),
         execution=Execution(environment=environment, can_execute=True),
         budget=SessionBudget(max_turns=max_turns, walltime_s=walltime_s),
         skills=("plain-style", "review-rubric"),

--- a/src/autoresearch/roles.py
+++ b/src/autoresearch/roles.py
@@ -22,11 +22,15 @@ from autoresearch.verifier import VERIFY_SCHEMA, verify_result_from_data
 # write-token split — the judge's session job holds at most a read-scoped token
 # (not worth lifting via /proc), and the write token lives in a separate post
 # job with no session next to it. Roles differ by prompt, not by tool posture.
-_JUDGE_TOOLS = ("Read", "Grep", "Glob", "Bash", "pr-context-read", "retriever")
+# Every role may read the web — literature, documentation, a paper's own
+# numbers. Each backend maps these two names to its native form.
+_WEB_TOOLS = ("WebSearch", "WebFetch")
+
+_JUDGE_TOOLS = ("Read", "Grep", "Glob", "Bash", "pr-context-read", "retriever", *_WEB_TOOLS)
 
 # The full editing set: the author implements, runs tests, and self-validates
 # inside its container. Execution is the role's job, not a leak.
-_AUTHOR_TOOLS = ("Read", "Grep", "Glob", "Write", "Edit", "Bash")
+_AUTHOR_TOOLS = ("Read", "Grep", "Glob", "Write", "Edit", "Bash", *_WEB_TOOLS)
 
 
 def author_spec(

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -1462,7 +1462,8 @@ def test_editor_harness_codex_backend_is_contained() -> None:
     assert harness.container_image == "img.sif"
     assert harness.model == "gpt-5.6-terra"
     assert harness.timeout_s == 300
-    assert harness.extra_args == ("-c", "use_legacy_landlock=true")  # host codex config
+    # host codex config, then the web (the author spec grants WebSearch)
+    assert harness.extra_args == ("-c", "use_legacy_landlock=true", "--search")
     assert harness.supports_resume is True  # codex exec resume, validated on 0.130.0
     with pytest.raises(ValueError, match="unknown backend"):
         build_harness("sk-o", spec, backend="bogus", container_image="img.sif")

--- a/tests/test_role_runner.py
+++ b/tests/test_role_runner.py
@@ -185,7 +185,7 @@ def test_build_harness_claude_judge_gets_tools_and_bare() -> None:
     assert isinstance(h, ClaudeCodeHarness)
     # native tools from the spec: the read set plus the shell that runs the
     # syscall tool (MCP names like pr-context-read are wired separately)
-    assert set(h.allowed_tools) == {"Read", "Grep", "Glob", "Bash"}
+    assert set(h.allowed_tools) == {"Read", "Grep", "Glob", "Bash", "WebSearch", "WebFetch"}
     assert h.bare is True  # untrusted checkout: never load its instructions
     assert h.max_turns == 40 and h.timeout_s == 1800  # budget from the spec
 
@@ -201,6 +201,7 @@ def test_build_harness_codex_is_uniform_for_all_roles() -> None:
     assert isinstance(judge, CodexHarness) and isinstance(editor, CodexHarness)
     assert judge.sandbox == editor.sandbox == "danger-full-access"
     assert judge.container_image == "" and editor.container_image == "img.sif"
+    assert "--search" in judge.extra_args and "--search" in editor.extra_args  # the web
 
 
 def test_build_harness_hermes_toolsets_follow_the_spec(tmp_path: Path) -> None:
@@ -214,8 +215,9 @@ def test_build_harness_hermes_toolsets_follow_the_spec(tmp_path: Path) -> None:
     assert h.repo_dir == tmp_path
     assert h.provider == "openai-api" and h.key_env == "OPENAI_API_KEY"
     # an executing role has the shell; everything else stays off for parity
-    assert set(h.enabled_toolsets) == {"file", "terminal"}
-    assert "terminal" not in h.disabled_toolsets and "web" in h.disabled_toolsets
+    assert set(h.enabled_toolsets) == {"file", "terminal", "web", "search"}
+    assert "terminal" not in h.disabled_toolsets and "web" not in h.disabled_toolsets
+    assert "browser" in h.disabled_toolsets
 
 
 def test_build_harness_hermes_terminal_keys_on_the_bash_tool(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

No role could reach the web for literature or documentation: Claude ran with an allowlist that stopped at the file tools, codex without `--search`, hermes with its `web`/`search` toolsets disabled. The role specs now grant `WebSearch` and `WebFetch` (authors, judges, steward, follow-ups), and each backend maps the grant to its native form:

- Claude: the two tools join `--allowedTools`.
- Codex: `--search` (verified on the deployed codex-cli 0.130.0: "Enable live web search … the native Responses `web_search` tool").
- hermes: the `web` and `search` toolsets are enabled; `browser` and the rest stay off.

What a role reads on the web is data, like everything else it reads. Egress stays as it is (open); an allowlist can come later if there is a reason.

## Test plan

- [x] ruff, format, mypy, pytest (874 passed)
- [x] Role-runner tests pin all three mappings; the codex editor harness test pins `--search` after the host config args
- [ ] Review round; then the next author session on Torch starts with the tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)