### PR TITLE
Research lines Phase 1: the memory boundary

### DIFF
--- a/docs/design/research-lines.md
+++ b/docs/design/research-lines.md
@@ -47,12 +47,12 @@ Each agent slot owns `agents/agent-NN` on the target repo.
   what no longer fits moves to a topic file instead of being deleted.
   Only the memory index is added to the brief. Memory, code, and beliefs travel
   as one lineage — and cross clusters for free, since the branch lives on
-  the shared repo. It NEVER reaches main, and can never
-  carry anything a run depends on: every MEASURABLE seal (gate candidates,
-  launches) excludes AGENT_MEMORY.md and agent_memory/ at snapshot time,
-  so the measured tree equals the published tree and memory-stashed
-  content can never influence a credited number; only the notebook seal
-  keeps them (panel grab-bag mandate as backstop).
+  the shared repo. Memory stays on the line branch.
+  Candidate and launch snapshots omit AGENT_MEMORY.md and agent_memory/,
+  so measured trees, main PRs, and panel claims never include them — and
+  memory-stashed content can never influence a credited number. The
+  notebook snapshot keeps them, even when the target's .gitignore matches
+  them.
 - **Selective integration is git**: harvesting a sibling's technique or
   main's progress = merge/cherry-pick, not bespoke machinery. One carve-out:
   `AGENT_MEMORY.md` is slot-private — any merge into a line keeps the

--- a/docs/design/research-lines.md
+++ b/docs/design/research-lines.md
@@ -47,10 +47,12 @@ Each agent slot owns `agents/agent-NN` on the target repo.
   what no longer fits moves to a topic file instead of being deleted.
   Only the memory index is added to the brief. Memory, code, and beliefs travel
   as one lineage — and cross clusters for free, since the branch lives on
-  the shared repo. It NEVER reaches main: the main-PR extraction re-applies
-  the winning change onto a main base, and the kernel mechanically rejects
-  AGENT_MEMORY.md and agent_memory/ in any main-PR candidate (panel
-  grab-bag mandate as backstop).
+  the shared repo. It NEVER reaches main, and can never
+  carry anything a run depends on: every MEASURABLE seal (gate candidates,
+  launches) excludes AGENT_MEMORY.md and agent_memory/ at snapshot time,
+  so the measured tree equals the published tree and memory-stashed
+  content can never influence a credited number; only the notebook seal
+  keeps them (panel grab-bag mandate as backstop).
 - **Selective integration is git**: harvesting a sibling's technique or
   main's progress = merge/cherry-pick, not bespoke machinery. One carve-out:
   `AGENT_MEMORY.md` is slot-private — any merge into a line keeps the

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -766,9 +766,10 @@ def _wake_author_sleep(
     # and park the run as a CANDIDATE); snapshots parent on base (same as the
     # first pass: the clone was at base).
     snapshots: list[Snapshot] = []
+    wake_line = _line_ref_for(bench, config.agent_id)
 
     def snapshot() -> str:
-        snap = snapshot_tree(ws, base_sha)
+        snap = snapshot_tree(ws, base_sha, exclude=LINE_MEMORY_PATHS if wake_line else ())
         snapshots.append(snap)
         return snap.commit
 
@@ -776,6 +777,8 @@ def _wake_author_sleep(
         ws.git("add", "-A")
         paths = ws.staged_paths()
         ws.git("reset")
+        if wake_line:
+            paths = [p for p in paths if not _is_line_memory(p)]
         return paths
 
     panel_runner = (
@@ -1005,6 +1008,18 @@ def _reset_instruction_files(ws: Workspace, workspace: Path, base_ref: str) -> N
     ]
     if base_paths:
         ws.git("checkout", base_ref, "--", *base_paths)
+
+
+# The agent's memory on its line (docs/design/research-lines.md): the bounded
+# index at the branch root plus the topic-file folder. They ride the NOTEBOOK
+# seal (the line branch is exactly where they live) and are excluded from
+# every MEASURABLE seal and from changed-path accounting — never a scope
+# violation, never claimable work, never part of a main-PR candidate.
+LINE_MEMORY_PATHS = ("AGENT_MEMORY.md", "agent_memory")
+
+
+def _is_line_memory(path: str) -> bool:
+    return path in LINE_MEMORY_PATHS or path.startswith("agent_memory/")
 
 
 def _line_ref_for(bench: Benchmark | None, agent_id: str) -> str:
@@ -1481,6 +1496,11 @@ def resume_run(
         from datetime import UTC as _UTC
         from datetime import datetime as _dt
 
+        # seal the notebook before any checkout mutates the persisted session
+        # tree (the memory files are excluded from the sealed candidate and
+        # would not survive the force-checkout + clean below)
+        _notebook("improved")
+
         branch = f"{config.branch_prefix}/{run_id}"
 
         # IDEMPOTENCY: a prior wake may have opened the PR but died before
@@ -1502,7 +1522,6 @@ def resume_run(
         if existing:
             pr_url = str(existing.get("html_url", ""))
             log.info("run %s: PR %s already open; reconciling the record", run_id, pr_url)
-            _notebook("improved")
             # put the workspace on the branch (a later follow-up expects it) and
             # finish the steps the prior wake may have died before completing.
             _best_effort(
@@ -1720,7 +1739,6 @@ def resume_run(
         # PR opened. Record IN_REVIEW *before* dropping the snapshot: if the save
         # fails, the record stays `waiting` with the snapshot intact, so the run
         # is recoverable rather than an ABORTED record over a live PR.
-        _notebook("improved")
         report_path = run_dir / "report.md"
         _best_effort(
             "run report",
@@ -2167,6 +2185,8 @@ def live_attempt(
             ws.git("add", "-A")
             paths = ws.staged_paths()
             ws.git("reset")
+            if line_ref:
+                paths = [p for p in paths if not _is_line_memory(p)]
             return paths
 
         if issue_number:
@@ -2256,7 +2276,7 @@ def live_attempt(
         snapshots: list[Snapshot] = []
 
         def snapshot() -> str:
-            snap = snapshot_tree(ws, pre_session_sha)
+            snap = snapshot_tree(ws, pre_session_sha, exclude=LINE_MEMORY_PATHS if line_ref else ())
             snapshots.append(snap)
             return snap.commit
 
@@ -2412,6 +2432,14 @@ def live_attempt(
     report = result.report(config, redact_secrets=secrets)
     report_path = run_dir / "report.md"
     wrote_report = _best_effort("run report", lambda: report_path.write_text(report), secrets)
+
+    # Research lines: seal the notebook NOW, while the tree is still the
+    # session's final tree — the publish below force-checkouts the sealed
+    # candidate and cleans untracked files, which would drop the agent's
+    # memory (it is excluded from measurable seals by design). The label is
+    # the GATE outcome, correct at this moment; a publish failure appends a
+    # publish-error snapshot at the tail.
+    _push_line_snapshot(ws, line_ref, run_id, result.outcome, secrets)
 
     pr_url = ""
     outcome_name = result.outcome
@@ -2585,11 +2613,11 @@ def live_attempt(
             redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
             secrets,
         )
-    # Research lines: the notebook records EVERY terminal, AFTER the publish
-    # settles — the snapshot then names the final outcome (a publish failure
-    # is publish-error, not improved), and an improved tree is the published
-    # candidate plus its ledger commit.
-    _push_line_snapshot(ws, line_ref, run_id, outcome_name, secrets)
+    if outcome_name != result.outcome:
+        # the publish failed after the gate credited the tree: the improved
+        # snapshot above stands (the measurement was real); append the
+        # publish-error marker so the notebook records how the run ended
+        _push_line_snapshot(ws, line_ref, run_id, outcome_name, secrets)
     log.info("run %s: %s %s", run_id, outcome_name, pr_url)
     return AttemptOutcome(
         run_id=run_id,

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -792,6 +792,7 @@ def _wake_author_sleep(
             config.benchmark,
             config.bot_login,
             _utc_date(now),
+            exclude=LINE_MEMORY_PATHS if wake_line else (),
         )
         if panel_lenses
         else None
@@ -1052,7 +1053,8 @@ def _push_line_snapshot(
         # raises if the ref is absent (e.g. a park that predates the line
         # feature) — _best_effort turns that into a logged skip
         parent = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
-        snap = snapshot_tree(ws, parent)
+        memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
+        snap = snapshot_tree(ws, parent, force=memory)
         try:
             # seal only when the tree moved past the local ref; the PUSH runs
             # either way — a session that COMMITTED its work advanced the
@@ -1611,6 +1613,9 @@ def resume_run(
                         config.benchmark,
                         config.bot_login,
                         _dt.fromtimestamp(now, _UTC).strftime("%Y-%m-%d"),
+                        exclude=(
+                            LINE_MEMORY_PATHS if _line_ref_for(bench, config.agent_id) else ()
+                        ),
                     )(baseline, candidate, str(stage.get("report", "")))
                 except Exception as exc:
                     log.warning(
@@ -1946,6 +1951,7 @@ def build_panel_runner(
     bot_login: str,
     today: str,
     start_round: int = 0,
+    exclude: tuple[str, ...] = (),
 ) -> Callable[[float, float, str], PanelVerdict]:
     """The git half of the pre-PR panel: prepare the two read-only checkouts
     and the synthetic claim, then hand off to `run_panel` (which owns no git).
@@ -1965,6 +1971,10 @@ def build_panel_runner(
         shutil.rmtree(panel_ws, ignore_errors=True)
         panel_ws.mkdir(parents=True, exist_ok=True)
         ws.git("add", "-A")
+        if exclude:
+            # the panel judges the CLAIM — the same tree the gate measured,
+            # which excludes line memory (docs/design/research-lines.md)
+            ws.git("rm", "--cached", "-r", "-q", "--ignore-unmatch", "--", *exclude)
         tree = ws.git("write-tree").strip()
         ws.git("reset")
         snapshot = ws.git(
@@ -2122,8 +2132,9 @@ def live_attempt(
         # line must not shape its own budgets), and the syscall-channel check
         # below must see the line's tree. A failed checkout falls back to the
         # base branch: a run is never lost to its notebook.
+        lines_active = _bench is not None and _bench.lines and bool(config.agent_id)
         line_ref = ""
-        if _bench is not None and _bench.lines and config.agent_id:
+        if lines_active:
             try:
                 line_ref = _checkout_line(ws, workspace, config.agent_id, base_branch)
             except Exception as exc:
@@ -2185,7 +2196,7 @@ def live_attempt(
             ws.git("add", "-A")
             paths = ws.staged_paths()
             ws.git("reset")
-            if line_ref:
+            if lines_active:
                 paths = [p for p in paths if not _is_line_memory(p)]
             return paths
 
@@ -2239,6 +2250,7 @@ def live_attempt(
                 config.benchmark,
                 config.bot_login,
                 created[:10],
+                exclude=LINE_MEMORY_PATHS if lines_active else (),
             )
             if panel_lenses
             else None
@@ -2276,7 +2288,9 @@ def live_attempt(
         snapshots: list[Snapshot] = []
 
         def snapshot() -> str:
-            snap = snapshot_tree(ws, pre_session_sha, exclude=LINE_MEMORY_PATHS if line_ref else ())
+            snap = snapshot_tree(
+                ws, pre_session_sha, exclude=LINE_MEMORY_PATHS if lines_active else ()
+            )
             snapshots.append(snap)
             return snap.commit
 

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -286,7 +286,10 @@ def render(brief: SessionBrief) -> str:
             "task (your divergence debt coming due). A PR to main is cut only "
             "from a credited win and must be ONE clean contribution: check "
             "out the base branch, re-apply the minimal winning change onto "
-            "it, and finish on that tree — never the whole line.",
+            "it, and finish on that tree — never the whole line. Your memory "
+            "(AGENT_MEMORY.md and agent_memory/) lives on this branch alone: "
+            "it is excluded from measured trees and can never carry "
+            "anything a run depends on.",
         ]
     if brief.lessons:
         fence = _fence(brief.lessons)

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -93,10 +93,14 @@ class Snapshot:
     ref: str
 
 
-def snapshot_tree(ws: Workspace, base_sha: str) -> Snapshot:
+def snapshot_tree(ws: Workspace, base_sha: str, exclude: tuple[str, ...] = ()) -> Snapshot:
     """Snapshot the workspace's current CONTENT as a commit parented on
     `base_sha`, without touching the working index, and retain it under a
     unique ref so gc cannot prune it before a queued job materializes it.
+    `exclude` drops those paths (files or whole directories) from the sealed
+    tree — research lines use it to keep the agent's memory out of every
+    MEASURABLE seal (gate candidates, launches) while the notebook seal
+    keeps it (docs/design/research-lines.md).
     """
     # Unique per snapshot: two snapshots against the SAME base run
     # concurrently (the design's paired baseline/candidate fan-out) and must
@@ -137,6 +141,8 @@ def snapshot_tree(ws: Workspace, base_sha: str) -> Snapshot:
         # index (a fresh empty index would drop tracked-but-ignored files)
         run([*git, "read-tree", base_sha], 60)
         run([*git, "add", "-A"], 120)
+        if exclude:
+            run([*git, "rm", "--cached", "-r", "-q", "--ignore-unmatch", "--", *exclude], 60)
         # .gitattributes are KEPT: the job materializes the tree by CHECKOUT
         # (git worktree), which reproduces content faithfully — including
         # .gitattributes — and does NOT apply export-ignore/export-subst

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -93,14 +93,19 @@ class Snapshot:
     ref: str
 
 
-def snapshot_tree(ws: Workspace, base_sha: str, exclude: tuple[str, ...] = ()) -> Snapshot:
+def snapshot_tree(
+    ws: Workspace, base_sha: str, exclude: tuple[str, ...] = (), force: tuple[str, ...] = ()
+) -> Snapshot:
     """Snapshot the workspace's current CONTENT as a commit parented on
     `base_sha`, without touching the working index, and retain it under a
     unique ref so gc cannot prune it before a queued job materializes it.
     `exclude` drops those paths (files or whole directories) from the sealed
     tree — research lines use it to keep the agent's memory out of every
     MEASURABLE seal (gate candidates, launches) while the notebook seal
-    keeps it (docs/design/research-lines.md).
+    keeps it (docs/design/research-lines.md). `force` adds those paths even
+    when the target's ignore rules match them — the notebook seal uses it so
+    a .gitignore entry cannot silently discard session memory; callers pass
+    only paths that exist.
     """
     # Unique per snapshot: two snapshots against the SAME base run
     # concurrently (the design's paired baseline/candidate fan-out) and must
@@ -141,6 +146,8 @@ def snapshot_tree(ws: Workspace, base_sha: str, exclude: tuple[str, ...] = ()) -
         # index (a fresh empty index would drop tracked-but-ignored files)
         run([*git, "read-tree", base_sha], 60)
         run([*git, "add", "-A"], 120)
+        if force:
+            run([*git, "add", "-f", "--", *force], 60)
         if exclude:
             run([*git, "rm", "--cached", "-r", "-q", "--ignore-unmatch", "--", *exclude], 60)
         # .gitattributes are KEPT: the job materializes the tree by CHECKOUT

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -2149,6 +2149,8 @@ def _write_parked_candidate(
     run_id="tsp-1",
     base_branch="main",
     issue_number=0,
+    contract=None,
+    agent_id="",
 ):
     """A candidate-parked run on disk in the REAL park state: HEAD is still the
     pre-session commit, the session's edits are UNCOMMITTED in the working tree,
@@ -2163,7 +2165,7 @@ def _write_parked_candidate(
     state = tmp_path / "state"
     wsroot = state / "runs" / run_id / "ws"
     (wsroot / "src" / "pilot" / "solvers").mkdir(parents=True)
-    (wsroot / ".autoresearch.yaml").write_text(CONTRACT_DISPATCH)
+    (wsroot / ".autoresearch.yaml").write_text(contract or CONTRACT_DISPATCH)
     (wsroot / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): ...\n")
     _git(wsroot, "init", "-q", "-b", "main")
     _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
@@ -2185,6 +2187,9 @@ def _write_parked_candidate(
     _git(tmp_path, "clone", "-q", "--bare", str(wsroot), str(bare))
     _git(wsroot, "remote", "add", "origin", str(bare))
 
+    if agent_id:
+        # a lines run parked here: the local line ref exists from run start
+        _git(wsroot, "branch", f"agents/{agent_id}", base_sha)
     record = RunRecord(
         run_id=run_id,
         target="org/pilot",
@@ -2193,6 +2198,7 @@ def _write_parked_candidate(
         state="waiting",
         resume_session_id="s1",
         issue_number=issue_number,
+        agent_id=agent_id,
         stage={
             "phase": "candidate",
             "base_sha": base_sha,
@@ -3790,3 +3796,82 @@ def test_memory_only_session_measures_nothing(tmp_path, target_repo_lines) -> No
         _git(target_repo_lines, "show", "agents/agent-07:AGENT_MEMORY.md")
         == "- muon low peak seems real\n"
     )
+
+
+def test_notebook_keeps_memory_the_target_gitignores(tmp_path: Path, target_repo) -> None:
+    """A target .gitignore matching the memory paths must not silently
+    discard session memory from the notebook seal."""
+    from autoresearch.attempt import _checkout_line, _push_line_snapshot
+
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    (ws.root / ".gitignore").write_text("AGENT_MEMORY.md\nagent_memory/\n")
+    (ws.root / "AGENT_MEMORY.md").write_text("survives the ignore\n")
+    (ws.root / "agent_memory").mkdir()
+    (ws.root / "agent_memory" / "muon.md").write_text("notes\n")
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "no-improvement")
+    tree = _git(target_repo, "ls-tree", "-r", "--name-only", "agents/agent-07")
+    assert "AGENT_MEMORY.md" in tree and "agent_memory/muon.md" in tree
+
+
+def test_fallback_run_still_excludes_memory_from_the_seal(
+    tmp_path, target_repo_lines, monkeypatch
+) -> None:
+    """A failed line checkout falls back to the base branch, but the memory
+    boundary keys on the CONTRACT: the sealed candidate must still exclude
+    memory paths (else scope config is the only thing keeping them off main)."""
+
+    def broken_checkout(*a, **k):
+        raise RuntimeError("simulated checkout failure")
+
+    monkeypatch.setattr(climb_mod, "_checkout_line", broken_checkout)
+    github = FakeGitHub()
+    with _queued_local([13.876, 13.1]):
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp", agent_id="agent-07"),
+            run_root=tmp_path / "state",
+            run_id="tsp-fallback-1",
+            harness=ScriptedHarness(
+                edits={
+                    "src/pilot/solvers/tsp.py": "def solve(): return 4\n",
+                    "AGENT_MEMORY.md": "- notes\n",
+                }
+            ),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="2026-08-06T00:00:00Z",
+        )
+    assert outcome.outcome == "improved" and len(github.prs) == 1
+    published = _git(target_repo_lines, "ls-tree", "-r", "--name-only", str(github.prs[0]["head"]))
+    assert "src/pilot/solvers/tsp.py" in published and "AGENT_MEMORY.md" not in published
+
+
+def test_wake_terminal_pushes_the_line_notebook(tmp_path, monkeypatch) -> None:
+    """A negative candidate wake on a lines run lands the session's final
+    tree — memory included — on the agent's branch."""
+    state, run_id = _write_parked_candidate(
+        tmp_path,
+        monkeypatch,
+        values={"baseline": 13.0, "candidate": 13.0},
+        contract=CONTRACT_DISPATCH.replace(
+            "    direction: min\n", "    direction: min\n    lines: true\n"
+        ),
+        agent_id="agent-07",
+    )
+    wsroot = state / "runs" / run_id / "ws"
+    (wsroot / "AGENT_MEMORY.md").write_text("- candidate was flat\n")
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert outcome.outcome == "no-improvement"
+    bare = tmp_path / f"origin-{run_id}.git"
+    tree = _git(bare, "ls-tree", "-r", "--name-only", "agents/agent-07")
+    assert "AGENT_MEMORY.md" in tree
+    msg = _git(bare, "log", "-1", "--format=%s", "agents/agent-07").strip()
+    assert run_id in msg and "no-improvement" in msg

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3712,9 +3712,9 @@ def test_push_line_snapshot_publishes_session_commits(tmp_path: Path, target_rep
 
 
 def test_improved_terminal_notebook_names_the_final_outcome(tmp_path, target_repo_lines) -> None:
-    """The notebook snapshot lands AFTER the publish settles: an improved
-    run's line tip carries the published candidate plus its ledger commit,
-    and the message names the final outcome."""
+    """An improved run's notebook seals BEFORE the publish mutates the tree
+    (memory survives) and the message names the gate outcome; the ledger
+    stays on main and reaches the line at the next run-start merge."""
     github = FakeGitHub()
     queue = [13.876, 13.1]  # improvement: PR + ledger
     with _queued_local(queue):
@@ -3732,4 +3732,61 @@ def test_improved_terminal_notebook_names_the_final_outcome(tmp_path, target_rep
     msg = _git(target_repo_lines, "log", "-1", "--format=%s", "agents/agent-07").strip()
     assert "tsp-lines-2" in msg and "improved" in msg
     tree = _git(target_repo_lines, "ls-tree", "-r", "--name-only", "agents/agent-07")
-    assert "results/leader.json" in tree  # the ledger commit rode the notebook
+    assert "src/pilot/solvers/tsp.py" in tree  # the session's final tree
+    assert "results/leader.json" not in tree  # the ledger lives on main
+
+
+def test_line_memory_never_reaches_a_measurable_seal(tmp_path, target_repo_lines) -> None:
+    """The memory boundary end to end: memory edits are neither scope
+    violations nor part of the sealed candidate the PR publishes — but the
+    notebook keeps them."""
+    github = FakeGitHub()
+    queue = [13.876, 13.1]  # improvement
+    with _queued_local(queue):
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp", agent_id="agent-07"),
+            run_root=tmp_path / "state",
+            run_id="tsp-mem-1",
+            harness=ScriptedHarness(
+                edits={
+                    "src/pilot/solvers/tsp.py": "def solve(): return 3\n",
+                    "AGENT_MEMORY.md": "- depth pays\n",
+                    "agent_memory/muon.md": "peak lr notes\n",
+                }
+            ),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="2026-08-06T00:00:00Z",
+        )
+    # memory at the repo root is OUTSIDE scope.allowed — with the boundary it
+    # is not a violation, and the improvement publishes
+    assert outcome.outcome == "improved" and len(github.prs) == 1
+    published = _git(target_repo_lines, "ls-tree", "-r", "--name-only", str(github.prs[0]["head"]))
+    assert "src/pilot/solvers/tsp.py" in published
+    assert "AGENT_MEMORY.md" not in published and "agent_memory/muon.md" not in published
+    notebook = _git(target_repo_lines, "ls-tree", "-r", "--name-only", "agents/agent-07")
+    assert "AGENT_MEMORY.md" in notebook and "agent_memory/muon.md" in notebook
+
+
+def test_memory_only_session_measures_nothing(tmp_path, target_repo_lines) -> None:
+    """A session that only wrote memory claims nothing: the unmeasured lane
+    ends it, and the notebook still preserves the memory."""
+    github = FakeGitHub()
+    with _queued_local([13.876]):
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp", agent_id="agent-07"),
+            run_root=tmp_path / "state",
+            run_id="tsp-mem-2",
+            harness=ScriptedHarness(edits={"AGENT_MEMORY.md": "- muon low peak seems real\n"}),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="2026-08-06T00:00:00Z",
+        )
+    assert outcome.outcome == "no-improvement"
+    assert github.prs == []
+    assert (
+        _git(target_repo_lines, "show", "agents/agent-07:AGENT_MEMORY.md")
+        == "- muon low peak seems real\n"
+    )

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -460,3 +460,22 @@ def test_job_tmp_lives_on_node_local_scratch(tmp_path: Path) -> None:
     text = Path(script).read_text()
     assert '--workdir "$SCRATCH/work"' in text
     assert 'mkdir -p "$SCRATCH/cache" "$SCRATCH/home" "$SCRATCH/work"' in text
+
+
+def test_snapshot_exclude_drops_files_and_directories(tmp_path):
+    root = _repo(tmp_path)
+    ws = _WS(root)
+    base = ws.git("rev-parse", "HEAD")
+    (root / "kept.py").write_text("x = 2\n")
+    (root / "AGENT_MEMORY.md").write_text("beliefs\n")
+    (root / "agent_memory").mkdir()
+    (root / "agent_memory" / "muon.md").write_text("notes\n")
+    snap = snapshot_tree(ws, base, exclude=("AGENT_MEMORY.md", "agent_memory"))  # type: ignore[arg-type]
+    files = ws.git("ls-tree", "-r", "--name-only", snap.commit).splitlines()
+    assert "kept.py" in files
+    assert not any(f == "AGENT_MEMORY.md" or f.startswith("agent_memory/") for f in files)
+    # the exclusion touches only the seal: the working tree keeps the files
+    assert (root / "AGENT_MEMORY.md").exists() and (root / "agent_memory" / "muon.md").exists()
+    # and an empty exclude still seals them
+    full = snapshot_tree(ws, base)  # type: ignore[arg-type]
+    assert "AGENT_MEMORY.md" in ws.git("ls-tree", "-r", "--name-only", full.commit).splitlines()


### PR DESCRIPTION
PR 3 of 3 for docs/design/research-lines.md Phase 1 (#204; substrate #206; terminal push #207).

Scoping this surfaced an interaction the design doc missed: on a lines run, memory edits would appear in `changed_paths` and trip the scope check — the feature would self-destruct on the first memory write. And the naive fixes are both wrong: filtering scope alone lets memory ride the sealed candidate into a main PR; stripping at publish breaks the sealed-sha invariant (published tree ≠ measured tree) and opens a gaming vector (stash load-bearing content in "memory", get it measured, watch CI diverge).

The invariant-preserving cut: **memory is excluded from every measurable seal at snapshot time.**

- `snapshot_tree(ws, base, exclude=())`: drops the given paths from the sealed tree (index-only; the working tree keeps the files). Lines runs pass `("AGENT_MEMORY.md", "agent_memory")` on the gate/launch/preseal closures (fresh and wake); the notebook seal passes nothing.
- `changed_paths` filters memory paths on lines runs: never a scope violation, never claimable work. A memory-only session lands in the existing unmeasured panel-only lane (#202) — and the notebook still preserves the memory.
- The notebook seal moved BEFORE the publish block: the improved-publish force-checkout + `clean -fd` would otherwise delete the (unsealed-by-design) memory files from the working tree. It labels with the gate outcome — factually right at that moment; a publish failure appends a `publish-error` snapshot, so the notebook records both the real measurement and how the run ended. The reconcile path is covered by the same pre-publish seal.
- Consequence made explicit in a test: the ledger commit (results/leader.json) no longer rides the notebook — it lives on main and reaches the line at the next run-start merge.
- Brief's line section now tells the agent its memory lives on the branch alone and can never carry anything a run depends on; the design doc's "mechanically rejects" wording replaced with these seal-boundary mechanics.

Feature remains inert (no contract sets `lines: true`). With this, Phase 1 is complete; Phase 2 (render the memory index into the brief) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
