### PR TITLE
Brief: the gate confirms evidence, it does not generate it

### DIFF
--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -306,10 +306,13 @@ def render(brief: SessionBrief) -> str:
             "your judgment says; they are generous, not a target to exhaust.",
             "",
             "READY means MEASURED: submit only when your own launch results "
-            "already show the candidate beating the baseline by at least the "
-            "contract's significance floor. The gate confirms evidence you "
-            "have — it is not your first experiment; an unvalidated submit "
-            "wastes gate compute and ends your run on a guess.",
+            "already show the candidate STRICTLY clearing the gate's "
+            "improvement threshold — better than the baseline by more than "
+            "the contract's significance floor, or by more than the default "
+            "relative margin when no floor is declared. The gate confirms "
+            "evidence you have — it is not your first experiment; an "
+            "unvalidated submit wastes gate compute and spends a sleep on a "
+            "guess.",
             "",
             "When your candidate is READY, stage `submit` and then `sleep`: "
             "your tree is sealed, measured against the baseline, and read by "
@@ -317,8 +320,9 @@ def render(brief: SessionBrief) -> str:
             "otherwise you wake with the gate result or the panel's findings "
             "and decide — revise and submit again, run more experiments, or "
             "finish with an honest negative report. A submit consumes no "
-            "launch from your budget, but its gate evals draw real GPU-hours "
-            "from this run — measure first. Finishing WITHOUT a submit still runs the "
+            "launch from your budget, but its gate evals spend real compute "
+            "(GPU-hours on metered benchmarks) — measure first. "
+            "Finishing WITHOUT a submit still runs the "
             "same gate and panel, but blocking findings then open a draft PR "
             "for a human instead of coming back to you.",
         ]

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -307,9 +307,9 @@ def render(brief: SessionBrief) -> str:
             "",
             "READY means MEASURED: submit only when your own launch results "
             "already show the candidate STRICTLY clearing the gate's "
-            "improvement threshold — better than the baseline by more than "
-            "the contract's significance floor, or by more than the default "
-            "relative margin when no floor is declared. The gate confirms "
+            "improvement bar — better than the baseline by more than BOTH "
+            "the gate's default relative margin AND the contract's "
+            "significance floor when one is declared. The gate confirms "
             "evidence you have — it is not your first experiment; an "
             "unvalidated submit wastes gate compute and spends a sleep on a "
             "guess.",

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -305,13 +305,20 @@ def render(brief: SessionBrief) -> str:
             "refreshes your session clock and costs one sleep). Spend them as "
             "your judgment says; they are generous, not a target to exhaust.",
             "",
+            "READY means MEASURED: submit only when your own launch results "
+            "already show the candidate beating the baseline by at least the "
+            "contract's significance floor. The gate confirms evidence you "
+            "have — it is not your first experiment; an unvalidated submit "
+            "wastes gate compute and ends your run on a guess.",
+            "",
             "When your candidate is READY, stage `submit` and then `sleep`: "
             "your tree is sealed, measured against the baseline, and read by "
             "the review panel. A clean pass is published as a PR directly; "
             "otherwise you wake with the gate result or the panel's findings "
             "and decide — revise and submit again, run more experiments, or "
-            "finish with an honest negative report. A submit costs only the "
-            "sleep it rides on. Finishing WITHOUT a submit still runs the "
+            "finish with an honest negative report. A submit consumes no "
+            "launch from your budget, but its gate evals draw real GPU-hours "
+            "from this run — measure first. Finishing WITHOUT a submit still runs the "
             "same gate and panel, but blocking findings then open a draft PR "
             "for a human instead of coming back to you.",
         ]

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -132,8 +132,8 @@ def test_brief_demands_measured_evidence_before_submit() -> None:
     draw real GPU-hours)."""
     text = render(build_brief(make_inputs(launch_budget=3, sleep_budget=2), created="t"))
     assert "READY means MEASURED" in text
-    assert "STRICTLY clearing the gate's improvement threshold" in text
-    assert "default relative margin when no floor is declared" in text
+    assert "STRICTLY clearing the gate's improvement bar" in text
+    assert "BOTH the gate's default relative margin AND" in text
     assert "costs only the sleep" not in text
 
 

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -126,6 +126,16 @@ def test_ground_rules_ask_for_a_report() -> None:
     assert "negative result" in text.casefold()
 
 
+def test_brief_demands_measured_evidence_before_submit() -> None:
+    """The gate confirms evidence, it does not generate it: the brief says
+    READY means MEASURED and never calls a submit cheap (its gate evals
+    draw real GPU-hours)."""
+    text = render(build_brief(make_inputs(launch_budget=3, sleep_budget=2), created="t"))
+    assert "READY means MEASURED" in text
+    assert "beating the baseline by at least the contract's significance floor" in text
+    assert "costs only the sleep" not in text
+
+
 def test_memory_sections_are_fenced_as_data() -> None:
     """Lessons/reports are written by prior agent sessions (notebook
     auto-merges prose) — they must render as data, not authority."""

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -132,7 +132,8 @@ def test_brief_demands_measured_evidence_before_submit() -> None:
     draw real GPU-hours)."""
     text = render(build_brief(make_inputs(launch_budget=3, sleep_budget=2), created="t"))
     assert "READY means MEASURED" in text
-    assert "beating the baseline by at least the contract's significance floor" in text
+    assert "STRICTLY clearing the gate's improvement threshold" in text
+    assert "default relative margin when no floor is declared" in text
     assert "costs only the sleep" not in text
 
 


### PR DESCRIPTION
Owner-directed policy change. Agents 01/02/04 submit unvalidated
candidates (one report literally said "Outcome: Unmeasured"), spending
~4 GPU-h gate evals as their FIRST measurement, while the launch-first
depth loop (agent-03) is the intended pattern.

- New rule ahead of the submit guidance: READY means MEASURED — submit
  only when your own launch results already beat the baseline by at
  least the contract's significance floor.
- Removes the counter-steering line "a submit costs only the sleep it
  rides on": true for the launch budget, misleading about cost — gate
  evals draw real GPU-hours from the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
