### PR TITLE
README: where it runs — a Slurm cluster first, one machine to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,37 @@ Nothing reports back to us.
   a rolling issue; credited improvements update the target's ledger
   (`BENCHMARKS.md`, `results/leader.json`).
 
+## Where it runs
+
+It is built for your own compute, and the first-class home is a **Slurm
+cluster**:
+
+- **No daemon.** The whole system is a chain of short Slurm jobs (a tick
+  every 15 minutes, ~20 seconds of work each) that resubmits itself. Nothing
+  listens, nothing needs inbound SSH, and a cluster that requires 2FA is
+  fine.
+- **Every role is a job.** Author sessions, gate evals, experiment launches,
+  sweeps (`launch --array K`), verification panels, and wakes are each their
+  own job, placed where you say: CPU roles on your CPU partition, evals and
+  experiments on a GPU lane you name — a comma-separated partition list lets
+  Slurm start each job wherever it fits first, and GPUs are requested per node.
+- **Wakes ride Slurm dependencies.** A run that is waiting on jobs parks with
+  no process alive; its wake is submitted `afterany` those jobs and starts
+  seconds after they finish. Preemption and requeue are survived the same
+  way, and a lost job heals on the next tick.
+- **Jobs are jailed and metered.** Evals and launches run inside your
+  Apptainer image with only the checked-out tree bound, `/tmp` on node-local
+  scratch, and no credentials; GPU-hours are charged per attempt against the
+  contract's budget and reconciled with what the jobs actually ran.
+
+You do not need a cluster to start. Level 1 (advisory PR reviews) is one
+workflow file in your repo's CI. The climber's compute interface is small —
+submit a job, poll it — and the local backend runs the same job scripts as
+subprocesses on **one machine**, so a workstation with a GPU can climb a
+cheap benchmark before you point the loop at a cluster. Adding another
+backend (a cloud queue, a CI runner, a hardware rig) means implementing those
+two verbs.
+
 ## The contract
 
 One file in the target repo. The minimum:

--- a/README.md
+++ b/README.md
@@ -48,31 +48,27 @@ Nothing reports back to us.
 It is built for your own compute, and the first-class home is a **Slurm
 cluster**:
 
-- **No daemon.** The whole system is a chain of short Slurm jobs (a tick
-  every 15 minutes, ~20 seconds of work each) that resubmits itself. Nothing
-  listens, nothing needs inbound SSH, and a cluster that requires 2FA is
-  fine.
-- **Every role is a job.** Author sessions, gate evals, experiment launches,
-  sweeps (`launch --array K`), verification panels, and wakes are each their
-  own job, placed where you say: CPU roles on your CPU partition, evals and
-  experiments on a GPU lane you name — a comma-separated partition list lets
-  Slurm start each job wherever it fits first, and GPUs are requested per node.
-- **Wakes ride Slurm dependencies.** A run that is waiting on jobs parks with
-  no process alive; its wake is submitted `afterany` those jobs and starts
-  seconds after they finish. Preemption and requeue are survived the same
-  way, and a lost job heals on the next tick.
+- **No daemon.** The whole system is a chain of short Slurm jobs on a cadence
+  you set, each resubmitting the next. Nothing listens and nothing needs
+  inbound SSH, so a cluster that requires 2FA is fine.
+- **Every role is a job.** Author sessions, gate evals, experiment launches
+  and sweeps, and wakes are each their own job, placed where you say: CPU
+  roles on your CPU partition, evals and experiments on the GPU lanes you
+  name.
+- **Waiting costs nothing.** A run that is waiting on jobs parks with no
+  process alive; its wake is queued behind those jobs and runs when they
+  finish. Preemption and lost jobs heal on the next tick.
 - **Jobs are jailed and metered.** Evals and launches run inside your
-  Apptainer image with only the checked-out tree bound, `/tmp` on node-local
-  scratch, and no credentials; GPU-hours are charged per attempt against the
-  contract's budget and reconciled with what the jobs actually ran.
+  Apptainer image, seeing only the checked-out tree and job-local scratch,
+  with no credentials; GPU-hours are metered per attempt against the
+  contract's budget.
 
 You do not need a cluster to start. Level 1 (advisory PR reviews) is one
-workflow file in your repo's CI. The climber's compute interface is small —
-submit a job, poll it — and the local backend runs the same job scripts as
-subprocesses on **one machine**, so a workstation with a GPU can climb a
-cheap benchmark before you point the loop at a cluster. Adding another
-backend (a cloud queue, a CI runner, a hardware rig) means implementing those
-two verbs.
+workflow file in your repo's CI. The climber's compute interface is small,
+and the local backend runs the same job scripts as subprocesses on **one
+machine**, so a workstation with a GPU can climb a cheap benchmark before you
+point the loop at a cluster. Another backend — a cloud queue, a CI runner, a
+hardware rig — plugs in by implementing that interface.
 
 ## The contract
 


### PR DESCRIPTION
## Summary

Self-hosters need to see, near the top, that the system is built for their own compute: a Slurm cluster as the first-class home (no daemon, every role a job, wakes on Slurm dependencies, jailed and metered jobs) and one machine to start (Level 1 is a CI workflow; the local backend runs the same job scripts as subprocesses). New section between "What it does" and "The contract".

## Test plan

- [x] Claims checked against the code and docs/install.md (tick chain, per-role jobs, GPU lane list, afterany wakes, Apptainer jail, GPU-hour metering + reconciliation, LocalCompute)
- [ ] Review round (prose lens)

🤖 Generated with [Claude Code](https://claude.com/claude-code)