### PR TITLE
Board curves: launch fallback + 5 per agent

### DIFF
--- a/src/autoresearch/climbboard.py
+++ b/src/autoresearch/climbboard.py
@@ -36,9 +36,10 @@ BOARD_BRANCH = "research-log"
 MAX_HYPOTHESIS_CHARS = 160
 MAX_SUMMARY_CHARS = 90  # what the table shows; the full line stays in the row
 MAX_CURVE_POINTS = 160
-MAX_CURVE_RUNS = 150  # curves are heavy; the newest runs keep theirs
-MAX_CURVE_RUNS_PER_AGENT = 5  # ...but at most this many per agent, so one busy
-# agent cannot crowd the panel and every agent stays represented
+MAX_CURVE_RUNS_PER_AGENT = 5  # at most this many curves per agent, so one
+# busy agent cannot crowd the panel AND every active agent stays represented
+# (this per-agent cap is the whole bound — no global total ceiling, which
+# would drop the oldest agent once agents * 5 exceeded it)
 MAX_ROWS_PER_BENCHMARK = 2000
 
 
@@ -994,8 +995,6 @@ def _merge_curves(
     per_agent: dict[str, int] = {}
     merged: dict[str, list[list[float]]] = {}
     for r in reversed(rows):
-        if len(merged) >= MAX_CURVE_RUNS:
-            break  # total safety ceiling
         agent = str(r.get("agent") or "")
         if per_agent.get(agent, 0) >= MAX_CURVE_RUNS_PER_AGENT:
             continue

--- a/src/autoresearch/climbboard.py
+++ b/src/autoresearch/climbboard.py
@@ -133,9 +133,9 @@ def _parse_curve_stdout(stdout_path: Path) -> list[list[float]]:
 def _curve_from_eval(run_directory: Path) -> list[list[float]]:
     """The training curve behind a run's row: the newest CANDIDATE eval when
     the run submitted, else the run's best LAUNCH experiment (lowest final
-    val loss). Without the launch fallback a run that measured experiments
-    but declined to submit — the common launch-first-then-negative case —
-    would show no curve, and its agent would vanish from the panel."""
+    val loss). Without the launch fallback a run that tested experiments
+    but did not submit would show no curve, and its agent would vanish from
+    the panel."""
 
     def mtime(d: Path) -> float:
         try:
@@ -148,7 +148,11 @@ def _curve_from_eval(run_directory: Path) -> list[list[float]]:
         key=mtime,
     )
     if candidates:
-        return _parse_curve_stdout(candidates[-1] / "stdout")
+        points = _parse_curve_stdout(candidates[-1] / "stdout")
+        if points:
+            return points
+        # a candidate whose stdout has no parsable points falls through to
+        # the launch fallback rather than leaving the run curveless
     # launch fallback: the experiment the agent did best on (lowest final val
     # loss — a display heuristic for the min-oriented speedrun curve, not a
     # credited measurement)
@@ -982,20 +986,25 @@ def _merge_curves(
             log.warning("board curves malformed for %s; skipped", benchmark)
             return None
         published = {str(k): v for k, v in data.items()}
-    # keep the newest curves, but at most MAX_CURVE_RUNS_PER_AGENT per agent
-    # so one busy agent cannot crowd out the others (rows are oldest-first)
+    # keep the newest curves, at most MAX_CURVE_RUNS_PER_AGENT per agent so
+    # one busy agent cannot crowd out the others. Walk ALL rows newest-first
+    # (no global pre-slice — that could bury a quiet agent whose rows all sit
+    # past the cut), and count the quota only for rows that ACTUALLY have a
+    # curve (a curveless attempt must not spend an agent's five slots).
     per_agent: dict[str, int] = {}
-    keep: list[str] = []
-    for r in reversed(rows[-MAX_CURVE_RUNS:]):
-        agent = str(r.get("agent") or "")
-        per_agent[agent] = per_agent.get(agent, 0) + 1
-        if per_agent[agent] <= MAX_CURVE_RUNS_PER_AGENT:
-            keep.append(str(r.get("run_id")))
     merged: dict[str, list[list[float]]] = {}
-    for run_id in keep:
+    for r in reversed(rows):
+        if len(merged) >= MAX_CURVE_RUNS:
+            break  # total safety ceiling
+        agent = str(r.get("agent") or "")
+        if per_agent.get(agent, 0) >= MAX_CURVE_RUNS_PER_AGENT:
+            continue
+        run_id = str(r.get("run_id"))
         curve = published.get(run_id) or fresh_for(run_id)
-        if curve:
-            merged[run_id] = curve
+        if not curve:
+            continue
+        per_agent[agent] = per_agent.get(agent, 0) + 1
+        merged[run_id] = curve
     return {"data": merged, "changed": merged != published}
 
 

--- a/src/autoresearch/climbboard.py
+++ b/src/autoresearch/climbboard.py
@@ -37,6 +37,8 @@ MAX_HYPOTHESIS_CHARS = 160
 MAX_SUMMARY_CHARS = 90  # what the table shows; the full line stays in the row
 MAX_CURVE_POINTS = 160
 MAX_CURVE_RUNS = 150  # curves are heavy; the newest runs keep theirs
+MAX_CURVE_RUNS_PER_AGENT = 5  # ...but at most this many per agent, so one busy
+# agent cannot crowd the panel and every agent stays represented
 MAX_ROWS_PER_BENCHMARK = 2000
 
 
@@ -101,25 +103,11 @@ _CURVE_LINE = re.compile(
 MAX_CURVE_STDOUT_BYTES = 32 * 1024 * 1024
 
 
-def _curve_from_eval(run_directory: Path) -> list[list[float]]:
-    """(step, val loss) points parsed from the newest candidate eval's
-    stdout, downsampled — the training curve behind the row's number.
+def _parse_curve_stdout(stdout_path: Path) -> list[list[float]]:
+    """(step, val loss) points parsed from an eval's stdout, downsampled.
     steps.jsonl dies with the job's scratch; stdout is what survives."""
-
-    def mtime(d: Path) -> float:
-        try:
-            return d.stat().st_mtime
-        except OSError:
-            return 0.0  # vanished between glob and sort: sorts oldest, still readable-guarded
-
-    evals = sorted(
-        (d for d in run_directory.glob("eval-candidate-*") if (d / "stdout").is_file()),
-        key=mtime,
-    )
-    if not evals:
-        return []
     try:
-        with (evals[-1] / "stdout").open("rb") as fh:
+        with stdout_path.open("rb") as fh:
             # a byte-mode bounded read caps memory whatever the content — a
             # text-mode read counts characters and 4-byte UTF-8 overshoots 4x
             raw = fh.read(MAX_CURVE_STDOUT_BYTES + 1)
@@ -140,6 +128,39 @@ def _curve_from_eval(run_directory: Path) -> list[list[float]]:
         stride = len(points) / (MAX_CURVE_POINTS - 1)
         points = [points[int(i * stride)] for i in range(MAX_CURVE_POINTS - 1)] + [points[-1]]
     return points
+
+
+def _curve_from_eval(run_directory: Path) -> list[list[float]]:
+    """The training curve behind a run's row: the newest CANDIDATE eval when
+    the run submitted, else the run's best LAUNCH experiment (lowest final
+    val loss). Without the launch fallback a run that measured experiments
+    but declined to submit — the common launch-first-then-negative case —
+    would show no curve, and its agent would vanish from the panel."""
+
+    def mtime(d: Path) -> float:
+        try:
+            return d.stat().st_mtime
+        except OSError:
+            return 0.0  # vanished between glob and sort: sorts oldest, still readable-guarded
+
+    candidates = sorted(
+        (d for d in run_directory.glob("eval-candidate-*") if (d / "stdout").is_file()),
+        key=mtime,
+    )
+    if candidates:
+        return _parse_curve_stdout(candidates[-1] / "stdout")
+    # launch fallback: the experiment the agent did best on (lowest final val
+    # loss — a display heuristic for the min-oriented speedrun curve, not a
+    # credited measurement)
+    best: list[list[float]] = []
+    best_final: float | None = None
+    for d in run_directory.glob("eval-launch-*"):
+        if not (d / "stdout").is_file():
+            continue
+        points = _parse_curve_stdout(d / "stdout")
+        if points and (best_final is None or points[-1][1] < best_final):
+            best_final, best = points[-1][1], points
+    return best
 
 
 def collect_rows(root: Path, target: str) -> dict[str, list[ClimbRow]]:
@@ -537,7 +558,15 @@ def render_html(
         "  cb.onchange = draw; ob.onchange = draw; draw(); redraws.push(draw);\n"
         "  // the training curves behind the numbers: newest attempts overlaid\n"
         "  const bcurves = data.curves[b] || {};\n"
-        "  const withCurve = rows.filter(r => bcurves[r.run_id]).slice(-8);\n"
+        "  // newest curves, capped per agent so every agent stays on the panel\n"
+        "  // (rows are oldest-first; walk newest-first, keep <=5 per agent)\n"
+        "  const perAgent = {}; const picked = [];\n"
+        "  for (let i = rows.length - 1; i >= 0; i--) {\n"
+        "    const r = rows[i]; if (!bcurves[r.run_id]) continue;\n"
+        "    perAgent[r.agent] = (perAgent[r.agent] || 0) + 1;\n"
+        "    if (perAgent[r.agent] <= 5) picked.push(r);\n"
+        "  }\n"
+        "  const withCurve = picked.reverse();\n"
         "  if (withCurve.length) {\n"
         "    const h3 = document.createElement('h2');\n"
         "    h3.textContent = b + ' — training curves (newest attempts)';\n"
@@ -953,7 +982,15 @@ def _merge_curves(
             log.warning("board curves malformed for %s; skipped", benchmark)
             return None
         published = {str(k): v for k, v in data.items()}
-    keep = [str(r.get("run_id")) for r in rows[-MAX_CURVE_RUNS:]]
+    # keep the newest curves, but at most MAX_CURVE_RUNS_PER_AGENT per agent
+    # so one busy agent cannot crowd out the others (rows are oldest-first)
+    per_agent: dict[str, int] = {}
+    keep: list[str] = []
+    for r in reversed(rows[-MAX_CURVE_RUNS:]):
+        agent = str(r.get("agent") or "")
+        per_agent[agent] = per_agent.get(agent, 0) + 1
+        if per_agent[agent] <= MAX_CURVE_RUNS_PER_AGENT:
+            keep.append(str(r.get("run_id")))
     merged: dict[str, list[list[float]]] = {}
     for run_id in keep:
         curve = published.get(run_id) or fresh_for(run_id)

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -613,6 +613,43 @@ def test_merge_curves_caps_five_per_agent(tmp_path: Path) -> None:
     assert len(b_kept) == 3  # agent-02 had only 3
 
 
+def test_curveless_rows_do_not_consume_the_per_agent_quota(tmp_path: Path) -> None:
+    """An attempt with no curve must not spend one of an agent's five slots —
+    the fifth CURVE should still be kept even behind curveless newer rows."""
+    from autoresearch.climbboard import _merge_curves
+
+    class _GH:
+        def get_file(self, repo, path, ref):
+            raise _GitHubError(404)
+
+    # newest four rows have no curve; the five older rows do
+    rows = [{"run_id": f"c{i}", "agent": "agent-01"} for i in range(5)] + [
+        {"run_id": f"n{i}", "agent": "agent-01"} for i in range(4)
+    ]
+    have = {f"c{i}": [[1, 1.0]] for i in range(5)}  # only the c-rows have curves
+    merged = _merge_curves(_GH(), "o/r", "speedrun", rows, lambda rid: have.get(rid, []))
+    assert merged is not None
+    assert set(merged["data"]) == {"c0", "c1", "c2", "c3", "c4"}  # all five curves kept
+
+
+def test_quiet_agent_curve_survives_a_busy_agent(tmp_path: Path) -> None:
+    """A quiet agent whose only row sits far down the list still keeps its
+    curve — the per-agent cap is applied across ALL rows, not a global slice."""
+    from autoresearch.climbboard import _merge_curves
+
+    class _GH:
+        def get_file(self, repo, path, ref):
+            raise _GitHubError(404)
+
+    rows = [{"run_id": "quiet", "agent": "agent-09"}] + [
+        {"run_id": f"busy{i}", "agent": "agent-01"} for i in range(300)
+    ]
+    curves = {r["run_id"]: [[1, 1.0]] for r in rows}
+    merged = _merge_curves(_GH(), "o/r", "speedrun", rows, lambda rid: curves[rid])
+    assert merged is not None
+    assert "quiet" in merged["data"]  # not buried by 300 busy rows
+
+
 def test_fresh_curve_skips_garbage_points(tmp_path: Path) -> None:
     """A 400-nines 'loss' parses as float inf and a 400-digit step exceeds
     JS-safe integers; both skip the point, not the curve."""

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -650,6 +650,28 @@ def test_quiet_agent_curve_survives_a_busy_agent(tmp_path: Path) -> None:
     assert "quiet" in merged["data"]  # not buried by 300 busy rows
 
 
+def test_every_agent_is_kept_beyond_any_total_ceiling(tmp_path: Path) -> None:
+    """No global total ceiling drops an agent: 40 agents * 5 curves = 200 are
+    all kept (the per-agent cap is the only bound)."""
+    from autoresearch.climbboard import MAX_CURVE_RUNS_PER_AGENT, _merge_curves
+
+    class _GH:
+        def get_file(self, repo, path, ref):
+            raise _GitHubError(404)
+
+    rows = [
+        {"run_id": f"a{a}-r{i}", "agent": f"agent-{a:02d}"}
+        for a in range(40)
+        for i in range(6)  # six each; the cap keeps five
+    ]
+    curves = {r["run_id"]: [[1, 1.0]] for r in rows}
+    merged = _merge_curves(_GH(), "o/r", "speedrun", rows, lambda rid: curves[rid])
+    assert merged is not None
+    agents_kept = {k.split("-r")[0] for k in merged["data"]}
+    assert len(agents_kept) == 40  # every agent represented
+    assert len(merged["data"]) == 40 * MAX_CURVE_RUNS_PER_AGENT
+
+
 def test_fresh_curve_skips_garbage_points(tmp_path: Path) -> None:
     """A 400-nines 'loss' parses as float inf and a 400-digit step exceeds
     JS-safe integers; both skip the point, not the curve."""

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -570,9 +570,47 @@ def test_curves_come_from_eval_stdout_downsampled(tmp_path: Path) -> None:
     pts = _curve_from_eval(run_dir(tmp_path, "speedrun-1"))
     assert 2 < len(pts) <= MAX_CURVE_POINTS
     assert pts[0][0] == 128 and pts[-1] == [9344, 3.276098]
-    # a run with no parsable eval simply has no curve
+    # a run with no eval dirs at all simply has no curve
     _terminal_run(tmp_path, "speedrun-2", ending="merged")
     assert _curve_from_eval(run_dir(tmp_path, "speedrun-2")) == []
+
+
+def test_curve_falls_back_to_the_best_launch(tmp_path: Path) -> None:
+    """A run that launched experiments but never submitted (no candidate
+    eval) shows its best launch's curve, so its agent stays on the panel."""
+    from autoresearch.climbboard import _curve_from_eval
+
+    _terminal_run(tmp_path, "speedrun-3")
+    rd = run_dir(tmp_path, "speedrun-3")
+    worse = rd / "eval-launch-wide"
+    worse.mkdir()
+    (worse / "stdout").write_text("step 128 val loss 5.0\nstep 256 val loss 4.8\n")
+    better = rd / "eval-launch-deep"
+    better.mkdir()
+    (better / "stdout").write_text("step 128 val loss 4.9\nstep 256 val loss 3.9\n")
+    # no candidate eval -> the best (lowest final) launch is used
+    assert _curve_from_eval(rd) == [[128, 4.9], [256, 3.9]]
+
+
+def test_merge_curves_caps_five_per_agent(tmp_path: Path) -> None:
+    from autoresearch.climbboard import MAX_CURVE_RUNS_PER_AGENT, _merge_curves
+
+    class _GH:
+        def get_file(self, repo, path, ref):
+            raise _GitHubError(404)  # no published curves yet
+
+    rows = [{"run_id": f"a{i}", "agent": "agent-01"} for i in range(8)] + [
+        {"run_id": f"b{i}", "agent": "agent-02"} for i in range(3)
+    ]
+    curves = {r["run_id"]: [[1, 1.0]] for r in rows}
+    merged = _merge_curves(_GH(), "o/r", "speedrun", rows, lambda rid: curves.get(rid, []))
+    assert merged is not None
+    kept = merged["data"]
+    a_kept = [k for k in kept if k.startswith("a")]
+    b_kept = [k for k in kept if k.startswith("b")]
+    assert len(a_kept) == MAX_CURVE_RUNS_PER_AGENT  # newest 5 of agent-01's 8
+    assert set(a_kept) == {"a3", "a4", "a5", "a6", "a7"}  # the newest
+    assert len(b_kept) == 3  # agent-02 had only 3
 
 
 def test_fresh_curve_skips_garbage_points(tmp_path: Path) -> None:


### PR DESCRIPTION
Two board asks (observed live): the training-curve panel is missing agent-01 — and "always some agent" — and should show 5 runs per agent.

Root cause: curves came only from `eval-candidate-*/stdout`, i.e. gate evals. A run that launches experiments then declines to submit (launch-first-negative, the common case now) runs no gate eval → no curve → its agent disappears from the panel.

- `_curve_from_eval`: candidate eval when the run submitted, else the run's best launch (`eval-launch-*/stdout`, lowest final val loss). Every terminal run now has a curve; every active agent stays on the panel. Bounded parse factored into `_parse_curve_stdout`.
- Per-agent cap of 5 (`MAX_CURVE_RUNS_PER_AGENT`) in `_merge_curves` (stored) and the panel's `withCurve` selection (was a global newest-8 slice; now newest-5-per-agent).
- No change to curve→agent association (curves key on board run_ids which carry the agent), so the existing per-agent legend grouping/coloring just works.

Preview (launch-curve fallback + 5-per-agent, all four agents present): https://claude.ai/code/artifact/ee31eb3c-7d9e-4ecd-a639-928b1ae0891b

🤖 Generated with [Claude Code](https://claude.com/claude-code)
