### PR TITLE
Base-identical syncs push without re-measure; the cursor spends on remote progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- A base sync whose merge changes only base-owned content pushes without a
+  re-measure — the solver and eval surface are bit-for-bit what was measured,
+  so the numbers stand (the topology rule, extended one rung). And the sync
+  cursor now spends only on REMOTE progress: a merge that exists solely in
+  the workspace (a withheld re-measure) leaves the head re-wakeable.
 - A PR left BEHIND by a base move now wakes its author the way a conflicted
   one does: merge the base in (cleanly — no resolving), reconsider the
   conclusion, and the result is re-measured before pushing. Publish already

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -633,36 +633,63 @@ def _respond(
         except GitError:
             base_synced = False
     sync_failed = conflict_wake and ((changed and not base_synced) or not history_known)
-    # A clean base merge can produce a commit whose TREE is unchanged (the
-    # branch already carried the base's content): committed/changed are both
-    # empty, but the merge commit IS the contribution — without pushing it
-    # the PR stays behind while the cursor is spent. Same measured tree, so
-    # no re-eval is owed; push the topology and say so.
-    if conflict_wake and not changed and base_synced and history_known:
-        # same #171 rule as every other push: an armed auto-mode PR would
-        # merge the new head on green CI, so the push is gated on a
-        # CONFIRMED disarm; a human merges the synced PR.
+    # The cursor spends only on REMOTE progress: a sync that exists solely in
+    # the workspace (e.g. the re-measure was withheld) leaves the head
+    # re-wakeable — the live lesson from gpt-speedrun#5, where a locally
+    # clean merge whose eval was withheld spent the cursor with the PR still
+    # behind on GitHub.
+    sync_pushed = False
+
+    def _sync_push(note: str) -> bool:
+        """Push the synced head under the #171 rule: an armed auto-mode PR
+        would merge the new head on green CI, so the push is gated on a
+        CONFIRMED disarm; a human merges the synced PR."""
+        nonlocal measured_note, sync_pushed
         disarm_ok = True
         if getattr(contract, "merge", "manual") == "auto":
             try:
                 disarm_ok = github.disable_auto_merge(record.target, number)
             except Exception as exc:
                 disarm_ok = False
-                log.warning("auto-merge disarm errored before topology push: %s", exc)
-        if disarm_ok:
-            ws.push(branch)
-            measured_note = (
-                f"\n\n_(Base sync: `origin/{base_ref}` merged; the tree is "
-                "unchanged, so the measured numbers above still describe "
-                "exactly this content — only the ancestry moved. A human "
-                "merges the synced PR.)_"
-            )
-        else:
-            base_synced = False  # withheld: cursor unspent, next tick retries
+                log.warning("auto-merge disarm errored before sync push: %s", exc)
+        if not disarm_ok:
             measured_note = (
                 "\n\n_(Base sync withheld: auto-merge could not be confirmed "
                 "disarmed on this auto-mode PR; the wake will retry.)_"
             )
+            return False
+        ws.push(branch)
+        sync_pushed = True
+        measured_note = note
+        return True
+
+    # A clean base merge can produce a commit whose TREE is unchanged (the
+    # branch already carried the base's content): committed/changed are both
+    # empty, but the merge commit IS the contribution. Same measured tree, so
+    # no re-eval is owed; push the topology and say so.
+    if conflict_wake and not changed and base_synced and history_known:
+        _sync_push(
+            f"\n\n_(Base sync: `origin/{base_ref}` merged; the tree is "
+            "unchanged, so the measured numbers above still describe "
+            "exactly this content — only the ancestry moved. A human "
+            "merges the synced PR.)_"
+        )
+    # The next rung: every changed path is the BASE'S OWN content (the merge
+    # brought it in; `_matches_base` pins against the fetched sha). The
+    # solver and eval surface are bit-for-bit what was measured, so the
+    # numbers stand and no re-measure is owed — exactly the topology case
+    # with a fatter diff. Any non-base-identical path (a solver edit, an
+    # eval tweak) falls through to the full scope-check + re-measure path.
+    base_only_sync = False
+    if conflict_wake and changed and base_synced and history_known:
+        base_only_sync = all(_matches_base(p) for p in changed)
+    if base_only_sync:
+        _sync_push(
+            f"\n\n_(Base sync: `origin/{base_ref}` merged; every changed "
+            "path is the base's own content, so the solver and eval surface "
+            "are bit-for-bit what was measured — the numbers above stand. "
+            "A human merges the synced PR.)_"
+        )
     if sync_failed:
         _revert_response()
         measured_note = (
@@ -671,7 +698,7 @@ def _respond(
             f"`origin/{base_ref}` — so it was not applied; the wake will "
             "retry.)_"
         )
-    elif changed:
+    elif changed and not base_only_sync:
         violations = [p for p in scope_check(changed, contract) if not _matches_base(p)]
         if violations:
             # revert the out-of-scope response; reply honestly, keep the PR
@@ -882,15 +909,22 @@ def _respond(
             last_comment_id=cursors["comment"],
             last_review_id=cursors["review"],
             last_review_comment_id=cursors["review_comment"],
-            # the cursor is spent only when the sync objectively happened
-            # (HEAD contains the fetched base); otherwise the head stays
-            # re-wakeable, bounded by the tick's submit-time billing — the
-            # count is kept, never advanced here, never reset without progress
+            # the cursor is spent only on REMOTE progress: a base-containing
+            # head was pushed (or the change was measured and pushed while
+            # synced); otherwise the head stays re-wakeable, bounded by the
+            # tick's submit-time billing — the count is kept, never advanced
+            # here, never reset without progress
             dirty_wake_head=(
-                conflict_head if (conflict_wake and base_synced) else record.dirty_wake_head
+                conflict_head
+                if (conflict_wake and (sync_pushed or (base_synced and change_pushed)))
+                else record.dirty_wake_head
             ),
             resume_session_id=session.session_id or record.resume_session_id,
-            wake_attempts=(record.wake_attempts if (conflict_wake and not base_synced) else 0),
+            wake_attempts=(
+                record.wake_attempts
+                if (conflict_wake and not (sync_pushed or (base_synced and change_pushed)))
+                else 0
+            ),
         ),
         now,
     )

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -614,6 +614,20 @@ def _respond(
             ws.git("reset", "--hard", pushed_tip)
 
     changed = sorted(set(_changed_paths(ws)) | set(committed))
+    # The merge may have brought a NEW contract in: everything downstream —
+    # the sync-skip comparison, the scope check, the re-measure's bench —
+    # must see the tree's contract, not the one loaded before the session
+    # ran. An unparsable merged contract withholds the response outright.
+    contract_path = ".autoresearch.yaml"
+    post_contract = contract
+    contract_broken = False
+    if contract_path in changed:
+        try:
+            post_contract = load_contract((workspace / contract_path).read_text(), record.target)
+        except Exception as exc:
+            contract_broken = True
+            log.warning("merged contract does not parse for %s: %s", run_id, exc)
+
     # A base-sync wake that changed the tree must actually CONTAIN the fetched
     # base: without the ancestry check a session could copy base files (or make
     # any edit) and push a re-measured PR that is still behind/conflicted
@@ -632,7 +646,9 @@ def _respond(
             base_synced = True
         except GitError:
             base_synced = False
-    sync_failed = conflict_wake and ((changed and not base_synced) or not history_known)
+    sync_failed = conflict_wake and (
+        (changed and not base_synced) or not history_known or contract_broken
+    )
     # The cursor spends only on REMOTE progress: a sync that exists solely in
     # the workspace (e.g. the re-measure was withheld) leaves the head
     # re-wakeable — the live lesson from gpt-speedrun#5, where a locally
@@ -674,32 +690,50 @@ def _respond(
             "exactly this content — only the ancestry moved. A human "
             "merges the synced PR.)_"
         )
-    # The next rung: every changed path is the BASE'S OWN content (the merge
-    # brought it in; `_matches_base` pins against the fetched sha). The
-    # solver and eval surface are bit-for-bit what was measured, so the
-    # numbers stand and no re-measure is owed — exactly the topology case
-    # with a fatter diff. Any non-base-identical path (a solver edit, an
-    # eval tweak) falls through to the full scope-check + re-measure path.
+    # The next rung, deliberately NARROW: the merge changed exactly one
+    # path — the contract file, with the base's own content — and the merged
+    # contract's benchmark definitions and scope parse IDENTICAL to the
+    # pre-merge ones. Then only kernel-workflow keys moved (a lines flip, a
+    # cadence knob): the eval command, metric, protocol, suite, and solver
+    # bytes are all exactly what was measured, so the numbers stand. ANY
+    # other changed path — eval/, docs, data, a solver edit — and any
+    # benchmark/scope difference takes the full scope-check + re-measure
+    # path: base-owned content is NOT the same thing as measured-under
+    # conditions (terra #225).
     base_only_sync = False
-    if conflict_wake and changed and base_synced and history_known:
-        base_only_sync = all(_matches_base(p) for p in changed)
-    if base_only_sync:
+    if (
+        conflict_wake
+        and base_synced
+        and history_known
+        and not contract_broken
+        and set(changed) == {contract_path}
+        and all(_matches_base(p) for p in changed)
+        and post_contract.benchmarks == contract.benchmarks
+        and post_contract.scope == contract.scope
+    ):
+        base_only_sync = True
         _sync_push(
-            f"\n\n_(Base sync: `origin/{base_ref}` merged; every changed "
-            "path is the base's own content, so the solver and eval surface "
-            "are bit-for-bit what was measured — the numbers above stand. "
-            "A human merges the synced PR.)_"
+            f"\n\n_(Base sync: `origin/{base_ref}` merged; the only change "
+            "is the contract file, whose benchmark definitions and scope are "
+            "identical — the eval surface and solver are bit-for-bit what "
+            "was measured, so the numbers above stand. A human merges the "
+            "synced PR.)_"
         )
     if sync_failed:
         _revert_response()
         measured_note = (
-            "\n\n_(A code change was attempted but does not include the "
-            "fetched base — the sync wake requires an actual merge of "
+            "\n\n_(The merged contract does not parse, so the change was "
+            "not applied; the wake will retry.)_"
+            if contract_broken
+            else "\n\n_(A code change was attempted but does not include "
+            "the fetched base — the sync wake requires an actual merge of "
             f"`origin/{base_ref}` — so it was not applied; the wake will "
             "retry.)_"
         )
     elif changed and not base_only_sync:
-        violations = [p for p in scope_check(changed, contract) if not _matches_base(p)]
+        # the tree's own contract governs its scope and its measurement
+        bench = next((b for b in post_contract.benchmarks if b.name == record.benchmark), bench)
+        violations = [p for p in scope_check(changed, post_contract) if not _matches_base(p)]
         if violations:
             # revert the out-of-scope response; reply honestly, keep the PR
             _revert_response()

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -662,7 +662,14 @@ def _respond(
         CONFIRMED disarm; a human merges the synced PR."""
         nonlocal measured_note, sync_pushed
         disarm_ok = True
-        if getattr(contract, "merge", "manual") == "auto":
+        # EITHER contract can have armed auto-merge: the pre-merge one at
+        # publish time, the merged one as the repo's current dial — a push
+        # to a possibly-armed PR is never made without a confirmed disarm
+        merge_modes = {
+            getattr(contract, "merge", "manual"),
+            getattr(post_contract, "merge", "manual"),
+        }
+        if "auto" in merge_modes:
             try:
                 disarm_ok = github.disable_auto_merge(record.target, number)
             except Exception as exc:

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -731,10 +731,21 @@ def _respond(
             "retry.)_"
         )
     elif changed and not base_only_sync:
-        # the tree's own contract governs its scope and its measurement
-        bench = next((b for b in post_contract.benchmarks if b.name == record.benchmark), bench)
+        # the tree's own contract governs its scope and its measurement; a
+        # merged contract that no longer defines this run's benchmark means
+        # there is nothing left to measure the change AGAINST — withhold and
+        # say so, never evaluate a command the contract removed (terra #225
+        # r2: the pre-merge fallback published a phantom benchmark)
+        post_bench = next((b for b in post_contract.benchmarks if b.name == record.benchmark), None)
         violations = [p for p in scope_check(changed, post_contract) if not _matches_base(p)]
-        if violations:
+        if post_bench is None:
+            _revert_response()
+            measured_note = (
+                f"\n\n_(The merged contract no longer defines benchmark "
+                f"`{record.benchmark}`, so the change was not applied — a "
+                "human decides whether this PR is superseded.)_"
+            )
+        elif violations:
             # revert the out-of-scope response; reply honestly, keep the PR
             _revert_response()
             measured_note = (
@@ -742,6 +753,7 @@ def _respond(
                 "the contract's scope and was not applied.)_"
             )
         else:
+            bench = post_bench
             pre_eval_tree = _tree_hash(ws)
             # one fresh seed for this re-measure, recorded with the row —
             # same pairing/reproducibility rule as the climb and steward

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -800,7 +800,7 @@ def _respond(
                         prior = None  # a re-base is not an improvement claim
                         rebase_leader_row(
                             workspace,
-                            contract,
+                            post_contract,
                             bench.name,
                             bench,
                             candidate,
@@ -912,7 +912,7 @@ def _respond(
                                 author=bot_login,
                                 forbidden=lambda p: (
                                     p not in PROGRESS_PATHS
-                                    and bool(scope_check([p], contract))
+                                    and bool(scope_check([p], post_contract))
                                     and not _matches_base(p)
                                 ),
                             )

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -771,7 +771,7 @@ def _respond(
                     from autoresearch.steward import validate_and_measure
 
                     candidate = validate_and_measure(
-                        workspace, contract, bench, evaluator, run_seed=run_seed
+                        workspace, post_contract, bench, evaluator, run_seed=run_seed
                     )
                 else:
                     candidate = evaluator.evaluate(
@@ -868,7 +868,7 @@ def _respond(
                                 record.target,
                                 digits={
                                     b.name: b.display_digits
-                                    for b in contract.benchmarks
+                                    for b in post_contract.benchmarks
                                     if b.display_digits
                                 },
                             )
@@ -879,7 +879,13 @@ def _respond(
                     # the change is withheld like a failed eval — workspace
                     # cleaned, the reply says so, next pass retries.
                     disarmed = True
-                    if getattr(contract, "merge", "manual") == "auto":
+                    # EITHER contract can have armed auto-merge — the
+                    # pre-merge one at publish, the merged one as the
+                    # repo's current dial (same rule as _sync_push)
+                    if "auto" in {
+                        getattr(contract, "merge", "manual"),
+                        getattr(post_contract, "merge", "manual"),
+                    }:
                         try:
                             disarmed = github.disable_auto_merge(record.target, number)
                         except Exception as exc:

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1521,3 +1521,30 @@ def test_bench_definition_change_in_base_still_remeasures(review_run) -> None:
     assert "eval failed" in github.posted[0]  # and was withheld honestly
     record = load_record(root, "tsp-r1")
     assert record.dirty_wake_head == ""  # nothing reached the remote
+
+
+def test_removed_benchmark_is_never_measured_with_the_old_definition(review_run) -> None:
+    """A base sync whose merged contract no longer defines the run's
+    benchmark withholds — the old command must not be evaluated or
+    published against a contract that removed it (terra #225 r2)."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2k"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / ".autoresearch.yaml").write_text(CONTRACT.replace("name: tsp", "name: tsp2"))
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "bench renamed")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    github = FakeGitHub(pr=_behind_pr(head=head))
+
+    class NeverEvaluator:
+        def evaluate(self, *a, **k):
+            raise AssertionError("a removed benchmark must never be measured")
+
+    outcome = respond(root, github, ResumingHarness(merge_base=True), NeverEvaluator())
+    assert outcome.action == "replied"
+    assert "no longer defines benchmark" in github.posted[0]
+    record = load_record(root, "tsp-r1")
+    assert record.dirty_wake_head == ""  # nothing reached the remote

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1486,3 +1486,38 @@ def test_withheld_sync_leaves_the_cursor_unspent(review_run) -> None:
     assert "eval failed" in github.posted[0]
     record = load_record(root, "tsp-r1")
     assert record.dirty_wake_head == ""  # unspent: nothing reached the remote
+
+
+def test_bench_definition_change_in_base_still_remeasures(review_run) -> None:
+    """The narrow skip applies ONLY to contract changes that leave every
+    benchmark definition and the scope identical. A base move that edits a
+    bench stanza (here: the command) changes the measurement conditions, so
+    the sync takes the full re-measure path — base-owned content is not the
+    same thing as measured-under conditions (terra #225)."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2j"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / ".autoresearch.yaml").write_text(
+        CONTRACT.replace("--env tsp --json", "--env tsp --json --fast")
+    )
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "bench change")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    github = FakeGitHub(pr=_behind_pr(head=head))
+
+    class RecordingEvaluator:
+        calls = 0
+
+        def evaluate(self, *a, **k):
+            RecordingEvaluator.calls += 1
+            raise RuntimeError("no GPU on this node")
+
+    outcome = respond(root, github, ResumingHarness(merge_base=True), RecordingEvaluator())
+    assert outcome.action == "replied"
+    assert RecordingEvaluator.calls == 1  # the re-measure path ran
+    assert "eval failed" in github.posted[0]  # and was withheld honestly
+    record = load_record(root, "tsp-r1")
+    assert record.dirty_wake_head == ""  # nothing reached the remote

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1579,3 +1579,34 @@ def test_base_flip_to_auto_is_disarmed_before_the_sync_push(review_run) -> None:
     assert "withheld" in github.posted[0]
     record = load_record(root, "tsp-r1")
     assert record.dirty_wake_head == ""  # nothing pushed, head re-wakeable
+
+
+def test_widened_merged_scope_publishes_its_allowed_edit(review_run) -> None:
+    """A base sync that widens the scope must let an edit in the NEW area
+    publish: the commit-time forbidden check reads the merged contract, not
+    the pre-merge one (terra #225 r5: commit_all raised ForbiddenPathError
+    after a successful re-measure)."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2m"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / ".autoresearch.yaml").write_text(
+        CONTRACT.replace(
+            "scope: {allowed: [src/pilot/solvers/]}",
+            "scope: {allowed: [src/pilot/solvers/, src/pilot/extra/]}",
+        )
+    )
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "scope widens")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    github = FakeGitHub(pr=_behind_pr(head=head))
+    harness = ResumingHarness(
+        merge_base=True, edits={"src/pilot/extra/helper.py": "new-area edit\n"}
+    )
+    outcome = respond(root, github, harness, QueueEvaluator(values=[10.2]))
+    assert outcome.action == "replied"
+    assert "Re-measured" in github.posted[0]
+    pushed = _git(bare, "show", "feat/auto/agent-01/tsp-r1:src/pilot/extra/helper.py")
+    assert "new-area edit" in pushed

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1548,3 +1548,34 @@ def test_removed_benchmark_is_never_measured_with_the_old_definition(review_run)
     assert "no longer defines benchmark" in github.posted[0]
     record = load_record(root, "tsp-r1")
     assert record.dirty_wake_head == ""  # nothing reached the remote
+
+
+def test_base_flip_to_auto_is_disarmed_before_the_sync_push(review_run) -> None:
+    """A base move that flips the contract's merge dial to auto must not
+    push without a confirmed disarm (terra #225 r3: _sync_push read the
+    pre-merge contract, so the flip pushed onto a potentially armed PR)."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2l"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / ".autoresearch.yaml").write_text(CONTRACT + "merge: auto\n")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "auto flip")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+
+    class DisarmRefusingGitHub(FakeGitHub):
+        disarm_calls = 0
+
+        def disable_auto_merge(self, repo, number):
+            DisarmRefusingGitHub.disarm_calls += 1
+            return False  # cannot confirm the disarm
+
+    github = DisarmRefusingGitHub(pr=_behind_pr(head=head))
+    outcome = respond(root, github, ResumingHarness(merge_base=True), QueueEvaluator(values=[]))
+    assert outcome.action == "replied"
+    assert DisarmRefusingGitHub.disarm_calls == 1  # the merged dial was honored
+    assert "withheld" in github.posted[0]
+    record = load_record(root, "tsp-r1")
+    assert record.dirty_wake_head == ""  # nothing pushed, head re-wakeable

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -897,7 +897,8 @@ def _dirty_pr(head="h" * 40) -> dict:
 
 def test_conflicted_pr_wakes_the_author_without_comments(review_run) -> None:
     root, _bare = review_run
-    github = FakeGitHub(pr=_dirty_pr())
+    head = _ws_head(root)
+    github = FakeGitHub(pr=_dirty_pr(head=head))
     harness = ResumingHarness()
     outcome = respond(root, github, harness, QueueEvaluator(values=[10.5]))
     assert outcome.action == "replied"
@@ -907,7 +908,7 @@ def test_conflicted_pr_wakes_the_author_without_comments(review_run) -> None:
     assert resume_id == "sess-original"  # same session lineage, full context
     # once per head: the cursor is persisted, the next pass no-ops
     record = load_record(root, "tsp-r1")
-    assert record.dirty_wake_head == "h" * 40
+    assert record.dirty_wake_head == head
     outcome2 = respond(root, github, ResumingHarness(), QueueEvaluator(values=[10.5]))
     assert outcome2.action == "no-op"
 
@@ -1420,3 +1421,68 @@ def test_do_nothing_session_leaves_the_behind_wake_rearmed(review_run) -> None:
     outcome2 = respond(root, github, second, QueueEvaluator(values=[10.2]))
     assert outcome2.action == "replied"
     assert second.calls, "the head must stay wakeable until the sync is real"
+
+
+def test_base_identical_sync_pushes_without_remeasure(review_run) -> None:
+    """A base move whose merge changes ONLY base-owned content (the live
+    gpt-speedrun#5 shape: a contract flip landed mid-attempt) pushes without
+    a re-measure — the solver and eval surface are bit-for-bit what was
+    measured — and spends the cursor."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2h"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / ".autoresearch.yaml").write_text(
+        (seed2 / ".autoresearch.yaml").read_text() + "# lines flip\n"
+    )
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "contract flip")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    _git(ws, "push", "-q", "origin", "HEAD:feat/auto/agent-01/tsp-r1")
+    github = FakeGitHub(pr=_behind_pr(head=head))
+
+    class FailingEvaluator:
+        def evaluate(self, *a, **k):  # the re-measure path must NOT run
+            raise AssertionError("base-identical sync must not re-measure")
+
+    harness = ResumingHarness(merge_base=True)  # merge brings only the contract
+    outcome = respond(root, github, harness, FailingEvaluator())
+    assert outcome.action == "replied"
+    assert "the numbers above stand" in github.posted[0]
+    # the pushed branch now contains the base tip
+    main_sha = _git(bare, "rev-parse", "main").strip()
+    branch_sha = _git(bare, "rev-parse", "feat/auto/agent-01/tsp-r1").strip()
+    assert _git(bare, "merge-base", main_sha, branch_sha).strip() == main_sha
+    record = load_record(root, "tsp-r1")
+    assert record.dirty_wake_head == head  # cursor spent: remote progress
+
+
+def test_withheld_sync_leaves_the_cursor_unspent(review_run) -> None:
+    """A sync whose re-measure fails (a solver edit rode along and the eval
+    errored) reaches the remote NOT AT ALL — so the cursor must stay unspent
+    and the head re-wakeable (the live gpt-speedrun#5 lesson: local ancestry
+    spent the cursor while GitHub still showed the PR behind)."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2i"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / "docs" / "news.md").write_text("from main\n")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "main moves")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    github = FakeGitHub(pr=_behind_pr(head=head))
+
+    class ErroringEvaluator:
+        def evaluate(self, *a, **k):
+            raise RuntimeError("no GPU on this node")
+
+    harness = ResumingHarness(merge_base=True, edits={"src/pilot/solvers/tsp.py": "solver tweak\n"})
+    outcome = respond(root, github, harness, ErroringEvaluator())
+    assert outcome.action == "replied"
+    assert "eval failed" in github.posted[0]
+    record = load_record(root, "tsp-r1")
+    assert record.dirty_wake_head == ""  # unspent: nothing reached the remote


### PR DESCRIPTION
## What

Two rules, straight from tonight's first live firing of the #224 behind wake on **gpt-speedrun#5** (the 9088→8640 record):

1. **Base-identical sync push** — when every changed path of a base sync is the base's own content (all `_matches_base` against the pinned fetch sha), the solver and eval surface are bit-for-bit what was measured: push under the same confirmed-disarm gate, no re-measure owed. Exactly the topology rule one rung up. Any non-base-identical path (a solver edit riding along, an eval tweak in the base) still takes the full scope-check + re-measure path.
2. **The cursor spends on REMOTE progress only** — live, the session merged cleanly but the re-measure (inline GPU eval on a CPU node) failed, nothing was pushed, and the cursor — keyed on local ancestry — was spent anyway, restranding the PR silently.

## What happened live

The wake fired as designed; the session's analysis was honest ('the base change only updates .autoresearch.yaml; it does not change train.py or supersede this result'); the withheld note posted. The two gaps were: re-measuring a tree whose measured surface didn't change, and burning the once-per-head cursor on workspace-only progress.

## Test / gate

Full gate green (1010). New pins: the #5 shape (contract-only base move) pushes without ever calling the evaluator (a FailingEvaluator asserts it); a withheld eval leaves the cursor unspent; the conflict fixture now carries real head shas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)