### PR TITLE
Research lines Phase 1: terminal notebook push

### DIFF
--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 from dataclasses import replace as dc_replace
 from functools import partial
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from autoresearch.brief import distill_lessons
 from autoresearch.compute import LocalCompute
@@ -660,7 +660,11 @@ def _wake_author_sleep(
 
     def _end(result: AttemptResult, drop_refs: list[str]) -> AttemptOutcome:
         # a terminal from the resumed climb: report, ending record, issue note —
-        # the same ending shape every other terminal takes.
+        # the same ending shape every other terminal takes. The line notebook
+        # records it first, while the tree is still the session's final tree.
+        _push_line_snapshot(
+            ws, _line_ref_for(bench, config.agent_id), run_id, result.outcome, secrets
+        )
         for ref in drop_refs:
             drop_snapshot(ws, Snapshot(commit="", tree="", ref=ref))
         report_path = run_dir / "report.md"
@@ -1001,6 +1005,59 @@ def _reset_instruction_files(ws: Workspace, workspace: Path, base_ref: str) -> N
     ]
     if base_paths:
         ws.git("checkout", base_ref, "--", *base_paths)
+
+
+def _line_ref_for(bench: Benchmark | None, agent_id: str) -> str:
+    """The agent's line branch when the benchmark opted in; "" otherwise.
+    Wake paths recompute this from the record — a malformed agent id could
+    never have created a line at run start, so "" (not an error) is right."""
+    if bench is None or not bench.lines or not agent_id:
+        return ""
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", agent_id):
+        return ""
+    return f"agents/{agent_id}"
+
+
+def _push_line_snapshot(
+    ws: Workspace, line_ref: str, run_id: str, outcome: str, secrets: tuple[str, ...] = ()
+) -> None:
+    """Publish the session's final tree to the agent's line as a sealed
+    snapshot commit — every terminal path, any outcome
+    (docs/design/research-lines.md). The seal parents on the LOCAL line ref
+    and advances it, so sequential terminals within one run chain as
+    fast-forwards; one slot never runs twice concurrently, so the remote
+    cannot have moved under us. Best-effort throughout: the notebook never
+    changes a run's outcome. An unchanged tree is not pushed (the run-start
+    push already holds it)."""
+    if not line_ref:
+        return
+
+    def _seal_and_push() -> None:
+        # raises if the ref is absent (e.g. a park that predates the line
+        # feature) — _best_effort turns that into a logged skip
+        parent = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
+        snap = snapshot_tree(ws, parent)
+        try:
+            if snap.tree == ws.git("rev-parse", f"{parent}^{{tree}}").strip():
+                return
+            sealed = ws.git(
+                "-c",
+                "user.name=autoresearch",
+                "-c",
+                "user.email=autoresearch@localhost",
+                "commit-tree",
+                snap.tree,
+                "-p",
+                parent,
+                "-m",
+                f"line snapshot: {run_id} ({outcome})",
+            ).strip()
+            ws.git("update-ref", f"refs/heads/{line_ref}", sealed)
+            ws.push(line_ref)
+        finally:
+            drop_snapshot(ws, snap)
+
+    _best_effort(f"line push ({outcome})", _seal_and_push, secrets)
 
 
 def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: str) -> str:
@@ -1387,6 +1444,10 @@ def resume_run(
             # resubmit runs an errored eval again
             judged=(candidate_sha, result),
         )
+
+    # Research lines: every path from here is terminal (publish or negative)
+    # and the publish force-checkouts the tree — seal the notebook first.
+    _push_line_snapshot(ws, _line_ref_for(bench, config.agent_id), run_id, result.outcome, secrets)
 
     if result.outcome == "improved":
         # Publish: branch the SEALED candidate sha, fold in the ledger, push,
@@ -2005,6 +2066,9 @@ def live_attempt(
             )
         return AttemptOutcome(run_id=run_id, outcome="attempt-error")
 
+    # what the attempt-error handler needs to salvage the line notebook: the
+    # exception path cannot rely on names bound inside the try
+    salvage: dict[str, object] = {}
     try:
         ws = Workspace.clone(_target_clone_url(config.target), workspace, auth=bot_auth)
         # Build ON the requested PR base: the clone checks out the remote
@@ -2041,6 +2105,8 @@ def live_attempt(
                 )
                 _best_effort("line merge abort", lambda: ws.git("merge", "--abort"))
                 ws.git("checkout", "-q", "-B", base_branch, f"origin/{base_branch}")
+        if line_ref:
+            salvage.update(ws=ws, line_ref=line_ref)
         author_syscalls = (
             dispatch is not None
             and getattr(harness, "supports_resume", True)
@@ -2277,6 +2343,15 @@ def live_attempt(
         exc_name = type(exc).__name__
         note = redact(f"{exc_name}: {exc}", secrets)[:500]
         log.warning("climb failed for %s: %s", run_id, note)
+        if salvage:
+            # a crashed attempt's tree is still notebook-worthy (best-effort)
+            _push_line_snapshot(
+                cast(Workspace, salvage["ws"]),
+                str(salvage["line_ref"]),
+                run_id,
+                "attempt-error",
+                secrets,
+            )
         failed = RunRecord(
             **{
                 **record.__dict__,
@@ -2326,6 +2401,10 @@ def live_attempt(
     report = result.report(config, redact_secrets=secrets)
     report_path = run_dir / "report.md"
     wrote_report = _best_effort("run report", lambda: report_path.write_text(report), secrets)
+
+    # Research lines: the notebook records EVERY terminal, sealed before the
+    # publish block below mutates the working tree (checkout -f).
+    _push_line_snapshot(ws, line_ref, run_id, result.outcome, secrets)
 
     pr_url = ""
     outcome_name = result.outcome

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1008,9 +1008,10 @@ def _reset_instruction_files(ws: Workspace, workspace: Path, base_ref: str) -> N
 
 
 def _line_ref_for(bench: Benchmark | None, agent_id: str) -> str:
-    """The agent's line branch when the benchmark opted in; "" otherwise.
-    Wake paths recompute this from the record — a malformed agent id could
-    never have created a line at run start, so "" (not an error) is right."""
+    """The agent's line branch when the benchmark opted in, or the empty
+    string when the feature is off. Wake paths recompute this from the
+    record — a malformed agent id could never have created a line at run
+    start, so empty (not an error) is right there too."""
     if bench is None or not bench.lines or not agent_id:
         return ""
     if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", agent_id):
@@ -1038,21 +1039,24 @@ def _push_line_snapshot(
         parent = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
         snap = snapshot_tree(ws, parent)
         try:
-            if snap.tree == ws.git("rev-parse", f"{parent}^{{tree}}").strip():
-                return
-            sealed = ws.git(
-                "-c",
-                "user.name=autoresearch",
-                "-c",
-                "user.email=autoresearch@localhost",
-                "commit-tree",
-                snap.tree,
-                "-p",
-                parent,
-                "-m",
-                f"line snapshot: {run_id} ({outcome})",
-            ).strip()
-            ws.git("update-ref", f"refs/heads/{line_ref}", sealed)
+            # seal only when the tree moved past the local ref; the PUSH runs
+            # either way — a session that COMMITTED its work advanced the
+            # local ref without dirtying the tree, and that commit must still
+            # reach the remote (an already-current ref push is a no-op).
+            if snap.tree != ws.git("rev-parse", f"{parent}^{{tree}}").strip():
+                sealed = ws.git(
+                    "-c",
+                    "user.name=autoresearch",
+                    "-c",
+                    "user.email=autoresearch@localhost",
+                    "commit-tree",
+                    snap.tree,
+                    "-p",
+                    parent,
+                    "-m",
+                    f"line snapshot: {run_id} ({outcome})",
+                ).strip()
+                ws.git("update-ref", f"refs/heads/{line_ref}", sealed)
             ws.push(line_ref)
         finally:
             drop_snapshot(ws, snap)
@@ -1445,9 +1449,11 @@ def resume_run(
             judged=(candidate_sha, result),
         )
 
-    # Research lines: every path from here is terminal (publish or negative)
-    # and the publish force-checkouts the tree — seal the notebook first.
-    _push_line_snapshot(ws, _line_ref_for(bench, config.agent_id), run_id, result.outcome, secrets)
+    def _notebook(outcome: str) -> None:
+        # Research lines: record the tree AS OF THIS DECIDED TERMINAL — never
+        # earlier, because a blocking panel verdict can still resume the
+        # author (a continuation, not a terminal).
+        _push_line_snapshot(ws, _line_ref_for(bench, config.agent_id), run_id, outcome, secrets)
 
     if result.outcome == "improved":
         # Publish: branch the SEALED candidate sha, fold in the ledger, push,
@@ -1469,6 +1475,7 @@ def resume_run(
                 RunRecord(**{**record.__dict__, "state": ENDED, "ending": NEGATIVE_RESULT})
             )
             _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
+            _notebook("no-improvement")
             return AttemptOutcome(run_id=run_id, outcome="no-improvement")
 
         from datetime import UTC as _UTC
@@ -1495,6 +1502,7 @@ def resume_run(
         if existing:
             pr_url = str(existing.get("html_url", ""))
             log.info("run %s: PR %s already open; reconciling the record", run_id, pr_url)
+            _notebook("improved")
             # put the workspace on the branch (a later follow-up expects it) and
             # finish the steps the prior wake may have died before completing.
             _best_effort(
@@ -1707,10 +1715,12 @@ def resume_run(
             )
             if _best_effort("ending record", lambda: save_record(run_root, failed, now), secrets):
                 drop_snapshot(ws, Snapshot(commit=candidate_sha, tree="", ref=candidate_ref))
+            _notebook("publish-error")
             return AttemptOutcome(run_id=run_id, outcome="publish-error")
         # PR opened. Record IN_REVIEW *before* dropping the snapshot: if the save
         # fails, the record stays `waiting` with the snapshot intact, so the run
         # is recoverable rather than an ABORTED record over a live PR.
+        _notebook("improved")
         report_path = run_dir / "report.md"
         _best_effort(
             "run report",
@@ -1752,6 +1762,7 @@ def resume_run(
     # BEFORE dropping (same ordering as the improved path): if the save fails,
     # the run stays WAITING with its snapshot intact, so a re-wake can still
     # reconstruct — never WAITING with the snapshot already gone.
+    _notebook(result.outcome)
     report_path = run_dir / "report.md"
     _best_effort(
         "run report",
@@ -2402,10 +2413,6 @@ def live_attempt(
     report_path = run_dir / "report.md"
     wrote_report = _best_effort("run report", lambda: report_path.write_text(report), secrets)
 
-    # Research lines: the notebook records EVERY terminal, sealed before the
-    # publish block below mutates the working tree (checkout -f).
-    _push_line_snapshot(ws, line_ref, run_id, result.outcome, secrets)
-
     pr_url = ""
     outcome_name = result.outcome
     branch = ""
@@ -2578,6 +2585,11 @@ def live_attempt(
             redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
             secrets,
         )
+    # Research lines: the notebook records EVERY terminal, AFTER the publish
+    # settles — the snapshot then names the final outcome (a publish failure
+    # is publish-error, not improved), and an improved tree is the published
+    # candidate plus its ledger commit.
+    _push_line_snapshot(ws, line_ref, run_id, outcome_name, secrets)
     log.info("run %s: %s %s", run_id, outcome_name, pr_url)
     return AttemptOutcome(
         run_id=run_id,

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3690,3 +3690,46 @@ def test_live_attempt_records_every_terminal_in_the_notebook(tmp_path, target_re
     )
     msg = _git(target_repo_lines, "log", "-1", "--format=%s", "agents/agent-07").strip()
     assert "tsp-lines-1" in msg and "no-improvement" in msg
+
+
+def test_push_line_snapshot_publishes_session_commits(tmp_path: Path, target_repo) -> None:
+    """A session that COMMITTED its work advanced the local ref without
+    dirtying the tree — the push must still publish that commit."""
+    from autoresearch.attempt import _checkout_line, _push_line_snapshot
+
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    (ws.root / "docs" / "belief.md").write_text("committed by the session\n")
+    ws.git("add", "-A")
+    ws.git("-c", "user.name=s", "-c", "user.email=s@s", "commit", "-qm", "agent commit")
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "no-improvement")
+    assert (
+        _git(target_repo, "show", "agents/agent-07:docs/belief.md") == "committed by the session\n"
+    )
+    assert _git(target_repo, "log", "-1", "--format=%s", "agents/agent-07").strip() == (
+        "agent commit"
+    )
+
+
+def test_improved_terminal_notebook_names_the_final_outcome(tmp_path, target_repo_lines) -> None:
+    """The notebook snapshot lands AFTER the publish settles: an improved
+    run's line tip carries the published candidate plus its ledger commit,
+    and the message names the final outcome."""
+    github = FakeGitHub()
+    queue = [13.876, 13.1]  # improvement: PR + ledger
+    with _queued_local(queue):
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp", agent_id="agent-07"),
+            run_root=tmp_path / "state",
+            run_id="tsp-lines-2",
+            harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "def solve(): return 2\n"}),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="2026-08-06T00:00:00Z",
+        )
+    assert outcome.outcome == "improved" and len(github.prs) == 1
+    msg = _git(target_repo_lines, "log", "-1", "--format=%s", "agents/agent-07").strip()
+    assert "tsp-lines-2" in msg and "improved" in msg
+    tree = _git(target_repo_lines, "ls-tree", "-r", "--name-only", "agents/agent-07")
+    assert "results/leader.json" in tree  # the ledger commit rode the notebook

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -34,6 +34,9 @@ CONTRACT_DISPATCH = CONTRACT.replace(
     "    direction: min\n", "    direction: min\n    eval_minutes: 30\n"
 )
 
+# Same contract with research lines on (docs/design/research-lines.md).
+CONTRACT_LINES = CONTRACT.replace("    direction: min\n", "    direction: min\n    lines: true\n")
+
 
 def _session(sid: str = "s1") -> SessionResult:
     return SessionResult(
@@ -3602,3 +3605,88 @@ def test_checkout_line_rejects_a_ref_shaping_agent_id(tmp_path: Path, target_rep
     ws = _line_ws(tmp_path, target_repo)
     with pytest.raises(ValueError, match="cannot shape a line ref"):
         _checkout_line(ws, ws.root, "../evil", "main")
+
+
+@pytest.fixture
+def target_repo_lines(tmp_path: Path, monkeypatch) -> Path:
+    return _seed_target(tmp_path, monkeypatch, CONTRACT_LINES)
+
+
+def test_push_line_snapshot_publishes_the_terminal_tree(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _checkout_line, _push_line_snapshot
+
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    (ws.root / "docs" / "belief.md").write_text("depth pays\n")
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "no-improvement")
+    assert _git(target_repo, "show", "agents/agent-07:docs/belief.md") == "depth pays\n"
+    msg = _git(target_repo, "log", "-1", "--format=%s", "agents/agent-07").strip()
+    assert "tsp-9" in msg and "no-improvement" in msg
+    # the local ref advanced with the remote: a later terminal chains on it
+    assert (
+        ws.git("rev-parse", "refs/heads/agents/agent-07").strip()
+        == _git(target_repo, "rev-parse", "agents/agent-07").strip()
+    )
+
+
+def test_push_line_snapshot_skips_an_unchanged_tree(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _checkout_line, _push_line_snapshot
+
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    before = _git(target_repo, "rev-parse", "agents/agent-07").strip()
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "no-improvement")
+    assert _git(target_repo, "rev-parse", "agents/agent-07").strip() == before
+
+
+def test_push_line_snapshot_chains_sequential_terminals(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _checkout_line, _push_line_snapshot
+
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    (ws.root / "docs" / "belief.md").write_text("first\n")
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "no-improvement")
+    first = _git(target_repo, "rev-parse", "agents/agent-07").strip()
+    (ws.root / "docs" / "belief.md").write_text("second\n")
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "eval-error")
+    tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
+    assert _git(target_repo, "rev-parse", f"{tip}^").strip() == first  # fast-forward chain
+    assert _git(target_repo, "show", "agents/agent-07:docs/belief.md") == "second\n"
+
+
+def test_push_line_snapshot_is_best_effort(tmp_path: Path, target_repo) -> None:
+    from autoresearch.attempt import _push_line_snapshot
+
+    ws = _line_ws(tmp_path, target_repo)
+    _push_line_snapshot(ws, "", "tsp-9", "no-improvement")  # feature off: no-op
+    _push_line_snapshot(
+        ws, "agents/agent-99", "tsp-9", "no-improvement"
+    )  # no such ref: logged skip
+    with pytest.raises(subprocess.CalledProcessError):
+        _git(target_repo, "rev-parse", "agents/agent-99")
+
+
+def test_live_attempt_records_every_terminal_in_the_notebook(tmp_path, target_repo_lines) -> None:
+    """End to end on the lines contract: a no-improvement run still lands the
+    session's final tree on the agent's branch, message naming run + outcome."""
+    github = FakeGitHub()
+    queue = [13.876, 14.5]  # candidate worse: negative terminal, no PR
+    with _queued_local(queue):
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp", agent_id="agent-07"),
+            run_root=tmp_path / "state",
+            run_id="tsp-lines-1",
+            harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "def solve(): return 1\n"}),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="2026-08-06T00:00:00Z",
+        )
+    assert outcome.outcome == "no-improvement"
+    assert github.prs == []
+    assert (
+        _git(target_repo_lines, "show", "agents/agent-07:src/pilot/solvers/tsp.py")
+        == "def solve(): return 1\n"
+    )
+    msg = _git(target_repo_lines, "log", "-1", "--format=%s", "agents/agent-07").strip()
+    assert "tsp-lines-1" in msg and "no-improvement" in msg


### PR DESCRIPTION
PR 2 of ~3 for docs/design/research-lines.md (#204; substrate in #206).

- `_push_line_snapshot`: seals the workspace's current content as a snapshot commit parented on the LOCAL line ref, advances that ref, and pushes — so sequential terminals within one run chain as fast-forwards. One slot never runs twice concurrently, so the remote cannot have moved. The commit message names the run and outcome (`line snapshot: <run_id> (<outcome>)`).
- Terminal coverage, per the design's "any terminal state": the fresh-run funnel (sealed before the improved-publish force-checkout mutates the tree — also covers publish-error), resume_run's post-decision point (candidate-wake publish and negative terminals; placed after the failed-submit author wake, which continues the run), `_wake_author_sleep`'s `_end` (all author-resumed terminals from both wake flavors), and the attempt-error handler (best-effort salvage via a pre-try stash).
- Deliberate non-events: a park pushes nothing (not a terminal); an unchanged tree pushes nothing (the run-start push from #206 already holds it); a missing local line ref (a park predating the feature) logs and skips; every path is best-effort — the notebook never changes a run's outcome.
- `_line_ref_for` recomputes the line ref on wake paths from the contract + agent id; a malformed id yields "" (it could never have created a line at run start).

Feature stays inert: no contract sets `lines: true` yet. Remaining phase PR: ledger/credit semantics (declared-base floor accounting) + the AGENT_MEMORY.md exclusion guard for main-PR candidates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
