### PR TITLE
GitHub App auth: design note + installation-token provider (scaffold)

### DIFF
--- a/docs/design/github-app-auth.md
+++ b/docs/design/github-app-auth.md
@@ -104,3 +104,22 @@ RW (comments, labels), **Actions** RW (`workflow_dispatch` the review/verify
 workflows), **Commit statuses** R (merge-on-green gate), **Metadata** R
 (mandatory). Not granted: Workflows (agents are scope-gated to the solver
 path, never `.github/`), Administration, Members.
+
+## Registration metadata
+
+The values entered when the App is created (recorded so the App can be
+re-created identically). It authenticates server-to-server only, so the whole
+user-authorization/OAuth half of the form is off: no callback URL, no device
+flow, no user-authorization-on-install. The webhook is inactive — the kernel
+polls each tick rather than receiving events — so no webhook URL, secret, or
+event subscriptions. Installation is restricted to **only this account**
+(`agentic-learning-ai-lab`); no organization, account, or enterprise
+permissions are requested.
+
+- **Name**: `Outerloop Autoresearch` → bot identity `outerloop-autoresearch[bot]`.
+- **Homepage**: `https://outerloop.science`.
+- **Description**: "Autonomous research agents working in an outer loop. Opens
+  pull requests, comments, and pushes branches as the Outerloop kernel on the
+  lab's repositories. Agents launch and evaluate their own training runs on
+  compute clusters, iterating on their results without human dispatch.
+  Developed by the Agentic Learning AI Lab at NYU."

--- a/docs/design/github-app-auth.md
+++ b/docs/design/github-app-auth.md
@@ -45,7 +45,10 @@ or network (and so the crypto dependency stays out of the hot path):
 - a **signer** `Callable[[bytes], bytes]` (RS256 over the signing input) —
   production signer built lazily from the PEM via `cryptography`; tests inject
   a fake.
-- a **transport** for the token-exchange POST — same pattern as `GitHubClient`.
+- a **transport** for the token-exchange POST — same pattern as `GitHubClient`,
+  and the default rides the same auth-stripping opener (a redirect that changes
+  host loses the `Authorization` header, so the App JWT can never be forwarded
+  off `api.github.com`).
 
 ## Configuration
 

--- a/docs/design/github-app-auth.md
+++ b/docs/design/github-app-auth.md
@@ -1,0 +1,106 @@
+# GitHub App auth: installation tokens replace the bot PAT
+
+The kernel authenticates to GitHub as a bot account holding a long-lived
+fine-grained PAT (`FileTokenProvider` over `~/.config/autoresearch/bot_pat`).
+This note designs its replacement by a **GitHub App**: the kernel mints
+short-lived installation tokens from the App's private key. It is the concrete
+form of the identity seam in [external.md](external.md) ("an App
+installation-token provider replaces one constructor call, not the callers").
+
+## Why (and why now)
+
+The public flip is the driver. A PAT is tied to a real account with broad
+reach; leaked from a public-repo CI run, its blast radius is that whole
+account. An App's installation tokens are **scoped** to only the installed
+repositories with **fine-grained permissions**, **short-lived** (~1h,
+auto-minted), **revocable** per installation, and carry **higher rate limits**
+(~15k/hr per installation vs 5k/hr for a PAT). The one durable secret becomes
+the App private key, which never travels to CI.
+
+The 2026-09-01 workflow audit found the `pull_request_target` fork-exfil gap
+already closed (same-repo guards on every secret-bearing PR job; the
+reviewer/verifier workflows are `workflow_dispatch`, unreachable by forks), so
+this App migration is the top remaining pre-flip credential item, not the
+exfil fix.
+
+## The provider
+
+`AppInstallationTokenProvider` satisfies the existing `TokenProvider` protocol
+(`token() -> str`), so it drops in where `FileTokenProvider` is constructed and
+no caller changes. Each `token()`:
+
+1. **Mint a JWT** signed RS256 with the App private key: `iss` = App ID,
+   `iat` backdated 60s (clock skew), `exp` ≤ 10 min (GitHub's cap; we use
+   ~9 min). The JWT authenticates *as the App*.
+2. **Exchange it** at `POST /app/installations/{installation_id}/access_tokens`
+   (Bearer JWT) for a **short-lived installation token** (`ghs_…`, ~1h) scoped
+   to the installation's repos and permissions.
+3. **Cache** the token until a refresh margin (5 min) before its `expires_at`,
+   so steady-state adds no per-call network cost; re-mint only across the
+   margin.
+
+Two collaborators are injected so the provider is fully testable without a key
+or network (and so the crypto dependency stays out of the hot path):
+
+- a **signer** `Callable[[bytes], bytes]` (RS256 over the signing input) —
+  production signer built lazily from the PEM via `cryptography`; tests inject
+  a fake.
+- a **transport** for the token-exchange POST — same pattern as `GitHubClient`.
+
+## Configuration
+
+Three values, mirroring the PAT handling:
+
+- **App ID** and **Installation ID**: non-secret integers (config keys).
+- **Private key** (`.pem`) on the orchestrator host, `chmod 600`, never
+  committed — the same custody the PAT file already has (`FileTokenProvider`
+  enforces the mode; the key loader enforces it too).
+
+## The crypto dependency
+
+GitHub App JWTs require RS256, which the stdlib cannot sign. The production
+signer uses `cryptography` (well-audited, ubiquitous). It is added to a new
+`app-auth` optional extra and `uv lock`-ed **at cutover**, not now — the
+scaffold injects the signer, so the provider and its tests build and run
+green without the dependency. The default signer lazy-imports `cryptography`
+and raises a clear "install the app-auth extra" error if absent.
+
+## Git compatibility
+
+Installation tokens authenticate git over HTTPS exactly as the PAT does — the
+`x-access-token:<token>` extraheader in `_git_env` is unchanged. Because
+tokens are short-lived, `git_network` already resolves the credential
+per-invocation (it calls `auth.token()` each time), so a token that expired
+between operations is simply re-minted on the next call. No git-path change.
+
+## Identity
+
+Commits and comments shift from the `agentic-learning-bot` account to
+`<app-name>[bot]`. Cosmetic but permanent — the App name is chosen once as the
+bot's durable identity.
+
+## Staged cutover (not a hot swap)
+
+Swapping the live fleet's identity mid-campaign is an ops event:
+
+1. **Build + unit-test** the provider (this note's scaffold) behind no live
+   wiring.
+2. **Validate on a throwaway repo**: point a provider instance at a scratch
+   installation, confirm git push/fetch, a PR, a comment, and a
+   `workflow_dispatch` all succeed with a minted token.
+3. **Cut over in a quiet window**: a config flag selects the provider; keep the
+   PAT provider as a one-cycle fallback, then retire it.
+
+## Out of scope
+
+The advisory-review workflows' `checkout_ssh_key` is a separate deploy key,
+not the bot PAT; migrating it (if ever) is independent of this change.
+
+## Permissions the App declares
+
+Least privilege for the kernel's operations: **Contents** RW (git, board
+publish, merge), **Pull requests** RW (create/comment/review/arm), **Issues**
+RW (comments, labels), **Actions** RW (`workflow_dispatch` the review/verify
+workflows), **Commit statuses** R (merge-on-green gate), **Metadata** R
+(mandatory). Not granted: Workflows (agents are scope-gated to the solver
+path, never `.github/`), Administration, Members.

--- a/docs/design/github-app-auth.md
+++ b/docs/design/github-app-auth.md
@@ -76,6 +76,15 @@ tokens are short-lived, `git_network` already resolves the credential
 per-invocation (it calls `auth.token()` each time), so a token that expired
 between operations is simply re-minted on the next call. No git-path change.
 
+## Redaction across refreshes
+
+Call sites today build a fixed secrets tuple from one `bot_auth.token()`
+snapshot — safe with an immortal PAT, stale the moment the App provider mints
+a refresh mid-run. The provider therefore remembers every token it has ever
+issued (`issued()`), and **cutover must rebuild redaction sets from
+`issued()` at write time** (report publish, session output, best-effort
+logging), not from a value captured at construction.
+
 ## Identity
 
 Commits and comments shift from the `agentic-learning-bot` account to

--- a/docs/design/github-app-auth.md
+++ b/docs/design/github-app-auth.md
@@ -119,7 +119,7 @@ permissions are requested.
 - **Name**: `Outerloop Autoresearch` → bot identity `outerloop-autoresearch[bot]`.
 - **Homepage**: `https://outerloop.science`.
 - **Description**: "Autonomous research agents working in an outer loop. Opens
-  pull requests, comments, and pushes branches as the Outerloop kernel on the
-  lab's repositories. Agents launch and evaluate their own training runs on
+  pull requests, comments, and pushes branches as the Outerloop kernel on
+  research repositories. Agents launch and evaluate their own training runs on
   compute clusters, iterating on their results without human dispatch.
   Developed by the Agentic Learning AI Lab at NYU."

--- a/src/autoresearch/appauth.py
+++ b/src/autoresearch/appauth.py
@@ -25,6 +25,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from autoresearch.github import AUTH_SAFE_OPENER
+
 # RS256-sign the JWT signing input, returning the raw signature bytes.
 Signer = Callable[[bytes], bytes]
 # Perform the token-exchange POST and return the parsed JSON body.
@@ -71,8 +73,9 @@ def _parse_expiry(expires_at: str) -> float:
 
 
 def _default_transport(request: urllib.request.Request) -> Any:
+    # the shared opener: a cross-host redirect must not forward the App JWT
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with AUTH_SAFE_OPENER.open(request, timeout=30) as response:
             payload = response.read()
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")[:500]

--- a/src/autoresearch/appauth.py
+++ b/src/autoresearch/appauth.py
@@ -104,6 +104,10 @@ class AppInstallationTokenProvider:
         self._now = now
         self._token = ""
         self._expiry = 0.0
+        # every token ever minted this process — the PAT was one immortal
+        # string, but these rotate ~hourly, so a redaction set snapshotted at
+        # construction goes stale; redaction must pull issued() at write time
+        self._issued: list[str] = []
 
     def token(self) -> str:
         now = self._now()
@@ -123,6 +127,7 @@ class AppInstallationTokenProvider:
         if not isinstance(body, dict) or not body.get("token"):
             raise ValueError("installation-token response missing a token")
         self._token = str(body["token"])
+        self._issued.append(self._token)
         expires_at = body.get("expires_at")
         # a missing/garbled expiry is treated as immediate — safe: we simply
         # re-mint on every call rather than trust an unknown lifetime
@@ -131,6 +136,11 @@ class AppInstallationTokenProvider:
         except ValueError:
             self._expiry = now
         return self._token
+
+    def issued(self) -> tuple[str, ...]:
+        """Every token this provider has minted, for redaction sets built at
+        write time — a set snapshotted at construction misses refreshes."""
+        return tuple(self._issued)
 
 
 def signer_from_private_key(pem_path: Path) -> Signer:

--- a/src/autoresearch/appauth.py
+++ b/src/autoresearch/appauth.py
@@ -1,0 +1,156 @@
+"""GitHub App installation-token auth (docs/design/github-app-auth.md).
+
+`AppInstallationTokenProvider` satisfies the `TokenProvider` protocol used
+throughout `github.py`, so it replaces `FileTokenProvider` at the one
+constructor call without touching any caller. Each `token()` mints a
+short-lived JWT (RS256, signed by the App private key), exchanges it for a
+~1h installation token scoped to the installation's repos, and caches that
+token until a refresh margin before it expires.
+
+The RS256 signer and the HTTP transport are injected so the provider — and
+its tests — build and run without the `cryptography` dependency or a network;
+that dependency is added to the `app-auth` extra only at live cutover.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+# RS256-sign the JWT signing input, returning the raw signature bytes.
+Signer = Callable[[bytes], bytes]
+# Perform the token-exchange POST and return the parsed JSON body.
+Transport = Callable[[urllib.request.Request], Any]
+
+API = "https://api.github.com"
+# GitHub caps App JWT lifetime at 10 minutes; stay comfortably under it.
+_JWT_TTL_S = 9 * 60
+# Backdate `iat` to tolerate clock skew between us and GitHub.
+_JWT_BACKDATE_S = 60
+# Re-mint the installation token this long before it actually expires, so a
+# token is never handed out on the edge of expiry.
+_REFRESH_MARGIN_S = 5 * 60
+
+
+def _b64url(data: bytes) -> str:
+    """URL-safe base64 without padding — the JWT wire encoding."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def build_app_jwt(app_id: int, now: float, sign: Signer) -> str:
+    """A GitHub App JWT: header.payload.signature, RS256 over the first two."""
+    header = _b64url(json.dumps({"alg": "RS256", "typ": "JWT"}).encode())
+    payload = _b64url(
+        json.dumps(
+            {
+                "iat": int(now) - _JWT_BACKDATE_S,
+                "exp": int(now) + _JWT_TTL_S,
+                "iss": str(app_id),
+            }
+        ).encode()
+    )
+    signing_input = f"{header}.{payload}"
+    signature = _b64url(sign(signing_input.encode("ascii")))
+    return f"{signing_input}.{signature}"
+
+
+def _parse_expiry(expires_at: str) -> float:
+    """`2026-09-01T12:00:00Z` (or with an offset) -> unix seconds."""
+    text = expires_at.strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    return datetime.fromisoformat(text).timestamp()
+
+
+def _default_transport(request: urllib.request.Request) -> Any:
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            payload = response.read()
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")[:500]
+        raise ValueError(f"installation-token exchange failed ({exc.code}): {body}") from None
+    except urllib.error.URLError as exc:
+        raise ValueError(f"installation-token exchange failed: {exc.reason}") from None
+    return json.loads(payload) if payload else None
+
+
+class AppInstallationTokenProvider:
+    """A `TokenProvider` minting cached, short-lived installation tokens."""
+
+    def __init__(
+        self,
+        app_id: int,
+        installation_id: int,
+        sign: Signer,
+        *,
+        transport: Transport | None = None,
+        now: Callable[[], float] = time.time,
+    ) -> None:
+        self.app_id = app_id
+        self.installation_id = installation_id
+        self._sign = sign
+        self._transport = transport or _default_transport
+        self._now = now
+        self._token = ""
+        self._expiry = 0.0
+
+    def token(self) -> str:
+        now = self._now()
+        if self._token and now < self._expiry - _REFRESH_MARGIN_S:
+            return self._token
+        jwt = build_app_jwt(self.app_id, now, self._sign)
+        request = urllib.request.Request(
+            f"{API}/app/installations/{self.installation_id}/access_tokens",
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {jwt}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        body = self._transport(request)
+        if not isinstance(body, dict) or not body.get("token"):
+            raise ValueError("installation-token response missing a token")
+        self._token = str(body["token"])
+        expires_at = body.get("expires_at")
+        # a missing/garbled expiry is treated as immediate — safe: we simply
+        # re-mint on every call rather than trust an unknown lifetime
+        try:
+            self._expiry = _parse_expiry(str(expires_at)) if expires_at else now
+        except ValueError:
+            self._expiry = now
+        return self._token
+
+
+def signer_from_private_key(pem_path: Path) -> Signer:
+    """The production RS256 signer, built from the App private-key PEM. Lazily
+    imports `cryptography` (the `app-auth` extra) so the module and its tests
+    do not depend on it; the key file must be owner-only (chmod 600), the same
+    custody the PAT file has."""
+    if not pem_path.is_file():
+        raise ValueError(f"{pem_path} is not a readable private-key file")
+    if pem_path.stat().st_mode & 0o077:
+        raise PermissionError(f"{pem_path} is group/world accessible; chmod 600 it")
+    try:
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import padding
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra
+        raise ImportError(
+            "GitHub App auth needs the 'app-auth' extra (cryptography); "
+            "install it before selecting the App token provider"
+        ) from exc
+
+    key = serialization.load_pem_private_key(pem_path.read_bytes(), password=None)
+
+    def sign(message: bytes) -> bytes:
+        return key.sign(message, padding.PKCS1v15(), hashes.SHA256())
+
+    return sign

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -138,13 +138,15 @@ class _NoAuthRedirect(urllib.request.HTTPRedirectHandler):
         return new
 
 
-_opener = urllib.request.build_opener(_NoAuthRedirect)
+# The one opener every API call shares — a redirect that changes host loses
+# the Authorization header instead of forwarding the credential.
+AUTH_SAFE_OPENER = urllib.request.build_opener(_NoAuthRedirect)
 
 
 def _raw_transport(request: urllib.request.Request) -> str:
     """Fetch a non-JSON body (the diff media type returns text/plain)."""
     try:
-        with _opener.open(request, timeout=30) as response:
+        with AUTH_SAFE_OPENER.open(request, timeout=30) as response:
             return str(response.read().decode(errors="replace"))
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")[:500]
@@ -157,7 +159,7 @@ def _raw_transport(request: urllib.request.Request) -> str:
 
 def _default_transport(request: urllib.request.Request) -> Any:
     try:
-        with _opener.open(request, timeout=30) as response:
+        with AUTH_SAFE_OPENER.open(request, timeout=30) as response:
             payload = response.read()
     except urllib.error.HTTPError as exc:
         body = exc.read().decode(errors="replace")[:500]

--- a/tests/test_appauth.py
+++ b/tests/test_appauth.py
@@ -94,6 +94,28 @@ def test_garbled_expiry_forces_a_re_mint_every_call() -> None:
     assert len(calls) == 2  # an unparsable expiry is treated as immediate
 
 
+def test_default_transport_routes_through_the_shared_opener(monkeypatch) -> None:
+    # the real exchange must go through github.py's auth-stripping opener, so
+    # a cross-host redirect can never forward the App JWT
+    import io
+
+    from autoresearch import appauth
+
+    seen = {}
+
+    class FakeOpener:
+        def open(self, request, timeout=None):
+            seen["url"] = request.full_url
+            return io.BytesIO(b'{"token": "ghs_ok"}')
+
+    monkeypatch.setattr(appauth, "AUTH_SAFE_OPENER", FakeOpener())
+    import urllib.request
+
+    body = appauth._default_transport(urllib.request.Request("https://api.github.com/x"))
+    assert body == {"token": "ghs_ok"}
+    assert seen["url"] == "https://api.github.com/x"
+
+
 def test_signer_refuses_a_missing_or_open_key(tmp_path) -> None:
     with pytest.raises(ValueError, match="not a readable"):
         signer_from_private_key(tmp_path / "nope.pem")

--- a/tests/test_appauth.py
+++ b/tests/test_appauth.py
@@ -69,6 +69,8 @@ def test_token_mints_caches_and_refreshes() -> None:
     clock["t"] += 400  # now within 5 min of expiry
     assert p.token() == "ghs_2"
     assert len(calls) == 2
+    # both minted tokens are remembered for write-time redaction sets
+    assert p.issued() == ("ghs_1", "ghs_2")
 
 
 def test_token_rejects_a_bodyless_response() -> None:

--- a/tests/test_appauth.py
+++ b/tests/test_appauth.py
@@ -1,0 +1,110 @@
+"""The GitHub App installation-token provider — exercised with an injected
+signer, transport, and clock, so no key, network, or cryptography is needed."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from autoresearch.appauth import (
+    AppInstallationTokenProvider,
+    build_app_jwt,
+    signer_from_private_key,
+)
+
+
+def _decode_segment(segment: str) -> dict:
+    pad = "=" * (-len(segment) % 4)
+    return json.loads(base64.urlsafe_b64decode(segment + pad))
+
+
+def test_build_app_jwt_shape() -> None:
+    jwt = build_app_jwt(app_id=12345, now=1_000_000.0, sign=lambda m: b"sig")
+    header_seg, payload_seg, sig_seg = jwt.split(".")
+    assert _decode_segment(header_seg) == {"alg": "RS256", "typ": "JWT"}
+    payload = _decode_segment(payload_seg)
+    assert payload["iss"] == "12345"
+    assert payload["iat"] == 1_000_000 - 60  # backdated for clock skew
+    assert payload["exp"] == 1_000_000 + 9 * 60  # under GitHub's 10-min cap
+    assert payload["exp"] - payload["iat"] <= 600
+    # the signature is base64url of the injected signer's output
+    assert base64.urlsafe_b64decode(sig_seg + "=" * (-len(sig_seg) % 4)) == b"sig"
+    # RS256 signs exactly "header.payload" (the first two segments)
+    signed = {}
+
+    def capture(message: bytes) -> bytes:
+        signed["input"] = message
+        return b"x"
+
+    jwt2 = build_app_jwt(1, 1000.0, capture)
+    assert signed["input"] == jwt2.rsplit(".", 1)[0].encode()
+
+
+def test_token_mints_caches_and_refreshes() -> None:
+    calls = []
+    clock = {"t": 1_000_000.0}
+
+    def transport(request):
+        calls.append(request.full_url)
+        # a token valid for one hour from the current clock
+        return {"token": f"ghs_{len(calls)}", "expires_at": _iso(clock["t"] + 3600)}
+
+    p = AppInstallationTokenProvider(
+        app_id=42,
+        installation_id=99,
+        sign=lambda m: b"sig",
+        transport=transport,
+        now=lambda: clock["t"],
+    )
+    # first call mints and hits the installation endpoint
+    assert p.token() == "ghs_1"
+    assert calls == ["https://api.github.com/app/installations/99/access_tokens"]
+    # within the validity window (minus refresh margin) the cache serves it
+    clock["t"] += 3000  # still inside 3600 - 300 margin
+    assert p.token() == "ghs_1"
+    assert len(calls) == 1  # no second exchange
+    # past the refresh margin, a fresh token is minted
+    clock["t"] += 400  # now within 5 min of expiry
+    assert p.token() == "ghs_2"
+    assert len(calls) == 2
+
+
+def test_token_rejects_a_bodyless_response() -> None:
+    p = AppInstallationTokenProvider(
+        app_id=1, installation_id=1, sign=lambda m: b"s", transport=lambda r: {}
+    )
+    with pytest.raises(ValueError, match="missing a token"):
+        p.token()
+
+
+def test_garbled_expiry_forces_a_re_mint_every_call() -> None:
+    calls = []
+
+    def transport(request):
+        calls.append(1)
+        return {"token": "ghs_x", "expires_at": "not-a-date"}
+
+    p = AppInstallationTokenProvider(
+        app_id=1, installation_id=1, sign=lambda m: b"s", transport=transport, now=lambda: 100.0
+    )
+    p.token()
+    p.token()
+    assert len(calls) == 2  # an unparsable expiry is treated as immediate
+
+
+def test_signer_refuses_a_missing_or_open_key(tmp_path) -> None:
+    with pytest.raises(ValueError, match="not a readable"):
+        signer_from_private_key(tmp_path / "nope.pem")
+    key = tmp_path / "key.pem"
+    key.write_text("-----BEGIN PRIVATE KEY-----\n...\n")
+    key.chmod(0o644)
+    with pytest.raises(PermissionError, match="group/world accessible"):
+        signer_from_private_key(key)
+
+
+def _iso(epoch: float) -> str:
+    from datetime import UTC, datetime
+
+    return datetime.fromtimestamp(epoch, UTC).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -430,3 +430,26 @@ def test_auto_mode_arming_merges_only_on_clean_status(monkeypatch) -> None:
     monkeypatch.setattr(client, "enable_auto_merge", not_allowed)
     assert client.arm_auto_merge_auto_mode("o/r", 8) is False
     assert merged == [7]  # no bulldozing a repo-owner control
+
+
+def test_redirect_off_host_loses_the_authorization_header() -> None:
+    # the shared opener forwards Authorization on a same-host redirect but
+    # strips it when the redirect changes host (or scheme)
+    from autoresearch.github import _NoAuthRedirect
+
+    handler = _NoAuthRedirect()
+    request = urllib.request.Request(
+        "https://api.github.com/app/installations/1/access_tokens",
+        headers={"Authorization": "Bearer jwt"},
+        method="POST",
+    )
+    hijacked = handler.redirect_request(
+        request, None, 302, "Found", {}, "https://attacker.example/steal"
+    )
+    assert hijacked is not None
+    assert "Authorization" not in hijacked.headers
+    same_host = handler.redirect_request(
+        request, None, 302, "Found", {}, "https://api.github.com/elsewhere"
+    )
+    assert same_host is not None
+    assert same_host.headers.get("Authorization") == "Bearer jwt"


### PR DESCRIPTION
## What

Design note + provider scaffold for migrating the kernel's GitHub auth off
the bot PAT to a **GitHub App** — the top remaining pre-flip credential item.

- `docs/design/github-app-auth.md` — why now (public flip), the provider,
  config surface, the crypto dependency (deferred to an `app-auth` extra at
  cutover), git compatibility, staged cutover, and the least-privilege
  permission set the App declares.
- `src/autoresearch/appauth.py` — `AppInstallationTokenProvider`, satisfying
  the existing `TokenProvider` protocol so it drops in at the one
  `FileTokenProvider` constructor without touching callers.
- `tests/test_appauth.py` — full coverage via injected fakes.

## Why

A PAT is tied to a real account with broad reach; leaked from a public-repo
CI run its blast radius is that whole account. An App's installation tokens
are scoped to the installed repos, short-lived (~1h), revocable per
installation, and carry higher rate limits. The one durable secret becomes
the App private key, which never travels to CI.

## Design choices worth a look

- **Injected signer + transport.** The RS256 signer and the token-exchange
  HTTP call are constructor params, so the provider and its tests build and
  run green with no `cryptography` dependency and no network. The production
  signer lazy-imports `cryptography` (added to an `app-auth` extra **at
  cutover**, not in this PR) and raises a clear "install the extra" error if
  absent.
- **Caching with a refresh margin.** `token()` returns the cached
  installation token until 5 min before its `expires_at`, so steady state
  adds no per-call network cost; a missing/garbled expiry is treated as
  immediate (safe: re-mint every call rather than trust an unknown lifetime).
- **No live wiring.** Scaffold only. The live cutover — a config flag
  selecting the provider, throwaway-repo validation, PAT fallback for one
  cycle — lands in a follow-up once the App exists (App ID, Installation ID,
  private-key path).

## Test / gate

`ruff check` + `ruff format --check` + `mypy` + `pytest` all green. The five
new tests assert the JWT payload shape, the exchange POST target/body
parsing, cache-hit within the window, re-mint past the margin, garbled-expiry
re-mint, and the key-file custody checks (missing file, group/world mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
