### PR TITLE
Codex web search uses the exec-compatible config override

### DIFF
--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -115,8 +115,12 @@ def build_harness(
     the ephemeral boundary (CI). The tokenless split keeps credentials out of
     the session either way."""
     if backend == "codex":
-        # the web: codex's native web_search tool, on when the spec grants it
-        web = ("--search",) if "WebSearch" in spec.tools else ()
+        # the web: codex's native web_search tool, on when the spec grants it.
+        # `--search` exists only on the interactive command — `codex exec`
+        # rejects it (it aborted every fleet attempt on 2026-08-29); the
+        # config override is the exec-compatible form, verified live on the
+        # deployed 0.130.0 (the session makes real web_search calls).
+        web = ("-c", "tools.web_search=true") if "WebSearch" in spec.tools else ()
         return CodexHarness(
             api_key=api_key,
             binary=binary or "codex",

--- a/src/autoresearch/role_runner.py
+++ b/src/autoresearch/role_runner.py
@@ -115,11 +115,8 @@ def build_harness(
     the ephemeral boundary (CI). The tokenless split keeps credentials out of
     the session either way."""
     if backend == "codex":
-        # the web: codex's native web_search tool, on when the spec grants it.
-        # `--search` exists only on the interactive command — `codex exec`
-        # rejects it (it aborted every fleet attempt on 2026-08-29); the
-        # config override is the exec-compatible form, verified live on the
-        # deployed 0.130.0 (the session makes real web_search calls).
+        # the web, when the spec grants it: the config override, because
+        # `codex exec` does not accept `--search`
         web = ("-c", "tools.web_search=true") if "WebSearch" in spec.tools else ()
         return CodexHarness(
             api_key=api_key,

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -1529,7 +1529,12 @@ def test_editor_harness_codex_backend_is_contained() -> None:
     assert harness.model == "gpt-5.6-terra"
     assert harness.timeout_s == 300
     # host codex config, then the web (the author spec grants WebSearch)
-    assert harness.extra_args == ("-c", "use_legacy_landlock=true", "--search")
+    assert harness.extra_args == (
+        "-c",
+        "use_legacy_landlock=true",
+        "-c",
+        "tools.web_search=true",
+    )
     assert harness.supports_resume is True  # codex exec resume, validated on 0.130.0
     with pytest.raises(ValueError, match="unknown backend"):
         build_harness("sk-o", spec, backend="bogus", container_image="img.sif")

--- a/tests/test_role_runner.py
+++ b/tests/test_role_runner.py
@@ -201,7 +201,10 @@ def test_build_harness_codex_is_uniform_for_all_roles() -> None:
     assert isinstance(judge, CodexHarness) and isinstance(editor, CodexHarness)
     assert judge.sandbox == editor.sandbox == "danger-full-access"
     assert judge.container_image == "" and editor.container_image == "img.sif"
-    assert "--search" in judge.extra_args and "--search" in editor.extra_args  # the web
+    # the web: the exec-compatible config override, never `--search` (which
+    # `codex exec` rejects — it killed every fleet attempt on 2026-08-29)
+    for h in (judge, editor):
+        assert "tools.web_search=true" in h.extra_args and "--search" not in h.extra_args
 
 
 def test_build_harness_hermes_toolsets_follow_the_spec(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

#189 shipped `--search` in the codex extra args — but that flag exists only on the interactive command; `codex exec` rejects it, so every new fleet attempt aborted at session start (first casualty: agent-02's 09:30 attempt). The exec-compatible form is `-c tools.web_search=true`.

Verified live on the deployed codex-cli 0.130.0 before this PR: an authenticated `codex exec --json -c tools.web_search=true` session made two `web_search` calls and returned the fetched page title.

## Test plan

- [x] ruff, format, mypy, pytest (881 passed)
- [x] Role-runner and harness tests now pin the config override and reject `--search`
- [ ] Review round; merge restores the fleet (next tick deploys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)