### PR TITLE
Merge conflict artifacts do not abort a line run

### DIFF
--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -988,6 +988,27 @@ def _fetch_research_reports(ws: Workspace, count: int) -> list[tuple[str, str]]:
         return []
 
 
+def _exclude_merge_artifacts(workspace: Path) -> None:
+    """Keep git's merge/patch conflict backups (*.orig, *.rej) out of the
+    diff via .git/info/exclude — repo-local, never a tracked edit. A line
+    run merges main at start and the agent resolves conflicts as its first
+    task; a leftover train.py.orig would otherwise read as an out-of-scope
+    edit and abort the run at launch. Idempotent, and effective for the
+    `git add -A` that builds changed-paths and every seal."""
+    exclude = workspace / ".git" / "info" / "exclude"
+    wanted = ["*.orig", "*.rej"]
+    try:
+        existing = exclude.read_text()
+    except OSError:
+        existing = ""
+    lines = existing.splitlines()
+    missing = [p for p in wanted if p not in lines]
+    if missing:
+        exclude.parent.mkdir(parents=True, exist_ok=True)
+        sep = "" if existing.endswith("\n") or not existing else "\n"
+        exclude.write_text(existing + sep + "\n".join(missing) + "\n")
+
+
 def _reset_instruction_files(ws: Workspace, workspace: Path, base_ref: str) -> None:
     """Make the checkout's instruction-bearing files EQUAL the base branch's
     reviewed versions (review_agent.INSTRUCTION_FILES owns the list): a line
@@ -2144,6 +2165,7 @@ def live_attempt(
         # edit, and the gate must measure, the tree the PR will land on.
         # A missing base branch fails loudly as attempt-error.
         ws.git("checkout", "-q", "-B", base_branch, f"origin/{base_branch}")
+        _exclude_merge_artifacts(workspace)
         contract_text = (workspace / ".autoresearch.yaml").read_text()
         contract = load_contract(contract_text, config.target)
         # Load the brief budget from the contract and run state: callers do

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -989,12 +989,12 @@ def _fetch_research_reports(ws: Workspace, count: int) -> list[tuple[str, str]]:
 
 
 def _exclude_merge_artifacts(workspace: Path) -> None:
-    """Keep git's merge/patch conflict backups (*.orig, *.rej) out of the
-    diff via .git/info/exclude — repo-local, never a tracked edit. A line
-    run merges main at start and the agent resolves conflicts as its first
-    task; a leftover train.py.orig would otherwise read as an out-of-scope
-    edit and abort the run at launch. Idempotent, and effective for the
-    `git add -A` that builds changed-paths and every seal."""
+    """Ignore *.orig and *.rej — git's merge/patch conflict backups, which
+    should never be committed — via .git/info/exclude (repo-local, never a
+    tracked edit). A line run merges main at start and the agent resolves
+    conflicts as its first task; a leftover train.py.orig would otherwise
+    read as an out-of-scope edit and abort the run at launch. Idempotent,
+    and effective for the `git add -A` behind changed-paths and every seal."""
     exclude = workspace / ".git" / "info" / "exclude"
     wanted = ["*.orig", "*.rej"]
     try:
@@ -1256,6 +1256,10 @@ def resume_run(
     # to another remote. Passing `url` here means `Workspace.push` uses it
     # instead of reading `remote.origin.url`.
     ws = Workspace(root=workspace, auth=bot_auth, url=_target_clone_url(record.target))
+    # Re-establish the merge-artifact exclude on the wake too: the workspace
+    # persisted across the park, but a session could have removed the exclude,
+    # and this wake's changed_paths / seal run `git add -A`. Idempotent.
+    _exclude_merge_artifacts(workspace)
     # Refresh origin refs on EVERY wake: the clone's refs froze at run
     # start, and this is the one credential-free freshness point — the
     # kernel fetches (from the canonical URL, never the session-writable

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4136,3 +4136,43 @@ def test_wake_fetch_ignores_worktree_config_rewrite(tmp_path, monkeypatch) -> No
         now=1_000_100.0,
     )
     assert _git(ws, "show", "origin/main:docs/news.md").strip() == "canonical"
+
+
+def test_merge_artifacts_do_not_trip_scope(tmp_path, target_repo) -> None:
+    """A *.orig left by a merge/mergetool is excluded, so a session that
+    edits only in-scope files (plus a stray train.py.orig) is not aborted as
+    out-of-scope and its seal omits the artifact."""
+    github = FakeGitHub()
+    with _queued_local([13.876, 13.1]):
+        outcome = live_attempt(
+            config=RunConfig(target="org/pilot", benchmark="tsp"),
+            run_root=tmp_path / "state",
+            run_id="tsp-orig",
+            harness=ScriptedHarness(
+                edits={
+                    "src/pilot/solvers/tsp.py": "def solve(): return 9\n",
+                    "src/pilot/solvers/tsp.py.orig": "conflict backup\n",
+                }
+            ),
+            github=github,  # type: ignore[arg-type]
+            bot_auth=NoAuth(),  # type: ignore[arg-type]
+            now=1_000_000.0,
+            created="2026-08-06T00:00:00Z",
+        )
+    assert outcome.outcome == "improved" and len(github.prs) == 1
+    published = _git(target_repo, "ls-tree", "-r", "--name-only", str(github.prs[0]["head"]))
+    assert "src/pilot/solvers/tsp.py" in published
+    assert "tsp.py.orig" not in published  # the artifact never entered the seal
+
+
+def test_exclude_merge_artifacts_is_idempotent(tmp_path) -> None:
+    from autoresearch.attempt import _exclude_merge_artifacts
+
+    ws = tmp_path
+    (ws / ".git" / "info").mkdir(parents=True)
+    (ws / ".git" / "info" / "exclude").write_text("/existing/\n")
+    _exclude_merge_artifacts(ws)
+    _exclude_merge_artifacts(ws)  # second call adds nothing
+    body = (ws / ".git" / "info" / "exclude").read_text()
+    assert body.count("*.orig") == 1 and body.count("*.rej") == 1
+    assert "/existing/" in body  # prior content preserved

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4176,3 +4176,28 @@ def test_exclude_merge_artifacts_is_idempotent(tmp_path) -> None:
     body = (ws / ".git" / "info" / "exclude").read_text()
     assert body.count("*.orig") == 1 and body.count("*.rej") == 1
     assert "/existing/" in body  # prior content preserved
+
+
+def test_wake_re_establishes_the_merge_artifact_exclude(tmp_path, monkeypatch) -> None:
+    """A session could delete .git/info/exclude before parking; the wake
+    re-establishes it so a .orig does not trip the wake's changed_paths."""
+    from autoresearch.syscall import SYSCALL_DIR
+
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    ws = state / "runs" / run_id / "ws"
+    # simulate a session that removed the exclude and left a .orig
+    exclude = ws / ".git" / "info" / "exclude"
+    if exclude.exists():
+        exclude.unlink()
+    (ws / SYSCALL_DIR).mkdir(exist_ok=True)
+    resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),  # type: ignore[arg-type]
+        now=1_000_100.0,
+    )
+    assert "*.orig" in exclude.read_text()  # re-established on the wake


### PR DESCRIPTION
Small fix, observed live tonight: agent-01's first line run of the night aborted at launch with `out-of-scope paths at launch: train.py.orig`.

- The lines run-start merges main; when it conflicts, resolving it (git, mergetool, or the agent by hand) can leave `train.py.orig`. The scope check then flags `train.py.orig` (scope allows `train.py`, not the backup) and aborts the run before any launch — a wasted session, though no gate spend.
- Fix: `_exclude_merge_artifacts` adds `*.orig`/`*.rej` to `.git/info/exclude` at run init — repo-local, idempotent, no tracked edit, and effective for the `git add -A` behind changed-paths and every seal. Standard-practice ignore for conflict artifacts.
- Applied unconditionally (not just line runs): any session can produce a `.orig` via mergetool.
- Tests: a session leaving a `tsp.py.orig` publishes cleanly with the artifact absent from the seal; the exclude is idempotent and preserves prior content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
