### PR TITLE
Same-tree and no-submit metered finishes are panel-only

### DIFF
--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1559,15 +1559,17 @@ def attempt_once(
                 assert failed_gate is not None
                 gpu_hours_used -= evals_charge  # nothing ran
                 outcome: AttemptResult | MeasureOK = failed_gate[1]
-            elif submitted is None and tree(candidate_sha) == tree(base_sha):
-                # nothing to measure: the final tree IS the base tree —
-                # measuring it would compare base against itself (any
-                # benchmark, metered or not)
+            elif not measured:
+                # nothing to measure: no paths changed against base, so the
+                # gate would compare base against itself (any benchmark,
+                # metered or not; a SUBMIT of the unchanged tree feeds back
+                # to the author below like any failed gate, charge refunded)
+                gpu_hours_used -= evals_charge
                 outcome = AttemptResult(
                     outcome="no-improvement",
                     baseline=baseline,
                     session=session,
-                    note="unmeasured finish: the final tree is unchanged from base",
+                    note="unmeasured: the sealed tree is unchanged from base",
                     run_seed=run_seed,
                     panel_transcript="\n\n".join(panel_sections),
                     panel_rounds=panel_reads,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1559,26 +1559,40 @@ def attempt_once(
                 assert failed_gate is not None
                 gpu_hours_used -= evals_charge  # nothing ran
                 outcome: AttemptResult | MeasureOK = failed_gate[1]
+            elif submitted is None and tree(candidate_sha) == tree(base_sha):
+                # nothing to measure: the final tree IS the base tree —
+                # measuring it would compare base against itself (any
+                # benchmark, metered or not)
+                outcome = AttemptResult(
+                    outcome="no-improvement",
+                    baseline=baseline,
+                    session=session,
+                    note="unmeasured finish: the final tree is unchanged from base",
+                    run_seed=run_seed,
+                    panel_transcript="\n\n".join(panel_sections),
+                    panel_rounds=panel_reads,
+                )
             elif (
                 submitted is None
                 and launcher is not None  # feature off = the gate IS the measurement
-                and launches_used == 0
                 and bench.depth_k > 0
                 and bench.gpus > 0
                 and float(contract.budgets.gpu_hours_per_run or 0) > 0
             ):
-                # the submit refusal's other half: a METERED finish with no
-                # returned launches measured nothing, so the gate does not
-                # run (the panel above still reviewed). This also closes the
-                # refuse-twice bypass — dropping a repeated bare submit must
-                # not buy the very measurement the refusal denied.
+                # a METERED finish without a submit is panel-only, launches or
+                # not: the author chose not to claim, and a human scientist
+                # does not spend the full experimental budget re-verifying
+                # their own negative before writing it in the notebook. (With
+                # zero launches this also closes the refuse-twice bypass —
+                # dropping a repeated bare submit must not buy the very
+                # measurement the refusal denied.)
                 outcome = AttemptResult(
-                    outcome="negative-result",
+                    outcome="no-improvement",
                     baseline=baseline,
                     session=session,
                     note=(
-                        "unmeasured finish: no experiment launches returned this "
-                        "run, so the metered gate did not run (panel only)"
+                        "unmeasured finish: no submit was made, so the metered "
+                        "gate did not run (panel only)"
                     ),
                     run_seed=run_seed,
                     panel_transcript="\n\n".join(panel_sections),

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -355,8 +355,32 @@ def test_dropped_bare_submit_does_not_buy_the_terminal_gate(tmp_path: Path) -> N
         created="t",
         launcher=_fake_launcher([]),
     )
-    assert result.outcome == "negative-result"
+    assert result.outcome == "no-improvement"  # maps to the negative-result ending
     assert "unmeasured finish" in result.note
+
+
+def test_unchanged_tree_finish_is_never_measured(tmp_path: Path) -> None:
+    """A finish whose final tree equals base has nothing to measure — the
+    gate would compare base against itself (metered or not)."""
+    harness = FakeHarness(result=ok_session())
+    evaluator = FakeEvaluator(values=[13.9])
+    measurer, snapshot = _wire(evaluator, tmp_path)
+    result = attempt_once(
+        CONFIG,
+        CONTRACT,
+        tmp_path,
+        harness,
+        measurer,
+        "base",
+        snapshot,
+        ruler="r",
+        changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+        created="t",
+        tree_of=lambda sha: "same-tree",
+    )
+    assert result.outcome == "no-improvement"  # maps to the negative-result ending
+    assert "unchanged from base" in result.note
+    assert evaluator.calls == []  # nothing was measured
 
 
 def test_feature_off_metered_runs_still_measure_at_finish(tmp_path: Path) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -360,8 +360,8 @@ def test_dropped_bare_submit_does_not_buy_the_terminal_gate(tmp_path: Path) -> N
 
 
 def test_unchanged_tree_finish_is_never_measured(tmp_path: Path) -> None:
-    """A finish whose final tree equals base has nothing to measure — the
-    gate would compare base against itself (metered or not)."""
+    """A finish with no changed paths has nothing to measure — the gate
+    would compare base against itself (metered or not)."""
     harness = FakeHarness(result=ok_session())
     evaluator = FakeEvaluator(values=[13.9])
     measurer, snapshot = _wire(evaluator, tmp_path)
@@ -374,13 +374,35 @@ def test_unchanged_tree_finish_is_never_measured(tmp_path: Path) -> None:
         "base",
         snapshot,
         ruler="r",
-        changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+        changed_paths=lambda: [],
         created="t",
-        tree_of=lambda sha: "same-tree",
     )
     assert result.outcome == "no-improvement"  # maps to the negative-result ending
     assert "unchanged from base" in result.note
     assert evaluator.calls == []  # nothing was measured
+
+
+def test_submitted_unchanged_tree_is_fed_back_without_a_gate(tmp_path: Path) -> None:
+    """A submit sealing an unchanged tree runs no base-vs-base gate: the
+    author gets the feedback (and the eval charge back); conceding then
+    ends the run honestly."""
+    harness = _SeqHarness(["the claim", "conceded"], submit_on=(1,))
+    evaluator = FakeEvaluator(values=[13.9])
+    measurer, snapshot = _wire(evaluator, tmp_path)
+    result = attempt_once(
+        CONFIG,
+        CONTRACT,
+        tmp_path,
+        harness,
+        measurer,
+        "base",
+        snapshot,
+        ruler="r",
+        changed_paths=lambda: [],
+        created="t",
+    )
+    assert result.outcome == "no-improvement"
+    assert evaluator.calls == []  # base-vs-base was never run
 
 
 def test_feature_off_metered_runs_still_measure_at_finish(tmp_path: Path) -> None:


### PR DESCRIPTION
Owner-ruled residual of the finish-gate refinement:

- A finish whose final tree equals base is never measured (the gate
  would compare base against itself) — any benchmark.
- A METERED finish without a submit is panel-only, launches or not:
  the author chose not to claim; the human-scientist test says a
  negative goes in the notebook without spending the full experimental
  budget re-verifying it. No unclaimed-win fishing, per the owner.
- Fixes a latent #200 bug found by the zero-change test: unmeasured
  branches returned outcome "negative-result" (an ending name, not an
  AttemptResult outcome) — attempt.py's ending map would KeyError in
  production. They now return "no-improvement".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
