### PR TITLE
The siblings tool: author-pulled fleet awareness

### DIFF
--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1958,17 +1958,22 @@ def live_attempt(
             # from, so it works across clusters) and best-effort throughout:
             # a missing or malformed snapshot just means no siblings known
             try:
-                fleet = json.loads(ws.git("show", "FETCH_HEAD:climb/status.json"))
+                # size-checked BEFORE show, like the report blobs: the branch
+                # is bot-written but never trusted with unbounded memory
+                blob = f"FETCH_HEAD:{'climb/status.json'}"
+                if int(ws.git("cat-file", "-s", blob).strip()) > 1_000_000:
+                    raise ValueError("status snapshot oversized; skipped")
+                fleet = json.loads(ws.git("show", blob))
                 syscall_write_siblings(
                     workspace,
                     [
                         {
-                            "agent": r.get("agent"),
-                            "state": r.get("state"),
-                            "phase": r.get("phase"),
-                            "direction": r.get("direction"),
+                            "agent": str(r.get("agent", ""))[:64],
+                            "state": str(r.get("state", ""))[:32],
+                            "phase": str(r.get("phase", ""))[:32],
+                            "direction": str(r.get("direction", ""))[:160],
                         }
-                        for r in fleet.get("runs", [])
+                        for r in fleet.get("runs", [])[:64]
                         if isinstance(r, dict) and r.get("agent") != config.agent_id
                     ],
                 )

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import contextlib
+import json
 import logging
 import os
 import shutil
@@ -79,6 +80,7 @@ from autoresearch.syscall import MAX_ARTIFACT_BYTES, SYSCALL_DIR, SyscallRequest
 from autoresearch.syscall import ensure_excluded as syscall_excluded
 from autoresearch.syscall import install_tool as syscall_install_tool
 from autoresearch.syscall import write_budget as syscall_write_budget
+from autoresearch.syscall import write_siblings as syscall_write_siblings
 from autoresearch.verifier import MAX_CLAIM_CHARS
 
 log = logging.getLogger(__name__)
@@ -1951,6 +1953,27 @@ def live_attempt(
             # AFTER install_tool: installing the tool recreates the channel
             # dir it owns, which would delete an archive written earlier
             _install_report_archive(workspace, reports)
+            # the fleet snapshot the `siblings` command shows — read from the
+            # research-log's status.json (the SAME branch the reports came
+            # from, so it works across clusters) and best-effort throughout:
+            # a missing or malformed snapshot just means no siblings known
+            try:
+                fleet = json.loads(ws.git("show", "FETCH_HEAD:climb/status.json"))
+                syscall_write_siblings(
+                    workspace,
+                    [
+                        {
+                            "agent": r.get("agent"),
+                            "state": r.get("state"),
+                            "phase": r.get("phase"),
+                            "direction": r.get("direction"),
+                        }
+                        for r in fleet.get("runs", [])
+                        if isinstance(r, dict) and r.get("agent") != config.agent_id
+                    ],
+                )
+            except Exception as exc:
+                log.info("no sibling snapshot for this session (%s)", exc)
 
         def changed_paths() -> list[str]:
             ws.git("add", "-A")

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -978,6 +978,32 @@ def _fetch_research_reports(ws: Workspace, count: int) -> list[tuple[str, str]]:
         return []
 
 
+def _sibling_entries(ws: Workspace, self_agent: str) -> list[dict]:
+    """The other agents' live directions from the research-log's
+    status.json (already fetched: the SAME FETCH_HEAD the reports came
+    from). Size-checked BEFORE show like the report blobs, entries and
+    fields bounded — the branch is bot-written but never trusted with
+    unbounded memory. Any failure means no siblings known, never a crash."""
+    try:
+        blob = "FETCH_HEAD:climb/status.json"
+        if int(ws.git("cat-file", "-s", blob).strip()) > 1_000_000:
+            raise ValueError("status snapshot oversized; skipped")
+        fleet = json.loads(ws.git("show", blob))
+        return [
+            {
+                "agent": str(r.get("agent", ""))[:64],
+                "state": str(r.get("state", ""))[:32],
+                "phase": str(r.get("phase", ""))[:32],
+                "direction": str(r.get("direction", ""))[:160],
+            }
+            for r in fleet.get("runs", [])[:64]
+            if isinstance(r, dict) and r.get("agent") != self_agent
+        ]
+    except Exception as exc:
+        log.info("no sibling snapshot for this session (%s)", exc)
+        return []
+
+
 def _install_report_archive(workspace: Path, reports: list[tuple[str, str]]) -> None:
     """Materialize the fetched reports under the kernel-owned channel
     (`.autoresearch/reports/`) so the session can read and search the full
@@ -1957,28 +1983,7 @@ def live_attempt(
             # research-log's status.json (the SAME branch the reports came
             # from, so it works across clusters) and best-effort throughout:
             # a missing or malformed snapshot just means no siblings known
-            try:
-                # size-checked BEFORE show, like the report blobs: the branch
-                # is bot-written but never trusted with unbounded memory
-                blob = f"FETCH_HEAD:{'climb/status.json'}"
-                if int(ws.git("cat-file", "-s", blob).strip()) > 1_000_000:
-                    raise ValueError("status snapshot oversized; skipped")
-                fleet = json.loads(ws.git("show", blob))
-                syscall_write_siblings(
-                    workspace,
-                    [
-                        {
-                            "agent": str(r.get("agent", ""))[:64],
-                            "state": str(r.get("state", ""))[:32],
-                            "phase": str(r.get("phase", ""))[:32],
-                            "direction": str(r.get("direction", ""))[:160],
-                        }
-                        for r in fleet.get("runs", [])[:64]
-                        if isinstance(r, dict) and r.get("agent") != config.agent_id
-                    ],
-                )
-            except Exception as exc:
-                log.info("no sibling snapshot for this session (%s)", exc)
+            syscall_write_siblings(workspace, _sibling_entries(ws, config.agent_id))
 
         def changed_paths() -> list[str]:
             ws.git("add", "-A")

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -294,10 +294,7 @@ def render(brief: SessionBrief) -> str:
             + (
                 " The full archive: `python .autoresearch/syscall reports` "
                 "lists every report one line each; add names to read full "
-                "reports, several in one call. `python .autoresearch/syscall "
-                "siblings` shows what the other agents were working on as of "
-                "your session start — prefer a direction no sibling is "
-                "actively on, unless you have a distinct angle."
+                "reports, several in one call."
                 if brief.report_archive
                 else ""
             )
@@ -326,6 +323,7 @@ def render(brief: SessionBrief) -> str:
             "    python .autoresearch/syscall launch --name <handle> "
             "--minutes <N> [--array <K>] --artifact <repo-relative file> -- <command>",
             "    python .autoresearch/syscall submit [--minutes <N>]",
+            "    python .autoresearch/syscall siblings",
             "    python .autoresearch/syscall sleep",
             "",
             *(
@@ -364,7 +362,10 @@ def render(brief: SessionBrief) -> str:
             f"{brief.launch_budget} experiment launches, {brief.sleep_budget} "
             "sleeps (a `sleep` with nothing staged is a checkpoint that "
             "refreshes your session clock and costs one sleep). Spend them as "
-            "your judgment says; they are generous, not a target to exhaust.",
+            "your judgment says; they are generous, not a target to exhaust. "
+            "`siblings` shows what the other agents were working on as of "
+            "your session start — prefer a direction no sibling is actively "
+            "on, unless you have a distinct angle.",
             "",
             "READY means MEASURED: submit only when your own launch results "
             "already show the candidate STRICTLY clearing the gate's "

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -294,7 +294,10 @@ def render(brief: SessionBrief) -> str:
             + (
                 " The full archive: `python .autoresearch/syscall reports` "
                 "lists every report one line each; add names to read full "
-                "reports, several in one call."
+                "reports, several in one call. `python .autoresearch/syscall "
+                "siblings` shows what the other agents were working on as of "
+                "your session start — prefer a direction no sibling is "
+                "actively on, unless you have a distinct angle."
                 if brief.report_archive
                 else ""
             )

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -508,6 +508,15 @@ def write_budget(
     (d / "budget.json").write_text(json.dumps(budget))
 
 
+def write_siblings(workspace: Path, entries: list[dict[str, Any]]) -> None:
+    """Kernel-written fleet snapshot the tool's `siblings` shows: what the
+    OTHER agents were working on as of this session's start. Informational,
+    author-pulled — never pushed into the brief."""
+    d = workspace / SYSCALL_DIR
+    d.mkdir(exist_ok=True)
+    (d / "siblings.json").write_text(json.dumps(entries))
+
+
 def budget_error(
     request: SyscallRequest,
     *,

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -377,8 +377,35 @@ def build_parser() -> argparse.ArgumentParser:
     )
     rp.add_argument("names", nargs="*", help="report file names from the summary list")
     sub.add_parser("status", help="show staged syscalls and remaining budget")
+    sub.add_parser(
+        "siblings",
+        help="what the other agents were working on as of this session's start",
+    )
     sub.add_parser("cancel", help="discard the staged request")
     return p
+
+
+def cmd_siblings(root: Path, _args) -> str:
+    """The fleet snapshot the kernel wrote at session start (informational;
+    other agents may have moved on since)."""
+    try:
+        entries = json.loads((root / DIR / "siblings.json").read_text())
+    except (OSError, ValueError):
+        entries = []
+    if not isinstance(entries, list) or not entries:
+        return "no sibling activity known."
+    lines = ["as of this session's start:"]
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        who = str(e.get("agent", "?"))
+        state = str(e.get("state", ""))
+        phase = str(e.get("phase", ""))
+        direction = str(e.get("direction", ""))
+        label = f"{state}/{phase}" if phase else state
+        lines.append(f"  - {who} ({label}): {direction}" if direction else f"  - {who} ({label})")
+    lines.append("prefer a direction no sibling is actively on, unless you have a distinct angle.")
+    return "\n".join(lines)
 
 
 def cmd_reports(root: Path, args) -> str:
@@ -420,6 +447,7 @@ _HANDLERS = {
     "finding": cmd_finding,
     "conclude": cmd_conclude,
     "reports": cmd_reports,
+    "siblings": cmd_siblings,
     "status": cmd_status,
     "cancel": cmd_cancel,
 }

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -398,10 +398,10 @@ def cmd_siblings(root: Path, _args) -> str:
     for e in entries:
         if not isinstance(e, dict):
             continue
-        who = str(e.get("agent", "?"))
-        state = str(e.get("state", ""))
-        phase = str(e.get("phase", ""))
-        direction = str(e.get("direction", ""))
+        who = str(e.get("agent", "?"))[:64]
+        state = str(e.get("state", ""))[:32]
+        phase = str(e.get("phase", ""))[:32]
+        direction = str(e.get("direction", ""))[:160]
         label = f"{state}/{phase}" if phase else state
         lines.append(f"  - {who} ({label}): {direction}" if direction else f"  - {who} ({label})")
     lines.append("prefer a direction no sibling is actively on, unless you have a distinct angle.")

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -271,6 +271,35 @@ def test_research_reports_fetch_and_archive(tmp_path) -> None:
     _git(seed, "push", "-q", str(origin), "research-log")
     assert [n for n, _ in _fetch_research_reports(ws, 1)] == ["2026-08-29-run-b.md"]
 
+    # the sibling snapshot rides the SAME fetch: status.json on the branch
+    # yields the other agents' entries, self excluded, bounded fields; a
+    # branch without it means no siblings known
+    import json as _json
+
+    from autoresearch.attempt import _sibling_entries
+
+    assert _sibling_entries(ws, "agent-01") == []  # no status.json yet
+    status = {
+        "runs": [
+            {"agent": "agent-01", "state": "waiting", "phase": "candidate", "direction": "me"},
+            {
+                "agent": "agent-02",
+                "state": "waiting",
+                "phase": "author-sleep",
+                "direction": "d" * 500,
+            },
+        ]
+    }
+    (seed / "climb").mkdir()
+    (seed / "climb" / "status.json").write_text(_json.dumps(status))
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "status")
+    _git(seed, "push", "-q", str(origin), "research-log")
+    _fetch_research_reports(ws, 5)  # refresh FETCH_HEAD
+    entries = _sibling_entries(ws, "agent-01")
+    assert [e["agent"] for e in entries] == ["agent-02"]  # self excluded
+    assert len(entries[0]["direction"]) == 160  # bounded
+
     # production order: the tool installer recreates the channel dir it owns,
     # so the archive must be written AFTER it (review #191: writing before
     # deleted every archive)

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -149,6 +149,35 @@ def test_minutes_are_clamped_to_the_ceiling(tmp_path: Path) -> None:
     assert req is not None and req.launches[0].minutes == 240
 
 
+def test_siblings_command_reads_the_fleet_snapshot(tmp_path: Path) -> None:
+    """`siblings` is author-PULLED: the kernel writes the snapshot at session
+    start and the command renders it; absent or malformed means none known."""
+    from autoresearch.syscall import write_siblings
+    from autoresearch.syscall_cli import main as cli_main
+
+    assert cli_main(["siblings"], root=tmp_path) == 0  # missing file: no crash
+    write_siblings(
+        tmp_path,
+        [
+            {
+                "agent": "agent-02",
+                "state": "waiting",
+                "phase": "candidate",
+                "direction": "compose embedding decay with earlier warmdown",
+            },
+            {"agent": "agent-03", "state": "implementing", "phase": "", "direction": ""},
+        ],
+    )
+    from autoresearch.syscall_cli import cmd_siblings
+
+    out = cmd_siblings(tmp_path, None)
+    assert "agent-02 (waiting/candidate): compose embedding decay" in out
+    assert "agent-03 (implementing)" in out
+    assert "prefer a direction no sibling" in out
+    (tmp_path / ".autoresearch" / "siblings.json").write_text("not json")
+    assert cmd_siblings(tmp_path, None) == "no sibling activity known."
+
+
 def test_budget_arithmetic() -> None:
     req = SyscallRequest(launches=(_launch("a"), _launch("b")))
     ok = budget_error(req, launches_used=0, launch_budget=4, sleeps_used=0, sleep_budget=2)


### PR DESCRIPTION
Owner-directed design: agents may PEEK at what other agents are working
on, via a tool they choose to run — never pushed into the brief.

- Kernel: at session setup, the fleet snapshot is read from the
  research-log's `climb/status.json` (the same FETCH_HEAD the report
  archive came from — zero extra API calls, and inherently
  cross-cluster since any cluster publishing to the repo is visible to
  any other). Written minus self as `.autoresearch/siblings.json`;
  fully best-effort.
- CLI: `python .autoresearch/syscall siblings` renders agent,
  state/phase, and direction one-liners, with one steering sentence:
  prefer a direction no sibling is actively on unless you have a
  distinct angle. Missing/malformed snapshot degrades gracefully.
- Brief: one advertisement sentence beside the `reports` one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
