### PR TITLE
Published curves cost no stdout scan

### DIFF
--- a/src/autoresearch/climbboard.py
+++ b/src/autoresearch/climbboard.py
@@ -142,25 +142,6 @@ def _curve_from_eval(run_directory: Path) -> list[list[float]]:
     return points
 
 
-def collect_curves(root: Path, target: str) -> dict[str, dict[str, list[list[float]]]]:
-    """{benchmark: {run_id: curve}} for terminal runs with a parsable eval.
-    Only the newest MAX_CURVE_RUNS per benchmark are scanned — the merge
-    keeps exactly that tail, so older stdouts cannot publish anyway."""
-    out: dict[str, dict[str, list[list[float]]]] = {}
-    ended = [r for r in list_runs(root) if r.target == target and r.state == ENDED]
-    ended.sort(key=lambda r: r.updated or r.created, reverse=True)
-    scanned: dict[str, int] = {}
-    for record in ended:
-        bench = record.benchmark or "benchmark"
-        if scanned.get(bench, 0) >= MAX_CURVE_RUNS:
-            continue
-        scanned[bench] = scanned.get(bench, 0) + 1
-        curve = _curve_from_eval(run_dir(root, record.run_id))
-        if curve:
-            out.setdefault(bench, {})[record.run_id] = curve
-    return out
-
-
 def collect_rows(root: Path, target: str) -> dict[str, list[ClimbRow]]:
     """Terminal attempts of `target` with a report, grouped by benchmark."""
     from datetime import UTC, datetime
@@ -929,12 +910,18 @@ def _valid_curve(curve: Any) -> bool:
 
 
 def _merge_curves(
-    github: Any, target: str, benchmark: str, rows: list[dict[str, Any]], fresh: dict
+    github: Any,
+    target: str,
+    benchmark: str,
+    rows: list[dict[str, Any]],
+    fresh_for: Any,
 ) -> dict[str, Any] | None:
     """Published curves plus new ones, kept only for the newest rows (curves
     are heavy; the cap is by recency of the attempt, and published curves
-    are never rewritten). None when the published file cannot be read — the
-    same sit-the-pass-out stance as everything else on the branch."""
+    are never rewritten). `fresh_for(run_id)` parses a run's eval stdout ON
+    DEMAND — a run with a published curve costs no I/O at all. None when
+    the published file cannot be read — the same sit-the-pass-out stance
+    as everything else on the branch."""
     path = f"climb/curves/{benchmark}.json"
     try:
         raw: str | None = github.get_file(target, path, BOARD_BRANCH)
@@ -958,7 +945,7 @@ def _merge_curves(
     keep = [str(r.get("run_id")) for r in rows[-MAX_CURVE_RUNS:]]
     merged: dict[str, list[list[float]]] = {}
     for run_id in keep:
-        curve = published.get(run_id) or fresh.get(run_id)
+        curve = published.get(run_id) or fresh_for(run_id)
         if curve:
             merged[run_id] = curve
     return {"data": merged, "changed": merged != published}
@@ -1005,7 +992,6 @@ def service_climb_board(
     board pass costs at most one commit of research-log history. A failed
     batch changes nothing; the whole pass retries next tick."""
     local = collect_rows(root, target)
-    local_curves = collect_curves(root, target)
     # snapshot BEFORE any branch read: put_files refuses if the head moves
     # mid-pass, so a concurrent write is never buried under stale content.
     # "" = branch missing (nothing to protect); None = outage — writing
@@ -1050,7 +1036,7 @@ def service_climb_board(
         if text != existing:
             pending[path] = text
         merged_curves = _merge_curves(
-            github, target, benchmark, rows, local_curves.get(benchmark, {})
+            github, target, benchmark, rows, lambda rid: _curve_from_eval(run_dir(root, rid))
         )
         if merged_curves is None:
             # an unreadable curve file must not republish the page without

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -558,7 +558,7 @@ STDOUT_WITH_CURVE = (
 
 
 def test_curves_come_from_eval_stdout_downsampled(tmp_path: Path) -> None:
-    from autoresearch.climbboard import MAX_CURVE_POINTS, collect_curves
+    from autoresearch.climbboard import MAX_CURVE_POINTS, _curve_from_eval
 
     _terminal_run(tmp_path, "speedrun-1")
     ev = run_dir(tmp_path, "speedrun-1") / "eval-candidate-abc-def"
@@ -567,13 +567,12 @@ def test_curves_come_from_eval_stdout_downsampled(tmp_path: Path) -> None:
     # eval output is job output: a malformed number must not abort collection
     with open(ev / "stdout", "a") as fh:
         fh.write("step 9999 val loss 1.2.3 (fp32)\n")
-    curves = collect_curves(tmp_path, "org/repo")["speedrun"]
-    pts = curves["speedrun-1"]
+    pts = _curve_from_eval(run_dir(tmp_path, "speedrun-1"))
     assert 2 < len(pts) <= MAX_CURVE_POINTS
     assert pts[0][0] == 128 and pts[-1] == [9344, 3.276098]
     # a run with no parsable eval simply has no curve
     _terminal_run(tmp_path, "speedrun-2", ending="merged")
-    assert "speedrun-2" not in collect_curves(tmp_path, "org/repo")["speedrun"]
+    assert _curve_from_eval(run_dir(tmp_path, "speedrun-2")) == []
 
 
 def test_fresh_curve_skips_garbage_points(tmp_path: Path) -> None:
@@ -623,29 +622,24 @@ def test_fresh_curve_bounds_a_newline_free_stdout(tmp_path: Path, monkeypatch) -
     assert cb._curve_from_eval(rd) == [[1, 4.5]]
 
 
-def test_collect_curves_scans_only_the_publishable_tail(tmp_path: Path, monkeypatch) -> None:
-    """Only the newest MAX_CURVE_RUNS attempts per benchmark are read —
-    older stdouts cannot publish and must not cost I/O."""
-    import autoresearch.climbboard as cb
+def test_published_curves_cost_no_stdout_scan(tmp_path: Path) -> None:
+    """A run whose curve is already on the branch is never re-read from
+    disk: only unpublished runs invoke the fresh supplier."""
+    from autoresearch.climbboard import _merge_curves
 
-    for i, rid in enumerate(["old-1", "mid-2", "new-3"]):
-        record = RunRecord(
-            run_id=rid,
-            target="org/repo",
-            task_title="t",
-            state="ended",
-            ending="negative-result",
-            benchmark="speedrun",
-            created=1.0,
-            updated=float(i + 1),
-        )
-        save_record(tmp_path, record, float(i + 1))
-        ev = run_dir(tmp_path, rid) / "eval-candidate-x"
-        ev.mkdir(parents=True)
-        (ev / "stdout").write_text(f"step {i + 1} val loss 4.{i}\n")
-    monkeypatch.setattr(cb, "MAX_CURVE_RUNS", 2)
-    curves = cb.collect_curves(tmp_path, "org/repo")["speedrun"]
-    assert set(curves) == {"mid-2", "new-3"}
+    gh = _BoardGitHub()
+    gh.files["climb/curves/b.json"] = json.dumps({"r1": [[1, 4.0]]})
+    rows = [{"run_id": "r1"}, {"run_id": "r2"}]
+    asked: list[str] = []
+
+    def fresh_for(rid):
+        asked.append(rid)
+        return [[2, 3.5]]
+
+    merged = _merge_curves(gh, "org/repo", "b", rows, fresh_for)
+    assert merged is not None
+    assert asked == ["r2"]  # r1 is published: no scan
+    assert merged["data"] == {"r1": [[1, 4.0]], "r2": [[2, 3.5]]}
 
 
 def test_fresh_curve_abandons_oversized_stdout(tmp_path: Path, monkeypatch) -> None:
@@ -673,7 +667,11 @@ def test_curves_publish_capped_and_never_clobbered(tmp_path: Path) -> None:
     ]
     published = {"r199": [[1, 4.0]]}
     gh.files["climb/curves/b.json"] = json.dumps(published)
-    fresh = {"r199": [[1, 9.9]], "r198": [[2, 3.5]]}
+    fresh_map = {"r199": [[1, 9.9]], "r198": [[2, 3.5]]}
+
+    def fresh(rid):
+        return fresh_map.get(rid)
+
     merged = _merge_curves(gh, "org/repo", "b", rows, fresh)
     assert merged is not None and merged["changed"] is True
     assert merged["data"]["r199"] == [[1, 4.0]]  # published wins; never rewritten


### PR DESCRIPTION
The round-26 advisory on #195: every board pass re-read up to 150 eval
stdouts per benchmark even though published curves always win the merge.

`_merge_curves` now takes a lazy `fresh_for(run_id)` supplier and reads
stdout only for keep-tail runs WITHOUT a published curve — typically a
handful of newly ended rows per pass. The bulk `collect_curves` scanner
lost its last caller and is removed (no-legacy), replaced by a
regression test asserting published runs never invoke the supplier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
