### PR TITLE
Sync diagnostics: the eval-failed note names the changed paths

### DIFF
--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -709,6 +709,14 @@ def _respond(
     # benchmark/scope difference takes the full scope-check + re-measure
     # path: base-owned content is NOT the same thing as measured-under
     # conditions (terra #225).
+    if conflict_wake and changed:
+        log.info(
+            "sync wake for %s: changed=%s base_synced=%s history_known=%s",
+            run_id,
+            changed[:20],
+            base_synced,
+            history_known,
+        )
     base_only_sync = False
     if (
         conflict_wake
@@ -783,8 +791,11 @@ def _respond(
             except Exception as exc:
                 _revert_response()
                 measured_note = (
-                    "\n\n_(A code change was attempted but the eval failed on "
-                    f"it, so it was not applied: {redact(str(exc), secrets)[:200]})_"
+                    "\n\n_(A code change was attempted but the eval failed "
+                    f"on it, so it was not applied. Changed paths: "
+                    f"{', '.join(f'`{p}`' for p in changed[:12])}"
+                    f"{' …' if len(changed) > 12 else ''}. "
+                    f"Error: {redact(str(exc), secrets)[:200]})_"
                 )
             else:
                 if _tree_hash(ws) != pre_eval_tree:

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -722,10 +722,12 @@ def _respond(
     # path: base-owned content is NOT the same thing as measured-under
     # conditions (terra #225).
     if conflict_wake and changed:
+        # session-controlled names: same sanitizer+scrub chain as the note
+        # (a raw list could leak a secret or forge log lines via newlines)
         log.info(
             "sync wake for %s: changed=%s base_synced=%s history_known=%s",
             run_id,
-            changed[:20],
+            _safe_paths(changed),
             base_synced,
             history_known,
         )

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
+import re
 from dataclasses import dataclass, replace
 from pathlib import Path
 
@@ -553,6 +554,17 @@ def _respond(
     reply_body = APPROVAL_PATTERN.sub(REDACTED, redact(session.final_text, secrets))[
         :MAX_REPLY_CHARS
     ]
+
+    def _safe_paths(paths: list[str]) -> str:
+        """Session-controlled filenames rendered into a bot comment: strip to
+        a markdown-inert charset (a name can carry backticks, newlines, a
+        secret, or the approval phrase), bound each, then run the same secret
+        redaction and self-approval scrub as every other reply line."""
+        cleaned = ", ".join(
+            "`" + re.sub(r"[^A-Za-z0-9._/@+-]", "?", p)[:120] + "`" for p in paths[:12]
+        ) + (" …" if len(paths) > 12 else "")
+        return APPROVAL_PATTERN.sub(REDACTED, redact(cleaned, secrets))
+
     measured_note = ""
     change_pushed = False
 
@@ -793,8 +805,7 @@ def _respond(
                 measured_note = (
                     "\n\n_(A code change was attempted but the eval failed "
                     f"on it, so it was not applied. Changed paths: "
-                    f"{', '.join(f'`{p}`' for p in changed[:12])}"
-                    f"{' …' if len(changed) > 12 else ''}. "
+                    f"{_safe_paths(changed)}. "
                     f"Error: {redact(str(exc), secrets)[:200]})_"
                 )
             else:

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -560,8 +560,13 @@ def _respond(
         a markdown-inert charset (a name can carry backticks, newlines, a
         secret, or the approval phrase), bound each, then run the same secret
         redaction and self-approval scrub as every other reply line."""
+        # redact each RAW name before the length cut: a secret straddling
+        # the boundary would otherwise leak its prefix uncaught
         cleaned = ", ".join(
-            "`" + re.sub(r"[^A-Za-z0-9._/@+-]", "?", p)[:120] + "`" for p in paths[:12]
+            # brackets stay: they cannot close a code span, and the
+            # redaction marker must survive the strip intact
+            "`" + re.sub(r"[^A-Za-z0-9._/@+\[\]-]", "?", redact(p, secrets))[:120] + "`"
+            for p in paths[:12]
         ) + (" …" if len(paths) > 12 else "")
         return APPROVAL_PATTERN.sub(REDACTED, redact(cleaned, secrets))
 

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1699,10 +1699,12 @@ def test_eval_failed_note_names_paths_and_scrubs_them(review_run) -> None:
     # neutralize the latter two
     hostile = "src/pilot/solvers/x`y\nz.py"
     keyed = "src/pilot/solvers/leak-sk-x-oops.py"  # carries the fixture secret
+    # the secret STRADDLES the 120-char cut: redact must run pre-truncation
+    straddle = "src/pilot/solvers/" + "a" * (120 - len("src/pilot/solvers/") - 2) + "sk-x.py"
     approving = "src/pilot/solvers/approved.py"  # matches APPROVAL_PATTERN
     harness = ResumingHarness(
         merge_base=True,
-        edits={hostile: "evil\n", keyed: "evil\n", approving: "evil\n"},
+        edits={p: "evil\n" for p in (hostile, keyed, approving, straddle)},
     )
     outcome = respond(root, github, harness, ErroringEvaluator())
     assert outcome.action == "replied"

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1672,3 +1672,35 @@ def test_gate_and_route_changes_are_in_the_signature(review_run) -> None:
         "o/r",
     ).benchmarks[0]
     assert dial.measurement_signature() == base.measurement_signature()
+
+
+def test_eval_failed_note_names_paths_and_scrubs_them(review_run) -> None:
+    """The changed-path list in the eval-failed note is session-controlled
+    text: markdown-inert charset, secrets redacted, the self-approval scrub
+    applied — and the diagnostic itself is pinned (terra #227)."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2o"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / "docs" / "news.md").write_text("from main\n")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "main moves")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    github = FakeGitHub(pr=_behind_pr(head=head))
+
+    class ErroringEvaluator:
+        def evaluate(self, *a, **k):
+            raise RuntimeError("boom")
+
+    # a hostile filename: backtick breakout attempt + shell-ish noise
+    hostile = "src/pilot/solvers/x`y\nz.py"
+    harness = ResumingHarness(merge_base=True, edits={hostile: "evil\n"})
+    outcome = respond(root, github, harness, ErroringEvaluator())
+    assert outcome.action == "replied"
+    note = github.posted[0]
+    assert "Changed paths:" in note
+    assert "docs/news.md" in note  # the diagnostic names the merge's paths
+    assert "x?y?z.py" in note  # hostile chars stripped to the inert charset
+    assert "x`y" not in note  # the raw breakout sequence never survives

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1694,9 +1694,16 @@ def test_eval_failed_note_names_paths_and_scrubs_them(review_run) -> None:
         def evaluate(self, *a, **k):
             raise RuntimeError("boom")
 
-    # a hostile filename: backtick breakout attempt + shell-ish noise
+    # hostile filenames: backtick breakout, a secret, the approval phrase —
+    # the inert charset keeps alphanumerics, so ONLY the scrub chain can
+    # neutralize the latter two
     hostile = "src/pilot/solvers/x`y\nz.py"
-    harness = ResumingHarness(merge_base=True, edits={hostile: "evil\n"})
+    keyed = "src/pilot/solvers/leak-sk-x-oops.py"  # carries the fixture secret
+    approving = "src/pilot/solvers/approved.py"  # matches APPROVAL_PATTERN
+    harness = ResumingHarness(
+        merge_base=True,
+        edits={hostile: "evil\n", keyed: "evil\n", approving: "evil\n"},
+    )
     outcome = respond(root, github, harness, ErroringEvaluator())
     assert outcome.action == "replied"
     note = github.posted[0]
@@ -1704,3 +1711,11 @@ def test_eval_failed_note_names_paths_and_scrubs_them(review_run) -> None:
     assert "docs/news.md" in note  # the diagnostic names the merge's paths
     assert "x?y?z.py" in note  # hostile chars stripped to the inert charset
     assert "x`y" not in note  # the raw breakout sequence never survives
+    # the fixture secret rode in via a filename: redact() must strip it, and
+    # the approval-like name must hit the same scrub as every reply line
+    assert "sk-x" not in note
+    assert "[redacted]" in note
+    from autoresearch.review import APPROVAL_PATTERN
+
+    tail = note.split("Changed paths:")[1]
+    assert not APPROVAL_PATTERN.search(tail.replace("[redacted: approval-like text]", ""))


### PR DESCRIPTION
Small observability fix from tonight's live loop: three sync-wake retries on gpt-speedrun#5 were undiagnosable from the PR — the withheld note said the eval failed but never WHAT the merge changed, which is the fact that decides which branch ran (the skip needs changed == {contract file}). The note now names the changed paths (capped at 12) and the tick log records the skip decision's inputs.

Full gate green (1016).

🤖 Generated with [Claude Code](https://claude.com/claude-code)