### PR TITLE
Research lines Phase 1: per-agent branch substrate

### DIFF
--- a/docs/design/research-lines.md
+++ b/docs/design/research-lines.md
@@ -43,9 +43,9 @@ Each agent slot owns `agents/agent-NN` on the target repo.
   decision). `AGENT_MEMORY.md` at the branch root is the bounded INDEX —
   the only memory rendered into the brief (data-fenced); `agent_memory/`
   beside it holds topic files the session reads from its own checkout on
-  demand, never auto-rendered. Curation without destruction: the index
-  stays within its budget, overflow moves to topic files instead of being
-  deleted. The kernel's only seam is "render the index". Memory, code, and beliefs travel
+  demand, never auto-rendered. The index stays within its size budget;
+  what no longer fits moves to a topic file instead of being deleted.
+  Only the memory index is added to the brief. Memory, code, and beliefs travel
   as one lineage — and cross clusters for free, since the branch lives on
   the shared repo. It NEVER reaches main: the main-PR extraction re-applies
   the winning change onto a main base, and the kernel mechanically rejects

--- a/docs/design/research-lines.md
+++ b/docs/design/research-lines.md
@@ -39,14 +39,18 @@ Each agent slot owns `agents/agent-NN` on the target repo.
   invents a commit. Progress pushes are the
   agent's lab notebook: ungated, panel may skim cheaply later. One slot
   never runs twice concurrently, so pushes are fast-forwards.
-- **Selfness memory rides the branch**: `AGENT_MEMORY.md` at the branch
-  root, author-owned, bounded, updated each session, rendered into the brief
-  as the agent's own memory (data-fenced). Memory, code, and beliefs travel
+- **Selfness memory rides the branch**: an index plus a folder (owner
+  decision). `AGENT_MEMORY.md` at the branch root is the bounded INDEX —
+  the only memory rendered into the brief (data-fenced); `agent_memory/`
+  beside it holds topic files the session reads from its own checkout on
+  demand, never auto-rendered. Curation without destruction: the index
+  stays within its budget, overflow moves to topic files instead of being
+  deleted. The kernel's only seam is "render the index". Memory, code, and beliefs travel
   as one lineage — and cross clusters for free, since the branch lives on
   the shared repo. It NEVER reaches main: the main-PR extraction re-applies
   the winning change onto a main base, and the kernel mechanically rejects
-  AGENT_MEMORY.md in any main-PR candidate (panel grab-bag mandate as
-  backstop).
+  AGENT_MEMORY.md and agent_memory/ in any main-PR candidate (panel
+  grab-bag mandate as backstop).
 - **Selective integration is git**: harvesting a sibling's technique or
   main's progress = merge/cherry-pick, not bespoke machinery. One carve-out:
   `AGENT_MEMORY.md` is slot-private — any merge into a line keeps the
@@ -132,8 +136,9 @@ v1).
    terminal path; per-target contract opt-in (`lines: true`); gate pairing
    against a line's declared base sha (today it is always main's base_sha).
    ~2–3 PRs.
-2. **Selfness memory**: AGENT_MEMORY.md render into the brief + author
-   instruction to maintain it. 1 PR.
+2. **Selfness memory**: render the AGENT_MEMORY.md index into the brief
+   (data-fenced) + author instruction to maintain index and agent_memory/
+   topic files. 1 PR.
 3. **Hygiene**: brief extraction workflow + panel mandate + diff-stat
    advisory. 1 PR.
 4. **Board**: strip shows the line each agent continues; later a lines view.

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1017,6 +1017,7 @@ def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: s
     base_ref = f"origin/{base_branch}"
     if not ws.git("branch", "--list", "-r", f"origin/{line}").strip():
         ws.git("checkout", "-q", "-B", line, base_ref)
+        ws.push(line)  # the line is durable from its first run
         return line
     ws.git("checkout", "-q", "-B", line, f"origin/{line}")
     conflicted = False
@@ -1049,6 +1050,14 @@ def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: s
                 "-m",
                 f"line hygiene: instruction files reset to {base_branch}",
             )
+        # Run-START persistence: the branch exists on the remote from its
+        # first run, and the merge-main + hygiene state survives a crashed
+        # run. One slot never runs twice concurrently, so this is a fast-
+        # forward. The run-END push of the sealed session tree is the next
+        # phase PR (it requires all-terminal sealing; the push must publish
+        # a sealed sha, never invent a commit). A conflicted merge is not
+        # pushed: the conflict is session work, not line state.
+        ws.push(line)
     return line
 
 

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -16,6 +16,7 @@ import contextlib
 import json
 import logging
 import os
+import re
 import shutil
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -976,6 +977,79 @@ def _fetch_research_reports(ws: Workspace, count: int) -> list[tuple[str, str]]:
     except Exception as exc:
         log.info("research log unavailable (%s: %s); starting without it", type(exc).__name__, exc)
         return []
+
+
+def _reset_instruction_files(ws: Workspace, workspace: Path, base_ref: str) -> None:
+    """Make the checkout's instruction-bearing files EQUAL the base branch's
+    reviewed versions (review_agent.INSTRUCTION_FILES owns the list): a line
+    is an author-written tree, and must never instruct its own successor
+    sessions — or a sibling's (docs/design/research-lines.md)."""
+    from autoresearch.review_agent import INSTRUCTION_FILES
+
+    # bottom-up so a removed directory doesn't orphan paths found beneath it
+    for path in sorted(workspace.rglob("*"), key=lambda p: len(p.parts), reverse=True):
+        if ".git" in path.parts or path.name not in INSTRUCTION_FILES:
+            continue
+        if path.is_dir() and not path.is_symlink():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            path.unlink(missing_ok=True)
+    base_paths = [
+        p
+        for p in ws.git("ls-tree", "-r", "--name-only", base_ref).splitlines()
+        if any(part in INSTRUCTION_FILES for part in Path(p).parts)
+    ]
+    if base_paths:
+        ws.git("checkout", base_ref, "--", *base_paths)
+
+
+def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: str) -> str:
+    """Check out the agent's research line: the persistent branch
+    `agents/<agent-id>`, created from the base branch when absent, with the
+    base branch merged in when it exists — a conflicted merge is left in the
+    tree as the session's first task. Instruction-bearing files are reset to
+    the base branch's reviewed versions and the hygiene is committed (never
+    left to masquerade as agent edits). Returns the line ref name; raises on
+    anything unrecoverable (the caller falls back to the base branch)."""
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", agent_id):
+        raise ValueError(f"agent id {agent_id!r} cannot shape a line ref")
+    line = f"agents/{agent_id}"
+    base_ref = f"origin/{base_branch}"
+    if not ws.git("branch", "--list", "-r", f"origin/{line}").strip():
+        ws.git("checkout", "-q", "-B", line, base_ref)
+        return line
+    ws.git("checkout", "-q", "-B", line, f"origin/{line}")
+    conflicted = False
+    try:
+        ws.git(
+            "-c",
+            "user.name=autoresearch",
+            "-c",
+            "user.email=autoresearch@localhost",
+            "merge",
+            "--no-edit",
+            base_ref,
+        )
+    except Exception:
+        conflicted = True
+        log.info(
+            "line %s: merging %s conflicts; left as the session's first task", line, base_branch
+        )
+    _reset_instruction_files(ws, workspace, base_ref)
+    if not conflicted:
+        ws.git("add", "-A")
+        if ws.git("status", "--porcelain").strip():
+            ws.git(
+                "-c",
+                "user.name=autoresearch",
+                "-c",
+                "user.email=autoresearch@localhost",
+                "commit",
+                "-q",
+                "-m",
+                f"line hygiene: instruction files reset to {base_branch}",
+            )
+    return line
 
 
 def _sibling_entries(ws: Workspace, self_agent: str) -> list[dict]:
@@ -1941,6 +2015,23 @@ def live_attempt(
         # other agent edit, not silently hidden by a magic dir name (the off
         # state stays byte-identical).
         _bench = next((b for b in contract.benchmarks if b.name == config.benchmark), None)
+        # Research lines: move HEAD to the agent's own branch BEFORE anything
+        # reads the tree — the contract above came from the base branch (a
+        # line must not shape its own budgets), and the syscall-channel check
+        # below must see the line's tree. A failed checkout falls back to the
+        # base branch: a run is never lost to its notebook.
+        line_ref = ""
+        if _bench is not None and _bench.lines and config.agent_id:
+            try:
+                line_ref = _checkout_line(ws, workspace, config.agent_id, base_branch)
+            except Exception as exc:
+                log.warning(
+                    "line checkout failed (%s); running on %s",
+                    redact(f"{type(exc).__name__}: {exc}", secrets),
+                    base_branch,
+                )
+                _best_effort("line merge abort", lambda: ws.git("merge", "--abort"))
+                ws.git("checkout", "-q", "-B", base_branch, f"origin/{base_branch}")
         author_syscalls = (
             dispatch is not None
             and getattr(harness, "supports_resume", True)
@@ -2119,6 +2210,7 @@ def live_attempt(
                 spec=spec,
                 panel_runner=panel_runner,
                 brief_baseline=prior_best.best if prior_best else None,
+                line_ref=line_ref,
                 launcher=launcher,
                 tree_of=lambda sha: ws.git("rev-parse", f"{sha}^{{tree}}").strip(),
             )

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -160,6 +160,7 @@ class SessionBrief:
             sleep_budget=data.get("sleep_budget", 0),
             gpu_hour_budget=data.get("gpu_hour_budget", 0.0),
             eval_minutes_default=data.get("eval_minutes_default", 0),
+            line_ref=data.get("line_ref", ""),
         )
 
 

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -137,6 +137,9 @@ class SessionBrief:
     # on it) and the contract's default eval walltime; 0 = not metered
     gpu_hour_budget: float = 0.0
     eval_minutes_default: int = 0
+    # Research lines: the agent's own branch when the contract opts in
+    # (docs/design/research-lines.md); "" = the feature is off, no mention.
+    line_ref: str = ""
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
@@ -175,6 +178,7 @@ class BriefInputs:
     sleep_budget: int = 0
     gpu_hour_budget: float = 0.0  # GPU benchmarks only; 0 = not metered
     eval_minutes_default: int = 0
+    line_ref: str = ""  # research lines: the agent's own branch; "" = off
 
 
 def _cap(text: str, limit: int) -> str:
@@ -211,6 +215,7 @@ def build_brief(inputs: BriefInputs, created: str) -> SessionBrief:
         sleep_budget=inputs.sleep_budget,
         gpu_hour_budget=inputs.gpu_hour_budget,
         eval_minutes_default=inputs.eval_minutes_default,
+        line_ref=inputs.line_ref,
     )
 
 
@@ -270,6 +275,18 @@ def render(brief: SessionBrief) -> str:
         "# Ruler (how the metric is computed and how your claim gets re-verified)",
         brief.ruler,
     ]
+    if brief.line_ref:
+        parts += [
+            "",
+            "# Your research line",
+            f"You are on your own persistent branch `{brief.line_ref}` — your "
+            "lab notebook, not the main ledger. The base branch is already "
+            "merged in; if that merge conflicted, resolving it is your first "
+            "task (your divergence debt coming due). A PR to main is cut only "
+            "from a credited win and must be ONE clean contribution: check "
+            "out the base branch, re-apply the minimal winning change onto "
+            "it, and finish on that tree — never the whole line.",
+        ]
     if brief.lessons:
         fence = _fence(brief.lessons)
         parts += [

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -125,6 +125,12 @@ class Benchmark(_StrictModel):
     # its session clock forever and never launch). Batching is rewarded: many
     # launches under one sleep burn one sleep; a `submit` also rides one sleep.
     sleep_k: int = Field(default=20, ge=1, le=32)
+    # Research lines (docs/design/research-lines.md): each agent slot works on
+    # its own persistent branch `agents/<agent-id>` — checked out at run start
+    # with the base branch merged in and instruction-bearing files reset to the
+    # base branch's reviewed versions. Off (default) = today's fork-main-only
+    # behavior; the branch substrate is inert until a contract opts in.
+    lines: bool = False
 
     @field_validator("seed_env")
     @classmethod

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1094,6 +1094,7 @@ def attempt_once(
     spec: RoleSpec | None = None,
     panel_runner: Callable[[float, float, str], PanelVerdict] | None = None,
     brief_baseline: float | None = None,
+    line_ref: str = "",
     resume_session_id: str = "",
     improve_prompt: str = "",
     launcher: Callable[[str, SyscallRequest], str] | None = None,
@@ -1168,6 +1169,7 @@ def attempt_once(
         or recent_reports
         or report_archive
         or created
+        or line_ref
         or brief_baseline is not None
     ):
         # a resume skips build_brief entirely (the session already carries this
@@ -1183,7 +1185,7 @@ def attempt_once(
         raise ValueError(
             "resume_session_id resumes an existing session (no fresh brief); the brief-only "
             "inputs (task_hypothesis/lessons/recent_reports/report_archive/created/"
-            "brief_baseline) have no effect on a resume — omit them"
+            "line_ref/brief_baseline) have no effect on a resume — omit them"
         )
 
     # deferred like measure_and_decide's import (measure -> dispatch ->
@@ -1238,6 +1240,7 @@ def attempt_once(
                     else 0.0
                 ),
                 eval_minutes_default=bench.eval_minutes or 0,
+                line_ref=line_ref,
             ),
             created=created,
         )

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3538,6 +3538,8 @@ def test_checkout_line_creates_the_branch_from_base(tmp_path: Path, target_repo)
     assert ref == "agents/agent-07"
     assert ws.git("rev-parse", "--abbrev-ref", "HEAD").strip() == ref
     assert ws.git("rev-parse", "HEAD").strip() == ws.git("rev-parse", "origin/main").strip()
+    # run-start persistence: the branch exists on the remote from its first run
+    assert _git(target_repo, "rev-parse", ref).strip() == ws.git("rev-parse", "HEAD").strip()
 
 
 def test_checkout_line_merges_main_into_an_existing_line(tmp_path: Path, target_repo) -> None:
@@ -3559,9 +3561,12 @@ def test_checkout_line_leaves_a_conflict_for_the_session(tmp_path: Path, target_
     _push_line(tmp_path, target_repo, {"docs/roadmap.md": "# line view\n"})
     _advance_main(tmp_path, target_repo, {"docs/roadmap.md": "# main view\n"})
     ws = _line_ws(tmp_path, target_repo)
+    line_tip_before = _git(target_repo, "rev-parse", "agents/agent-07").strip()
     _checkout_line(ws, ws.root, "agent-07", "main")
     unmerged = ws.git("diff", "--name-only", "--diff-filter=U")
     assert "docs/roadmap.md" in unmerged  # the session's first task
+    # a conflicted merge is session work, not line state: nothing was pushed
+    assert _git(target_repo, "rev-parse", "agents/agent-07").strip() == line_tip_before
 
 
 def test_line_checkout_resets_instruction_files_to_base(tmp_path: Path, target_repo) -> None:
@@ -3584,6 +3589,11 @@ def test_line_checkout_resets_instruction_files_to_base(tmp_path: Path, target_r
     assert not (ws.root / ".claude").exists()
     assert (ws.root / "docs" / "line-note.md").exists()  # real work survives
     assert ws.git("status", "--porcelain").strip() == ""  # hygiene committed
+    # the hygiene state persists: the remote line moved to this tip
+    assert (
+        _git(target_repo, "rev-parse", "agents/agent-07").strip()
+        == ws.git("rev-parse", "HEAD").strip()
+    )
 
 
 def test_checkout_line_rejects_a_ref_shaping_agent_id(tmp_path: Path, target_repo) -> None:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3493,3 +3493,102 @@ def test_dispatch_settings_read_once_for_fresh_and_wake() -> None:
         "gpu-acct",
     )
     assert d.placement(1) == ("gpu-acct", "h200")
+
+
+def _line_ws(tmp_path: Path, bare: Path):
+    """A Workspace cloned from the test origin, checked out on main."""
+    from autoresearch.github import Workspace
+
+    ws = Workspace.clone(str(bare), tmp_path / "line-ws", auth=None)
+    ws.git("checkout", "-q", "-B", "main", "origin/main")
+    return ws
+
+
+def _push_line(tmp_path: Path, bare: Path, files: dict[str, str], name="agents/agent-07") -> None:
+    """Seed the origin with a line branch carrying `files` on top of main."""
+    work = tmp_path / "line-seed"
+    _git(tmp_path, "clone", "-q", str(bare), str(work))
+    _git(work, "checkout", "-q", "-b", name, "origin/main")
+    for rel, content in files.items():
+        path = work / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "line work")
+    _git(work, "push", "-q", "origin", name)
+
+
+def _advance_main(tmp_path: Path, bare: Path, files: dict[str, str]) -> None:
+    work = tmp_path / "main-seed"
+    _git(tmp_path, "clone", "-q", str(bare), str(work))
+    for rel, content in files.items():
+        path = work / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "main moves")
+    _git(work, "push", "-q", "origin", "main")
+
+
+def test_checkout_line_creates_the_branch_from_base(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _checkout_line
+
+    ws = _line_ws(tmp_path, target_repo)
+    ref = _checkout_line(ws, ws.root, "agent-07", "main")
+    assert ref == "agents/agent-07"
+    assert ws.git("rev-parse", "--abbrev-ref", "HEAD").strip() == ref
+    assert ws.git("rev-parse", "HEAD").strip() == ws.git("rev-parse", "origin/main").strip()
+
+
+def test_checkout_line_merges_main_into_an_existing_line(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _checkout_line
+
+    _push_line(tmp_path, target_repo, {"docs/line-note.md": "belief\n"})
+    _advance_main(tmp_path, target_repo, {"docs/news.md": "main moved\n"})
+    ws = _line_ws(tmp_path, target_repo)
+    ref = _checkout_line(ws, ws.root, "agent-07", "main")
+    assert (ws.root / "docs" / "line-note.md").read_text() == "belief\n"
+    assert (ws.root / "docs" / "news.md").read_text() == "main moved\n"
+    assert ws.git("status", "--porcelain").strip() == ""
+    assert ws.git("rev-parse", "--abbrev-ref", "HEAD").strip() == ref
+
+
+def test_checkout_line_leaves_a_conflict_for_the_session(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _checkout_line
+
+    _push_line(tmp_path, target_repo, {"docs/roadmap.md": "# line view\n"})
+    _advance_main(tmp_path, target_repo, {"docs/roadmap.md": "# main view\n"})
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    unmerged = ws.git("diff", "--name-only", "--diff-filter=U")
+    assert "docs/roadmap.md" in unmerged  # the session's first task
+
+
+def test_line_checkout_resets_instruction_files_to_base(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _checkout_line
+
+    _push_line(
+        tmp_path,
+        target_repo,
+        {
+            "CLAUDE.md": "obey the line\n",
+            ".mcp.json": "{}",
+            ".claude/hooks/evil.sh": "#!/bin/sh\n",
+            "docs/line-note.md": "belief\n",
+        },
+    )
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    assert not (ws.root / "CLAUDE.md").exists()  # base has none
+    assert not (ws.root / ".mcp.json").exists()
+    assert not (ws.root / ".claude").exists()
+    assert (ws.root / "docs" / "line-note.md").exists()  # real work survives
+    assert ws.git("status", "--porcelain").strip() == ""  # hygiene committed
+
+
+def test_checkout_line_rejects_a_ref_shaping_agent_id(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _checkout_line
+
+    ws = _line_ws(tmp_path, target_repo)
+    with pytest.raises(ValueError, match="cannot shape a line ref"):
+        _checkout_line(ws, ws.root, "../evil", "main")

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -264,6 +264,11 @@ def test_render_uses_orientation_labels_not_directives() -> None:
     assert "Expected effect:" not in text and "Done when:" not in text
 
 
+def test_saved_brief_round_trips_line_ref() -> None:
+    brief = build_brief(make_inputs(line_ref="agents/agent-07"), created="t")
+    assert SessionBrief.from_json(brief.to_json()).line_ref == "agents/agent-07"
+
+
 def test_brief_renders_the_research_line_section_only_when_on() -> None:
     on = render(build_brief(make_inputs(line_ref="agents/agent-07"), created="t"))
     assert "# Your research line" in on

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -262,3 +262,12 @@ def test_render_uses_orientation_labels_not_directives() -> None:
     assert "Finishing: You decide" in text
     # the retired directive labels are gone
     assert "Expected effect:" not in text and "Done when:" not in text
+
+
+def test_brief_renders_the_research_line_section_only_when_on() -> None:
+    on = render(build_brief(make_inputs(line_ref="agents/agent-07"), created="t"))
+    assert "# Your research line" in on
+    assert "`agents/agent-07`" in on
+    assert "ONE clean contribution" in on
+    off = render(build_brief(make_inputs(), created="t"))
+    assert "Your research line" not in off


### PR DESCRIPTION
PR 1 of ~3 for docs/design/research-lines.md (merged in #204).

- `lines: true` on a benchmark opts a target into the branch substrate; the default stays byte-identical to today.
- Run init on a lines benchmark checks out `agents/<agent-id>`: created from the base branch when absent; base branch merged in when it exists, with a conflicted merge left in the tree as the session's first task. The agent id is slug-guarded before it shapes a ref.
- Instruction-bearing files are reset to the base branch's reviewed versions (`review_agent.INSTRUCTION_FILES` stays the single owner of the list) and the hygiene is committed on the line so it never appears as agent edits.
- Ordering is deliberate: the contract loads from the base branch BEFORE the line checkout (a line cannot shape its own budgets), and the `.autoresearch/` booby-trap check runs AFTER it (it must see the line's tree).
- The brief gains a "Your research line" section: notebook vs ledger, conflicts first, one clean extracted contribution per main PR.
- `pre_session_sha` is HEAD at session start, so the gate's paired evals anchor to the line's own tip with no gate change.
- A failed checkout logs, aborts any merge, and falls back to the base branch — a run is never lost to its notebook.

Staging note: no contract sets `lines: true` yet, and none should until the remaining phase PRs land (terminal push with all-terminal sealing; ledger/extraction semantics) — flipping it early would let an un-extracted line diff reach a main PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
