### PR TITLE
Metered submits require a returned launch first

### DIFF
--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -281,7 +281,9 @@ def render(brief: SessionBrief) -> str:
                     f"{brief.eval_minutes_default} min per eval, the baseline's "
                     "runtime with headroom); an eval that runs out of walltime is an "
                     "eval error, not a result. Budget your experiments against the "
-                    "final eval you will need.",
+                    "final eval you will need. On this benchmark a submit is "
+                    "REFUSED until at least one launch has returned results "
+                    "this run.",
                     "",
                 ]
                 if brief.gpu_hour_budget > 0

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1559,6 +1559,30 @@ def attempt_once(
                 assert failed_gate is not None
                 gpu_hours_used -= evals_charge  # nothing ran
                 outcome: AttemptResult | MeasureOK = failed_gate[1]
+            elif (
+                submitted is None
+                and launches_used == 0
+                and bench.depth_k > 0
+                and bench.gpus > 0
+                and float(contract.budgets.gpu_hours_per_run or 0) > 0
+            ):
+                # the submit refusal's other half: a METERED finish with no
+                # returned launches measured nothing, so the gate does not
+                # run (the panel above still reviewed). This also closes the
+                # refuse-twice bypass — dropping a repeated bare submit must
+                # not buy the very measurement the refusal denied.
+                outcome = AttemptResult(
+                    outcome="negative-result",
+                    baseline=baseline,
+                    session=session,
+                    note=(
+                        "unmeasured finish: no experiment launches returned this "
+                        "run, so the metered gate did not run (panel only)"
+                    ),
+                    run_seed=run_seed,
+                    panel_transcript="\n\n".join(panel_sections),
+                    panel_rounds=panel_reads,
+                )
             else:
                 outcome = measure_and_decide(
                     contract,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1561,6 +1561,7 @@ def attempt_once(
                 outcome: AttemptResult | MeasureOK = failed_gate[1]
             elif (
                 submitted is None
+                and launcher is not None  # feature off = the gate IS the measurement
                 and launches_used == 0
                 and bench.depth_k > 0
                 and bench.gpus > 0

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -532,6 +532,17 @@ def budget_error(
             f"sleep budget exhausted ({sleeps_used}/{sleep_budget} used): "
             "conclude with what you have"
         )
+    if request.submit and launch_budget > 0 and gpus > 0 and launches_used == 0:
+        # the gate confirms evidence, it does not generate it: on a METERED
+        # benchmark (the gate costs real GPU-hours) a run that never launched
+        # has measured nothing. Launches staged ALONGSIDE this submit do not
+        # count — their results are unseen. Exempt: launches disabled
+        # (depth_k 0) and CPU benchmarks (an in-job gate costs seconds).
+        return (
+            "submit refused: this run has not measured anything yet. Launch "
+            "first and sleep for the results, then submit once your own "
+            "numbers strictly clear the gate's bar."
+        )
     if launches_used + len(request.launches) > launch_budget:
         return (
             f"launch budget would be exceeded: {launches_used} used + "

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -532,7 +532,13 @@ def budget_error(
             f"sleep budget exhausted ({sleeps_used}/{sleep_budget} used): "
             "conclude with what you have"
         )
-    if request.submit and launch_budget > 0 and gpus > 0 and launches_used == 0:
+    if (
+        request.submit
+        and launch_budget > 0
+        and gpus > 0
+        and (gpu_hour_budget or 0) > 0
+        and launches_used == 0
+    ):
         # the gate confirms evidence, it does not generate it: on a METERED
         # benchmark (the gate costs real GPU-hours) a run that never launched
         # has measured nothing. Launches staged ALONGSIDE this submit do not

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -137,6 +137,15 @@ def test_brief_demands_measured_evidence_before_submit() -> None:
     assert "costs only the sleep" not in text
 
 
+def test_metered_brief_states_the_submit_refusal() -> None:
+    text = render(
+        build_brief(
+            make_inputs(launch_budget=3, sleep_budget=2, gpu_hour_budget=400.0), created="t"
+        )
+    )
+    assert "a submit is REFUSED until at least one launch" in text
+
+
 def test_memory_sections_are_fenced_as_data() -> None:
     """Lessons/reports are written by prior agent sessions (notebook
     auto-merges prose) — they must render as data, not authority."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -331,6 +331,34 @@ def test_submit_parks_the_dispatched_gate_with_the_submitted_marker(tmp_path: Pa
     assert sha == "cand1" and request.launches[0].name == "probe"
 
 
+def test_dropped_bare_submit_does_not_buy_the_terminal_gate(tmp_path: Path) -> None:
+    """The refuse-twice bypass: after two bare submits are refused, the
+    dropped request must not be measured at finish — a metered run with no
+    returned launches ends as an unmeasured negative (panel only), never a
+    gate eval."""
+    metered = CONTRACT.replace(
+        "    metric: mean_tour_length\n",
+        "    metric: mean_tour_length\n    gpus: 1\n    eval_minutes: 240\n",
+    ).replace("gpu_hours_per_run: 1", "gpu_hours_per_run: 10")
+    harness = _SeqHarness(["first try", "second try"], submit_on=(1, 2))
+    m = ParkingMeasurer(park_on_call=1)  # any measurement would PARK loudly
+    result = attempt_once(
+        CONFIG,
+        metered,
+        tmp_path,
+        harness,
+        m,
+        "base",
+        _bare_snapshot(),
+        ruler="r",
+        changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+        created="t",
+        launcher=_fake_launcher([]),
+    )
+    assert result.outcome == "negative-result"
+    assert "unmeasured finish" in result.note
+
+
 def test_failed_gate_submit_feeds_back_to_the_author(tmp_path: Path) -> None:
     # an inline gate that rejects a submitted candidate resumes the AUTHOR with
     # the result (it decides what happens next) — never a silent terminal; the

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -359,6 +359,35 @@ def test_dropped_bare_submit_does_not_buy_the_terminal_gate(tmp_path: Path) -> N
     assert "unmeasured finish" in result.note
 
 
+def test_feature_off_metered_runs_still_measure_at_finish(tmp_path: Path) -> None:
+    """With syscalls disabled (launcher None) zero launches is structural,
+    not a choice: the terminal gate is the run's ONLY measurement and must
+    run."""
+    from autoresearch.orchestrator import RunParked
+
+    metered = CONTRACT.replace(
+        "    metric: mean_tour_length\n",
+        "    metric: mean_tour_length\n    gpus: 1\n    eval_minutes: 240\n",
+    ).replace("gpu_hours_per_run: 1", "gpu_hours_per_run: 10")
+    harness = FakeHarness(result=ok_session())
+    m = ParkingMeasurer(park_on_call=1)
+    with pytest.raises(RunParked) as exc:  # the gate parked = it RAN
+        attempt_once(
+            CONFIG,
+            metered,
+            tmp_path,
+            harness,
+            m,
+            "base",
+            _bare_snapshot(),
+            ruler="r",
+            changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+            created="t",
+            launcher=None,
+        )
+    assert exc.value.phase == "candidate"
+
+
 def test_failed_gate_submit_feeds_back_to_the_author(tmp_path: Path) -> None:
     # an inline gate that rejects a submitted candidate resumes the AUTHOR with
     # the result (it decides what happens next) — never a silent terminal; the

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -188,6 +188,21 @@ def test_submit_requires_a_prior_launch() -> None:
     assert check(bare, launches_used=1) == ""
     # launches disabled (depth_k 0): the rule cannot apply
     assert check(bare, launches_used=0, launch_budget=0) == ""
+    # GPU benchmark with a ZERO gpu-hour budget is not metered: the brief's
+    # metered paragraph (which discloses the rule) is absent there, so the
+    # rule must not silently apply
+    assert (
+        budget_error(
+            bare,
+            launches_used=0,
+            launch_budget=4,
+            sleeps_used=0,
+            sleep_budget=8,
+            gpus=8,
+            gpu_hour_budget=0.0,
+        )
+        == ""
+    )
     # CPU benchmark (in-job gate costs seconds): submit-to-measure stays legal
     assert budget_error(bare, launches_used=0, launch_budget=4, sleeps_used=0, sleep_budget=8) == ""
 

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -159,6 +159,39 @@ def test_budget_arithmetic() -> None:
     assert "sleep budget exhausted" in spent
 
 
+def test_submit_requires_a_prior_launch() -> None:
+    """On a METERED benchmark the gate confirms evidence, it does not
+    generate it: a submit is refused until at least one launch has
+    RETURNED results this run — launches staged alongside the submit do
+    not count (results unseen). Exempt: launches disabled (depth_k 0)
+    and CPU benchmarks (an in-job gate costs seconds)."""
+
+    def check(request, launches_used: int, launch_budget: int = 4) -> str:
+        return budget_error(
+            request,
+            launches_used=launches_used,
+            launch_budget=launch_budget,
+            sleeps_used=0,
+            sleep_budget=8,
+            gpus=8,
+            gpu_hour_budget=400.0,
+        )
+
+    bare = SyscallRequest(launches=(), submit=True)
+    refused = check(bare, launches_used=0)
+    assert "submit refused" in refused and "not measured anything" in refused
+    # staging launches WITH the submit does not lift the refusal
+    with_launch = SyscallRequest(launches=(_launch("a"),), submit=True)
+    assert "submit refused" in check(with_launch, launches_used=0)
+    # one completed launch from a prior park: submit freely, as often as
+    # sleeps allow (revise-and-resubmit is unaffected)
+    assert check(bare, launches_used=1) == ""
+    # launches disabled (depth_k 0): the rule cannot apply
+    assert check(bare, launches_used=0, launch_budget=0) == ""
+    # CPU benchmark (in-job gate costs seconds): submit-to-measure stays legal
+    assert budget_error(bare, launches_used=0, launch_budget=4, sleeps_used=0, sleep_budget=8) == ""
+
+
 def _launch(name: str):
     from autoresearch.syscall import Launch
 
@@ -567,7 +600,7 @@ def test_gpu_hours_are_metered_against_the_run_budget() -> None:
     # fits: 8 GPU-hours of evals into a 60-hour budget with 50 used
     ok = budget_error(
         sub_default,
-        launches_used=0,
+        launches_used=1,
         launch_budget=4,
         sleeps_used=0,
         sleep_budget=4,
@@ -580,7 +613,7 @@ def test_gpu_hours_are_metered_against_the_run_budget() -> None:
     # does not fit: a 14-hour eval pair on top of 50 used
     over = budget_error(
         sub_declared,
-        launches_used=0,
+        launches_used=1,
         launch_budget=4,
         sleeps_used=0,
         sleep_budget=4,


### PR DESCRIPTION
Kernel enforcement of the gate-evidence rule (#199 was prose; post-rule
observation: 3 of 5 fresh sessions still bare-submitted).

- `budget_error`: on a metered benchmark (gpus > 0, launch_budget > 0),
  a submit with `launches_used == 0` is refused with guidance. Prior
  launches_used is the pre-park count, so launches staged alongside the
  submit do not lift the refusal (their results are unseen).
- Revise-and-resubmit is unaffected: one returned launch opens
  submitting for the rest of the run.
- Exemptions: `depth_k: 0` (launches disabled — no deadlock) and CPU
  benchmarks (an in-job gate costs seconds; the rule exists because the
  gate costs GPU-hours).
- The brief's metered paragraph states the refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
