### PR TITLE
A conflicted PR wakes its author

### DIFF
--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from autoresearch.brief import render_review_wake
 from autoresearch.contract import load_contract
-from autoresearch.github import GitHubClient, Workspace
+from autoresearch.github import GitHubClient, NothingToCommit, Workspace
 from autoresearch.harness import Harness, outage, redact
 from autoresearch.orchestrator import (
     Evaluator,
@@ -533,13 +533,33 @@ def _respond(
         except Exception:
             return False
 
-    changed = _changed_paths(ws)
+    branch = _current_branch(ws)
+    committed: list[str] = []
+    try:
+        # a session that COMMITTED its work (a resolved merge commit is the
+        # normal shape) leaves the working tree clean — the diff against the
+        # PR branch's pushed tip is where those changes show
+        committed = [
+            p
+            for p in ws.git("diff", "--name-only", f"origin/{branch}..HEAD").splitlines()
+            if p.strip()
+        ]
+    except Exception:
+        committed = []
+
+    def _revert_response() -> None:
+        # drop working-tree edits AND any local commits past the pushed tip
+        ws.git("checkout", "--", ".")
+        ws.git("clean", "-fdq")
+        if committed:
+            ws.git("reset", "--hard", f"origin/{branch}")
+
+    changed = sorted(set(_changed_paths(ws)) | set(committed))
     if changed:
         violations = [p for p in scope_check(changed, contract) if not _matches_base(p)]
         if violations:
             # revert the out-of-scope response; reply honestly, keep the PR
-            ws.git("checkout", "--", ".")
-            ws.git("clean", "-fdq")
+            _revert_response()
             measured_note = (
                 "\n\n_(A code change was attempted but touched paths outside "
                 "the contract's scope and was not applied.)_"
@@ -562,8 +582,7 @@ def _respond(
                         workspace, bench.command, bench.metric, extra_env=seed_env
                     )
             except Exception as exc:
-                ws.git("checkout", "--", ".")
-                ws.git("clean", "-fdq")
+                _revert_response()
                 measured_note = (
                     "\n\n_(A code change was attempted but the eval failed on "
                     f"it, so it was not applied: {redact(str(exc), secrets)[:200]})_"
@@ -572,8 +591,7 @@ def _respond(
                 if _tree_hash(ws) != pre_eval_tree:
                     # same drift rule as the climb: the pushed tree must be
                     # exactly the measured tree
-                    ws.git("checkout", "--", ".")
-                    ws.git("clean", "-fdq")
+                    _revert_response()
                     measured_note = (
                         "\n\n_(A code change was attempted but the tree "
                         "changed during measurement, so it was not applied.)_"
@@ -672,27 +690,33 @@ def _respond(
                             disarmed = False
                             log.warning("auto-merge disarm errored: %s", exc)
                     if not disarmed:
-                        ws.git("checkout", "--", ".")
-                        ws.git("clean", "-fdq")
+                        _revert_response()
                         measured_note = (
                             "\n\n_(A code change was validated but WITHHELD: "
                             "auto-merge could not be confirmed disarmed on this "
                             "auto-mode PR; the follow-up will retry.)_"
                         )
                     else:
-                        branch = _current_branch(ws)
                         verb = "steward" if is_steward else "agent"
-                        ws.commit_all(
-                            f"{verb}: address review feedback "
-                            f"({bench.metric}={fmt_metric(candidate, bench.display_digits)})"
-                            f"\n\nAgent: {record.agent_id}",
-                            author=bot_login,
-                            forbidden=lambda p: (
-                                p not in PROGRESS_PATHS
-                                and bool(scope_check([p], contract))
-                                and not _matches_base(p)
-                            ),
-                        )
+                        # a session that committed its work (a resolved merge)
+                        # leaves nothing to stage; the committed diff was
+                        # already scope-checked above, so push what is there
+                        try:
+                            ws.commit_all(
+                                f"{verb}: address review feedback "
+                                f"({bench.metric}="
+                                f"{fmt_metric(candidate, bench.display_digits)})"
+                                f"\n\nAgent: {record.agent_id}",
+                                author=bot_login,
+                                forbidden=lambda p: (
+                                    p not in PROGRESS_PATHS
+                                    and bool(scope_check([p], contract))
+                                    and not _matches_base(p)
+                                ),
+                            )
+                        except NothingToCommit:
+                            if not committed:
+                                raise
                         ws.push(branch)
                         change_pushed = True
                         worse = prior is not None and not orch_improved(

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -128,6 +128,28 @@ def context_comments(comments: list[dict], since_id: int) -> list[tuple[str, str
     return picked[-MAX_CONTEXT_COMMENTS:]
 
 
+def dirty_pr_head(pr: dict) -> str:
+    """The head sha when an OPEN PR conflicts with its base, else "".
+    GitHub computes mergeability lazily: mergeable None means unknown (not
+    dirty), so a fresh PR never false-positives — the next tick re-asks."""
+    if pr.get("state") != "open" or pr.get("merged"):
+        return ""
+    if pr.get("mergeable") is False or pr.get("mergeable_state") == "dirty":
+        return str((pr.get("head") or {}).get("sha", ""))
+    return ""
+
+
+def needs_conflict_wake(record: RunRecord, github: GitHubClient) -> bool:
+    """Tick-side gate (cheap, read-only): an in-review PR that conflicts
+    with its base and has not been woken for THIS head yet."""
+    try:
+        pr = github.get_pull_request(record.target, _pr_number(record.pr_url))
+    except Exception:
+        return False
+    head = dirty_pr_head(pr)
+    return bool(head) and head != record.dirty_wake_head
+
+
 def qualifying_comments(
     comments: list[dict], bot_login: str, since_id: int
 ) -> list[tuple[int, str, str]]:
@@ -346,7 +368,9 @@ def _respond(
         for source, (items, _) in per_source.items()
         for cid, author, body in items
     ]
-    if not merged:
+    conflict_head = dirty_pr_head(pr)
+    conflict_wake = bool(conflict_head) and conflict_head != record.dirty_wake_head
+    if not merged and not conflict_wake:
         return FollowupOutcome(run_id, "no-op", "no new qualifying comments")
     # oldest first WITHIN each source (ids are monotonic per source); cap the
     # wake, and advance each cursor only to the max id actually processed
@@ -390,6 +414,25 @@ def _respond(
     spec = replace(spec, key="steward" if is_steward else "author", scope=tuple(owned))
 
     prompt = render_review_wake([(author, body) for _, author, body in comments])
+    if conflict_wake:
+        base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
+        try:
+            # the session has no credentials; fetch on its behalf so
+            # origin/<base> is current in the workspace
+            ws.git_network("fetch", "origin", base_ref)
+        except Exception as exc:
+            log.warning("conflict-wake fetch failed for %s: %s", run_id, exc)
+        prompt = (
+            "# Your PR conflicts with its base\n"
+            f"`{base_ref}` moved and this PR no longer merges cleanly. "
+            f"`origin/{base_ref}` has been fetched into your workspace. "
+            "Merge it into the PR branch and resolve the conflicts "
+            "honestly — the PR stays ONE clean contribution, so if the "
+            "conflict shows your change is superseded by what landed, say "
+            "so plainly instead of forcing it (a maintainer will close the "
+            "PR). Any change you keep is re-measured before it is pushed, "
+            "and auto-merge stays off — a human merges the updated PR.\n\n"
+        ) + prompt
     if is_steward:
         from autoresearch.steward import STEWARD_WAKE_PREAMBLE
 
@@ -453,9 +496,23 @@ def _respond(
     measured_note = ""
     change_pushed = False
 
+    base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
+
+    def _matches_base(path: str) -> bool:
+        # content identical to origin/<base> is the base branch's own (a
+        # merge brings it in); it can neither smuggle nor exceed scope.
+        # Blob-hash comparison: `git diff <commit> -- path` would call an
+        # UNTRACKED working file "deleted" instead of reading its content.
+        try:
+            local = ws.git("hash-object", "--", path).strip()
+            base = ws.git("rev-parse", f"origin/{base_ref}:{path}").strip()
+            return bool(local) and local == base
+        except Exception:
+            return False
+
     changed = _changed_paths(ws)
     if changed:
-        violations = scope_check(changed, contract)
+        violations = [p for p in scope_check(changed, contract) if not _matches_base(p)]
         if violations:
             # revert the out-of-scope response; reply honestly, keep the PR
             ws.git("checkout", "--", ".")
@@ -608,7 +665,9 @@ def _respond(
                             f"\n\nAgent: {record.agent_id}",
                             author=bot_login,
                             forbidden=lambda p: (
-                                p not in PROGRESS_PATHS and bool(scope_check([p], contract))
+                                p not in PROGRESS_PATHS
+                                and bool(scope_check([p], contract))
+                                and not _matches_base(p)
                             ),
                         )
                         ws.push(branch)
@@ -660,6 +719,7 @@ def _respond(
             last_comment_id=cursors["comment"],
             last_review_id=cursors["review"],
             last_review_comment_id=cursors["review_comment"],
+            dirty_wake_head=conflict_head if conflict_wake else record.dirty_wake_head,
             resume_session_id=session.session_id or record.resume_session_id,
             wake_attempts=0,  # progress: the retry cap starts fresh
         ),

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -413,15 +413,29 @@ def _respond(
     )
     spec = replace(spec, key="steward" if is_steward else "author", scope=tuple(owned))
 
+    # Every wake needs a CURRENT origin/<base>: the conflict wake tells the
+    # session to merge it, and the scope check's base-content exemption must
+    # never compare against a stale ref (old base content could smuggle).
+    # The session has no credentials, so the kernel fetches on its behalf.
+    base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
+    base_fetched = False
+    try:
+        ws.git_network("fetch", "origin", base_ref)
+        base_fetched = True
+    except Exception as exc:
+        log.warning("base fetch failed for %s: %s", run_id, exc)
+    if conflict_wake and not base_fetched:
+        # never tell the session the base was fetched when it was not, and
+        # never spend the once-per-head cursor on a failed setup — the next
+        # tick retries the whole wake
+        conflict_wake = False
+        if not merged:
+            return FollowupOutcome(
+                run_id, "error", "conflict wake: base fetch failed; retrying next tick"
+            )
+
     prompt = render_review_wake([(author, body) for _, author, body in comments])
     if conflict_wake:
-        base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
-        try:
-            # the session has no credentials; fetch on its behalf so
-            # origin/<base> is current in the workspace
-            ws.git_network("fetch", "origin", base_ref)
-        except Exception as exc:
-            log.warning("conflict-wake fetch failed for %s: %s", run_id, exc)
         prompt = (
             "# Your PR conflicts with its base\n"
             f"`{base_ref}` moved and this PR no longer merges cleanly. "
@@ -496,17 +510,26 @@ def _respond(
     measured_note = ""
     change_pushed = False
 
-    base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
-
     def _matches_base(path: str) -> bool:
         # content identical to origin/<base> is the base branch's own (a
-        # merge brings it in); it can neither smuggle nor exceed scope.
+        # merge brings it in); it can neither smuggle nor exceed scope. Only
+        # against a FRESHLY fetched ref — stale base content must not vouch.
         # Blob-hash comparison: `git diff <commit> -- path` would call an
         # UNTRACKED working file "deleted" instead of reading its content.
+        # A deletion matches when the base deleted the path too.
+        if not base_fetched:
+            return False
         try:
-            local = ws.git("hash-object", "--", path).strip()
-            base = ws.git("rev-parse", f"origin/{base_ref}:{path}").strip()
-            return bool(local) and local == base
+            base_blob = ws.git("rev-parse", f"origin/{base_ref}:{path}").strip()
+        except Exception:
+            base_blob = ""  # absent on base
+        local_path = Path(ws.root) / path
+        if not local_path.exists():
+            return not base_blob  # both absent: a base-side deletion merged in
+        if not base_blob:
+            return False
+        try:
+            return ws.git("hash-object", "--", path).strip() == base_blob
         except Exception:
             return False
 

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -139,15 +139,22 @@ def dirty_pr_head(pr: dict) -> str:
     return ""
 
 
-def needs_conflict_wake(record: RunRecord, github: GitHubClient) -> bool:
-    """Tick-side gate (cheap, read-only): an in-review PR that conflicts
-    with its base and has not been woken for THIS head yet."""
+def conflict_wake_action(record: RunRecord, github: GitHubClient) -> str:
+    """Tick-side gate (cheap, read-only): "wake" for an in-review PR that
+    conflicts with its base and has not been woken for THIS head yet;
+    "clear" when a previously-woken PR is clean again (base moved back or
+    forward past the conflict — the same head can conflict AGAIN later and
+    must be able to re-wake); "" otherwise."""
     try:
         pr = github.get_pull_request(record.target, _pr_number(record.pr_url))
     except Exception:
-        return False
+        return ""
     head = dirty_pr_head(pr)
-    return bool(head) and head != record.dirty_wake_head
+    if head and head != record.dirty_wake_head:
+        return "wake"
+    if not head and record.dirty_wake_head and pr.get("mergeable") is True:
+        return "clear"
+    return ""
 
 
 def qualifying_comments(
@@ -418,12 +425,16 @@ def _respond(
     # never compare against a stale ref (old base content could smuggle).
     # The session has no credentials, so the kernel fetches on its behalf.
     base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
-    base_fetched = False
+    base_sha_at_fetch = ""
     try:
         ws.git_network("fetch", "origin", base_ref)
-        base_fetched = True
+        # pinned NOW, before the session runs: refs/remotes/* are plain
+        # files a session can rewrite, so the scope exemption compares
+        # against this sha, never the ref name
+        base_sha_at_fetch = ws.git("rev-parse", f"origin/{base_ref}").strip()
     except Exception as exc:
         log.warning("base fetch failed for %s: %s", run_id, exc)
+    base_fetched = bool(base_sha_at_fetch)
     if conflict_wake and not base_fetched:
         # never tell the session the base was fetched when it was not, and
         # never spend the once-per-head cursor on a failed setup — the next
@@ -513,14 +524,15 @@ def _respond(
     def _matches_base(path: str) -> bool:
         # content identical to origin/<base> is the base branch's own (a
         # merge brings it in); it can neither smuggle nor exceed scope. Only
-        # against a FRESHLY fetched ref — stale base content must not vouch.
-        # Blob-hash comparison: `git diff <commit> -- path` would call an
-        # UNTRACKED working file "deleted" instead of reading its content.
-        # A deletion matches when the base deleted the path too.
+        # against the sha PINNED at fetch time — the ref itself is a plain
+        # file the session could have rewritten while it ran. Blob-hash
+        # comparison: `git diff <commit> -- path` would call an UNTRACKED
+        # working file "deleted" instead of reading its content. A deletion
+        # matches when the base deleted the path too.
         if not base_fetched:
             return False
         try:
-            base_blob = ws.git("rev-parse", f"origin/{base_ref}:{path}").strip()
+            base_blob = ws.git("rev-parse", f"{base_sha_at_fetch}:{path}").strip()
         except Exception:
             base_blob = ""  # absent on base
         local_path = Path(ws.root) / path

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -146,6 +146,9 @@ class RunRecord:
     last_comment_id: int = 0
     last_review_id: int = 0
     last_review_comment_id: int = 0
+    # head sha the last conflict wake was issued for: a dirty PR wakes the
+    # author ONCE per head — a new push (or new conflict) re-arms it
+    dirty_wake_head: str = ""
     followup_job_id: str = ""  # slurm job servicing this run's review comments
     issue_number: int = 0  # the requesting issue, when the requested lane started this run
     wake_attempts: int = 0

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -487,7 +487,7 @@ def service_in_review(
     duplicate submission no-ops on the lease, and `followup_job_id` keeps the
     tick from queueing duplicates in the first place.
     """
-    from autoresearch.followup import close_if_done, has_new_comments
+    from autoresearch.followup import close_if_done, has_new_comments, needs_conflict_wake
 
     ended: list[tuple[str, str]] = []
     submitted: list[tuple[str, str]] = []
@@ -512,7 +512,9 @@ def service_in_review(
             if paused:
                 log.info("follow-up for %s paused (api outage: %s)", record.run_id, paused)
                 continue
-            if not has_new_comments(record, github, spec.bot_login):
+            if not has_new_comments(record, github, spec.bot_login) and not needs_conflict_wake(
+                record, github
+            ):
                 continue
             if record.followup_job_id:
                 try:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -487,7 +487,7 @@ def service_in_review(
     duplicate submission no-ops on the lease, and `followup_job_id` keeps the
     tick from queueing duplicates in the first place.
     """
-    from autoresearch.followup import close_if_done, has_new_comments, needs_conflict_wake
+    from autoresearch.followup import close_if_done, conflict_wake_action, has_new_comments
 
     ended: list[tuple[str, str]] = []
     submitted: list[tuple[str, str]] = []
@@ -512,9 +512,15 @@ def service_in_review(
             if paused:
                 log.info("follow-up for %s paused (api outage: %s)", record.run_id, paused)
                 continue
-            if not has_new_comments(record, github, spec.bot_login) and not needs_conflict_wake(
-                record, github
-            ):
+            wake_action = conflict_wake_action(record, github)
+            if wake_action == "clear":
+                # the PR is clean again: re-arm the wake for this head — the
+                # base can move and conflict the SAME head a second time
+                try:
+                    save_record(root, replace(record, dirty_wake_head=""), now)
+                except OSError as exc:
+                    log.warning("conflict cursor clear failed for %s: %s", record.run_id, exc)
+            if not has_new_comments(record, github, spec.bot_login) and wake_action != "wake":
                 continue
             if record.followup_job_id:
                 try:

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -886,17 +886,22 @@ def test_conflicted_pr_wakes_the_author_without_comments(review_run) -> None:
     assert outcome2.action == "no-op"
 
 
-def test_needs_conflict_wake_is_once_per_head(review_run) -> None:
-    from autoresearch.followup import needs_conflict_wake
+def test_conflict_wake_action_lifecycle(review_run) -> None:
+    from autoresearch.followup import conflict_wake_action
 
     root, _ = review_run
     record = load_record(root, "tsp-r1")
-    assert needs_conflict_wake(record, cast(Any, FakeGitHub(pr=_dirty_pr())))
-    assert not needs_conflict_wake(record, cast(Any, FakeGitHub()))  # clean PR
+    assert conflict_wake_action(record, cast(Any, FakeGitHub(pr=_dirty_pr()))) == "wake"
+    assert conflict_wake_action(record, cast(Any, FakeGitHub())) == ""  # clean, never woken
     woken = replace(record, dirty_wake_head="h" * 40)
-    assert not needs_conflict_wake(woken, cast(Any, FakeGitHub(pr=_dirty_pr())))
+    assert conflict_wake_action(woken, cast(Any, FakeGitHub(pr=_dirty_pr()))) == ""  # once/head
     # a new head (author pushed, conflicted again) re-arms
-    assert needs_conflict_wake(woken, cast(Any, FakeGitHub(pr=_dirty_pr(head="i" * 40))))
+    assert conflict_wake_action(woken, cast(Any, FakeGitHub(pr=_dirty_pr(head="i" * 40)))) == (
+        "wake"
+    )
+    # a PR that turned CLEAN clears the cursor so the SAME head can re-wake
+    clean = {"state": "open", "merged": False, "mergeable": True, "mergeable_state": "clean"}
+    assert conflict_wake_action(woken, cast(Any, FakeGitHub(pr=clean))) == "clear"
 
 
 def test_content_matching_base_is_not_out_of_scope(review_run) -> None:
@@ -1043,3 +1048,38 @@ def test_committed_out_of_scope_resolution_is_reset(review_run) -> None:
     assert "outside the contract" in github.posted[0]
     assert _git(bare, "rev-parse", "feat/auto/agent-01/tsp-r1").strip() == tip_before
     assert _git(ws, "rev-parse", "HEAD").strip() == tip_before  # local commit gone
+
+
+def test_forged_base_ref_cannot_vouch(review_run) -> None:
+    """refs/remotes/origin/<base> is a plain file the session can rewrite;
+    the exemption must compare against the sha PINNED at fetch time, so a
+    forged ref pointing at the session's own commit vouches for nothing."""
+    root, bare = review_run
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "push", "-q", "origin", "feat/auto/agent-01/tsp-r1")
+    tip_before = _git(bare, "rev-parse", "feat/auto/agent-01/tsp-r1").strip()
+    github = FakeGitHub(comments=[member(101, "tidy")])
+
+    def forging_run(brief_text, workspace, resume_session_id=None):
+        (workspace / "docs" / "rogue.md").write_text("smuggled\n")
+        _git(ws, "add", "-A")
+        _git(ws, "-c", "user.name=a", "-c", "user.email=a@a", "commit", "-qm", "forge")
+        sha = _git(ws, "rev-parse", "HEAD").strip()
+        _git(ws, "update-ref", "refs/remotes/origin/main", sha)  # the forgery
+        return SessionResult(
+            stop_reason="end_turn",
+            is_error=False,
+            cost_usd=0.2,
+            num_turns=3,
+            session_id="s5",
+            final_text="done",
+            transcript_path="",
+        )
+
+    class Forger:
+        run = staticmethod(forging_run)
+
+    outcome = respond(root, github, Forger(), QueueEvaluator(values=[10.2]))
+    assert outcome.action == "replied"
+    assert "outside the contract" in github.posted[0]  # forgery did not vouch
+    assert _git(bare, "rev-parse", "feat/auto/agent-01/tsp-r1").strip() == tip_before

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -890,12 +891,12 @@ def test_needs_conflict_wake_is_once_per_head(review_run) -> None:
 
     root, _ = review_run
     record = load_record(root, "tsp-r1")
-    assert needs_conflict_wake(record, FakeGitHub(pr=_dirty_pr()))
-    assert not needs_conflict_wake(record, FakeGitHub())  # clean PR
+    assert needs_conflict_wake(record, cast(Any, FakeGitHub(pr=_dirty_pr())))
+    assert not needs_conflict_wake(record, cast(Any, FakeGitHub()))  # clean PR
     woken = replace(record, dirty_wake_head="h" * 40)
-    assert not needs_conflict_wake(woken, FakeGitHub(pr=_dirty_pr()))
+    assert not needs_conflict_wake(woken, cast(Any, FakeGitHub(pr=_dirty_pr())))
     # a new head (author pushed, conflicted again) re-arms
-    assert needs_conflict_wake(woken, FakeGitHub(pr=_dirty_pr(head="i" * 40)))
+    assert needs_conflict_wake(woken, cast(Any, FakeGitHub(pr=_dirty_pr(head="i" * 40))))
 
 
 def test_content_matching_base_is_not_out_of_scope(review_run) -> None:

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -976,3 +976,70 @@ def test_deletions_converging_to_base_are_exempt(review_run) -> None:
     outcome2 = respond(root, github2, Deleter(), QueueEvaluator(values=[10.2]))
     assert outcome2.action == "replied"
     assert "outside the contract" in github2.posted[0]  # reverted, not pushed
+
+
+def test_committed_resolution_is_measured_and_pushed(review_run) -> None:
+    """A session that COMMITS its work (the normal shape of a resolved merge)
+    leaves the working tree clean; the follow-up must still measure and push
+    the committed head instead of leaving the PR conflicted."""
+    root, bare = review_run
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "push", "-q", "origin", "feat/auto/agent-01/tsp-r1")  # as publish did
+    github = FakeGitHub(comments=[member(101, "please resolve the conflict")])
+
+    def committing_run(brief_text, workspace, resume_session_id=None):
+        (workspace / "src" / "pilot" / "solvers" / "tsp.py").write_text("v2 resolved\n")
+        _git(ws, "add", "-A")
+        _git(ws, "-c", "user.name=a", "-c", "user.email=a@a", "commit", "-qm", "resolve merge")
+        return SessionResult(
+            stop_reason="end_turn",
+            is_error=False,
+            cost_usd=0.2,
+            num_turns=3,
+            session_id="s3",
+            final_text="Merged main and resolved the conflict.",
+            transcript_path="",
+        )
+
+    class Committer:
+        run = staticmethod(committing_run)
+
+    outcome = respond(root, github, Committer(), QueueEvaluator(values=[10.2]))
+    assert outcome.action == "replied"
+    assert "Re-measured" in github.posted[0]
+    assert (
+        _git(bare, "show", "feat/auto/agent-01/tsp-r1:src/pilot/solvers/tsp.py") == "v2 resolved\n"
+    )
+
+
+def test_committed_out_of_scope_resolution_is_reset(review_run) -> None:
+    """Committed out-of-scope changes are reverted INCLUDING the commit —
+    the local branch resets to the pushed tip."""
+    root, bare = review_run
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "push", "-q", "origin", "feat/auto/agent-01/tsp-r1")  # as publish did
+    tip_before = _git(bare, "rev-parse", "feat/auto/agent-01/tsp-r1").strip()
+    github = FakeGitHub(comments=[member(101, "tidy")])
+
+    def committing_run(brief_text, workspace, resume_session_id=None):
+        (workspace / "docs" / "rogue.md").write_text("out of scope\n")
+        _git(ws, "add", "-A")
+        _git(ws, "-c", "user.name=a", "-c", "user.email=a@a", "commit", "-qm", "rogue")
+        return SessionResult(
+            stop_reason="end_turn",
+            is_error=False,
+            cost_usd=0.2,
+            num_turns=3,
+            session_id="s4",
+            final_text="done",
+            transcript_path="",
+        )
+
+    class Committer:
+        run = staticmethod(committing_run)
+
+    outcome = respond(root, github, Committer(), QueueEvaluator(values=[10.2]))
+    assert outcome.action == "replied"
+    assert "outside the contract" in github.posted[0]
+    assert _git(bare, "rev-parse", "feat/auto/agent-01/tsp-r1").strip() == tip_before
+    assert _git(ws, "rev-parse", "HEAD").strip() == tip_before  # local commit gone

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -927,3 +927,52 @@ def test_content_matching_base_is_not_out_of_scope(review_run) -> None:
     files = _git(bare, "show", "feat/auto/agent-01/tsp-r1:src/pilot/solvers/tsp.py")
     assert "v2 after merge" in files
     assert _git(bare, "show", "feat/auto/agent-01/tsp-r1:docs/news.md") == "from main\n"
+
+
+def test_deletions_converging_to_base_are_exempt(review_run) -> None:
+    """The exemption's invariant is FINAL STATE == origin/<base>: a path the
+    base also lacks (a base-side deletion merged in, or a branch-only file
+    removed) converges to the reviewed base state and cannot smuggle or
+    exceed scope. Deleting a file the base still HAS stays guarded."""
+    root, bare = review_run
+    ws = run_dir(root, "tsp-r1") / "ws"
+    # a branch-only out-of-scope file from an earlier (reviewed) round
+    (ws / "docs" / "branch-only.md").write_text("old note\n")
+    _git(ws, "add", "-A")
+    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "prior round")
+    _git(ws, "push", "-q", "origin", "feat/auto/agent-01/tsp-r1")
+    github = FakeGitHub(comments=[member(101, "tidy up")])
+    harness = ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v3\n"})
+
+    def deleting_run(brief_text, workspace, resume_session_id=None):
+        (workspace / "docs" / "branch-only.md").unlink()
+        return ResumingHarness.run(harness, brief_text, workspace, resume_session_id)
+
+    harness.run = deleting_run  # type: ignore[method-assign]
+    _git(ws, "fetch", "-q", "origin", "main")
+    outcome = respond(root, github, harness, QueueEvaluator(values=[10.2]))
+    assert outcome.action == "replied"
+    assert "Re-measured" in github.posted[0]
+    tree = _git(bare, "ls-tree", "-r", "--name-only", "feat/auto/agent-01/tsp-r1")
+    assert "docs/branch-only.md" not in tree  # converged to base: allowed
+
+    # deleting a file the base still has is NOT exempt: roadmap.md is on main
+    def roadmap_deleter(brief_text, workspace, resume_session_id=None):
+        (workspace / "docs" / "roadmap.md").unlink()
+        return SessionResult(
+            stop_reason="end_turn",
+            is_error=False,
+            cost_usd=0.1,
+            num_turns=2,
+            session_id="s2",
+            final_text="removed the roadmap",
+            transcript_path="",
+        )
+
+    class Deleter:
+        run = staticmethod(roadmap_deleter)
+
+    github2 = FakeGitHub(comments=[member(102, "again")])
+    outcome2 = respond(root, github2, Deleter(), QueueEvaluator(values=[10.2]))
+    assert outcome2.action == "replied"
+    assert "outside the contract" in github2.posted[0]  # reverted, not pushed

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -855,3 +855,74 @@ def test_auto_mode_followup_withholds_push_when_disarm_fails(tmp_path) -> None:
     assert client.disable_auto_merge("o/r", 1) is True  # nothing armed = safe
     client._graphql = types.MethodType(lambda self, q, v: hard_fail(), client)  # type: ignore[method-assign]
     assert client.disable_auto_merge("o/r", 1) is False  # unknown state = block
+
+
+def _dirty_pr(head="h" * 40) -> dict:
+    return {
+        "state": "open",
+        "merged": False,
+        "mergeable": False,
+        "mergeable_state": "dirty",
+        "head": {"sha": head},
+        "base": {"ref": "main"},
+    }
+
+
+def test_conflicted_pr_wakes_the_author_without_comments(review_run) -> None:
+    root, _bare = review_run
+    github = FakeGitHub(pr=_dirty_pr())
+    harness = ResumingHarness()
+    outcome = respond(root, github, harness, QueueEvaluator(values=[10.5]))
+    assert outcome.action == "replied"
+    prompt, resume_id = harness.calls[0]
+    assert "Your PR conflicts with its base" in prompt
+    assert "origin/main` has been fetched" in prompt
+    assert resume_id == "sess-original"  # same session lineage, full context
+    # once per head: the cursor is persisted, the next pass no-ops
+    record = load_record(root, "tsp-r1")
+    assert record.dirty_wake_head == "h" * 40
+    outcome2 = respond(root, github, ResumingHarness(), QueueEvaluator(values=[10.5]))
+    assert outcome2.action == "no-op"
+
+
+def test_needs_conflict_wake_is_once_per_head(review_run) -> None:
+    from autoresearch.followup import needs_conflict_wake
+
+    root, _ = review_run
+    record = load_record(root, "tsp-r1")
+    assert needs_conflict_wake(record, FakeGitHub(pr=_dirty_pr()))
+    assert not needs_conflict_wake(record, FakeGitHub())  # clean PR
+    woken = replace(record, dirty_wake_head="h" * 40)
+    assert not needs_conflict_wake(woken, FakeGitHub(pr=_dirty_pr()))
+    # a new head (author pushed, conflicted again) re-arms
+    assert needs_conflict_wake(woken, FakeGitHub(pr=_dirty_pr(head="i" * 40)))
+
+
+def test_content_matching_base_is_not_out_of_scope(review_run) -> None:
+    """A merge brings the base branch's own files into the diff; content
+    identical to origin/<base> must not be reverted as out-of-scope."""
+    root, bare = review_run
+    # main moves: an out-of-scope doc lands upstream
+    seed2 = root.parent / "seed2"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / "docs" / "news.md").write_text("from main\n")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "main moves")
+    _git(seed2, "push", "-q", "origin", "main")
+    github = FakeGitHub(comments=[member(101, "please update your branch")])
+    # the session merges main (simulated: the identical file appears) and
+    # keeps an in-scope edit of its own
+    harness = ResumingHarness(
+        edits={
+            "docs/news.md": "from main\n",
+            "src/pilot/solvers/tsp.py": "v2 after merge\n",
+        }
+    )
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    outcome = respond(root, github, harness, QueueEvaluator(values=[10.2]))
+    assert outcome.action == "replied"
+    assert "Re-measured" in github.posted[0]
+    files = _git(bare, "show", "feat/auto/agent-01/tsp-r1:src/pilot/solvers/tsp.py")
+    assert "v2 after merge" in files
+    assert _git(bare, "show", "feat/auto/agent-01/tsp-r1:docs/news.md") == "from main\n"

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3188,3 +3188,78 @@ def test_dispatch_wake_switch_reads_env_or_sentinel(tmp_path: Path, monkeypatch)
     (tmp_path / "DISPATCH_WAKE").unlink()
     monkeypatch.setenv("AUTORESEARCH_DISPATCH_WAKE", "1")
     assert dispatch_wake_armed(tmp_path)
+
+
+def test_service_in_review_wakes_a_conflicted_pr_without_comments(tmp_path: Path) -> None:
+    """A DIRTY PR is its own wake condition: no comments, job still submitted;
+    a record already woken for this head is skipped."""
+    from autoresearch.compute import CommandResult
+    from autoresearch.runstate import IN_REVIEW, RunRecord, save_record
+    from autoresearch.tick import FollowupSpec, service_in_review
+
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="r-dirty",
+            target="org/pilot",
+            task_title="improve tsp",
+            benchmark="tsp",
+            state=IN_REVIEW,
+            pr_url="https://github.com/org/pilot/pull/7",
+        ),
+        now=NOW,
+    )
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="r-dirty-woken",
+            target="org/pilot",
+            task_title="improve tsp",
+            benchmark="tsp",
+            state=IN_REVIEW,
+            pr_url="https://github.com/org/pilot/pull/8",
+            dirty_wake_head="h" * 40,
+        ),
+        now=NOW,
+    )
+
+    class G:
+        def get_pull_request(self, repo, number):
+            return {
+                "state": "open",
+                "merged": False,
+                "mergeable": False,
+                "mergeable_state": "dirty",
+                "head": {"sha": "h" * 40},
+                "base": {"ref": "main"},
+            }
+
+        def list_comments(self, repo, number, max_pages=20):
+            return []
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return []
+
+    submits = []
+
+    def runner(argv, timeout_s):
+        if argv[0] == "sbatch":
+            submits.append(list(argv))
+            return CommandResult(0, "4243\n", "")
+        if argv[0] == "sacct":
+            return CommandResult(0, "RUNNING\n", "")
+        raise AssertionError(argv)
+
+    compute = SlurmCompute(runner=runner)
+    spec = FollowupSpec(
+        account="acct",
+        partition="cpu_short",
+        run_root=tmp_path,
+        image="/img/a.sif",
+        home=Path("/home/x/autoresearch"),
+    )
+    _ended, submitted = service_in_review(tmp_path, G(), compute, spec, NOW)
+    assert submitted == [("r-dirty", "4243")]  # the already-woken head is skipped


### PR DESCRIPTION
Item 2 of the freshness set (gpt-speedrun PR #3 postmortem): a conflicted in-review PR now wakes its author instead of rotting.

- `dirty_pr_head(pr)`: open + `mergeable is False`/`mergeable_state == "dirty"` → head sha; GitHub's lazy `mergeable: null` reads as unknown, so a fresh PR never false-positives (the next tick re-asks).
- Tick: `needs_conflict_wake` joins `has_new_comments` as a wake condition — reuses the followup job path unchanged.
- Followup: the wake prompt leads with the conflict notice; the kernel fetches `origin/<base>` on the session's behalf (workspaces are credential-less); the notice tells the author the honest options — resolve keeping ONE contribution, or say the change is superseded. The existing revise loop then re-measures before any push and keeps auto-merge disarmed, so a human merges the updated head. Idempotent per head via a `dirty_wake_head` record cursor; a new conflicted push re-arms.
- Scope-check exemption for merge content: paths whose blob hash equals `origin/<base>`'s are the base's own and are neither smuggle nor scope risk. Blob-hash comparison deliberately, not `git diff <commit> -- path` — that reports an untracked working file as "deleted" rather than reading its content (found by the new test).
- Tests: conflict wake fires without comments and resumes the same session; once-per-head idempotence + re-arm on a new head; base-content exemption end to end (main moves with an out-of-scope file, the merged copy passes, the author's in-scope edit is re-measured and pushed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
