### PR TITLE
Lessons distiller v1: takeaways in every brief

### DIFF
--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -23,6 +23,7 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 
+from autoresearch.brief import distill_lessons
 from autoresearch.compute import LocalCompute
 from autoresearch.contract import Benchmark, Contract, load_contract
 from autoresearch.dispatch import (
@@ -2079,6 +2080,7 @@ def live_attempt(
                 created=created,
                 task_hypothesis=task_hypothesis,
                 recent_reports=tuple(text for _name, text in reports),
+                lessons=distill_lessons(reports),
                 report_archive=author_syscalls,
                 spec=spec,
                 panel_runner=panel_runner,

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -25,7 +25,12 @@ from autoresearch.style import PLAIN_STYLE
 # stops being an experiment variable and starts being noise.
 MAX_LESSONS_CHARS = 8_000
 
-_REPORT_FIELD = re.compile(r"\*\*(Outcome|Takeaway)[^:]*:\*\* *(.+)")
+# any label-colon form on its own line: "- **Takeaway:** x", "Takeaway: x",
+# "**Outcome**: x", plural "Takeaways:" — the report format is a convention,
+# not a schema, so the extractor meets authors where they write
+_REPORT_FIELD = re.compile(
+    r"^[\-#*> ]*\**(Outcome|Takeaway)s?\**\s*:\**\s*(.+)", re.M | re.I
+)
 # the kernel's own header form ("Outcome: **negative-result**") — the gate's
 # verdict, preferred over the author's prose outcome when both appear
 _KERNEL_OUTCOME = re.compile(r"^Outcome: \*\*(.+?)\*\*", re.M)
@@ -41,7 +46,10 @@ def distill_lessons(reports: Sequence[tuple[str, str]]) -> str:
     lines: list[str] = []
     total = 0
     for name, text in reports:
-        fields = {k: v.strip() for k, v in _REPORT_FIELD.findall(text)}
+        fields = {
+            k.capitalize(): v.strip().strip("*").strip()
+            for k, v in _REPORT_FIELD.findall(text)
+        }
         takeaway = fields.get("Takeaway", "")
         if not takeaway:
             continue

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -32,7 +32,6 @@ _REPORT_FIELD = re.compile(r"^[\-#*> ]*\**(Outcome|Takeaway)s?\**\s*:\**\s*(.+)"
 # the kernel's own header form ("Outcome: **negative-result**") — the gate's
 # verdict, preferred over the author's prose outcome when both appear
 _KERNEL_OUTCOME = re.compile(r"^Outcome: \*\*(.+?)\*\*", re.M)
-_REPORT_META = re.compile(r"^(\d{4}-\d{2}-\d{2}).*?(agent-\d+)")
 
 
 def distill_lessons(reports: Sequence[tuple[str, str]]) -> str:
@@ -59,8 +58,11 @@ def distill_lessons(reports: Sequence[tuple[str, str]]) -> str:
         takeaway = fields.get("Takeaway", "")
         if not takeaway:
             continue
-        meta = _REPORT_META.match(name)
-        date, agent = (meta.group(1), meta.group(2)) if meta else ("", "")
+        day = re.search(r"\d{4}-\d{2}-\d{2}", name)
+        who = re.search(r"agent-\d+", name)
+        date = day.group(0) if day else ""
+        # steward runs carry no agent id; label them for what they are
+        agent = who.group(0) if who else ("steward" if "steward" in name else "")
         kernel = _KERNEL_OUTCOME.search(text)
         outcome = kernel.group(1) if kernel else fields.get("Outcome", "")
         line = (

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field
 
 from autoresearch.style import PLAIN_STYLE
@@ -23,6 +24,40 @@ from autoresearch.style import PLAIN_STYLE
 # Bounds are part of the brief's contract: a brief that grows without limit
 # stops being an experiment variable and starts being noise.
 MAX_LESSONS_CHARS = 8_000
+
+_REPORT_FIELD = re.compile(r"\*\*(Outcome|Takeaway)[^:]*:\*\* *(.+)")
+_REPORT_META = re.compile(r"^(\d{4}-\d{2}-\d{2}).*?(agent-\d+)")
+
+
+def distill_lessons(reports: Sequence[tuple[str, str]]) -> str:
+    """One line per archived report (newest first): date, agent, outcome,
+    takeaway — the cross-attempt facts every author should start with,
+    extracted mechanically from the reports' own structured fields. A
+    report without a Takeaway contributes nothing. Bounded by the brief's
+    MAX_LESSONS_CHARS cap (re-capped there)."""
+    lines: list[str] = []
+    total = 0
+    for name, text in reports:
+        fields = {k: v.strip() for k, v in _REPORT_FIELD.findall(text)}
+        takeaway = fields.get("Takeaway", "")
+        if not takeaway:
+            continue
+        meta = _REPORT_META.match(name)
+        date, agent = (meta.group(1), meta.group(2)) if meta else ("", "")
+        outcome = fields.get("Outcome", "")
+        line = (
+            "- "
+            + " ".join(p for p in (date, agent) if p)
+            + (f" [{outcome[:90]}]" if outcome else "")
+            + f": {takeaway[:220]}"
+        )
+        if total + len(line) > MAX_LESSONS_CHARS:
+            break
+        lines.append(line)
+        total += len(line) + 1
+    return "\n".join(lines)
+
+
 MAX_REPORTS = 5
 MAX_REPORT_CHARS = 4_000
 MAX_TASK_CHARS = 4_000

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -41,9 +41,18 @@ def distill_lessons(reports: Sequence[tuple[str, str]]) -> str:
     extracted mechanically from the reports' own structured fields. A
     report without a Takeaway contributes nothing. Bounded by the brief's
     MAX_LESSONS_CHARS cap (re-capped there)."""
+
+    def _when(name: str) -> str:
+        # the date prefix sorts days; the run id embeds the full timestamp
+        # (bench-YYYYMMDD-HHMMSS-agent-NN) and breaks same-day ties — the
+        # fetcher's own order is arbitrary within a day
+        day = re.search(r"\d{4}-\d{2}-\d{2}", name)
+        ts = re.search(r"\d{8}-\d{6}", name)
+        return (day.group(0) if day else "") + "|" + (ts.group(0) if ts else "")
+
     lines: list[str] = []
     total = 0
-    for name, text in reports:
+    for name, text in sorted(reports, key=lambda r: _when(r[0]), reverse=True):
         fields = {
             k.capitalize(): v.strip().strip("*").strip() for k, v in _REPORT_FIELD.findall(text)
         }

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -28,9 +28,7 @@ MAX_LESSONS_CHARS = 8_000
 # any label-colon form on its own line: "- **Takeaway:** x", "Takeaway: x",
 # "**Outcome**: x", plural "Takeaways:" — the report format is a convention,
 # not a schema, so the extractor meets authors where they write
-_REPORT_FIELD = re.compile(
-    r"^[\-#*> ]*\**(Outcome|Takeaway)s?\**\s*:\**\s*(.+)", re.M | re.I
-)
+_REPORT_FIELD = re.compile(r"^[\-#*> ]*\**(Outcome|Takeaway)s?\**\s*:\**\s*(.+)", re.M | re.I)
 # the kernel's own header form ("Outcome: **negative-result**") — the gate's
 # verdict, preferred over the author's prose outcome when both appear
 _KERNEL_OUTCOME = re.compile(r"^Outcome: \*\*(.+?)\*\*", re.M)
@@ -47,8 +45,7 @@ def distill_lessons(reports: Sequence[tuple[str, str]]) -> str:
     total = 0
     for name, text in reports:
         fields = {
-            k.capitalize(): v.strip().strip("*").strip()
-            for k, v in _REPORT_FIELD.findall(text)
+            k.capitalize(): v.strip().strip("*").strip() for k, v in _REPORT_FIELD.findall(text)
         }
         takeaway = fields.get("Takeaway", "")
         if not takeaway:

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -26,6 +26,9 @@ from autoresearch.style import PLAIN_STYLE
 MAX_LESSONS_CHARS = 8_000
 
 _REPORT_FIELD = re.compile(r"\*\*(Outcome|Takeaway)[^:]*:\*\* *(.+)")
+# the kernel's own header form ("Outcome: **negative-result**") — the gate's
+# verdict, preferred over the author's prose outcome when both appear
+_KERNEL_OUTCOME = re.compile(r"^Outcome: \*\*(.+?)\*\*", re.M)
 _REPORT_META = re.compile(r"^(\d{4}-\d{2}-\d{2}).*?(agent-\d+)")
 
 
@@ -44,7 +47,8 @@ def distill_lessons(reports: Sequence[tuple[str, str]]) -> str:
             continue
         meta = _REPORT_META.match(name)
         date, agent = (meta.group(1), meta.group(2)) if meta else ("", "")
-        outcome = fields.get("Outcome", "")
+        kernel = _KERNEL_OUTCOME.search(text)
+        outcome = kernel.group(1) if kernel else fields.get("Outcome", "")
         line = (
             "- "
             + " ".join(p for p in (date, agent) if p)

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -59,10 +59,11 @@ def distill_lessons(reports: Sequence[tuple[str, str]]) -> str:
         if not takeaway:
             continue
         day = re.search(r"\d{4}-\d{2}-\d{2}", name)
-        who = re.search(r"agent-\d+", name)
+        # the run's agent id is the LAST match — a benchmark slug may itself
+        # contain "agent-N"; steward runs carry none and are labeled as such
+        who = re.findall(r"agent-\d+", name)
         date = day.group(0) if day else ""
-        # steward runs carry no agent id; label them for what they are
-        agent = who.group(0) if who else ("steward" if "steward" in name else "")
+        agent = who[-1] if who else ("steward" if "steward" in name else "")
         kernel = _KERNEL_OUTCOME.search(text)
         outcome = kernel.group(1) if kernel else fields.get("Outcome", "")
         line = (

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -152,10 +152,15 @@ def test_distill_lessons_extracts_takeaways_newest_first() -> None:
             "- **Takeaway:** Shorter warmdown is harmful below 2048.\n",
         ),
     ]
+    # the kernel's header form is the authoritative outcome when present
+    reports[0] = (
+        reports[0][0],
+        "Outcome: **negative-result**\n" + reports[0][1],
+    )
     text = distill_lessons(reports)
     lines = text.splitlines()
     assert len(lines) == 2  # the field-less report contributes nothing
-    assert lines[0].startswith("- 2026-08-31 agent-03 [Baseline")
+    assert lines[0].startswith("- 2026-08-31 agent-03 [negative-result]")
     assert "one val-interval short" in lines[0]
     assert lines[1] == "- 2026-08-29 agent-01: Shorter warmdown is harmful below 2048."
     # bounded: a flood of reports cannot exceed the cap

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -137,6 +137,32 @@ def test_brief_demands_measured_evidence_before_submit() -> None:
     assert "costs only the sleep" not in text
 
 
+def test_distill_lessons_extracts_takeaways_newest_first() -> None:
+    from autoresearch.brief import MAX_LESSONS_CHARS, distill_lessons
+
+    reports = [
+        (
+            "2026-08-31-speedrun-20260831-x-agent-03.md",
+            "# Run report\n- **Outcome:** Baseline `9472`; candidate `9088`/`9216` split.\n"
+            "- **Takeaway:** Very long warmdowns are real but one val-interval short.\n",
+        ),
+        ("2026-08-30-speedrun-y-agent-02.md", "# Run report\nno structured fields\n"),
+        (
+            "2026-08-29-speedrun-z-agent-01.md",
+            "- **Takeaway:** Shorter warmdown is harmful below 2048.\n",
+        ),
+    ]
+    text = distill_lessons(reports)
+    lines = text.splitlines()
+    assert len(lines) == 2  # the field-less report contributes nothing
+    assert lines[0].startswith("- 2026-08-31 agent-03 [Baseline")
+    assert "one val-interval short" in lines[0]
+    assert lines[1] == "- 2026-08-29 agent-01: Shorter warmdown is harmful below 2048."
+    # bounded: a flood of reports cannot exceed the cap
+    flood = [("2026-01-01-a-agent-01.md", "- **Takeaway:** " + "x" * 300 + "\n")] * 200
+    assert len(distill_lessons(flood)) <= MAX_LESSONS_CHARS
+
+
 def test_metered_brief_states_the_submit_refusal() -> None:
     text = render(
         build_brief(

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -148,6 +148,10 @@ def test_distill_lessons_extracts_takeaways_newest_first() -> None:
         ),
         ("2026-08-30-speedrun-y-agent-02.md", "# Run report\nno structured fields\n"),
         (
+            "2026-08-30-speedrun-w-agent-04.md",
+            "Outcome: **aborted**\nTakeaways: plain-label forms parse too.\n",
+        ),
+        (
             "2026-08-29-speedrun-z-agent-01.md",
             "- **Takeaway:** Shorter warmdown is harmful below 2048.\n",
         ),
@@ -159,10 +163,11 @@ def test_distill_lessons_extracts_takeaways_newest_first() -> None:
     )
     text = distill_lessons(reports)
     lines = text.splitlines()
-    assert len(lines) == 2  # the field-less report contributes nothing
+    assert len(lines) == 3  # the field-less report contributes nothing
     assert lines[0].startswith("- 2026-08-31 agent-03 [negative-result]")
     assert "one val-interval short" in lines[0]
-    assert lines[1] == "- 2026-08-29 agent-01: Shorter warmdown is harmful below 2048."
+    assert lines[1] == "- 2026-08-30 agent-04 [aborted]: plain-label forms parse too."
+    assert lines[2] == "- 2026-08-29 agent-01: Shorter warmdown is harmful below 2048."
     # bounded: a flood of reports cannot exceed the cap
     flood = [("2026-01-01-a-agent-01.md", "- **Takeaway:** " + "x" * 300 + "\n")] * 200
     assert len(distill_lessons(flood)) <= MAX_LESSONS_CHARS

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -168,6 +168,20 @@ def test_distill_lessons_extracts_takeaways_newest_first() -> None:
     assert "one val-interval short" in lines[0]
     assert lines[1] == "- 2026-08-30 agent-04 [aborted]: plain-label forms parse too."
     assert lines[2] == "- 2026-08-29 agent-01: Shorter warmdown is harmful below 2048."
+    # same-day ties break on the run id's embedded timestamp, not on the
+    # benchmark name (zbench earlier in the day must sort after abench later)
+    same_day = [
+        (
+            "2026-08-31-zbench-20260831-010000-agent-01.md",
+            "- **Takeaway:** earlier.\n",
+        ),
+        (
+            "2026-08-31-abench-20260831-090000-agent-02.md",
+            "- **Takeaway:** later.\n",
+        ),
+    ]
+    ordered = distill_lessons(same_day).splitlines()
+    assert "later." in ordered[0] and "earlier." in ordered[1]
     # bounded: a flood of reports cannot exceed the cap
     flood = [("2026-01-01-a-agent-01.md", "- **Takeaway:** " + "x" * 300 + "\n")] * 200
     assert len(distill_lessons(flood)) <= MAX_LESSONS_CHARS

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -168,6 +168,11 @@ def test_distill_lessons_extracts_takeaways_newest_first() -> None:
     assert "one val-interval short" in lines[0]
     assert lines[1] == "- 2026-08-30 agent-04 [aborted]: plain-label forms parse too."
     assert lines[2] == "- 2026-08-29 agent-01: Shorter warmdown is harmful below 2048."
+    # a benchmark slug containing "agent-N" must not steal the label
+    tricky = distill_lessons(
+        [("2026-08-27-agent-7-sim-20260827-010101-agent-02.md", "- **Takeaway:** t.\n")]
+    )
+    assert tricky.startswith("- 2026-08-27 agent-02:")
     # steward reports carry no agent id: the date survives and the line is
     # labeled for what it is
     steward = distill_lessons(

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -168,6 +168,12 @@ def test_distill_lessons_extracts_takeaways_newest_first() -> None:
     assert "one val-interval short" in lines[0]
     assert lines[1] == "- 2026-08-30 agent-04 [aborted]: plain-label forms parse too."
     assert lines[2] == "- 2026-08-29 agent-01: Shorter warmdown is harmful below 2048."
+    # steward reports carry no agent id: the date survives and the line is
+    # labeled for what it is
+    steward = distill_lessons(
+        [("2026-08-27-steward-20260827-010101.md", "- **Takeaway:** ruler tidied.\n")]
+    )
+    assert steward.startswith("- 2026-08-27 steward: ruler tidied.")
     # same-day ties break on the run id's embedded timestamp, not on the
     # benchmark name (zbench earlier in the day must sort after abench later)
     same_day = [


### PR DESCRIPTION
The brief has always had a bounded, data-fenced `lessons` section — but
nothing populated it, so hard-won cross-line facts (e.g. "the effective
credit bar is crossing at <=9088 on every run") lived only in the one
report that learned them.

v1 is mechanical extraction, per the keep-it-lean principle: at attempt
setup, `distill_lessons` walks the already-fetched report archive and
emits one line per report — date, agent, bracketed outcome, takeaway —
newest first, capped at MAX_LESSONS_CHARS. Reports without a Takeaway
contribute nothing. No LLM call, no new tick service, no extra API
traffic; an LLM-summarized v2 stays open if the line count outgrows the
cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
