### PR TITLE
Every wake refreshes origin refs

### DIFF
--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -959,7 +959,7 @@ def _fetch_research_reports(ws: Workspace, count: int) -> list[tuple[str, str]]:
     target, wherever it ran. Fail-soft: a target with no research log yet
     (or an unreachable remote) is an empty memory, never a dead attempt."""
     try:
-        ws.git_network("fetch", "origin", RESEARCH_LOG_BRANCH)
+        ws.fetch_branch(RESEARCH_LOG_BRANCH)
         listing = ws.git("ls-tree", "-r", "--name-only", "FETCH_HEAD", "reports/")
         # only direct children (the publisher's layout): a nested path would
         # flatten to a basename that overwrites another archived report

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1237,11 +1237,12 @@ def resume_run(
     ws = Workspace(root=workspace, auth=bot_auth, url=_target_clone_url(record.target))
     # Refresh origin refs on EVERY wake: the clone's refs froze at run
     # start, and this is the one credential-free freshness point — the
-    # kernel fetches, the session only ever reads local refs. `sleep`
+    # kernel fetches (from the canonical URL, never the session-writable
+    # remote config), the session only ever reads local refs. `sleep`
     # thereby doubles as the author's sync primitive. Best-effort: a fetch
     # outage must not cost the wake.
     try:
-        ws.git_network("fetch", "origin")
+        ws.fetch_origin()
     except Exception as exc:
         log.warning("wake fetch failed for %s: %s", run_id, exc)
 

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1235,6 +1235,15 @@ def resume_run(
     # to another remote. Passing `url` here means `Workspace.push` uses it
     # instead of reading `remote.origin.url`.
     ws = Workspace(root=workspace, auth=bot_auth, url=_target_clone_url(record.target))
+    # Refresh origin refs on EVERY wake: the clone's refs froze at run
+    # start, and this is the one credential-free freshness point — the
+    # kernel fetches, the session only ever reads local refs. `sleep`
+    # thereby doubles as the author's sync primitive. Best-effort: a fetch
+    # outage must not cost the wake.
+    try:
+        ws.git_network("fetch", "origin")
+    except Exception as exc:
+        log.warning("wake fetch failed for %s: %s", run_id, exc)
 
     # Two park kinds reach the wake: a CANDIDATE park (the gate's measures were
     # dispatched) and an AUTHOR-SLEEP park (the author launched work and slept —

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -379,7 +379,10 @@ def render(brief: SessionBrief) -> str:
             "anything that will not finish inside this session) runs OUTSIDE "
             "it. To run something and get its result, use the tool, then END "
             "YOUR TURN — you will be woken in this same session with the "
-            "output and any artifacts delivered under .autoresearch/results/:",
+            "output and any artifacts delivered under .autoresearch/results/. "
+            "Your git remote refs (origin/*) are refreshed at every wake, so "
+            "after a sleep you can read the current state of the base branch "
+            "and sibling branches locally:",
             "",
             "    python .autoresearch/syscall launch --name <handle> "
             "--minutes <N> [--array <K>] --artifact <repo-relative file> -- <command>",

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -395,7 +395,9 @@ def _respond(
     workspace = run_dir(run_root, run_id) / "ws"
     if not workspace.is_dir():
         return FollowupOutcome(run_id, "error", "workspace no longer exists (GC'd?)")
-    ws = Workspace(root=workspace, auth=github.auth, url=None)
+    from autoresearch.attempt import _target_clone_url
+
+    ws = Workspace(root=workspace, auth=github.auth, url=_target_clone_url(record.target))
     contract_text = (workspace / ".autoresearch.yaml").read_text()
     contract = load_contract(contract_text, record.target)
     bench = next((b for b in contract.benchmarks if b.name == record.benchmark), None)
@@ -427,7 +429,7 @@ def _respond(
     base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
     base_sha_at_fetch = ""
     try:
-        ws.git_network("fetch", "origin", base_ref)
+        ws.fetch_origin()
         # pinned NOW, before the session runs: refs/remotes/* are plain
         # files a session can rewrite, so the scope exemption compares
         # against this sha, never the ref name

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -1005,6 +1005,20 @@ class Workspace:
             message,
         )
 
+    def fetch_origin(self) -> None:
+        """Refresh refs/remotes/origin/* from the URL captured at clone time —
+        never the "origin" remote, whose url and uploadpack live in
+        session-writable .git/config. The credential is host-scoped
+        (extraheader), so a rewritten URL could not receive it, but the
+        CONTENT must come from the canonical repo too: a poisoned fetch
+        source would forge what origin/<base> means to every downstream
+        comparison."""
+        if self.dry_run:
+            log.info("[dry-run] fetch into %s", self.root)
+            return
+        target = self.url or self.remote_url()
+        self.git_network("fetch", target, "--", "+refs/heads/*:refs/remotes/origin/*")
+
     def push(self, branch: str) -> None:
         if self.dry_run:
             log.info("[dry-run] push %s from %s", branch, self.root)

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -28,7 +28,7 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
@@ -912,11 +912,6 @@ def _git_env(token: str | None, root: Path | None = None) -> dict[str, str]:
     return env
 
 
-def _best_effort_git(argv: list[str], env: dict[str, str]) -> None:
-    with contextlib.suppress(Exception):
-        _run_git(argv, env)
-
-
 def _run_git(args: list[str], env: dict[str, str]) -> str:
     result = subprocess.run(args, capture_output=True, text=True, env=env, check=False)
     if result.returncode != 0:
@@ -946,59 +941,41 @@ class Workspace:
             ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(None, self.root)
         )
 
-    def _strip_url_rewrites(self) -> None:
-        """Remove session-written url.*.insteadOf / pushInsteadOf from the
-        local config. Git applies these rewrite rules even to an explicitly
-        passed URL, so without this a session could redirect a credentialed
-        fetch/push at attacker-controlled refs (poisoning what origin/<base>
-        means to every downstream comparison). The workspace .git/config is
-        session-writable and the ONLY config source here (global/system are
-        /dev/null), so this is the one place they can enter."""
-        if not (self.root / ".git").exists():
-            return  # a clone creating the repo has no local config yet
+    @contextlib.contextmanager
+    def _neutral_local_config(self) -> Iterator[None]:
+        """Run the body with the workspace's local .git/config swapped for a
+        MINIMAL one. The session-writable local config is the only config
+        source under credential (global/system are /dev/null), and git honors
+        url.*.insteadOf, include.path, includeIf, etc. even for an explicitly
+        passed URL — any of which could redirect a credentialed fetch/push at
+        attacker-controlled refs and poison what origin/<base> means to every
+        downstream comparison. Swapping the whole file neutralizes the entire
+        config-redirect class at once. The fetch/push pass an explicit URL and
+        refspec, so no remote.* config is needed for the op; the session's
+        config is restored after (only the kernel runs network ops, serially,
+        so nothing else races this window)."""
+        cfg = self.root / ".git" / "config"
+        if not cfg.exists():
+            yield  # a clone creating the repo has no local config yet
+            return
+        saved = cfg.read_bytes()
         try:
-            keys = _run_git(
-                [
-                    "git",
-                    "-C",
-                    str(self.root),
-                    *SAFE_GIT_FLAGS,
-                    "config",
-                    "--local",
-                    "--name-only",
-                    "--get-regexp",
-                    r"^url\..*\.(insteadof|pushinsteadof)$",
-                ],
-                _git_env(None, self.root),
-            )
-        except Exception:
-            return  # no matches -> git exits non-zero; nothing to strip
-        sections = {key.rsplit(".", 1)[0] for key in keys.split() if key.startswith("url.")}
-        for section in sections:
-            _best_effort_git(
-                [
-                    "git",
-                    "-C",
-                    str(self.root),
-                    *SAFE_GIT_FLAGS,
-                    "config",
-                    "--local",
-                    "--remove-section",
-                    section,
-                ],
-                _git_env(None, self.root),
-            )
+            cfg.write_bytes(b"[core]\n\trepositoryformatversion = 0\n")
+            yield
+        finally:
+            cfg.write_bytes(saved)
 
     def git_network(self, *args: str) -> str:
         """Run a git subcommand that talks to the remote, with credentials."""
         if args and args[0] not in NETWORK_GIT_COMMANDS:
             raise ValueError(f"{args[0]!r} is not a network git command")
-        if args and args[0] != "clone":
-            self._strip_url_rewrites()
         token = self.auth.token() if self.auth is not None else None
-        return _run_git(
-            ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(token, self.root)
-        )
+        argv = ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args]
+        env = _git_env(token, self.root)
+        if args and args[0] == "clone":
+            return _run_git(argv, env)  # no local config to neutralize yet
+        with self._neutral_local_config():
+            return _run_git(argv, env)
 
     def remote_url(self) -> str:
         """The remote URL as recorded at clone time, read token-free."""

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -29,7 +29,7 @@ import subprocess
 import urllib.error
 import urllib.parse
 import urllib.request
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
@@ -841,14 +841,25 @@ class GitHubClient:
         self._request("POST", path, {"body": body})
 
 
+_MINIMAL_GIT_CONFIG = b"[core]\n\trepositoryformatversion = 0\n"
+# config sections that can REDIRECT a git operation to attacker-chosen refs
+# or files: url.*.insteadOf rewrites, and include/includeIf that pull in more
+# config (possibly a FIFO that would block git's own parse forever). The
+# session-writable .git/config is the only config source under credential
+# (global/system are /dev/null), so stripping these here disarms the whole
+# class before any git subcommand — local or network — reads the file.
+_REDIRECT_SECTIONS = ("url", "include", "includeif")
+_SECTION_RE = re.compile(r"^\s*\[\s*([A-Za-z0-9.-]+)")
+
+
 def _ensure_regular_config(root: Path | None) -> None:
-    """Refuse a non-regular .git/config before any git command reads it. A
-    session can replace the (session-writable) config with a FIFO — a plain
-    read, or git's own config parse, would BLOCK forever with no writer,
-    hanging the wake — or a symlink/device to mislead a read. Any such file
-    is hostile or broken (git cannot operate on it either), so it is replaced
-    with a minimal regular config; a regular config is left untouched (cheap
-    lstat, no write)."""
+    """Sanitize .git/config before any git command reads it. A session can
+    (a) replace the file with a FIFO/symlink/device — git's own parse, or a
+    read, would BLOCK forever with no writer, hanging the wake — or (b) leave
+    a regular file that INCLUDES a FIFO or rewrites URLs. Non-regular files are
+    replaced with a minimal config; a regular file's redirect sections
+    (url/include/includeIf) are stripped in place. A clean config is left
+    untouched (a cheap lstat and, at most, one small read)."""
     if root is None:
         return
     cfg = root / ".git" / "config"
@@ -856,14 +867,39 @@ def _ensure_regular_config(root: Path | None) -> None:
         st = os.lstat(cfg)
     except OSError:
         return
-    if not stat.S_ISREG(st.st_mode) or st.st_size > 1_000_000:
+
+    def _write(data: bytes) -> None:
         with contextlib.suppress(OSError):
-            cfg.unlink()
+            if cfg.exists():
+                cfg.unlink()
             fd = os.open(cfg, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
             try:
-                os.write(fd, b"[core]\n\trepositoryformatversion = 0\n")
+                os.write(fd, data)
             finally:
                 os.close(fd)
+
+    if not stat.S_ISREG(st.st_mode) or st.st_size > 1_000_000:
+        _write(_MINIMAL_GIT_CONFIG)  # FIFO/symlink/device/oversize: hostile
+        return
+    # a regular file never blocks a read (reading does NOT follow includes),
+    # so this is safe; only the redirect sections are removed
+    try:
+        text = cfg.read_text(errors="replace")
+    except OSError:
+        return
+    kept: list[str] = []
+    dropping = False
+    changed = False
+    for line in text.splitlines(keepends=True):
+        m = _SECTION_RE.match(line)
+        if m is not None:  # a new section header decides the next block
+            dropping = m.group(1).split(".", 1)[0].casefold() in _REDIRECT_SECTIONS
+        if dropping:
+            changed = True
+            continue
+        kept.append(line)
+    if changed:
+        _write("".join(kept).encode())
 
 
 def _filter_override_pairs(root: Path | None) -> list[tuple[str, str]]:
@@ -968,75 +1004,18 @@ class Workspace:
             ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(None, self.root)
         )
 
-    @contextlib.contextmanager
-    def _neutral_local_config(self) -> Iterator[None]:
-        """Run the body with the workspace's local .git/config swapped for a
-        MINIMAL one. The session-writable local config is the only config
-        source under credential (global/system are /dev/null), and git honors
-        url.*.insteadOf, include.path, includeIf, etc. even for an explicitly
-        passed URL — any of which could redirect a credentialed fetch/push at
-        attacker-controlled refs and poison what origin/<base> means to every
-        downstream comparison. Swapping the whole file neutralizes the entire
-        config-redirect class at once. The fetch/push pass an explicit URL and
-        refspec, so no remote.* config is needed for the op; the session's
-        config is restored after (only the kernel runs network ops, serially,
-        so nothing else races this window)."""
-        cfg = self.root / ".git" / "config"
-        minimal = b"[core]\n\trepositoryformatversion = 0\n"
-
-        def _write(data: bytes) -> None:
-            # O_NOFOLLOW: never write THROUGH a symlink a session planted at
-            # the config path; truncate-and-write the regular file in place
-            fd = os.open(cfg, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o644)
-            try:
-                os.write(fd, data)
-            finally:
-                os.close(fd)
-
-        # Read the current config through a fd opened O_NOFOLLOW | O_NONBLOCK:
-        # a session can replace .git/config with a symlink (NOFOLLOW refuses)
-        # or a FIFO (a plain read_bytes would BLOCK the wake forever with no
-        # writer — NONBLOCK + the regular-file check below refuse it).
-        try:
-            fd = os.open(cfg, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
-        except OSError:
-            yield  # no config yet (fresh clone), or a symlink we refuse to follow
-            return
-        try:
-            st = os.fstat(fd)
-            if not stat.S_ISREG(st.st_mode) or st.st_size > 1_000_000:
-                # a non-regular (FIFO/socket/device) or absurdly large config
-                # is hostile or broken: replace it and do not restore — there
-                # is nothing legitimate to keep.
-                os.close(fd)
-                cfg.unlink()
-                _write(minimal)
-                yield
-                return
-            saved = b""
-            while chunk := os.read(fd, 65536):
-                saved += chunk
-        finally:
-            with contextlib.suppress(OSError):
-                os.close(fd)
-        try:
-            _write(minimal)
-            yield
-        finally:
-            _write(saved)
-
     def git_network(self, *args: str) -> str:
-        """Run a git subcommand that talks to the remote, with credentials."""
+        """Run a git subcommand that talks to the remote, with credentials.
+        The config is sanitized first (redirect sections stripped), and the
+        fetch/push pass an explicit URL + refspec, so no session-controlled
+        remote or rewrite can steer a credentialed op."""
         if args and args[0] not in NETWORK_GIT_COMMANDS:
             raise ValueError(f"{args[0]!r} is not a network git command")
         _ensure_regular_config(self.root)
         token = self.auth.token() if self.auth is not None else None
-        argv = ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args]
-        env = _git_env(token, self.root)
-        if args and args[0] == "clone":
-            return _run_git(argv, env)  # no local config to neutralize yet
-        with self._neutral_local_config():
-            return _run_git(argv, env)
+        return _run_git(
+            ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(token, self.root)
+        )
 
     def remote_url(self) -> str:
         """The remote URL as recorded at clone time, read token-free."""

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -24,6 +24,7 @@ import json
 import logging
 import os
 import re
+import stat
 import subprocess
 import urllib.error
 import urllib.parse
@@ -840,6 +841,31 @@ class GitHubClient:
         self._request("POST", path, {"body": body})
 
 
+def _ensure_regular_config(root: Path | None) -> None:
+    """Refuse a non-regular .git/config before any git command reads it. A
+    session can replace the (session-writable) config with a FIFO — a plain
+    read, or git's own config parse, would BLOCK forever with no writer,
+    hanging the wake — or a symlink/device to mislead a read. Any such file
+    is hostile or broken (git cannot operate on it either), so it is replaced
+    with a minimal regular config; a regular config is left untouched (cheap
+    lstat, no write)."""
+    if root is None:
+        return
+    cfg = root / ".git" / "config"
+    try:
+        st = os.lstat(cfg)
+    except OSError:
+        return
+    if not stat.S_ISREG(st.st_mode) or st.st_size > 1_000_000:
+        with contextlib.suppress(OSError):
+            cfg.unlink()
+            fd = os.open(cfg, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o644)
+            try:
+                os.write(fd, b"[core]\n\trepositoryformatversion = 0\n")
+            finally:
+                os.close(fd)
+
+
 def _filter_override_pairs(root: Path | None) -> list[tuple[str, str]]:
     """GIT_CONFIG pairs that neutralize every filter driver the REPO config
     defines (each overridden to a passthrough) plus attribute files. The
@@ -937,6 +963,7 @@ class Workspace:
     def git(self, *args: str) -> str:
         """Run a local git subcommand: no credential, no child-spawning config,
         repo-defined filter drivers neutralized."""
+        _ensure_regular_config(self.root)
         return _run_git(
             ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(None, self.root)
         )
@@ -955,20 +982,54 @@ class Workspace:
         config is restored after (only the kernel runs network ops, serially,
         so nothing else races this window)."""
         cfg = self.root / ".git" / "config"
-        if not cfg.exists():
-            yield  # a clone creating the repo has no local config yet
-            return
-        saved = cfg.read_bytes()
+        minimal = b"[core]\n\trepositoryformatversion = 0\n"
+
+        def _write(data: bytes) -> None:
+            # O_NOFOLLOW: never write THROUGH a symlink a session planted at
+            # the config path; truncate-and-write the regular file in place
+            fd = os.open(cfg, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o644)
+            try:
+                os.write(fd, data)
+            finally:
+                os.close(fd)
+
+        # Read the current config through a fd opened O_NOFOLLOW | O_NONBLOCK:
+        # a session can replace .git/config with a symlink (NOFOLLOW refuses)
+        # or a FIFO (a plain read_bytes would BLOCK the wake forever with no
+        # writer — NONBLOCK + the regular-file check below refuse it).
         try:
-            cfg.write_bytes(b"[core]\n\trepositoryformatversion = 0\n")
+            fd = os.open(cfg, os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK)
+        except OSError:
+            yield  # no config yet (fresh clone), or a symlink we refuse to follow
+            return
+        try:
+            st = os.fstat(fd)
+            if not stat.S_ISREG(st.st_mode) or st.st_size > 1_000_000:
+                # a non-regular (FIFO/socket/device) or absurdly large config
+                # is hostile or broken: replace it and do not restore — there
+                # is nothing legitimate to keep.
+                os.close(fd)
+                cfg.unlink()
+                _write(minimal)
+                yield
+                return
+            saved = b""
+            while chunk := os.read(fd, 65536):
+                saved += chunk
+        finally:
+            with contextlib.suppress(OSError):
+                os.close(fd)
+        try:
+            _write(minimal)
             yield
         finally:
-            cfg.write_bytes(saved)
+            _write(saved)
 
     def git_network(self, *args: str) -> str:
         """Run a git subcommand that talks to the remote, with credentials."""
         if args and args[0] not in NETWORK_GIT_COMMANDS:
             raise ValueError(f"{args[0]!r} is not a network git command")
+        _ensure_regular_config(self.root)
         token = self.auth.token() if self.auth is not None else None
         argv = ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args]
         env = _git_env(token, self.root)

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -1017,7 +1017,7 @@ class Workspace:
             log.info("[dry-run] fetch into %s", self.root)
             return
         target = self.url or self.remote_url()
-        self.git_network("fetch", target, "--", "+refs/heads/*:refs/remotes/origin/*")
+        self.git_network("fetch", "--prune", target, "--", "+refs/heads/*:refs/remotes/origin/*")
 
     def push(self, branch: str) -> None:
         if self.dry_run:

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -19,6 +19,7 @@ Credential rules enforced here:
 from __future__ import annotations
 
 import base64
+import contextlib
 import json
 import logging
 import os
@@ -911,6 +912,11 @@ def _git_env(token: str | None, root: Path | None = None) -> dict[str, str]:
     return env
 
 
+def _best_effort_git(argv: list[str], env: dict[str, str]) -> None:
+    with contextlib.suppress(Exception):
+        _run_git(argv, env)
+
+
 def _run_git(args: list[str], env: dict[str, str]) -> str:
     result = subprocess.run(args, capture_output=True, text=True, env=env, check=False)
     if result.returncode != 0:
@@ -940,10 +946,55 @@ class Workspace:
             ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(None, self.root)
         )
 
+    def _strip_url_rewrites(self) -> None:
+        """Remove session-written url.*.insteadOf / pushInsteadOf from the
+        local config. Git applies these rewrite rules even to an explicitly
+        passed URL, so without this a session could redirect a credentialed
+        fetch/push at attacker-controlled refs (poisoning what origin/<base>
+        means to every downstream comparison). The workspace .git/config is
+        session-writable and the ONLY config source here (global/system are
+        /dev/null), so this is the one place they can enter."""
+        if not (self.root / ".git").exists():
+            return  # a clone creating the repo has no local config yet
+        try:
+            keys = _run_git(
+                [
+                    "git",
+                    "-C",
+                    str(self.root),
+                    *SAFE_GIT_FLAGS,
+                    "config",
+                    "--local",
+                    "--name-only",
+                    "--get-regexp",
+                    r"^url\..*\.(insteadof|pushinsteadof)$",
+                ],
+                _git_env(None, self.root),
+            )
+        except Exception:
+            return  # no matches -> git exits non-zero; nothing to strip
+        sections = {key.rsplit(".", 1)[0] for key in keys.split() if key.startswith("url.")}
+        for section in sections:
+            _best_effort_git(
+                [
+                    "git",
+                    "-C",
+                    str(self.root),
+                    *SAFE_GIT_FLAGS,
+                    "config",
+                    "--local",
+                    "--remove-section",
+                    section,
+                ],
+                _git_env(None, self.root),
+            )
+
     def git_network(self, *args: str) -> str:
         """Run a git subcommand that talks to the remote, with credentials."""
         if args and args[0] not in NETWORK_GIT_COMMANDS:
             raise ValueError(f"{args[0]!r} is not a network git command")
+        if args and args[0] != "clone":
+            self._strip_url_rewrites()
         token = self.auth.token() if self.auth is not None else None
         return _run_git(
             ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(token, self.root)

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -1047,6 +1047,12 @@ class Workspace:
         target = self.url or self.remote_url()
         self.git_network("fetch", "--prune", target, "--", "+refs/heads/*:refs/remotes/origin/*")
 
+    def fetch_branch(self, branch: str) -> None:
+        """Fetch one branch into FETCH_HEAD from the canonical URL (resolved
+        before the clean-config window, never the mutable "origin" remote)."""
+        target = self.url or self.remote_url()
+        self.git_network("fetch", target, branch)
+
     def push(self, branch: str) -> None:
         if self.dry_run:
             log.info("[dry-run] push %s from %s", branch, self.root)

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4089,8 +4089,12 @@ def test_wake_fetch_survives_a_fifo_config(tmp_path, monkeypatch) -> None:
     bare = tmp_path / f"origin-{run_id}.git"
     _advance_main(tmp_path, bare, {"docs/news.md": "canonical\n"})
     cfg = ws / ".git" / "config"
-    cfg.unlink()
-    _os.mkfifo(cfg)  # the trap: no writer, a plain read blocks
+    # a REGULAR config that includes a FIFO: git would follow the include
+    # and block on the parse. The sanitizer strips the include first.
+    fifo = ws / ".git" / "evil.fifo"
+    _os.mkfifo(fifo)
+    with cfg.open("a") as fh:
+        fh.write(f"\n[include]\n\tpath = {fifo}\n")
     outcome = resume_run(
         state,
         run_id,

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4019,3 +4019,23 @@ def test_cli_rejects_ref_shaping_agent_ids(capsys, monkeypatch) -> None:
         with pytest.raises(SystemExit):
             climb_main()
         assert "cannot shape a git ref" in capsys.readouterr().err
+
+
+def test_wake_refreshes_origin_refs(tmp_path, monkeypatch) -> None:
+    """The clone's refs freeze at run start; a wake fetches origin so the
+    resumed session reads current base and sibling refs locally."""
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    ws = state / "runs" / run_id / "ws"
+    bare = tmp_path / f"origin-{run_id}.git"
+    _advance_main(tmp_path, bare, {"docs/news.md": "landed while parked\n"})
+    resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert _git(ws, "show", "origin/main:docs/news.md").strip() == "landed while parked"

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4060,8 +4060,11 @@ def test_wake_fetch_ignores_session_url_rewrites(tmp_path, monkeypatch) -> None:
     _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
     _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "poison")
     _git(work, "push", "-q", "origin", "main")
-    # the session plants the rewrite: canonical bare -> decoy
-    _git(ws, "config", "--local", f"url.{decoy}.insteadOf", str(bare))
+    # the session plants the rewrite via an INCLUDED file (a --local scan
+    # would miss it; the clean-config window neutralizes the whole class)
+    inc = ws / ".git" / "evil.inc"
+    inc.write_text(f'[url "{decoy}"]\n\tinsteadOf = {bare}\n')
+    _git(ws, "config", "--local", "include.path", "evil.inc")
     resume_run(
         state,
         run_id,

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4074,3 +4074,31 @@ def test_wake_fetch_ignores_session_url_rewrites(tmp_path, monkeypatch) -> None:
         now=1_000_100.0,
     )
     assert _git(ws, "show", "origin/main:docs/news.md").strip() == "canonical"
+
+
+def test_wake_fetch_survives_a_fifo_config(tmp_path, monkeypatch) -> None:
+    """A session can replace .git/config with a FIFO; read_bytes would block
+    the wake forever. The hardened swap refuses a non-regular config and
+    proceeds instead of hanging."""
+    import os as _os
+
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    ws = state / "runs" / run_id / "ws"
+    bare = tmp_path / f"origin-{run_id}.git"
+    _advance_main(tmp_path, bare, {"docs/news.md": "canonical\n"})
+    cfg = ws / ".git" / "config"
+    cfg.unlink()
+    _os.mkfifo(cfg)  # the trap: no writer, a plain read blocks
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    # the run completed (did not hang) and origin/main is canonical
+    assert outcome.outcome == "no-improvement"
+    assert _git(ws, "show", "origin/main:docs/news.md").strip() == "canonical"

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4039,3 +4039,35 @@ def test_wake_refreshes_origin_refs(tmp_path, monkeypatch) -> None:
         now=1_000_100.0,
     )
     assert _git(ws, "show", "origin/main:docs/news.md").strip() == "landed while parked"
+
+
+def test_wake_fetch_ignores_session_url_rewrites(tmp_path, monkeypatch) -> None:
+    """A session can write url.<x>.insteadOf into .git/config; the wake
+    fetch strips those rewrites so origin/* comes from the canonical repo,
+    not an attacker-redirected source."""
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    ws = state / "runs" / run_id / "ws"
+    bare = tmp_path / f"origin-{run_id}.git"
+    _advance_main(tmp_path, bare, {"docs/news.md": "canonical\n"})
+    # a decoy repo the rewrite would point at, with DIFFERENT content
+    decoy = tmp_path / "decoy.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(bare), str(decoy))
+    work = tmp_path / "decoy-work"
+    _git(tmp_path, "clone", "-q", str(decoy), str(work))
+    (work / "docs" / "news.md").write_text("ATTACKER\n")
+    _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "poison")
+    _git(work, "push", "-q", "origin", "main")
+    # the session plants the rewrite: canonical bare -> decoy
+    _git(ws, "config", "--local", f"url.{decoy}.insteadOf", str(bare))
+    resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert _git(ws, "show", "origin/main:docs/news.md").strip() == "canonical"

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -125,8 +125,10 @@ class QueueEvaluator:
 
 
 @pytest.fixture
-def review_run(tmp_path: Path):
-    """A bare origin + an in-review run with a retained workspace on a branch."""
+def review_run(tmp_path: Path, monkeypatch):
+    """A bare origin + an in-review run with a retained workspace on a branch.
+    The canonical clone URL is patched to the bare: the follow-up pins its
+    fetch/push source to it, never the workspace's mutable remote config."""
     seed = tmp_path / "seed"
     (seed / "src" / "pilot" / "solvers").mkdir(parents=True)
     (seed / "docs").mkdir()
@@ -156,6 +158,7 @@ def review_run(tmp_path: Path):
         last_comment_id=100,
     )
     save_record(root, record, NOW - 1000)
+    monkeypatch.setattr("autoresearch.attempt._target_clone_url", lambda target: str(bare))
     return root, bare
 
 
@@ -577,7 +580,7 @@ roadmap: docs/roadmap.md
 
 
 @pytest.fixture
-def steward_review_run(tmp_path: Path):
+def steward_review_run(tmp_path: Path, monkeypatch):
     """An in-review STEWARD run with a retained workspace on a branch."""
     seed = tmp_path / "seed"
     (seed / "src" / "pilot" / "solvers").mkdir(parents=True)
@@ -615,6 +618,7 @@ def steward_review_run(tmp_path: Path):
         last_comment_id=100,
     )
     save_record(root, record, NOW - 1000)
+    monkeypatch.setattr("autoresearch.attempt._target_clone_url", lambda target: str(bare))
     return root, bare
 
 


### PR DESCRIPTION
Owner direction ("if it can do literature search, why not pull from remote — it's the same codebase"): mid-run freshness without in-session credentials.

- `resume_run` fetches `origin` (all refs) right after the workspace handle exists — every wake flavor, uniformly: candidate wakes, author-sleep wakes, failed-submit feedback wakes. Best-effort; an outage logs and the wake proceeds on frozen refs as today.
- The session still never holds credentials: the kernel fetches, the agent reads `origin/*` locally — current base branch, sibling lines, everything, one sleep old at most. An agent that wants fresher refs can simply sleep: the existing primitive becomes the sync syscall for free.
- Brief's experiments section tells the author its `origin/*` refs refresh at every wake.
- Test: a candidate wake on a parked run sees a commit that landed on main while it was parked.

At the public flip, anonymous fetch removes even this mediation for reads; until then this closes the freshness gap flagged in the mediation discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
