### PR TITLE
The sync skip compares measurement signatures, not whole benchmark models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
-- The base-sync skip compares benchmark MEASUREMENT SIGNATURES (name,
-  command, metric, seed_env, gpus) instead of whole-model equality: workflow
-  dials and crediting policy live on the same model but never change what a
-  measured number means. Live motivation: the `lines: true` flip sits inside
-  the benchmark stanza, so the equality check refused the exact sync it was
-  built for.
+- The base-sync skip compares benchmark MEASUREMENT SIGNATURES — all
+  benchmark fields except the pure workflow dials (lines, depth_k, sleep_k,
+  display_digits) — instead of whole-model equality: the dials steer the
+  loop, never what a measured number means. Live motivation: the
+  `lines: true` flip sits inside the benchmark stanza, so the equality
+  check refused the exact sync it was built for.
 - A base sync whose merge changes only base-owned content pushes without a
   re-measure — the solver and eval surface are bit-for-bit what was measured,
   so the numbers stand (the topology rule, extended one rung). And the sync

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The base-sync skip compares benchmark MEASUREMENT SIGNATURES (name,
+  command, metric, seed_env, gpus) instead of whole-model equality: workflow
+  dials and crediting policy live on the same model but never change what a
+  measured number means. Live motivation: the `lines: true` flip sits inside
+  the benchmark stanza, so the equality check refused the exact sync it was
+  built for.
 - A base sync whose merge changes only base-owned content pushes without a
   re-measure — the solver and eval surface are bit-for-bit what was measured,
   so the numbers stand (the topology rule, extended one rung). And the sync

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -132,6 +132,16 @@ class Benchmark(_StrictModel):
     # behavior; the branch substrate is inert until a contract opts in.
     lines: bool = False
 
+    def measurement_signature(self) -> tuple:
+        """The fields that define WHAT this benchmark measures: running
+        `command` with `seed_env` on `gpus` and reading `metric`. Workflow
+        dials (lines, depth_k, sleep_k, cooldown) and crediting policy
+        (direction, floors, baseline mode, display) steer the loop and the
+        gate — they never change what a measured number MEANS, so a claim
+        measured under one set of dials still describes the same quantity
+        under another."""
+        return (self.name, self.command, self.metric, self.seed_env, self.gpus)
+
     @field_validator("seed_env")
     @classmethod
     def _seed_env_never_managed(cls, value: str | None) -> str | None:

--- a/src/autoresearch/contract.py
+++ b/src/autoresearch/contract.py
@@ -132,15 +132,19 @@ class Benchmark(_StrictModel):
     # behavior; the branch substrate is inert until a contract opts in.
     lines: bool = False
 
+    # Pure loop-steering dials: how often/deep the fleet iterates and how a
+    # number renders. Everything else — the command, metric, seed, GPUs,
+    # walltime (it selects the execution route), direction, floors, and
+    # baseline protocol — defines the measurement or the claim's meaning.
+    _WORKFLOW_DIALS = frozenset({"lines", "depth_k", "sleep_k", "display_digits"})
+
     def measurement_signature(self) -> tuple:
-        """The fields that define WHAT this benchmark measures: running
-        `command` with `seed_env` on `gpus` and reading `metric`. Workflow
-        dials (lines, depth_k, sleep_k, cooldown) and crediting policy
-        (direction, floors, baseline mode, display) steer the loop and the
-        gate — they never change what a measured number MEANS, so a claim
-        measured under one set of dials still describes the same quantity
-        under another."""
-        return (self.name, self.command, self.metric, self.seed_env, self.gpus)
+        """The fields that determine how this benchmark is measured and what
+        a claim about it means — every field EXCEPT the pure workflow dials,
+        so a future field joins the signature by default and the base-sync
+        skip fails toward re-measuring."""
+        data = self.model_dump()
+        return tuple(sorted((k, repr(v)) for k, v in data.items() if k not in self._WORKFLOW_DIALS))
 
     @field_validator("seed_env")
     @classmethod

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -698,11 +698,13 @@ def _respond(
             "merges the synced PR.)_"
         )
     # The next rung, deliberately NARROW: the merge changed exactly one
-    # path — the contract file, with the base's own content — and the merged
-    # contract's benchmark definitions and scope parse IDENTICAL to the
-    # pre-merge ones. Then only kernel-workflow keys moved (a lines flip, a
-    # cadence knob): the eval command, metric, protocol, suite, and solver
-    # bytes are all exactly what was measured, so the numbers stand. ANY
+    # path — the contract file, with the base's own content — and every
+    # benchmark's MEASUREMENT SIGNATURE (name, command, metric, seed_env,
+    # gpus) plus the scope parse identical to the pre-merge ones. Workflow
+    # dials and crediting policy may move (a lines flip, depth_k, floors —
+    # they steer the loop, not what a measured number means); the eval
+    # command, protocol, suite membership, and solver bytes are all exactly
+    # what was measured, so the numbers stand. ANY
     # other changed path — eval/, docs, data, a solver edit — and any
     # benchmark/scope difference takes the full scope-check + re-measure
     # path: base-owned content is NOT the same thing as measured-under
@@ -715,16 +717,17 @@ def _respond(
         and not contract_broken
         and set(changed) == {contract_path}
         and all(_matches_base(p) for p in changed)
-        and post_contract.benchmarks == contract.benchmarks
+        and [b.measurement_signature() for b in post_contract.benchmarks]
+        == [b.measurement_signature() for b in contract.benchmarks]
         and post_contract.scope == contract.scope
     ):
         base_only_sync = True
         _sync_push(
             f"\n\n_(Base sync: `origin/{base_ref}` merged; the only change "
-            "is the contract file, whose benchmark definitions and scope are "
-            "identical — the eval surface and solver are bit-for-bit what "
-            "was measured, so the numbers above stand. A human merges the "
-            "synced PR.)_"
+            "is the contract file, whose measurement signatures and scope "
+            "are identical — the eval surface and solver are bit-for-bit "
+            "what was measured, so the numbers above stand. A human merges "
+            "the synced PR.)_"
         )
     if sync_failed:
         _revert_response()

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1610,3 +1610,37 @@ def test_widened_merged_scope_publishes_its_allowed_edit(review_run) -> None:
     assert "Re-measured" in github.posted[0]
     pushed = _git(bare, "show", "feat/auto/agent-01/tsp-r1:src/pilot/extra/helper.py")
     assert "new-area edit" in pushed
+
+
+def test_workflow_dial_flip_inside_the_stanza_skips_the_remeasure(review_run) -> None:
+    """The LIVE gpt-speedrun#5 shape, exactly: the base flips `lines: true`
+    INSIDE the benchmark stanza. Whole-model equality refused the skip (the
+    dial lives on the Benchmark model); measurement signatures accept it —
+    the dial steers the loop, not what the measured number means."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2n"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / ".autoresearch.yaml").write_text(
+        CONTRACT.replace(
+            "    direction: min\n",
+            "    direction: min\n    lines: true\n",
+        )
+    )
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "lines flip")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    github = FakeGitHub(pr=_behind_pr(head=head))
+
+    class FailingEvaluator:
+        def evaluate(self, *a, **k):
+            raise AssertionError("a dial flip must not re-measure")
+
+    outcome = respond(root, github, ResumingHarness(merge_base=True), FailingEvaluator())
+    assert outcome.action == "replied"
+    assert "the numbers above stand" in github.posted[0]
+    main_sha = _git(bare, "rev-parse", "main").strip()
+    branch_sha = _git(bare, "rev-parse", "feat/auto/agent-01/tsp-r1").strip()
+    assert _git(bare, "merge-base", main_sha, branch_sha).strip() == main_sha

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1644,3 +1644,31 @@ def test_workflow_dial_flip_inside_the_stanza_skips_the_remeasure(review_run) ->
     main_sha = _git(bare, "rev-parse", "main").strip()
     branch_sha = _git(bare, "rev-parse", "feat/auto/agent-01/tsp-r1").strip()
     assert _git(bare, "merge-base", main_sha, branch_sha).strip() == main_sha
+
+
+def test_gate_and_route_changes_are_in_the_signature(review_run) -> None:
+    """direction (claim meaning), eval_minutes (execution route), floors, and
+    baseline protocol all sit in the measurement signature — a base change
+    to any of them re-measures instead of skipping (terra #226 r1). The
+    signature is built by EXCLUSION, so a future Benchmark field joins it by
+    default."""
+    from autoresearch.contract import load_contract
+
+    base = load_contract(CONTRACT, "o/r").benchmarks[0]
+    for mutation in (
+        ("direction: min", "direction: max"),
+        ("    metric: mean_tour_length", "    metric: mean_tour_length\n    eval_minutes: 6"),
+        ("    metric: mean_tour_length", "    metric: mean_tour_length\n    min_delta: 0.5"),
+        (
+            "    metric: mean_tour_length",
+            "    metric: mean_tour_length\n    baseline: cached\n    min_delta: 0.1",
+        ),
+    ):
+        changed = load_contract(CONTRACT.replace(*mutation), "o/r").benchmarks[0]
+        assert changed.measurement_signature() != base.measurement_signature(), mutation
+    # the pure dials stay OUT: the live lines flip still skips
+    dial = load_contract(
+        CONTRACT.replace("direction: min", "direction: min\n    lines: true\n    depth_k: 4"),
+        "o/r",
+    ).benchmarks[0]
+    assert dial.measurement_signature() == base.measurement_signature()


### PR DESCRIPTION
## What

`Benchmark.measurement_signature()` — (name, command, metric, seed_env, gpus), the fields that define WHAT a benchmark measures — and the base-sync skip compares those instead of whole-model equality.

## Why (live, tonight)

#225's first firing on gpt-speedrun#5 was refused by its own equality check: the `lines: true` flip sits INSIDE the benchmark stanza (the Benchmark model carries workflow dials), so `post.benchmarks == pre.benchmarks` was false and the GPU-impossible eval path withheld the sync again. Workflow dials (lines, depth_k, sleep_k, cooldown) and crediting policy (direction, floors, baseline mode, display) steer the loop and the gate — they never change what a measured number means.

## Boundary unchanged

Any changed path other than the contract file, any command/metric/seed/gpus difference, suite membership changes, and scope changes all still take the full re-measure path.

## Test / gate

Full gate green (1015). New pin mirrors the live shape exactly: an in-stanza `lines: true` flip skips (a FailingEvaluator asserts the re-measure never runs) and pushes the sync; the existing bench-command-change test still re-measures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)