### PR TITLE
PR branches name the agent that made them

### DIFF
--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -2776,10 +2776,20 @@ def main() -> int:
     # on a --resume wake instead, so they are optional (validated below).
     parser.add_argument("--target", default="")
     parser.add_argument("--benchmark", default="")
+
     # WIDTH: the tick assigns each concurrent slot its own agent identity;
     # branches, ledger rows, and reports key on it. Resumed runs inherit
     # the identity from their record instead.
-    parser.add_argument("--agent-id", default="agent-01")
+    def _agent_id(value: str) -> str:
+        # the id shapes refs (feat/auto/<id>/<run>, agents/<id>): slug only —
+        # same rule the line checkout enforces
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", value):
+            raise argparse.ArgumentTypeError(
+                f"agent id {value!r} cannot shape a git ref (want [A-Za-z0-9][A-Za-z0-9_-]*)"
+            )
+        return value
+
+    parser.add_argument("--agent-id", default="agent-01", type=_agent_id)
     parser.add_argument("--run-root", required=True, type=Path)
     parser.add_argument(
         "--resume",

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -408,7 +408,6 @@ def _metric_from_output(stdout: str, metric: str) -> float | None:
 class RunConfig:
     target: str  # owner/repo
     benchmark: str  # the ONE benchmark this loop works on
-    branch_prefix: str = "feat/auto/agent-01"
     agent_id: str = "agent-01"
     # Commits are AUTHORED as the bot account (a real GitHub identity):
     # a bare "agent-01" noreply address links to whoever owns that login.
@@ -418,6 +417,14 @@ class RunConfig:
     # configurable later; this is the loop-side floor)
     min_relative_improvement: float = 0.005
     budget: BudgetState = field(default_factory=lambda: BudgetState(0.0, 1))
+
+    @property
+    def branch_prefix(self) -> str:
+        # derived, never stored: every call site passed agent_id but left the
+        # old field at its default, so every PR branch said agent-01. An
+        # empty agent id (a legacy record) keeps the old spelling rather
+        # than minting "feat/auto//<run>".
+        return f"feat/auto/{self.agent_id or 'agent-01'}"
 
 
 @dataclass(frozen=True)

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -421,10 +421,15 @@ class RunConfig:
     @property
     def branch_prefix(self) -> str:
         # derived, never stored: every call site passed agent_id but left the
-        # old field at its default, so every PR branch said agent-01. An
-        # empty agent id (a legacy record) keeps the old spelling rather
-        # than minting "feat/auto//<run>".
-        return f"feat/auto/{self.agent_id or 'agent-01'}"
+        # old field at its default, so every PR branch said agent-01. An id
+        # that cannot shape a ref — empty, or a malformed value an old CLI
+        # accepted into a record — keeps the old spelling rather than
+        # handing git an invalid branch name at publish.
+        import re
+
+        if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", self.agent_id or ""):
+            return f"feat/auto/{self.agent_id}"
+        return "feat/auto/agent-01"
 
 
 @dataclass(frozen=True)

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3940,3 +3940,15 @@ def test_line_divergence_reaches_the_brief(tmp_path: Path, target_repo_lines) ->
         )
     brief = str(BriefCapture2.seen["brief"])
     assert "differs from the base branch by: 1 file changed" in brief
+
+
+def test_cli_rejects_ref_shaping_agent_ids(capsys, monkeypatch) -> None:
+    from autoresearch.attempt import main as climb_main
+
+    for bad in ("bad id", "bad..id", "-leading", "a/b"):
+        monkeypatch.setattr(
+            "sys.argv", ["climb", "--target", "o/r", "--benchmark", "b", "--agent-id", bad]
+        )
+        with pytest.raises(SystemExit):
+            climb_main()
+        assert "cannot shape a git ref" in capsys.readouterr().err

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3945,7 +3945,9 @@ def test_line_divergence_reaches_the_brief(tmp_path: Path, target_repo_lines) ->
 def test_cli_rejects_ref_shaping_agent_ids(capsys, monkeypatch) -> None:
     from autoresearch.attempt import main as climb_main
 
-    for bad in ("bad id", "bad..id", "-leading", "a/b"):
+    # "-leading" is not here: argparse consumes it as an option flag and
+    # rejects it on its own ("expected one argument")
+    for bad in ("bad id", "bad..id", "a/b", "_leading"):
         monkeypatch.setattr(
             "sys.argv", ["climb", "--target", "o/r", "--benchmark", "b", "--agent-id", bad]
         )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1696,3 +1696,13 @@ def test_gate_rejects_an_exact_floor_delta(tmp_path: Path) -> None:
     # delta exactly at the floor is the noise the floor models (terra #169)
     result, _, _ = run_climb(tmp_path, [13.876, 13.376], contract=FLOOR_CONTRACT)
     assert result.outcome == "no-improvement"
+
+
+def test_branch_prefix_derives_from_the_agent_id() -> None:
+    assert RunConfig(target="o/r", benchmark="b", agent_id="agent-02").branch_prefix == (
+        "feat/auto/agent-02"
+    )
+    # a legacy record with no agent id keeps the old spelling, never "//"
+    assert RunConfig(target="o/r", benchmark="b", agent_id="").branch_prefix == (
+        "feat/auto/agent-01"
+    )

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1702,7 +1702,9 @@ def test_branch_prefix_derives_from_the_agent_id() -> None:
     assert RunConfig(target="o/r", benchmark="b", agent_id="agent-02").branch_prefix == (
         "feat/auto/agent-02"
     )
-    # a legacy record with no agent id keeps the old spelling, never "//"
-    assert RunConfig(target="o/r", benchmark="b", agent_id="").branch_prefix == (
-        "feat/auto/agent-01"
-    )
+    # a legacy record with no agent id — or a malformed one an old CLI let
+    # into a record — keeps the old spelling, never an invalid ref
+    for legacy in ("", "bad..id", "bad id", "a/b"):
+        assert RunConfig(target="o/r", benchmark="b", agent_id=legacy).branch_prefix == (
+            "feat/auto/agent-01"
+        )


### PR DESCRIPTION
Every agent PR branch said feat/auto/agent-01 regardless of the actual agent (gpt-speedrun PR #3, an agent-02 run, lived on an agent-01-prefixed branch): both RunConfig call sites passed agent_id but left branch_prefix at its default. The field is now a derived property — feat/auto/<agent_id>, with the legacy spelling for an empty agent id so old records never mint feat/auto//<run>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)