### PR TITLE
Research lines Phase 3: extraction hygiene

### DIFF
--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1940,6 +1940,29 @@ def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str
     return tuple(lenses), tuple(dict.fromkeys(secrets))
 
 
+def _panel_claim_body(
+    benchmark: str, baseline: float, candidate: float, report: str, *, lines: bool
+) -> str:
+    """The synthetic claim the panel judges. On a research-lines target the
+    one-contribution mandate is part of the claim itself: the panel is the
+    backstop against a line's accumulated tweaks reaching main as one PR
+    (docs/design/research-lines.md)."""
+    mandate = (
+        "\n\nThis target runs research lines: a PR to main must be ONE "
+        "clean contribution, extracted onto the base branch. A diff that "
+        "bundles unrelated or unablated changes is a BLOCKING finding — "
+        "name the pieces that should be separated."
+        if lines
+        else ""
+    )
+    return (
+        f"Automated improvement claim (pre-PR): {benchmark} "
+        f"{baseline} -> {candidate}, measured by the orchestrator.{mandate}\n\n"
+        f"## Research report\n\n*Session prose, written before "
+        f"the orchestrator measured.*\n\n{report[:MAX_CLAIM_CHARS]}"
+    )
+
+
 def build_panel_runner(
     ws: Workspace,
     run_dir: Path,
@@ -2010,12 +2033,7 @@ def build_panel_runner(
                 repo=target,
                 number=0,
                 title=f"[agent] {benchmark}: {_title_pair(baseline, candidate)}",
-                body=(
-                    f"Automated improvement claim (pre-PR): {benchmark} "
-                    f"{baseline} -> {candidate}, measured by the orchestrator.\n\n"
-                    f"## Research report\n\n*Session prose, written before "
-                    f"the orchestrator measured.*\n\n{report[:MAX_CLAIM_CHARS]}"
-                ),
+                body=_panel_claim_body(benchmark, baseline, candidate, report, lines=bool(exclude)),
                 # base..snapshot, never base..worktree: the snapshot commit
                 # includes newly ADDED files, which a working-tree diff omits
                 diff=ws.git("diff", f"{base_sha}..{snapshot}"),
@@ -2146,6 +2164,7 @@ def live_attempt(
                 _best_effort("line merge abort", lambda: ws.git("merge", "--abort"))
                 ws.git("checkout", "-q", "-B", base_branch, f"origin/{base_branch}")
         line_memory = ""
+        line_divergence = ""
         if line_ref:
             salvage.update(ws=ws, line_ref=line_ref)
             try:
@@ -2159,6 +2178,15 @@ def live_attempt(
                         line_memory = fh.read(65_536).decode("utf-8", errors="replace")
             except OSError as exc:
                 log.warning("could not read AGENT_MEMORY.md: %s", exc)
+            try:
+                # divergence debt, made visible each session (a conflicted
+                # merge skips it — the diff is not meaningful mid-merge)
+                if not ws.git("diff", "--name-only", "--diff-filter=U").strip():
+                    line_divergence = ws.git(
+                        "diff", "--shortstat", f"origin/{base_branch}", "HEAD"
+                    ).strip()
+            except Exception:
+                line_divergence = ""
         author_syscalls = (
             dispatch is not None
             and getattr(harness, "supports_resume", True)
@@ -2344,6 +2372,7 @@ def live_attempt(
                 brief_baseline=prior_best.best if prior_best else None,
                 line_ref=line_ref,
                 line_memory=line_memory,
+                line_divergence=line_divergence,
                 launcher=launcher,
                 tree_of=lambda sha: ws.git("rev-parse", f"{sha}^{{tree}}").strip(),
             )

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -147,6 +147,9 @@ class SessionBrief:
     # The line's AGENT_MEMORY.md content — the agent's own memory index,
     # rendered data-fenced; "" = no memory yet (or the feature is off).
     memory: str = ""
+    # git shortstat of line vs base at run start — divergence debt, visible
+    # every session; "" = none (or the feature is off).
+    line_divergence: str = ""
 
     def to_json(self) -> str:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
@@ -169,6 +172,7 @@ class SessionBrief:
             eval_minutes_default=data.get("eval_minutes_default", 0),
             line_ref=data.get("line_ref", ""),
             memory=data.get("memory", ""),
+            line_divergence=data.get("line_divergence", ""),
         )
 
 
@@ -189,6 +193,7 @@ class BriefInputs:
     eval_minutes_default: int = 0
     line_ref: str = ""  # research lines: the agent's own branch; "" = off
     memory: str = ""  # the line's AGENT_MEMORY.md, raw; build_brief caps it
+    line_divergence: str = ""  # shortstat of line vs base at run start
 
 
 def _cap(text: str, limit: int) -> str:
@@ -227,6 +232,7 @@ def build_brief(inputs: BriefInputs, created: str) -> SessionBrief:
         eval_minutes_default=inputs.eval_minutes_default,
         line_ref=inputs.line_ref,
         memory=_cap(inputs.memory, MAX_MEMORY_CHARS),
+        line_divergence=_cap(inputs.line_divergence, 200),
     )
 
 
@@ -301,6 +307,13 @@ def render(brief: SessionBrief) -> str:
             "it is excluded from measured trees and can never carry "
             "anything a run depends on.",
         ]
+        if brief.line_divergence:
+            parts += [
+                f"Your line currently differs from the base branch by: "
+                f"{brief.line_divergence}. That distance is debt you pay at "
+                "every merge and every extraction — keep what earns its "
+                "keep, retire what does not.",
+            ]
         if brief.memory:
             fence = _fence(brief.memory)
             parts += [

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -310,9 +310,9 @@ def render(brief: SessionBrief) -> str:
         if brief.line_divergence:
             parts += [
                 f"Your line currently differs from the base branch by: "
-                f"{brief.line_divergence}. That distance is debt you pay at "
-                "every merge and every extraction — keep what earns its "
-                "keep, retire what does not.",
+                f"{brief.line_divergence}. Each merge and extraction is "
+                "harder when this difference is large, so keep only changes "
+                "you still need.",
             ]
         if brief.memory:
             fence = _fence(brief.memory)

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -1096,6 +1096,7 @@ def attempt_once(
     brief_baseline: float | None = None,
     line_ref: str = "",
     line_memory: str = "",
+    line_divergence: str = "",
     resume_session_id: str = "",
     improve_prompt: str = "",
     launcher: Callable[[str, SyscallRequest], str] | None = None,
@@ -1172,6 +1173,7 @@ def attempt_once(
         or created
         or line_ref
         or line_memory
+        or line_divergence
         or brief_baseline is not None
     ):
         # a resume skips build_brief entirely (the session already carries this
@@ -1187,7 +1189,8 @@ def attempt_once(
         raise ValueError(
             "resume_session_id resumes an existing session (no fresh brief); the brief-only "
             "inputs (task_hypothesis/lessons/recent_reports/report_archive/created/"
-            "line_ref/line_memory/brief_baseline) have no effect on a resume — omit them"
+            "line_ref/line_memory/line_divergence/brief_baseline) have no effect on a "
+            "resume — omit them"
         )
 
     # deferred like measure_and_decide's import (measure -> dispatch ->
@@ -1244,6 +1247,7 @@ def attempt_once(
                 eval_minutes_default=bench.eval_minutes or 0,
                 line_ref=line_ref,
                 memory=line_memory,
+                line_divergence=line_divergence,
             ),
             created=created,
         )

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3905,3 +3905,38 @@ def test_line_memory_reaches_the_next_session_brief(tmp_path: Path, target_repo_
     assert "# Your memory (AGENT_MEMORY.md" in brief
     assert "- depth pays, width unclear" in brief
     assert "Maintain the memory before you finish" in brief
+
+
+def test_panel_claim_carries_the_one_contribution_mandate() -> None:
+    from autoresearch.attempt import _panel_claim_body
+
+    lines = _panel_claim_body("tsp", 13.8, 13.1, "report text", lines=True)
+    assert "ONE clean contribution" in lines and "BLOCKING finding" in lines
+    plain = _panel_claim_body("tsp", 13.8, 13.1, "report text", lines=False)
+    assert "ONE clean contribution" not in plain
+    assert "measured by the orchestrator" in plain
+
+
+def test_line_divergence_reaches_the_brief(tmp_path: Path, target_repo_lines) -> None:
+    _push_line(tmp_path, target_repo_lines, {"docs/line-note.md": "belief\n"})
+
+    class BriefCapture2(ScriptedHarness):
+        seen: ClassVar[dict] = {}
+
+        def run(self, brief_text, workspace, resume_session_id=None):
+            BriefCapture2.seen["brief"] = brief_text
+            return super().run(brief_text, workspace, resume_session_id)
+
+    with _queued_local([13.876, 14.5]):
+        live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp", agent_id="agent-07"),
+            run_root=tmp_path / "state",
+            run_id="tsp-div-1",
+            harness=BriefCapture2(edits={}),
+            github=FakeGitHub(),  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="2026-08-06T00:00:00Z",
+        )
+    brief = str(BriefCapture2.seen["brief"])
+    assert "differs from the base branch by: 1 file changed" in brief

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -308,3 +308,22 @@ def test_memory_index_is_capped_and_round_trips() -> None:
     )
     assert len(brief.memory) == MAX_MEMORY_CHARS
     assert SessionBrief.from_json(brief.to_json()).memory == brief.memory
+
+
+def test_brief_renders_the_divergence_stat() -> None:
+    on = render(
+        build_brief(
+            make_inputs(
+                line_ref="agents/agent-07",
+                line_divergence="3 files changed, 40 insertions(+), 2 deletions(-)",
+            ),
+            created="t",
+        )
+    )
+    assert "differs from the base branch by: 3 files changed" in on
+    off = render(build_brief(make_inputs(line_ref="agents/agent-07"), created="t"))
+    assert "differs from the base branch" not in off
+    brief = build_brief(
+        make_inputs(line_ref="agents/agent-07", line_divergence="1 file changed"), created="t"
+    )
+    assert SessionBrief.from_json(brief.to_json()).line_divergence == "1 file changed"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -209,8 +209,9 @@ def test_resume_entry_rejects_brief_only_inputs(tmp_path: Path) -> None:
         {"created": "2026-08-06T00:00:00Z"},
         {"line_ref": "agents/agent-07"},
         {"line_memory": "- depth pays"},
+        {"line_divergence": "1 file changed"},
         {"brief_baseline": 13.876},
-    ):  # every one of the eight guarded brief-only inputs, so dropping any regresses
+    ):  # every one of the nine guarded brief-only inputs, so dropping any regresses
         with pytest.raises(ValueError, match="no effect on a resume"):
             run_climb(
                 tmp_path,


### PR DESCRIPTION
Phase 3 of docs/design/research-lines.md (#204; earlier phases #206–#209). The extraction workflow itself has lived in the brief's line section since #206; this adds its two enforcement/visibility halves:

- **Panel mandate**: `_panel_claim_body` (factored out, unit-tested) appends the one-contribution mandate to the synthetic claim when the target runs lines — a diff that bundles unrelated or unablated changes is a BLOCKING finding, with instructions to name the pieces to separate. Signal is the existing memory-exclusion flag, so there is exactly one lines-active source per call site.
- **Divergence advisory**: run start computes `git diff --shortstat base..HEAD` on the checked-out line (best-effort; skipped mid-conflict where the diff is meaningless) and the brief renders it as debt paid at every merge and extraction. Capped, round-tripped, resume-guarded (the guard test now enumerates nine brief-only inputs).
- e2e: a divergent line's shortstat reaches the next session's brief through `live_attempt`.

With this, the full lines design is built end to end and still inert — flipping `lines: true` on gpt-speedrun's contract is now purely a deployment decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
