### PR TITLE
Onboarding stage 1: local compute mode + the design note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- `AUTORESEARCH_COMPUTE=local` runs the whole loop without a cluster: jobs
+  become synchronous subprocesses (`LocalCompute` at every seam), Slurm
+  placement env is not required, park-time wake arming yields to the sweep,
+  and `tick --loop` is the foreground chain. The zero-Slurm on-ramp and the
+  serialized-monolith ablation are the same switch (`docs/design/onboarding.md`).
 - The kernel can authenticate as a GitHub App: set `AUTORESEARCH_GITHUB_APP_FILE`
   to a JSON config (`app_id`, `installation_id`, `private_key` path) and every
   role mints short-lived installation tokens instead of reading the bot PAT

--- a/docs/design/onboarding.md
+++ b/docs/design/onboarding.md
@@ -1,0 +1,115 @@
+# Onboarding: the simplest path from zero to a climbing fleet
+
+Adoption is a design constraint now, not an afterthought: the public flip
+positions Outerloop as something other groups install and run. This note
+designs the whole funnel — GitHub identity, credentials, compute — around
+one wizard and two compute modes, so the landing page's setup panel is
+honest when it says three steps:
+
+1. **`init`** — one wizard mints the GitHub App, writes the config, and
+   validates the host (two browser clicks and one paste).
+2. **A contract** — add `.autoresearch.yaml` + an eval ruler to the target
+   repo.
+3. **Start** — one `sbatch` (cluster) or one foreground process
+   (workstation).
+
+## What the wizard does
+
+`python -m autoresearch.init` (interactive; every answer has a flag for
+non-interactive use):
+
+- **Detect compute.** `sbatch` on PATH → Slurm mode (prompt for account and
+  partition, verify with a real `sbatch --test-only`); otherwise local mode
+  (no placement questions at all).
+- **Mint the GitHub identity.** The **App manifest flow**: the wizard prints
+  a GitHub URL carrying our manifest (name, description, the least-privilege
+  permission set from [github-app-auth.md](github-app-auth.md), webhook off);
+  the operator clicks *Create App* in their org, GitHub redirects with a
+  one-time code, the operator pastes it back; the wizard exchanges the code —
+  **the conversion response carries the App ID and the private key in-band**,
+  so the wizard writes `github_app.json` + the PEM straight to
+  `~/.config/autoresearch/` (0600) on the host that will use them. No browser
+  download, no file shuffling between machines. It then prints the install
+  URL; after the operator installs the App on their repos, the wizard
+  discovers the installation id itself (App JWT → `GET /app/installations`).
+  A pre-existing PAT path is accepted as the alternative for orgs that
+  prefer it.
+- **Collect the author key.** One path prompt per configured backend
+  (`AUTORESEARCH_HARNESS_KEY_FILE` / codex equivalent), mode-600 enforced.
+- **Write `~/.config/autoresearch/.env`** — only keys the operator chose;
+  the tick chain's allowlist is the contract for what matters.
+- **Doctor.** Re-run every check the tick already preflights, plus the
+  wizard-level ones, and print a pass/fail table: git reachable with the
+  minted token, key files present and 0600, image present (offer
+  `apptainer pull` from the published registry), shared-FS/state root
+  writable, Slurm placement accepted, contract readable on the target.
+  The doctor is re-runnable on its own (`init --doctor`) and is the first
+  thing support asks for.
+- **Print the start command.** Nothing starts implicitly.
+
+The wizard invents no new validation: every check calls the same functions
+the tick preflights with, so the doctor and the tick cannot disagree
+(the `_panel_preflight_error` precedent).
+
+## Compute modes
+
+The `Compute` protocol already has both implementations; onboarding adds
+**selection** and a **local chain**, nothing more.
+
+- `AUTORESEARCH_COMPUTE=slurm` (default) — unchanged: the self-resubmitting
+  sbatch chain, every role its own job.
+- `AUTORESEARCH_COMPUTE=local` — `LocalCompute` at the two construction
+  sites (tick, attempt). Jobs run as subprocesses of the tick process,
+  **synchronously**: `submit` returns with the job already terminal.
+
+### What local mode degenerates to (by design)
+
+Local mode is the **monolith**: one process, one thing at a time. This is
+simultaneously the zero-Slurm on-ramp and the paper's Karpathy-loop
+ablation cell (width 1 × serialized) — the same kernel, the compute seam
+swapped, nothing else different.
+
+- **The chain is a loop.** No sbatch → `python -m autoresearch.tick --loop`
+  runs a tick every cadence in the foreground. State stays in records on
+  disk, so killing and restarting the loop resumes exactly like the Slurm
+  chain surviving a dead tick.
+- **Serialization is the semantics, not a bug.** A tick that launches a
+  climb blocks until the session ends; a launch syscall blocks the
+  orchestrator until training ends. Width is effectively 1 regardless of
+  the contract. The landing-page taste run and the ablation both want
+  exactly this.
+- **No dependency jobs.** `arm_wake` submits afterany wake jobs — under
+  local compute the dependencies are already terminal when `submit`
+  returns, and a synchronous wake would recurse into the park. Local mode
+  skips arming; the next loop iteration's sweep delivers every wake. Wake
+  latency = the cadence, as the pre-#184 fleet ran.
+- **Containment is best-effort.** With apptainer present, sessions run
+  contained exactly as on the cluster. Without it (macOS), sessions run
+  `--uncontained` — acceptable for an operator's own machine and keys, and
+  the doctor says so out loud rather than hiding it.
+
+## Stages
+
+1. **Kernel enablement** (this note's PR series, part 1):
+   `AUTORESEARCH_COMPUTE` selection at the two `SlurmCompute()` sites,
+   `tick --loop`, local-mode wake-arming skip, per-mode required-env
+   relaxation (no account/partition in local mode).
+2. **The wizard**: `autoresearch.init` — detection, prompts, `.env` writer,
+   doctor (PAT path first).
+3. **The manifest flow**: App mint + installation discovery inside the
+   wizard.
+4. **Docs + landing page**: QUICKSTART.md that is literally the three
+   steps, and the landing page's setup panel quoting it.
+
+Each stage lands as its own reviewed PR; the wizard is useful after stage
+2 even before the manifest flow exists (PAT path).
+
+## Non-goals
+
+- No hosted service, no telemetry, no accounts: onboarding ends at the
+  operator's own hardware and their own GitHub org.
+- No second config system: the wizard writes the same `.env` the chain
+  already reads, and the allowlist in `tick_chain.sbatch` remains the
+  single statement of which keys the chain honors.
+- Local mode does not simulate Slurm (no fake queue, no fake dependencies);
+  it embraces the synchronous degenerate case.

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -27,7 +27,7 @@ from typing import Any, cast
 
 from autoresearch.appauth import resolve_bot_auth
 from autoresearch.brief import BudgetState, distill_lessons
-from autoresearch.compute import LocalCompute
+from autoresearch.compute import LocalCompute, local_mode
 from autoresearch.contract import Benchmark, Contract, load_contract
 from autoresearch.dispatch import (
     Snapshot,
@@ -2992,10 +2992,12 @@ def main() -> int:
     # and re-enter the decision. The wake job the WakeDispatcher submits runs
     # exactly this.
     if args.resume:
-        if not (args.account and args.partition and args.image and Path(args.image).is_file()):
+        placed = bool(args.account and args.partition) or local_mode()
+        if not (placed and args.image and Path(args.image).is_file()):
             parser.error(
                 "--resume needs the cluster triple (--account/--partition/--image) "
-                "to rebuild the dispatched measurer"
+                "to rebuild the dispatched measurer (local compute waives the "
+                "account/partition pair, never the image)"
             )
         from autoresearch.runstate import load_record
 
@@ -3149,7 +3151,9 @@ def main() -> int:
     # file to bind against; missing any, the climb measures inline (the tick
     # sets these on the climb job's env, a bare CLI run leaves them empty).
     dispatch: DispatchSettings | None = None
-    if args.account and args.partition and args.image and Path(args.image).is_file():
+    if (bool(args.account and args.partition) or local_mode()) and (
+        args.image and Path(args.image).is_file()
+    ):
         dispatch = _dispatch_settings(args)
     try:
         try:

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -545,10 +545,10 @@ def _dispatch_settings(args: argparse.Namespace) -> DispatchSettings:
     """The cluster coordinates from the CLI, read in ONE place for both the
     fresh climb and the wake (a second constructor drifted once — terra
     #174: the wake dropped the GPU lane)."""
-    from autoresearch.compute import SlurmCompute
+    from autoresearch.compute import compute_from_env
 
     return DispatchSettings(
-        compute=SlurmCompute(),
+        compute=compute_from_env(),
         image=args.image,
         account=args.account,
         partition=args.partition,

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -295,10 +295,17 @@ class LocalCompute:
         # the submitting process holds live keys (and any inherited
         # APPTAINERENV_* would cross --cleanenv into the container), so the
         # job script starts from a minimal environment and sets its own.
+        # AUTORESEARCH_* / REVIEW_HERMES_* pass through as a PREFIX rule:
+        # Slurm jobs inherit the tick's whole environment, and local jobs
+        # need the same config surface (compute mode, author backend, panel,
+        # key-file PATHS — never raw secrets, which are not env-borne under
+        # this prefix). Enumerating names here is how a mode flag dies
+        # silently (terra #222 and #223 both found exactly that).
         job_env = {
             k: v
             for k, v in os.environ.items()
             if k in ("PATH", "HOME", "LANG", "TMPDIR", "SLURM_TMPDIR", "USER", "LOGNAME")
+            or k.startswith(("AUTORESEARCH_", "REVIEW_HERMES_"))
         }
         try:
             # the job runs in its OWN session (= process group), so the

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -308,6 +308,7 @@ class LocalCompute:
         if self._seq >= 1_000_000:
             raise SlurmError("local job id space exhausted for this process")
         job_id = str(_LOCAL_JOB_BASE + (os.getpid() % 10_000) * 1_000_000 + self._seq)
+
         # An explicit env allowlist:
         # the submitting process holds live keys (and any inherited
         # APPTAINERENV_* would cross --cleanenv into the container), so the
@@ -315,14 +316,18 @@ class LocalCompute:
         # AUTORESEARCH_* / REVIEW_HERMES_* pass through as a PREFIX rule:
         # Slurm jobs inherit the tick's whole environment, and local jobs
         # need the same config surface (compute mode, author backend, panel,
-        # key-file PATHS — never raw secrets, which are not env-borne under
-        # this prefix). Enumerating names here is how a mode flag dies
-        # silently (terra #222 and #223 both found exactly that).
+        # key-file PATHS). Enumerating allowed names is how a mode flag dies
+        # silently (terra #222/#223) — but VALUE-bearing secret names under
+        # the prefix (a *_PAT / *_TOKEN / *_KEY, as opposed to a *_KEY_FILE
+        # path) must never reach a job that runs untrusted evaluation code.
+        def _secret_name(name: str) -> bool:
+            return name.endswith(("_PAT", "_TOKEN", "_SECRET", "_PASSWORD", "_KEY"))
+
         job_env = {
             k: v
             for k, v in os.environ.items()
             if k in ("PATH", "HOME", "LANG", "TMPDIR", "SLURM_TMPDIR", "USER", "LOGNAME")
-            or k.startswith(("AUTORESEARCH_", "REVIEW_HERMES_"))
+            or (k.startswith(("AUTORESEARCH_", "REVIEW_HERMES_")) and not _secret_name(k))
         }
         try:
             # the job runs in its OWN session (= process group), so the

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -21,6 +21,7 @@ import os
 import shlex
 import signal
 import subprocess
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -361,6 +362,16 @@ class LocalCompute:
                 tmp = state_dir / f".{job_id}.{os.getpid()}.tmp"
                 tmp.write_text(state)
                 os.replace(tmp, state_dir / job_id)
+                # opportunistic prune: one entry per job would leak forever
+                # on a long-running loop; anything the sweep could still want
+                # is far younger than a day
+                cutoff = time.time() - 24 * 3600
+                for old in state_dir.iterdir():
+                    try:
+                        if old.stat().st_mtime < cutoff:
+                            old.unlink()
+                    except OSError:
+                        pass
             except OSError as exc:
                 log.warning("local job %s: state persist failed: %s", spec.job_name, exc)
         if spec.output and spec.output != "/dev/null":

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -136,9 +136,24 @@ class Compute(Protocol):
 
     def submit(self, spec: JobSpec) -> str: ...
     def status(self, job_id: str) -> str: ...
+    def pending_reason(self, job_id: str) -> str: ...
     def active_job_names(self) -> list[str]: ...
     def job_id_for_name(self, name: str) -> str: ...
     def cancel(self, job_id: str) -> None: ...
+
+
+def local_mode() -> bool:
+    """AUTORESEARCH_COMPUTE=local selects the monolith: every job a
+    synchronous subprocess of the caller (docs/design/onboarding.md) — the
+    zero-cluster on-ramp and the paper's serialized-baseline ablation. Any
+    other value (or none) is Slurm. This helper is the only reader of the
+    env var, so mode checks cannot drift."""
+    return os.environ.get("AUTORESEARCH_COMPUTE", "").strip().lower() == "local"
+
+
+def compute_from_env() -> SlurmCompute | LocalCompute:
+    """The deployment's compute backend, per `local_mode`."""
+    return LocalCompute() if local_mode() else SlurmCompute()
 
 
 @dataclass
@@ -335,6 +350,9 @@ class LocalCompute:
         if not job_id.isdigit():
             raise ValueError(f"not a job id: {job_id!r}")
         return self._states.get(job_id, GONE)
+
+    def pending_reason(self, job_id: str) -> str:
+        return ""  # synchronous jobs are terminal at submit — never pending
 
     def active_job_names(self) -> list[str]:
         return []  # synchronous: nothing is ever pending or running

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -23,6 +23,7 @@ import signal
 import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Protocol
 
 log = logging.getLogger(__name__)
@@ -270,6 +271,15 @@ class SlurmCompute:
 _LOCAL_JOB_BASE = 9_000_000_000
 
 
+def _local_state_dir() -> Path | None:
+    """Where local job states persist across processes (the tick and the
+    attempts it spawns each hold their own LocalCompute): under the state
+    root when the deployment names one, else nowhere (memory-only — tests).
+    Local jobs are synchronous, so only TERMINAL states ever need sharing."""
+    root = os.environ.get("AUTORESEARCH_ROOT", "").strip()
+    return Path(root) / "local_jobs" if root else None
+
+
 @dataclass
 class LocalCompute:
     """The same verbs, run as subprocesses in THIS allocation — synchronously:
@@ -290,7 +300,8 @@ class LocalCompute:
             raise ValueError("exactly one of command/script must be set")
         argv = ["sh", spec.script, *spec.script_args] if spec.script else ["sh", "-c", spec.command]
         self._seq += 1
-        job_id = str(_LOCAL_JOB_BASE + self._seq)
+        # unique across processes: the tick and its attempts each count from 1
+        job_id = str(_LOCAL_JOB_BASE + (os.getpid() % 100_000) * 10_000 + self._seq)
         # An explicit env allowlist:
         # the submitting process holds live keys (and any inherited
         # APPTAINERENV_* would cross --cleanenv into the container), so the
@@ -343,6 +354,15 @@ class LocalCompute:
                     "local job %s: an escaped child survived the walltime kill", spec.job_name
                 )
             state = "TIMEOUT"
+        state_dir = _local_state_dir()
+        if state_dir is not None:
+            try:
+                state_dir.mkdir(parents=True, exist_ok=True)
+                tmp = state_dir / f".{job_id}.{os.getpid()}.tmp"
+                tmp.write_text(state)
+                os.replace(tmp, state_dir / job_id)
+            except OSError as exc:
+                log.warning("local job %s: state persist failed: %s", spec.job_name, exc)
         if spec.output and spec.output != "/dev/null":
             try:
                 with open(spec.output, "w") as fh:
@@ -356,7 +376,18 @@ class LocalCompute:
     def status(self, job_id: str) -> str:
         if not job_id.isdigit():
             raise ValueError(f"not a job id: {job_id!r}")
-        return self._states.get(job_id, GONE)
+        state = self._states.get(job_id, "")
+        if state:
+            return state
+        # another process's job (an attempt's launch, polled by the tick):
+        # synchronous jobs are terminal, so the persisted state is the truth
+        state_dir = _local_state_dir()
+        if state_dir is not None:
+            try:
+                return (state_dir / job_id).read_text().strip() or GONE
+            except OSError:
+                pass
+        return GONE
 
     def pending_reason(self, job_id: str) -> str:
         return ""  # synchronous jobs are terminal at submit — never pending

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -301,8 +301,13 @@ class LocalCompute:
             raise ValueError("exactly one of command/script must be set")
         argv = ["sh", spec.script, *spec.script_args] if spec.script else ["sh", "-c", spec.command]
         self._seq += 1
-        # unique across processes: the tick and its attempts each count from 1
-        job_id = str(_LOCAL_JOB_BASE + (os.getpid() % 100_000) * 10_000 + self._seq)
+        # unique across processes: the tick and its attempts each count from 1.
+        # A million-wide slot per (pid mod 10k); exhausting it fails LOUD —
+        # a silent wraparound would let one process read another's terminal
+        # state under a reused id.
+        if self._seq >= 1_000_000:
+            raise SlurmError("local job id space exhausted for this process")
+        job_id = str(_LOCAL_JOB_BASE + (os.getpid() % 10_000) * 1_000_000 + self._seq)
         # An explicit env allowlist:
         # the submitting process holds live keys (and any inherited
         # APPTAINERENV_* would cross --cleanenv into the container), so the

--- a/src/autoresearch/measure.py
+++ b/src/autoresearch/measure.py
@@ -485,8 +485,11 @@ class DispatchSettings:
     def placement(self, gpus: int) -> tuple[str, str]:
         """(account, partition) for a job needing `gpus` GPUs. Raises when a
         GPU job has no lane — a queue that can never run is worse than a
-        loud refusal."""
-        if gpus <= 0:
+        loud refusal. Local compute has no lanes: jobs are subprocesses on
+        whatever GPUs the machine has, so placement is empty by design."""
+        from autoresearch.compute import local_mode
+
+        if gpus <= 0 or local_mode():
             return self.account, self.partition
         if not self.gpu_partition:
             raise ValueError(

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -29,12 +29,15 @@ from uuid import uuid4
 
 from autoresearch.compute import (
     GONE,
+    Compute,
     JobSpec,
-    SlurmCompute,
+    LocalCompute,
     SlurmError,
     SlurmQueryError,
+    compute_from_env,
     is_pending,
     is_terminal,
+    local_mode,
     quote_command,
 )
 from autoresearch.disk import DEFAULT_MIN_FREE_BYTES, check_disk
@@ -473,7 +476,7 @@ def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: A
 def service_in_review(
     root: Path,
     github: Any,  # GitHubClient (Any keeps tick importable without github deps)
-    compute: SlurmCompute,
+    compute: Compute,
     spec: FollowupSpec,
     now: float,
     dry_run: bool = False,
@@ -664,7 +667,7 @@ def write_heartbeat(root: Path, now: float, disk: dict[str, object] | None = Non
         log.warning("heartbeat write failed: %s", exc)
 
 
-def _holder_alive(compute: SlurmCompute, lease_job_id: str) -> bool | None:
+def _holder_alive(compute: Compute, lease_job_id: str) -> bool | None:
     """True/False when Slurm answered; None when it could not (an outage
     must not look like a dead holder)."""
     if not lease_job_id:
@@ -802,7 +805,7 @@ def arm_wake(
 
 def _armed_wake_lost(
     root: Path,
-    compute: SlurmCompute,
+    compute: Compute,
     record: RunRecord,
     lease: Lease,
     now: float,
@@ -849,7 +852,7 @@ def _armed_wake_lost(
 
 def sweep(
     root: Path,
-    compute: SlurmCompute,
+    compute: Compute,
     dispatcher: WakeDispatcher,
     now: float,
     grace_s: float = DEFAULT_GRACE_S,
@@ -1096,7 +1099,7 @@ def _kill_stamp(root: Path, run_id: str) -> Path:
     return run_dir(root, run_id) / "attempt-terminal-seen"
 
 
-def _sweep_implementing(root: Path, compute: SlurmCompute, now: float, grace_s: float) -> list[str]:
+def _sweep_implementing(root: Path, compute: Compute, now: float, grace_s: float) -> list[str]:
     """End `implementing` records whose climb job died without a verdict.
 
     A climb that CRASHES contains its own ending (attempt.py); a climb that is
@@ -1220,7 +1223,7 @@ def _poll_targets(record: RunRecord) -> list[str]:
 
 def _sweep_one(
     root: Path,
-    compute: SlurmCompute,
+    compute: Compute,
     dispatcher: WakeDispatcher,
     now: float,
     grace_s: float,
@@ -1338,7 +1341,7 @@ def _sweep_one(
 
 def tick(
     root: Path,
-    compute: SlurmCompute,
+    compute: Compute,
     dispatcher: WakeDispatcher,
     now: float,
     grace_s: float = DEFAULT_GRACE_S,
@@ -2031,7 +2034,7 @@ def _climb_limit_argv(limits: EffectiveLimits, job_minutes: int) -> list[str]:
 
 def service_self_initiated(
     root: Path,
-    compute: SlurmCompute,
+    compute: Compute,
     spec: FollowupSpec,
     contract: Any,
     now: float,
@@ -2200,7 +2203,7 @@ def service_self_initiated(
 def service_steward(
     root: Path,
     github: Any,
-    compute: SlurmCompute,
+    compute: Compute,
     spec: FollowupSpec,
     now: float,
     contract: Any,
@@ -2343,7 +2346,7 @@ def service_steward(
 def service_intake(
     root: Path,
     github: Any,
-    compute: SlurmCompute,
+    compute: Compute,
     spec: FollowupSpec,
     now: float,
     contract: Any = None,
@@ -2501,7 +2504,7 @@ class JobWakeDispatcher:
     never holds a GPU. Returns the wake job id (async: it owns the lease until
     it completes)."""
 
-    compute: SlurmCompute
+    compute: Compute
     spec: FollowupSpec
     now: float
     wake_minutes: int = 20
@@ -2590,7 +2593,7 @@ def _wake_panel_minutes(spec: FollowupSpec) -> int:
 
 
 def _wake_dispatcher_from_env(
-    compute: SlurmCompute, followup_spec: FollowupSpec | None, now: float, root: Path
+    compute: Compute, followup_spec: FollowupSpec | None, now: float, root: Path
 ) -> tuple[WakeDispatcher, bool]:
     """The wake delivery for this tick, behind an EXPLICIT on-switch so the
     dispatched-wake path lands DARK. Returns `(dispatcher, live)`:
@@ -2709,7 +2712,10 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         os.path.expanduser("~/autoresearch-images/agent-py312.sif"),
     )
     home = os.environ.get("AUTORESEARCH_HOME", "")
-    if (pat_file or app_file) and account and partition and home and Path(image).is_file():
+    # Local compute runs jobs as subprocesses: Slurm placement is meaningless
+    # there, so account/partition are only required when a cluster is in play.
+    placed = bool(account and partition) or local_mode()
+    if (pat_file or app_file) and placed and home and Path(image).is_file():
         from autoresearch.appauth import resolve_bot_auth
         from autoresearch.github import GitHubClient
 
@@ -2742,8 +2748,8 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         name
         for name, value in [
             ("AUTORESEARCH_PAT_FILE or _GITHUB_APP_FILE", pat_file or app_file),
-            ("AUTORESEARCH_ACCOUNT", account),
-            ("AUTORESEARCH_PARTITION", partition),
+            ("AUTORESEARCH_ACCOUNT", account or ("-" if local_mode() else "")),
+            ("AUTORESEARCH_PARTITION", partition or ("-" if local_mode() else "")),
             ("AUTORESEARCH_HOME", home),
         ]
         if not value
@@ -2768,6 +2774,18 @@ def main() -> int:
         default=DEFAULT_MIN_FREE_BYTES / 1024**3,
         help="skip launching new work when the state filesystem has less free",
     )
+    parser.add_argument(
+        "--loop",
+        action="store_true",
+        help="run a tick every cadence in the foreground — the local-mode "
+        "chain (Slurm deployments use tick_chain.sbatch instead)",
+    )
+    parser.add_argument(
+        "--cadence-min",
+        type=float,
+        default=float(os.environ.get("AUTORESEARCH_CADENCE_MIN", "30") or 30),
+        help="minutes between --loop ticks (AUTORESEARCH_CADENCE_MIN)",
+    )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
@@ -2777,54 +2795,75 @@ def main() -> int:
     # operator arms it — the AUTORESEARCH_DISPATCH_WAKE env var or a
     # <root>/DISPATCH_WAKE sentinel — and the env is complete; by default it
     # stays dry with the LoggingDispatcher — dispatched climbing lands DARK.
-    github, followup_spec = _followup_spec_from_env(args.root)
-    compute = SlurmCompute()
-    now = time.time()
-    dispatcher, wake_live = _wake_dispatcher_from_env(compute, followup_spec, now, args.root)
-    # parks arm their own wake from this recipe; without it the sweep delivers
-    if wake_live and followup_spec is not None:
-        write_wake_spec(args.root, followup_spec)
-    else:
-        remove_wake_spec(args.root)
+    # ONE compute for the process: LocalCompute remembers its jobs' states
+    # in memory, so a --loop deployment must not discard them between ticks.
+    compute = compute_from_env()
 
-    report = tick(
-        args.root,
-        compute,
-        dispatcher,
-        now=now,
-        grace_s=args.grace_s,
-        lease_ttl_s=args.lease_ttl_s,
-        dry_run=not wake_live,
-        github=github,
-        followup_spec=followup_spec,
-        followup_dry_run=False,
-        min_free_bytes=int(args.min_free_gb * 1024**3),
-        min_tick_s=_min_tick_s_from_env(),
-    )
-    # Stamp the coalesce marker at REAL completion time (a fresh time.time(),
-    # not the start-of-tick `now`), so a long tick does not leave a stale marker.
-    mark_tick_complete(args.root, report, time.time())
-    log.info(
-        "tick done: paused=%s coalesced=%s swept=%d woken=%d deferred=%d reaped=%d stuck=%d "
-        "impl_ended=%s review_ended=%s followups=%s intake=%s self_initiated=%s steward=%s "
-        "disk=%s launch_blocked=%s",
-        report.paused,
-        report.coalesced,
-        report.swept,
-        len(report.woken),
-        len(report.deferred),
-        len(report.reaped_leases),
-        len(report.stuck),
-        report.implementing_ended or "-",
-        report.review_ended,
-        report.followups_submitted,
-        report.intake,
-        report.self_initiated,
-        report.steward,
-        report.disk or "ok",
-        report.launch_blocked,
-    )
-    return 0
+    def run_once() -> None:
+        github, followup_spec = _followup_spec_from_env(args.root)
+        now = time.time()
+        dispatcher, wake_live = _wake_dispatcher_from_env(compute, followup_spec, now, args.root)
+        # parks arm their own wake from this recipe; without it the sweep delivers.
+        # Local compute never arms: jobs are synchronous, so an afterany wake's
+        # dependencies are terminal before submit returns — the next loop
+        # iteration's sweep delivers every wake instead (wake latency = cadence).
+        if wake_live and followup_spec is not None and not isinstance(compute, LocalCompute):
+            write_wake_spec(args.root, followup_spec)
+        else:
+            remove_wake_spec(args.root)
+
+        report = tick(
+            args.root,
+            compute,
+            dispatcher,
+            now=now,
+            grace_s=args.grace_s,
+            lease_ttl_s=args.lease_ttl_s,
+            dry_run=not wake_live,
+            github=github,
+            followup_spec=followup_spec,
+            followup_dry_run=False,
+            min_free_bytes=int(args.min_free_gb * 1024**3),
+            min_tick_s=_min_tick_s_from_env(),
+        )
+        # Stamp the coalesce marker at REAL completion time (a fresh time.time(),
+        # not the start-of-tick `now`), so a long tick does not leave a stale marker.
+        mark_tick_complete(args.root, report, time.time())
+        log.info(
+            "tick done: paused=%s coalesced=%s swept=%d woken=%d deferred=%d reaped=%d stuck=%d "
+            "impl_ended=%s review_ended=%s followups=%s intake=%s self_initiated=%s steward=%s "
+            "disk=%s launch_blocked=%s",
+            report.paused,
+            report.coalesced,
+            report.swept,
+            len(report.woken),
+            len(report.deferred),
+            len(report.reaped_leases),
+            len(report.stuck),
+            report.implementing_ended or "-",
+            report.review_ended,
+            report.followups_submitted,
+            report.intake,
+            report.self_initiated,
+            report.steward,
+            report.disk or "ok",
+            report.launch_blocked,
+        )
+
+    if not args.loop:
+        run_once()
+        return 0
+    # The local-mode chain: same stateless tick, a foreground loop instead of
+    # sbatch successors. Records on disk carry all state, so killing and
+    # restarting the loop resumes exactly like the Slurm chain would.
+    cadence_s = max(60.0, args.cadence_min * 60)
+    while True:
+        started = time.time()
+        try:
+            run_once()
+        except Exception:
+            log.exception("tick failed; the loop continues")
+        time.sleep(max(0.0, cadence_s - (time.time() - started)))
 
 
 if __name__ == "__main__":

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -2793,6 +2793,12 @@ def main() -> int:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     args.root.mkdir(parents=True, exist_ok=True)
+    # The tick's --root is the authority; children (and this process's own
+    # LocalCompute) read AUTORESEARCH_ROOT, so a bare `tick --loop --root X`
+    # must not split-brain them: local job states would land nowhere and
+    # every finished job would read GONE until the park deadline.
+    if os.environ.get("AUTORESEARCH_ROOT", "") != str(args.root):
+        os.environ["AUTORESEARCH_ROOT"] = str(args.root)
     # In-review servicing is LIVE when credentials + image are available in the
     # chain environment. The waiting-run sweep delivers real wakes only when the
     # operator arms it — the AUTORESEARCH_DISPATCH_WAKE env var or a

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -2772,6 +2772,13 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     return None, None
 
 
+def _loop_cadence_s(cadence_min: float) -> float:
+    """The --loop sleep, clamped to [60s, 24h]: argparse accepts inf (which
+    would OverflowError out of time.sleep) and sub-minute values would spin.
+    A non-positive argument defers to AUTORESEARCH_CADENCE_MIN."""
+    return min(24 * 3600.0, max(60.0, cadence_min * 60 if cadence_min > 0 else _cadence_s()))
+
+
 def main() -> int:
     import argparse
     import time
@@ -2877,12 +2884,7 @@ def main() -> int:
     # The local-mode chain: same stateless tick, a foreground loop instead of
     # sbatch successors. Records on disk carry all state, so killing and
     # restarting the loop resumes exactly like the Slurm chain would.
-    # clamp both ends: argparse accepts inf (time.sleep would OverflowError
-    # out of the loop after one tick) and garbage negatives fall to the env
-    cadence_s = min(
-        24 * 3600.0,
-        max(60.0, args.cadence_min * 60 if args.cadence_min > 0 else _cadence_s()),
-    )
+    cadence_s = _loop_cadence_s(args.cadence_min)
     while True:
         started = time.time()
         try:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1305,6 +1305,12 @@ def _sweep_one(
             # Layer 3, with real grace: time runs from when the sweep FIRST
             # saw every job terminal, not from submission — the afterany
             # job gets the full window to deliver before the backup steps in.
+            # Local compute has no afterany jobs to wait for (jobs are
+            # terminal at submit): the sweep IS the delivery, so grace would
+            # only cost a whole extra loop iteration.
+            if local_mode():
+                wake(record, f"experiment {state}", state)
+                return
             if record.terminal_seen <= 0:
                 if dry_run:
                     # no writes in dry-run: report the would-wake now so the

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -2859,7 +2859,12 @@ def main() -> int:
     # The local-mode chain: same stateless tick, a foreground loop instead of
     # sbatch successors. Records on disk carry all state, so killing and
     # restarting the loop resumes exactly like the Slurm chain would.
-    cadence_s = max(60.0, args.cadence_min * 60 if args.cadence_min > 0 else _cadence_s())
+    # clamp both ends: argparse accepts inf (time.sleep would OverflowError
+    # out of the loop after one tick) and garbage negatives fall to the env
+    cadence_s = min(
+        24 * 3600.0,
+        max(60.0, args.cadence_min * 60 if args.cadence_min > 0 else _cadence_s()),
+    )
     while True:
         started = time.time()
         try:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -255,8 +255,10 @@ def _gpu_lane_error(contract: Any, benchmark: str, spec: FollowupSpec) -> str:
     with GPU benchmarks needs this deployment to name a GPU lane — otherwise
     evals would queue into jobs that can never run (the climb would then
     park forever on a phantom eval). ANY GPU benchmark in the contract
-    counts, not just the climbed one: the suite gate measures siblings."""
-    if spec.gpu_partition:
+    counts, not just the climbed one: the suite gate measures siblings.
+    Local compute has no lanes — jobs run on whatever GPUs the machine
+    has — so the check is waived there."""
+    if spec.gpu_partition or local_mode():
         return ""
     gpu_benches = [
         b.name for b in getattr(contract, "benchmarks", []) if int(getattr(b, "gpus", 0) or 0)
@@ -2783,8 +2785,9 @@ def main() -> int:
     parser.add_argument(
         "--cadence-min",
         type=float,
-        default=float(os.environ.get("AUTORESEARCH_CADENCE_MIN", "30") or 30),
-        help="minutes between --loop ticks (AUTORESEARCH_CADENCE_MIN)",
+        default=0.0,
+        help="minutes between --loop ticks; unset defers to "
+        "AUTORESEARCH_CADENCE_MIN via the chain's own parser (default 30)",
     )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
@@ -2856,7 +2859,7 @@ def main() -> int:
     # The local-mode chain: same stateless tick, a foreground loop instead of
     # sbatch successors. Records on disk carry all state, so killing and
     # restarting the loop resumes exactly like the Slurm chain would.
-    cadence_s = max(60.0, args.cadence_min * 60)
+    cadence_s = max(60.0, args.cadence_min * 60 if args.cadence_min > 0 else _cadence_s())
     while True:
         started = time.time()
         try:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -710,11 +710,15 @@ def _wake(
         log.warning("wake dispatch failed for %s: %s: %s", record.run_id, type(exc).__name__, exc)
         release_lease(root, record.run_id)
         return False
-    if holder_job:
+    if holder_job and not local_mode():
         # An async wake job now owns the lease; it releases on completion,
         # and the TTL/holder-dead check reaps it if it dies.
         update_lease_holder(root, record.run_id, f"wake-job:{holder_job}", holder_job, now)
     else:
+        # No job to hand the lease to — or a LOCAL dispatch, which ran the
+        # whole wake synchronously: the attempt already finished and released
+        # its own lease, and recreating one under a terminal job id would
+        # make the next sweep reap a corpse instead of delivering.
         release_lease(root, record.run_id)
     return True
 

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -2807,8 +2807,10 @@ def main() -> int:
     # LocalCompute) read AUTORESEARCH_ROOT, so a bare `tick --loop --root X`
     # must not split-brain them: local job states would land nowhere and
     # every finished job would read GONE until the park deadline.
-    if os.environ.get("AUTORESEARCH_ROOT", "") != str(args.root):
-        os.environ["AUTORESEARCH_ROOT"] = str(args.root)
+    # RESOLVED: local jobs cd into flight checkouts, so a relative root
+    # would scatter their state dirs across working directories
+    if os.environ.get("AUTORESEARCH_ROOT", "") != str(args.root.resolve()):
+        os.environ["AUTORESEARCH_ROOT"] = str(args.root.resolve())
     # In-review servicing is LIVE when credentials + image are available in the
     # chain environment. The waiting-run sweep delivers real wakes only when the
     # operator arms it — the AUTORESEARCH_DISPATCH_WAKE env var or a

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -124,3 +124,19 @@ def test_quote_command_shell_safety() -> None:
     quoted = quote_command(["python", "-c", "print('hi; rm -rf /')"])
     assert "'" in quoted
     assert quoted.startswith("python -c ")
+
+
+def test_compute_from_env_selects_the_backend(monkeypatch) -> None:
+    """AUTORESEARCH_COMPUTE=local is the monolith switch; anything else —
+    unset, empty, or a typo — stays Slurm (fail toward the real scheduler,
+    never silently toward subprocesses)."""
+    from autoresearch.compute import LocalCompute, SlurmCompute, compute_from_env, local_mode
+
+    monkeypatch.delenv("AUTORESEARCH_COMPUTE", raising=False)
+    assert isinstance(compute_from_env(), SlurmCompute) and not local_mode()
+    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    assert isinstance(compute_from_env(), LocalCompute) and local_mode()
+    monkeypatch.setenv("AUTORESEARCH_COMPUTE", " Local ")
+    assert isinstance(compute_from_env(), LocalCompute)
+    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "lokal")
+    assert isinstance(compute_from_env(), SlurmCompute)

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -278,3 +278,22 @@ def test_gpu_contracts_pass_the_lane_check_under_local_mode(monkeypatch) -> None
     assert "no GPU lane" in _gpu_lane_error(contract, "speedrun", spec)
     monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
     assert _gpu_lane_error(contract, "speedrun", spec) == ""
+
+
+def test_local_mode_places_gpu_measures_without_a_lane(monkeypatch) -> None:
+    """DispatchSettings.placement must not raise for a GPU measure under
+    local mode (terra #223 r7: the lane waiver admitted GPU contracts that
+    then failed at placement) — local jobs run on the machine's own GPUs."""
+    from autoresearch.compute import LocalCompute
+    from autoresearch.measure import DispatchSettings
+
+    settings = DispatchSettings(
+        compute=LocalCompute(), image="", account="", partition="", gpu_partition=""
+    )
+    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    assert settings.placement(1) == ("", "")
+    monkeypatch.delenv("AUTORESEARCH_COMPUTE")
+    import pytest
+
+    with pytest.raises(ValueError, match="no GPU lane"):
+        settings.placement(1)  # slurm mode still refuses loudly

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -188,6 +188,9 @@ def test_job_terminal_without_a_result_fails_instead_of_parking(tmp_path: Path) 
         def status(self, job_id: str) -> str:
             return "TIMEOUT"
 
+        def pending_reason(self, job_id: str) -> str:
+            return ""
+
         def active_job_names(self) -> list:
             return []
 

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -243,3 +243,38 @@ def test_job_env_is_an_allowlist_not_the_submitter_env(tmp_path: Path) -> None:
     finally:
         del os.environ["APPTAINERENV_SECRET"]
     assert out.read_text().strip() == "xx"
+
+
+def test_terminal_states_survive_across_instances(tmp_path, monkeypatch) -> None:
+    """The tick and the attempts it spawns each hold their own LocalCompute;
+    a launch submitted by one must not read as GONE to another (terra #223:
+    the sweep would sit on the 12h park deadline instead of waking at the
+    next cadence). With a state root, terminal states persist; without one,
+    memory-only behavior is unchanged."""
+    from autoresearch.compute import GONE, JobSpec, LocalCompute
+
+    monkeypatch.setenv("AUTORESEARCH_ROOT", str(tmp_path))
+    submitter = LocalCompute()
+    job_id = submitter.submit(
+        JobSpec(job_name="probe", account="", partition="", time_minutes=1, command="true")
+    )
+    poller = LocalCompute()  # a different process in real life
+    assert poller.status(job_id) == "COMPLETED"
+    monkeypatch.delenv("AUTORESEARCH_ROOT")
+    assert poller.status(job_id) == GONE  # no root -> memory-only, as before
+
+
+def test_gpu_contracts_pass_the_lane_check_under_local_mode(monkeypatch) -> None:
+    """Local compute has no lanes: a contract with GPU benchmarks must not be
+    rejected for a missing AUTORESEARCH_GPU_PARTITION (terra #223)."""
+    from types import SimpleNamespace
+
+    from autoresearch.tick import FollowupSpec, _gpu_lane_error
+
+    spec = FollowupSpec(
+        account="", partition="", run_root=Path("/tmp/x"), image="", home=Path("/tmp/x")
+    )
+    contract = SimpleNamespace(benchmarks=[SimpleNamespace(name="speedrun", gpus=1)])
+    assert "no GPU lane" in _gpu_lane_error(contract, "speedrun", spec)
+    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    assert _gpu_lane_error(contract, "speedrun", spec) == ""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3458,11 +3458,15 @@ def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> 
 
 def test_loop_cadence_is_clamped_finite(monkeypatch: Any) -> None:
     """--cadence-min inf must not OverflowError out of the loop after one
-    tick (terra #223): the loop clamps to [60s, 24h]."""
+    tick (terra #223): the PRODUCTION clamp bounds to [60s, 24h] and defers
+    non-positive values to the env knob."""
     import math
 
-    # the clamp expression itself, mirrored from main(): pin both ends
+    from autoresearch.tick import _loop_cadence_s
+
+    monkeypatch.setenv("AUTORESEARCH_CADENCE_MIN", "45")
     for raw, expect in ((math.inf, 24 * 3600.0), (0.0001, 60.0), (30.0, 1800.0)):
-        clamped = min(24 * 3600.0, max(60.0, raw * 60))
+        clamped = _loop_cadence_s(raw)
         assert clamped == expect
         assert math.isfinite(clamped)
+    assert _loop_cadence_s(0.0) == 45 * 60  # non-positive defers to the env

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -632,7 +632,7 @@ def test_cli_grace_flag_reaches_the_sweep(tmp_path: Path, monkeypatch) -> None:
         return real_tick(root, compute, dispatcher, now, grace_s, lease_ttl_s, dry_run)
 
     monkeypatch.setattr(tick_mod, "tick", spy)
-    monkeypatch.setattr(tick_mod, "SlurmCompute", lambda: FakeSlurm(states={}).compute())
+    monkeypatch.setattr(tick_mod, "compute_from_env", lambda: FakeSlurm(states={}).compute())
     monkeypatch.setattr(sys, "argv", ["tick", "--root", str(tmp_path), "--grace-s", "1"])
     assert tick_mod.main() == 0
     assert captured["grace_s"] == 1.0
@@ -3349,3 +3349,29 @@ def test_service_syncs_fetches_for_live_sessions(tmp_path: Path, monkeypatch) ->
     service_syncs(tmp_path, Spec(), 2.0)
     assert sync_requested(ws) is None  # done stamped
     assert _g(ws, "show", "origin/main:docs/b.md").strip() == "new"
+
+
+def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -> None:
+    """Under AUTORESEARCH_COMPUTE=local the followup service comes up without
+    account/partition (subprocess jobs have no placement); Slurm mode still
+    requires them."""
+    from autoresearch.tick import _followup_spec_from_env
+
+    image = tmp_path / "agent.sif"
+    image.write_text("")
+    pat = tmp_path / "pat"
+    pat.write_text("t")
+    env = {
+        "AUTORESEARCH_PAT_FILE": str(pat),
+        "AUTORESEARCH_IMAGE": str(image),
+        "AUTORESEARCH_HOME": str(tmp_path),
+    }
+    import autoresearch.tick as tick_mod
+
+    monkeypatch.setattr(tick_mod.os, "environ", env)
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is None  # slurm mode: placement required
+    env["AUTORESEARCH_COMPUTE"] = "local"
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is not None
+    assert spec.account == "" and spec.partition == ""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3435,6 +3435,9 @@ def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> 
     monkeypatch.setenv("REVIEW_HERMES_REPO", "/x/hermes")
     monkeypatch.setenv("APPTAINERENV_EVIL", "1")
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-live")
+    monkeypatch.setenv("AUTORESEARCH_BOT_PAT", "github_pat_secret")
+    monkeypatch.setenv("AUTORESEARCH_PANEL_KEY", "sk-ant-secret")
+    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", "/keys/codex")
     out = tmp_path / "env.txt"
     from autoresearch.compute import JobSpec
 
@@ -3454,6 +3457,10 @@ def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> 
     assert "REVIEW_HERMES_REPO=/x/hermes" in dumped
     assert "APPTAINERENV_EVIL" not in dumped  # would cross --cleanenv
     assert "OPENROUTER_API_KEY" not in dumped  # raw secrets never pass
+    # secret-VALUED names under the prefix are excluded; path names survive
+    assert "AUTORESEARCH_BOT_PAT" not in dumped
+    assert "AUTORESEARCH_PANEL_KEY" not in dumped
+    assert "AUTORESEARCH_CODEX_KEY_FILE=/keys/codex" in dumped
 
 
 def test_loop_cadence_is_clamped_finite(monkeypatch: Any) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3377,34 +3377,80 @@ def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -
     assert spec.account == "" and spec.partition == ""
 
 
-def test_local_mode_waives_placement_at_the_attempt_gates(monkeypatch: Any, tmp_path: Path) -> None:
-    """The resume and dispatch gates accept empty account/partition under
+def test_local_mode_waives_placement_at_the_attempt_gates(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
+    """The resume gate accepts empty account/partition under
     AUTORESEARCH_COMPUTE=local (terra #223: locally dispatched wakes died at
-    the parser; fresh climbs silently downgraded to inline measurement)."""
+    the parser). Proof of admission: the CLI proceeds far enough to complain
+    about the missing parked run, not about the cluster triple — and without
+    local mode the same argv still trips the triple."""
     import sys
+
+    import pytest
 
     import autoresearch.attempt as attempt_mod
 
     image = tmp_path / "agent.sif"
     image.write_text("")
-    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    pat = tmp_path / "pat"
+    pat.write_text("t")
+    pat.chmod(0o600)
+    argv = [
+        "attempt",
+        "--resume",
+        "r-x",
+        "--run-root",
+        str(tmp_path),
+        "--image",
+        str(image),
+        "--pat-file",
+        str(pat),
+    ]
     monkeypatch.delenv("AUTORESEARCH_ACCOUNT", raising=False)
     monkeypatch.delenv("AUTORESEARCH_PARTITION", raising=False)
-    monkeypatch.setattr(
-        sys,
-        "argv",
-        ["attempt", "--resume", "r-x", "--run-root", str(tmp_path), "--image", str(image)],
-    )
-    # past the placement gate means the parser no longer errors; the resume
-    # then fails on the missing run record — proof the gate admitted it
-    import pytest
+    monkeypatch.setattr(sys, "argv", argv)
 
-    monkeypatch.setattr(
-        attempt_mod,
-        "load_record",
-        lambda *a, **k: (_ for _ in ()).throw(SystemExit(3)),
-        raising=False,
-    )
-    with pytest.raises(SystemExit) as exc:
+    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    # past the placement gate, the resume proceeds to the record read and
+    # fails THERE (no parked run in this tmp root) — proof of admission
+    with pytest.raises(FileNotFoundError, match=r"state\.json"):
         attempt_mod.main()
-    assert "cluster triple" not in str(exc.value)
+    assert "cluster triple" not in capsys.readouterr().err
+
+    monkeypatch.delenv("AUTORESEARCH_COMPUTE", raising=False)
+    with pytest.raises(SystemExit):
+        attempt_mod.main()
+    assert "cluster triple" in capsys.readouterr().err
+
+
+def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> None:
+    """LocalCompute's job-env scrub passes AUTORESEARCH_*/REVIEW_HERMES_*
+    through as a prefix rule — a locally submitted wake must arrive still in
+    local mode (terra #223), and enumerated names are how flags die."""
+    from autoresearch.compute import LocalCompute
+
+    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    monkeypatch.setenv("AUTORESEARCH_AUTHOR_BACKEND", "codex")
+    monkeypatch.setenv("REVIEW_HERMES_REPO", "/x/hermes")
+    monkeypatch.setenv("APPTAINERENV_EVIL", "1")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-live")
+    out = tmp_path / "env.txt"
+    from autoresearch.compute import JobSpec
+
+    LocalCompute().submit(
+        JobSpec(
+            job_name="envprobe",
+            account="",
+            partition="",
+            time_minutes=1,
+            command="env",
+            output=str(out),
+        )
+    )
+    dumped = out.read_text()
+    assert "AUTORESEARCH_COMPUTE=local" in dumped
+    assert "AUTORESEARCH_AUTHOR_BACKEND=codex" in dumped
+    assert "REVIEW_HERMES_REPO=/x/hermes" in dumped
+    assert "APPTAINERENV_EVIL" not in dumped  # would cross --cleanenv
+    assert "OPENROUTER_API_KEY" not in dumped  # raw secrets never pass

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3454,3 +3454,15 @@ def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> 
     assert "REVIEW_HERMES_REPO=/x/hermes" in dumped
     assert "APPTAINERENV_EVIL" not in dumped  # would cross --cleanenv
     assert "OPENROUTER_API_KEY" not in dumped  # raw secrets never pass
+
+
+def test_loop_cadence_is_clamped_finite(monkeypatch: Any) -> None:
+    """--cadence-min inf must not OverflowError out of the loop after one
+    tick (terra #223): the loop clamps to [60s, 24h]."""
+    import math
+
+    # the clamp expression itself, mirrored from main(): pin both ends
+    for raw, expect in ((math.inf, 24 * 3600.0), (0.0001, 60.0), (30.0, 1800.0)):
+        clamped = min(24 * 3600.0, max(60.0, raw * 60))
+        assert clamped == expect
+        assert math.isfinite(clamped)

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3375,3 +3375,36 @@ def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None
     assert spec.account == "" and spec.partition == ""
+
+
+def test_local_mode_waives_placement_at_the_attempt_gates(monkeypatch: Any, tmp_path: Path) -> None:
+    """The resume and dispatch gates accept empty account/partition under
+    AUTORESEARCH_COMPUTE=local (terra #223: locally dispatched wakes died at
+    the parser; fresh climbs silently downgraded to inline measurement)."""
+    import sys
+
+    import autoresearch.attempt as attempt_mod
+
+    image = tmp_path / "agent.sif"
+    image.write_text("")
+    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    monkeypatch.delenv("AUTORESEARCH_ACCOUNT", raising=False)
+    monkeypatch.delenv("AUTORESEARCH_PARTITION", raising=False)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["attempt", "--resume", "r-x", "--run-root", str(tmp_path), "--image", str(image)],
+    )
+    # past the placement gate means the parser no longer errors; the resume
+    # then fails on the missing run record — proof the gate admitted it
+    import pytest
+
+    monkeypatch.setattr(
+        attempt_mod,
+        "load_record",
+        lambda *a, **k: (_ for _ in ()).throw(SystemExit(3)),
+        raising=False,
+    )
+    with pytest.raises(SystemExit) as exc:
+        attempt_mod.main()
+    assert "cluster triple" not in str(exc.value)


### PR DESCRIPTION
## What

Stage 1 of the onboarding plan (Mengye 2026-09-01: "Build the simplest
onboarding workflow for slurm and local compute"): the design note plus the
kernel enablement that makes a zero-Slurm deployment real.

- `docs/design/onboarding.md` — the whole funnel: the `init` wizard (GitHub
  App manifest flow — the conversion response carries the private key
  in-band, so credentials are written in place on the host, no downloads or
  scp), the doctor (reuses the tick's own preflights), and the two compute
  modes with local mode's degenerate semantics stated honestly.
- `AUTORESEARCH_COMPUTE=local` — `compute_from_env()` / `local_mode()` in
  compute.py are the single owner of the switch; the two `SlurmCompute()`
  construction sites (tick main, `_dispatch_settings`) go through it. Any
  value other than `local` stays Slurm — fail toward the real scheduler.
- `tick --loop` — the local-mode chain: the same stateless tick in a
  foreground loop every cadence. One compute instance for the process
  (LocalCompute remembers job states in memory).
- Local mode skips park-time wake arming (synchronous jobs make afterany
  meaningless; the sweep delivers every wake — pre-#184 semantics) and does
  not require Slurm placement env (`account`/`partition`).
- `pending_reason` joins the `Compute` protocol (LocalCompute: always "" —
  synchronous jobs are never pending); `compute:` annotations widen from
  `SlurmCompute` to the protocol.

## Why local mode is cheap to trust

`LocalCompute` already existed (in-allocation evals, tests) with the same
job scripts, walltime kill, and env allowlist as the cluster path. This PR
adds selection and the loop, not a new backend. Serialization is the
designed semantics: local mode is simultaneously the zero-cluster on-ramp
and the paper's Karpathy-loop ablation cell.

## Stages that follow (per the design note)

2. the `init` wizard (detection, prompts, .env writer, doctor; PAT path
   first) 3. the App manifest flow inside it 4. QUICKSTART + landing-page
   setup panel.

## Test / gate

ruff check + format, mypy clean, 1002 passed, lock check clean. New tests:
backend selection (default/`local`/whitespace/typo), local-mode placement
relaxation vs Slurm-mode requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
