### PR TITLE
One atomic commit per board pass

### DIFF
--- a/src/autoresearch/climbboard.py
+++ b/src/autoresearch/climbboard.py
@@ -1007,8 +1007,13 @@ def service_climb_board(
     local = collect_rows(root, target)
     local_curves = collect_curves(root, target)
     # snapshot BEFORE any branch read: put_files refuses if the head moves
-    # mid-pass, so a concurrent write is never buried under stale content
-    head = getattr(github, "branch_head", lambda *a: "")(target, BOARD_BRANCH)
+    # mid-pass, so a concurrent write is never buried under stale content.
+    # "" = branch missing (nothing to protect); None = outage — writing
+    # unguarded could bury a mid-pass write, so the pass sits out
+    head = github.branch_head(target, BOARD_BRANCH)
+    if head is None:
+        log.warning("board head unreadable for %s; pass sits out", target)
+        return 0
     index = _read_index(github, target)
     names = set(local) | set(index or {})
     directions = {**(index or {}), **(directions or {})}

--- a/src/autoresearch/climbboard.py
+++ b/src/autoresearch/climbboard.py
@@ -1006,6 +1006,9 @@ def service_climb_board(
     batch changes nothing; the whole pass retries next tick."""
     local = collect_rows(root, target)
     local_curves = collect_curves(root, target)
+    # snapshot BEFORE any branch read: put_files refuses if the head moves
+    # mid-pass, so a concurrent write is never buried under stale content
+    head = getattr(github, "branch_head", lambda *a: "")(target, BOARD_BRANCH)
     index = _read_index(github, target)
     names = set(local) | set(index or {})
     directions = {**(index or {}), **(directions or {})}
@@ -1073,6 +1076,8 @@ def service_climb_board(
         return 0
     if not github.ensure_branch(target, BOARD_BRANCH):
         return 0
-    if not github.put_files(target, pending, BOARD_BRANCH, "climb board"):
+    if not github.put_files(
+        target, pending, BOARD_BRANCH, "climb board", expected_head=head or None
+    ):
         return 0
     return len(pending)

--- a/src/autoresearch/climbboard.py
+++ b/src/autoresearch/climbboard.py
@@ -961,8 +961,7 @@ def _merge_curves(
         curve = published.get(run_id) or fresh.get(run_id)
         if curve:
             merged[run_id] = curve
-    kept_published = {r: published[r] for r in keep if published.get(r)}
-    return {"data": merged, "published": kept_published, "changed": merged != published}
+    return {"data": merged, "changed": merged != published}
 
 
 def contract_directions(contract: Any) -> dict[str, str]:
@@ -1000,18 +999,20 @@ def service_climb_board(
 ) -> int:
     """Publish the board for `target`. Returns how many files changed.
 
-    Every file is compared against the branch and written only when
-    different — which is also the retry: a view (or index) whose upload
-    failed last pass differs again next pass. A benchmark whose fresh JSON
-    could not be uploaded is rendered from its last PUBLISHED rows, so the
-    views never point at data that is not on the branch."""
+    Every file is compared against the branch, and all changed files land
+    as ONE commit (`put_files`) — data, curves, and the views are atomic,
+    so the page can never point at data that is not on the branch, and a
+    board pass costs at most one commit of research-log history. A failed
+    batch changes nothing; the whole pass retries next tick."""
     local = collect_rows(root, target)
     local_curves = collect_curves(root, target)
     index = _read_index(github, target)
     names = set(local) | set(index or {})
     directions = {**(index or {}), **(directions or {})}
-    changed = 0
+    pending: dict[str, str] = {}
     boards: dict[str, list[dict[str, Any]]] = {}
+    curves: dict[str, dict[str, list[list[float]]]] = {}
+    curves_ok = True
     for benchmark in sorted(names):
         path = f"climb/data/{benchmark}.json"
         try:
@@ -1036,21 +1037,10 @@ def service_climb_board(
         rows = merge_rows(existing, local.get(benchmark, []))
         if not rows:
             continue
+        boards[benchmark] = rows
         text = json.dumps(rows, indent=1) + "\n"
-        if text == existing:
-            boards[benchmark] = rows
-            continue
-        if github.ensure_branch(target, BOARD_BRANCH) and github.put_file(
-            target, path, text, BOARD_BRANCH, f"climb board: {benchmark}"
-        ):
-            changed += 1
-            boards[benchmark] = rows
-        elif existing:
-            # the branch still holds the previous rows: render those
-            boards[benchmark] = merge_rows(existing, [])
-    curves: dict[str, dict[str, list[list[float]]]] = {}
-    curves_ok = True
-    for benchmark, rows in boards.items():
+        if text != existing:
+            pending[path] = text
         merged_curves = _merge_curves(
             github, target, benchmark, rows, local_curves.get(benchmark, {})
         )
@@ -1059,23 +1049,13 @@ def service_climb_board(
             # its curves — the html rewrite sits this pass out
             curves_ok = False
             continue
-        data = merged_curves["data"]
+        curves[benchmark] = merged_curves["data"]
         if merged_curves["changed"]:
-            uploaded = github.ensure_branch(target, BOARD_BRANCH) and github.put_file(
-                target,
-                f"climb/curves/{benchmark}.json",
-                json.dumps(data, indent=1) + "\n",
-                BOARD_BRANCH,
-                f"climb curves: {benchmark}",
+            pending[f"climb/curves/{benchmark}.json"] = (
+                json.dumps(merged_curves["data"], indent=1) + "\n"
             )
-            changed += bool(uploaded)
-            if not uploaded:
-                # the page embeds only what the branch holds; fresh points
-                # return next pass, when their upload can be retried
-                data = merged_curves["published"]
-        curves[benchmark] = data
     if not boards and names:
-        return changed  # every benchmark sat the pass out: leave the views alone
+        return 0  # every benchmark sat the pass out: leave the views alone
     # the index keeps every benchmark it knows — a transient failed read of
     # one benchmark's JSON must not orphan its history; the views simply
     # render without it until a later pass reads it again. An index that
@@ -1087,10 +1067,12 @@ def service_climb_board(
     if index is not None:
         views.insert(0, ("climb/index.json", json.dumps(wanted, indent=1) + "\n"))
     for path, content in views:
-        if (
-            content != github.get_file_content(target, path, BOARD_BRANCH)
-            and github.ensure_branch(target, BOARD_BRANCH)
-            and github.put_file(target, path, content, BOARD_BRANCH, "climb board")
-        ):
-            changed += 1
-    return changed
+        if content != github.get_file_content(target, path, BOARD_BRANCH):
+            pending[path] = content
+    if not pending:
+        return 0
+    if not github.ensure_branch(target, BOARD_BRANCH):
+        return 0
+    if not github.put_files(target, pending, BOARD_BRANCH, "climb board"):
+        return 0
+    return len(pending)

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -746,12 +746,36 @@ class GitHubClient:
             log.warning("could not put %s on %s@%s: %s", path, repo, branch, exc)
             return ""
 
-    def put_files(self, repo: str, files: dict[str, str], branch: str, message: str) -> bool:
+    def branch_head(self, repo: str, branch: str) -> str:
+        """The branch's current commit sha, or "" (missing branch, outage)."""
+        quoted = urllib.parse.quote(repo)
+        try:
+            ref = self._request(
+                "GET", f"/repos/{quoted}/git/ref/heads/{urllib.parse.quote(branch)}"
+            )
+            return str(ref["object"]["sha"])
+        except (GitHubError, KeyError, TypeError):
+            return ""
+
+    def put_files(
+        self,
+        repo: str,
+        files: dict[str, str],
+        branch: str,
+        message: str,
+        expected_head: str | None = None,
+    ) -> bool:
         """Create or update SEVERAL files on `branch` as ONE commit (git data
         API: blobs -> tree -> commit -> ref). All-or-nothing: True only when
         the ref moved; on failure nothing changed and the caller retries the
-        whole batch next pass. The ref update is not forced, so a concurrent
-        writer makes this batch fail instead of being clobbered."""
+        whole batch next pass.
+
+        Concurrency: pass `expected_head` (the head the caller SNAPSHOTTED
+        before reading the files it compared against) and the batch refuses
+        when the branch has moved since — a write that landed mid-pass is
+        never buried under stale content. A write landing after this check
+        still cannot be clobbered: the unforced ref update rejects any
+        non-fast-forward."""
         if not files:
             return True
         if self.dry_run:
@@ -764,6 +788,15 @@ class GitHubClient:
                 "GET", f"/repos/{quoted}/git/ref/heads/{urllib.parse.quote(branch)}"
             )
             base_sha = ref["object"]["sha"]
+            if expected_head and base_sha != expected_head:
+                log.warning(
+                    "batch on %s@%s refused: head moved %s -> %s (retry next pass)",
+                    repo,
+                    branch,
+                    expected_head[:9],
+                    str(base_sha)[:9],
+                )
+                return False
             base_tree = self._request("GET", f"/repos/{quoted}/git/commits/{base_sha}")["tree"][
                 "sha"
             ]

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -746,16 +746,20 @@ class GitHubClient:
             log.warning("could not put %s on %s@%s: %s", path, repo, branch, exc)
             return ""
 
-    def branch_head(self, repo: str, branch: str) -> str:
-        """The branch's current commit sha, or "" (missing branch, outage)."""
+    def branch_head(self, repo: str, branch: str) -> str | None:
+        """The branch's current commit sha; "" when the branch does not
+        exist (nothing to protect), None on an outage or malformed reply
+        (the caller must not write unguarded)."""
         quoted = urllib.parse.quote(repo)
         try:
             ref = self._request(
                 "GET", f"/repos/{quoted}/git/ref/heads/{urllib.parse.quote(branch)}"
             )
             return str(ref["object"]["sha"])
-        except (GitHubError, KeyError, TypeError):
-            return ""
+        except GitHubError as exc:
+            return "" if getattr(exc, "status", None) == 404 else None
+        except (KeyError, TypeError):
+            return None
 
     def put_files(
         self,

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -746,6 +746,54 @@ class GitHubClient:
             log.warning("could not put %s on %s@%s: %s", path, repo, branch, exc)
             return ""
 
+    def put_files(self, repo: str, files: dict[str, str], branch: str, message: str) -> bool:
+        """Create or update SEVERAL files on `branch` as ONE commit (git data
+        API: blobs -> tree -> commit -> ref). All-or-nothing: True only when
+        the ref moved; on failure nothing changed and the caller retries the
+        whole batch next pass. The ref update is not forced, so a concurrent
+        writer makes this batch fail instead of being clobbered."""
+        if not files:
+            return True
+        if self.dry_run:
+            log.info("[dry-run] batch put %d file(s) on %s@%s", len(files), repo, branch)
+            return True
+        quoted = urllib.parse.quote(repo)
+        ref_path = f"/repos/{quoted}/git/refs/heads/{urllib.parse.quote(branch)}"
+        try:
+            ref = self._request(
+                "GET", f"/repos/{quoted}/git/ref/heads/{urllib.parse.quote(branch)}"
+            )
+            base_sha = ref["object"]["sha"]
+            base_tree = self._request("GET", f"/repos/{quoted}/git/commits/{base_sha}")["tree"][
+                "sha"
+            ]
+            entries = []
+            for path, content in sorted(files.items()):
+                blob = self._request(
+                    "POST",
+                    f"/repos/{quoted}/git/blobs",
+                    {
+                        "content": base64.b64encode(content.encode()).decode(),
+                        "encoding": "base64",
+                    },
+                )
+                entries.append({"path": path, "mode": "100644", "type": "blob", "sha": blob["sha"]})
+            tree = self._request(
+                "POST", f"/repos/{quoted}/git/trees", {"base_tree": base_tree, "tree": entries}
+            )
+            commit = self._request(
+                "POST",
+                f"/repos/{quoted}/git/commits",
+                {"message": message, "tree": tree["sha"], "parents": [base_sha]},
+            )
+            self._request("PATCH", ref_path, {"sha": commit["sha"]})
+            return True
+        except (GitHubError, KeyError, TypeError) as exc:
+            log.warning(
+                "batched put of %d file(s) on %s@%s failed: %s", len(files), repo, branch, exc
+            )
+            return False
+
     def comment(self, repo: str, issue_number: int, body: str) -> None:
         if self.dry_run:
             log.info("[dry-run] comment on %s#%s (%d chars)", repo, issue_number, len(body))

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -223,6 +223,7 @@ class _BoardGitHub:
         self.files: dict[str, str] = {}
         self.puts: list[str] = []
         self.index_outage = False
+        self.batch_fail = False
 
     def get_file(self, repo, path, ref):
         if self.index_outage:
@@ -241,6 +242,14 @@ class _BoardGitHub:
         self.files[path] = content
         self.puts.append(path)
         return "created"
+
+    def put_files(self, repo, files, branch, message):
+        if self.batch_fail:
+            return False
+        for path, content in files.items():
+            self.files[path] = content
+            self.puts.append(path)
+        return True
 
 
 def test_service_publishes_once_per_change(tmp_path: Path) -> None:
@@ -386,53 +395,6 @@ def test_failed_index_read_never_rewrites_the_index(tmp_path: Path) -> None:
     gh.index_outage = False  # outage over: the union is restored
     service_climb_board(tmp_path, gh, "org/repo", {"speedrun": "min"})
     assert json.loads(gh.files["climb/index.json"]) == {"old-bench": "max", "speedrun": "min"}
-
-
-def test_failed_view_upload_is_retried_next_pass(tmp_path: Path) -> None:
-    _terminal_run(tmp_path, "speedrun-1")
-
-    gh = _BoardGitHub()
-    fail = {"CLIMB.md"}
-    real_put = gh.put_file
-
-    def flaky(repo, path, content, branch, message):
-        if path in fail:
-            return ""
-        return real_put(repo, path, content, branch, message)
-
-    gh.put_file = flaky  # type: ignore[method-assign]
-    service_climb_board(tmp_path, gh, "org/repo")
-    assert "CLIMB.md" not in gh.files
-    fail.clear()  # the outage ends; the next pass sees the view differ and retries
-    assert service_climb_board(tmp_path, gh, "org/repo") == 1
-    assert "## speedrun" in gh.files["CLIMB.md"]
-
-
-def test_failed_json_upload_renders_last_published_rows(tmp_path: Path) -> None:
-    """Views never point at data that is not on the branch: when a fresh
-    JSON cannot be uploaded, the benchmark renders from its last published
-    rows."""
-    gh = _BoardGitHub()
-    published = [
-        {"run_id": "old-1", "ended": "2026-01-01 00:00", "candidate": 9472, "outcome": "improved"}
-    ]
-    gh.files["climb/index.json"] = json.dumps({"speedrun": "min"})
-    gh.files["climb/data/speedrun.json"] = json.dumps(published)
-    _terminal_run(tmp_path, "speedrun-1")  # fresh row that will fail to upload
-    fail = {"climb/data/speedrun.json"}
-    real_put = gh.put_file
-
-    def flaky(repo, path, content, branch, message):
-        if path in fail:
-            return ""
-        return real_put(repo, path, content, branch, message)
-
-    gh.put_file = flaky  # type: ignore[method-assign]
-    service_climb_board(tmp_path, gh, "org/repo")
-    md = gh.files["CLIMB.md"]
-    # the published row renders (its report link carries the run id); the
-    # failed fresh row must not
-    assert "9472" in md and "38146" not in md
 
 
 def test_status_strip_publishes_on_shape_change_only(tmp_path: Path) -> None:
@@ -714,31 +676,24 @@ def test_curves_publish_capped_and_never_clobbered(tmp_path: Path) -> None:
     assert _merge_curves(gh, "org/repo", "b", rows, fresh) is None
 
 
-def test_page_embeds_only_branch_truth_for_curves(tmp_path: Path) -> None:
-    """A failed curves upload must not leak fresh points into index.html
-    (the page embeds branch truth only), and a curve-file OUTAGE skips the
-    page rewrite entirely instead of publishing a curveless page."""
+def test_board_publish_is_one_atomic_batch(tmp_path: Path) -> None:
+    """Data, curves, and views land as ONE commit: a failed batch changes
+    NOTHING (the page can never point at data missing from the branch),
+    and the whole pass retries next time. A curve-file OUTAGE still skips
+    the page rewrite instead of publishing a curveless page."""
     _terminal_run(tmp_path, "speedrun-1")
     gh = _BoardGitHub()
     ev = run_dir(tmp_path, "speedrun-1") / "eval-candidate-abc"
     ev.mkdir(parents=True)
     (ev / "stdout").write_text("step 1 val loss 4.5\nstep 2 val loss 4.1\n")
 
-    real_put = gh.put_file
+    gh.batch_fail = True
+    assert service_climb_board(tmp_path, gh, "org/repo") == 0
+    assert gh.files == {}  # all-or-nothing: nothing landed
 
-    def flaky_put(repo, path, content, branch, message):
-        if path.startswith("climb/curves/"):
-            return None
-        return real_put(repo, path, content, branch, message)
-
-    gh.put_file = flaky_put  # type: ignore[method-assign]
-    service_climb_board(tmp_path, gh, "org/repo")
-    assert "climb/curves/speedrun.json" not in gh.files
-    assert "4.5" not in gh.files["index.html"]  # not on the branch, not on the page
-
-    # upload heals: the curve lands on the branch and then on the page
-    gh.put_file = real_put  # type: ignore[method-assign]
-    service_climb_board(tmp_path, gh, "org/repo")
+    # the batch heals: everything lands together, curve on branch AND page
+    gh.batch_fail = False
+    assert service_climb_board(tmp_path, gh, "org/repo") == 5
     assert "climb/curves/speedrun.json" in gh.files
     assert "4.5" in gh.files["index.html"]
 

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -420,6 +420,9 @@ def test_batch_refuses_when_the_head_moved_mid_pass(tmp_path: Path) -> None:
     assert gh.files == {}
     gh.branch_head = real_head  # type: ignore[method-assign]
     assert service_climb_board(tmp_path, gh, "org/repo") == 4  # no curves here
+    # a head-read OUTAGE must not disable the guard: the pass sits out
+    gh.branch_head = lambda repo, branch: None  # type: ignore[method-assign]
+    assert service_climb_board(tmp_path, gh, "org/repo") == 0
 
 
 def test_status_strip_publishes_on_shape_change_only(tmp_path: Path) -> None:

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -224,6 +224,7 @@ class _BoardGitHub:
         self.puts: list[str] = []
         self.index_outage = False
         self.batch_fail = False
+        self.head = "h0"
 
     def get_file(self, repo, path, ref):
         if self.index_outage:
@@ -243,9 +244,15 @@ class _BoardGitHub:
         self.puts.append(path)
         return "created"
 
-    def put_files(self, repo, files, branch, message):
+    def branch_head(self, repo, branch):
+        return self.head
+
+    def put_files(self, repo, files, branch, message, expected_head=None):
         if self.batch_fail:
             return False
+        if expected_head and expected_head != self.head:
+            return False
+        self.head += "+"
         for path, content in files.items():
             self.files[path] = content
             self.puts.append(path)
@@ -395,6 +402,24 @@ def test_failed_index_read_never_rewrites_the_index(tmp_path: Path) -> None:
     gh.index_outage = False  # outage over: the union is restored
     service_climb_board(tmp_path, gh, "org/repo", {"speedrun": "min"})
     assert json.loads(gh.files["climb/index.json"]) == {"old-bench": "max", "speedrun": "min"}
+
+
+def test_batch_refuses_when_the_head_moved_mid_pass(tmp_path: Path) -> None:
+    """A concurrent write between the pass's reads and its commit must not
+    be buried: the batch refuses and the whole pass retries next tick."""
+    _terminal_run(tmp_path, "speedrun-1")
+    gh = _BoardGitHub()
+    real_head = gh.branch_head
+
+    def moving_head(repo, branch):
+        gh.head = "h-moved"  # someone commits right after our snapshot
+        return "h0"
+
+    gh.branch_head = moving_head  # type: ignore[method-assign]
+    assert service_climb_board(tmp_path, gh, "org/repo") == 0
+    assert gh.files == {}
+    gh.branch_head = real_head  # type: ignore[method-assign]
+    assert service_climb_board(tmp_path, gh, "org/repo") == 4  # no curves here
 
 
 def test_status_strip_publishes_on_shape_change_only(tmp_path: Path) -> None:


### PR DESCRIPTION
Each board pass could commit up to five times (per-benchmark data,
curves, index, CLIMB.md, index.html), which buried real research-log
history under board noise — a concern the owner raised twice.

- `GitHubClient.put_files`: several files as ONE commit via the git
  data API (blobs → tree → commit → ref). The ref update is not forced,
  so a concurrent writer makes the batch fail instead of being
  clobbered; on any failure nothing changes and the caller retries.
- `service_climb_board` collects every changed file and lands them
  atomically. This *replaces* the per-file failure fallbacks (render
  from last published rows / embed published-only curves): the views
  and their data are now consistent by construction.
- Superseded fallback code and its two tests removed (no-legacy rule).

The status strip keeps its own single-file publisher (different
cadence, shape-change-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
