### PR TITLE
A signature-clean sync re-arms auto-merge when both worlds say auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- A signature-clean base sync re-arms auto-merge when the merge dial is
+  `auto` in BOTH the measured and merged worlds (auto at publish means the
+  panel ran; auto now means the owner still wants it) — the clean sync
+  restores exactly the freshness that withheld arming at publish. Any other
+  combination still leaves the merge to a human.
 - `AUTORESEARCH_COMPUTE=local` runs the whole loop without a cluster: jobs
   become synchronous subprocesses (`LocalCompute` at every seam), Slurm
   placement env is not required, park-time wake arming yields to the sweep,

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -171,6 +171,23 @@ def _target_clone_url(target: str) -> str:
     return f"https://github.com/{target}.git"
 
 
+def _blessed_head(ws: Workspace, result: Any, contract: Any) -> str:
+    """The pushed PR head the tick may later self-merge — only when this
+    publish was under merge:auto with a CLEAN panel (#171's arming
+    condition); "" otherwise. Best-effort: an unreadable HEAD blesses
+    nothing (never arm on doubt)."""
+    if not (
+        result.panel_rounds > 0
+        and not (result.panel_blocking_open or result.panel_degraded)
+        and getattr(contract, "merge", "manual") == "auto"
+    ):
+        return ""
+    try:
+        return ws.git("rev-parse", "HEAD").strip()
+    except Exception:
+        return ""
+
+
 def _arm_unless_base_moved(
     github: GitHubClient,
     ws: Workspace,
@@ -1591,9 +1608,7 @@ def resume_run(
                         **record.__dict__,
                         "state": IN_REVIEW,
                         "pr_url": pr_url,
-                        "auto_eligible": result.panel_rounds > 0
-                        and not (result.panel_blocking_open or result.panel_degraded)
-                        and getattr(contract, "merge", "manual") == "auto",
+                        "auto_blessed_head": _blessed_head(ws, result, contract),
                         "resume_session_id": result.session.session_id if result.session else "",
                         "ending_note": pr_url,
                     }
@@ -1796,9 +1811,7 @@ def resume_run(
                     **record.__dict__,
                     "state": IN_REVIEW,
                     "pr_url": pr_url,
-                    "auto_eligible": result.panel_rounds > 0
-                    and not (result.panel_blocking_open or result.panel_degraded)
-                    and getattr(contract, "merge", "manual") == "auto",
+                    "auto_blessed_head": _blessed_head(ws, result, contract),
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
                 }
@@ -2677,9 +2690,7 @@ def live_attempt(
                     **record.__dict__,
                     "state": IN_REVIEW,
                     "pr_url": pr_url,
-                    "auto_eligible": result.panel_rounds > 0
-                    and not (result.panel_blocking_open or result.panel_degraded)
-                    and getattr(contract, "merge", "manual") == "auto",
+                    "auto_blessed_head": _blessed_head(ws, result, contract),
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
                 }

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1591,6 +1591,7 @@ def resume_run(
                         **record.__dict__,
                         "state": IN_REVIEW,
                         "pr_url": pr_url,
+                        "panel_ran": result.panel_rounds > 0,
                         "resume_session_id": result.session.session_id if result.session else "",
                         "ending_note": pr_url,
                     }
@@ -1793,6 +1794,7 @@ def resume_run(
                     **record.__dict__,
                     "state": IN_REVIEW,
                     "pr_url": pr_url,
+                    "panel_ran": result.panel_rounds > 0,
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
                 }
@@ -2671,6 +2673,7 @@ def live_attempt(
                     **record.__dict__,
                     "state": IN_REVIEW,
                     "pr_url": pr_url,
+                    "panel_ran": result.panel_rounds > 0,
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
                 }

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1591,7 +1591,8 @@ def resume_run(
                         **record.__dict__,
                         "state": IN_REVIEW,
                         "pr_url": pr_url,
-                        "panel_ran": result.panel_rounds > 0,
+                        "auto_eligible": result.panel_rounds > 0
+                        and getattr(contract, "merge", "manual") == "auto",
                         "resume_session_id": result.session.session_id if result.session else "",
                         "ending_note": pr_url,
                     }
@@ -1794,7 +1795,8 @@ def resume_run(
                     **record.__dict__,
                     "state": IN_REVIEW,
                     "pr_url": pr_url,
-                    "panel_ran": result.panel_rounds > 0,
+                    "auto_eligible": result.panel_rounds > 0
+                    and getattr(contract, "merge", "manual") == "auto",
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
                 }
@@ -2673,7 +2675,8 @@ def live_attempt(
                     **record.__dict__,
                     "state": IN_REVIEW,
                     "pr_url": pr_url,
-                    "panel_ran": result.panel_rounds > 0,
+                    "auto_eligible": result.panel_rounds > 0
+                    and getattr(contract, "merge", "manual") == "auto",
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
                 }

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1592,6 +1592,7 @@ def resume_run(
                         "state": IN_REVIEW,
                         "pr_url": pr_url,
                         "auto_eligible": result.panel_rounds > 0
+                        and not (result.panel_blocking_open or result.panel_degraded)
                         and getattr(contract, "merge", "manual") == "auto",
                         "resume_session_id": result.session.session_id if result.session else "",
                         "ending_note": pr_url,
@@ -1796,6 +1797,7 @@ def resume_run(
                     "state": IN_REVIEW,
                     "pr_url": pr_url,
                     "auto_eligible": result.panel_rounds > 0
+                    and not (result.panel_blocking_open or result.panel_degraded)
                     and getattr(contract, "merge", "manual") == "auto",
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,
@@ -2676,6 +2678,7 @@ def live_attempt(
                     "state": IN_REVIEW,
                     "pr_url": pr_url,
                     "auto_eligible": result.panel_rounds > 0
+                    and not (result.panel_blocking_open or result.panel_degraded)
                     and getattr(contract, "merge", "manual") == "auto",
                     "resume_session_id": result.session.session_id if result.session else "",
                     "ending_note": pr_url,

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -1011,6 +1011,11 @@ def _respond(
                 else record.dirty_wake_head
             ),
             resume_session_id=session.session_id or record.resume_session_id,
+            # a pushed CODE CHANGE replaces the panel-blessed content, so the
+            # publish-time auto blessing dies with it (sync pushes preserve
+            # the measured content bit-for-bit and keep it) — the changed PR
+            # needs a human merge, panel or not (terra #228 r4)
+            auto_eligible=record.auto_eligible and not change_pushed,
             wake_attempts=(
                 record.wake_attempts
                 if (conflict_wake and not (sync_pushed or (base_synced and change_pushed)))

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -159,16 +159,13 @@ def base_sync_head(pr: dict) -> str:
     return dirty_pr_head(pr) or stale_pr_head(pr)
 
 
-def conflict_wake_action(record: RunRecord, github: GitHubClient) -> str:
-    """Tick-side gate (cheap, read-only): "wake" for an in-review PR whose
-    base moved out from under it — conflicted OR cleanly behind — and that
-    has not been woken for THIS head yet; "clear" when a previously-woken PR
-    is current again (the base can move and stale the SAME head a second
-    time, so the cursor must re-arm); "" otherwise."""
-    try:
-        pr = github.get_pull_request(record.target, _pr_number(record.pr_url))
-    except Exception:
-        return ""
+def conflict_wake_action(record: RunRecord, pr: dict) -> str:
+    """Tick-side gate (cheap, read-only, PURE — the caller fetched the PR):
+    "wake" for an in-review PR whose base moved out from under it —
+    conflicted OR cleanly behind — and that has not been woken for THIS
+    head yet; "clear" when a previously-woken PR is current again (the base
+    can move and stale the SAME head a second time, so the cursor must
+    re-arm); "" otherwise."""
     head = base_sync_head(pr)
     if head and head != record.dirty_wake_head:
         return "wake"
@@ -676,21 +673,22 @@ def _respond(
     def _sync_push(note: str) -> bool:
         """Push the synced head under the #171 rule: an armed auto-mode PR
         would merge the new head on green CI, so the push is gated on a
-        CONFIRMED disarm. After a SIGNATURE-CLEAN push, auto-merge re-arms
-        when BOTH worlds say auto: auto at publish means the panel
-        necessarily ran (the publish gate enforces it), auto now means the
-        owner still wants self-merging — and the clean sync restored exactly
-        the freshness _arm_unless_base_moved was protecting. Any other
-        combination leaves the merge to a human. (Live motivation:
-        gpt-speedrun#5 sat CLEAN-but-unarmed until a human click.)"""
+        CONFIRMED disarm. Arming is NOT this function's job: the tick's
+        in-review service re-arms idempotently once GitHub reports the PR
+        clean — panel provenance from the record, the dial from the
+        kernel-read contract, freshness from GitHub's own up-to-date check —
+        which survives crashes here and never trusts two contract dials as
+        proof a panel ran."""
         nonlocal measured_note, sync_pushed
         disarm_ok = True
-        pre_mode = getattr(contract, "merge", "manual")
-        post_mode = getattr(post_contract, "merge", "manual")
         # EITHER contract can have armed auto-merge: the pre-merge one at
         # publish time, the merged one as the repo's current dial — a push
         # to a possibly-armed PR is never made without a confirmed disarm
-        if "auto" in {pre_mode, post_mode}:
+        merge_modes = {
+            getattr(contract, "merge", "manual"),
+            getattr(post_contract, "merge", "manual"),
+        }
+        if "auto" in merge_modes:
             try:
                 disarm_ok = github.disable_auto_merge(record.target, number)
             except Exception as exc:
@@ -704,19 +702,7 @@ def _respond(
             return False
         ws.push(branch)
         sync_pushed = True
-        rearmed = False
-        if pre_mode == "auto" and post_mode == "auto":
-            try:
-                rearmed = bool(github.arm_auto_merge_auto_mode(record.target, number))
-            except Exception as exc:  # un-armed is just a normal PR
-                log.warning("auto-merge re-arm errored after sync push: %s", exc)
-        measured_note = note + (
-            "\n\n_(Auto-merge re-armed: the sync is signature-clean and the "
-            "contract's merge dial is `auto` in both the measured and merged "
-            "worlds.)_"
-            if rearmed
-            else ""
-        )
+        measured_note = note
         return True
 
     # A clean base merge can produce a commit whose TREE is unchanged (the

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -669,6 +669,7 @@ def _respond(
     # clean merge whose eval was withheld spent the cursor with the PR still
     # behind on GitHub.
     sync_pushed = False
+    blessed_head = record.auto_blessed_head
 
     def _sync_push(note: str) -> bool:
         """Push the synced head under the #171 rule: an armed auto-mode PR
@@ -703,6 +704,14 @@ def _respond(
         ws.push(branch)
         sync_pushed = True
         measured_note = note
+        # a signature-clean sync preserves the measured bytes: the blessing
+        # follows the head it now lives on (empty stays empty)
+        nonlocal blessed_head
+        if blessed_head:
+            try:
+                blessed_head = ws.git("rev-parse", "HEAD").strip()
+            except Exception:
+                blessed_head = ""
         return True
 
     # A clean base merge can produce a commit whose TREE is unchanged (the
@@ -1011,11 +1020,11 @@ def _respond(
                 else record.dirty_wake_head
             ),
             resume_session_id=session.session_id or record.resume_session_id,
-            # a pushed CODE CHANGE replaces the panel-blessed content, so the
-            # publish-time auto blessing dies with it (sync pushes preserve
-            # the measured content bit-for-bit and keep it) — the changed PR
-            # needs a human merge, panel or not (terra #228 r4)
-            auto_eligible=record.auto_eligible and not change_pushed,
+            # a pushed CODE CHANGE replaces the panel-blessed content: the
+            # blessing dies with it (sync pushes carried it to the new head);
+            # the tick arms only on an exact head match, so even a crash
+            # before this write can never bless the pushed code (#228 r4/r8)
+            auto_blessed_head="" if change_pushed else blessed_head,
             wake_attempts=(
                 record.wake_attempts
                 if (conflict_wake and not (sync_pushed or (base_synced and change_pushed)))

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -676,17 +676,21 @@ def _respond(
     def _sync_push(note: str) -> bool:
         """Push the synced head under the #171 rule: an armed auto-mode PR
         would merge the new head on green CI, so the push is gated on a
-        CONFIRMED disarm; a human merges the synced PR."""
+        CONFIRMED disarm. After a SIGNATURE-CLEAN push, auto-merge re-arms
+        when BOTH worlds say auto: auto at publish means the panel
+        necessarily ran (the publish gate enforces it), auto now means the
+        owner still wants self-merging — and the clean sync restored exactly
+        the freshness _arm_unless_base_moved was protecting. Any other
+        combination leaves the merge to a human. (Live motivation:
+        gpt-speedrun#5 sat CLEAN-but-unarmed until a human click.)"""
         nonlocal measured_note, sync_pushed
         disarm_ok = True
+        pre_mode = getattr(contract, "merge", "manual")
+        post_mode = getattr(post_contract, "merge", "manual")
         # EITHER contract can have armed auto-merge: the pre-merge one at
         # publish time, the merged one as the repo's current dial — a push
         # to a possibly-armed PR is never made without a confirmed disarm
-        merge_modes = {
-            getattr(contract, "merge", "manual"),
-            getattr(post_contract, "merge", "manual"),
-        }
-        if "auto" in merge_modes:
+        if "auto" in {pre_mode, post_mode}:
             try:
                 disarm_ok = github.disable_auto_merge(record.target, number)
             except Exception as exc:
@@ -700,7 +704,19 @@ def _respond(
             return False
         ws.push(branch)
         sync_pushed = True
-        measured_note = note
+        rearmed = False
+        if pre_mode == "auto" and post_mode == "auto":
+            try:
+                rearmed = bool(github.arm_auto_merge_auto_mode(record.target, number))
+            except Exception as exc:  # un-armed is just a normal PR
+                log.warning("auto-merge re-arm errored after sync push: %s", exc)
+        measured_note = note + (
+            "\n\n_(Auto-merge re-armed: the sync is signature-clean and the "
+            "contract's merge dial is `auto` in both the measured and merged "
+            "worlds.)_"
+            if rearmed
+            else ""
+        )
         return True
 
     # A clean base merge can produce a commit whose TREE is unchanged (the
@@ -711,8 +727,7 @@ def _respond(
         _sync_push(
             f"\n\n_(Base sync: `origin/{base_ref}` merged; the tree is "
             "unchanged, so the measured numbers above still describe "
-            "exactly this content — only the ancestry moved. A human "
-            "merges the synced PR.)_"
+            "exactly this content — only the ancestry moved.)_"
         )
     # The next rung, deliberately NARROW: the merge changed exactly one
     # path — the contract file, with the base's own content — and every
@@ -753,8 +768,7 @@ def _respond(
             f"\n\n_(Base sync: `origin/{base_ref}` merged; the only change "
             "is the contract file, whose measurement signatures and scope "
             "are identical — the eval surface and solver are bit-for-bit "
-            "what was measured, so the numbers above stand. A human merges "
-            "the synced PR.)_"
+            "what was measured, so the numbers above stand.)_"
         )
     if sync_failed:
         _revert_response()

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -383,8 +383,13 @@ class GitHubClient:
         ]
         return [m for m, key in order if settings.get(key)]
 
-    def enable_auto_merge(self, repo: str, number: int, method: str = "MERGE") -> None:
+    def enable_auto_merge(
+        self, repo: str, number: int, method: str = "MERGE", expected_head: str = ""
+    ) -> None:
         """Arm GitHub's auto-merge on a PR (a GraphQL-only capability).
+        `expected_head` binds the arm to that head oid: GitHub refuses when
+        the PR head has moved, so a push racing the caller's check can never
+        be the thing that merges.
 
         Arming does not merge anything: it hands the merge to whatever
         branch protection still requires. Callers that must preserve the
@@ -400,12 +405,21 @@ class GitHubClient:
         node_id = self.get_pull_request(repo, number).get("node_id")
         if not node_id:
             raise GitHubError(0, pr_path, "no node_id in PR payload")
-        mutation = (
-            "mutation($pr: ID!, $method: PullRequestMergeMethod!) {"
-            " enablePullRequestAutoMerge(input: {pullRequestId: $pr, mergeMethod: $method})"
-            " { pullRequest { number } } }"
-        )
-        self._graphql(mutation, {"pr": str(node_id), "method": method})
+        variables: dict[str, Any] = {"pr": str(node_id), "method": method}
+        if expected_head:
+            mutation = (
+                "mutation($pr: ID!, $method: PullRequestMergeMethod!, $head: GitObjectID!) {"
+                " enablePullRequestAutoMerge(input: {pullRequestId: $pr, mergeMethod: $method,"
+                " expectedHeadOid: $head}) { pullRequest { number } } }"
+            )
+            variables["head"] = expected_head
+        else:
+            mutation = (
+                "mutation($pr: ID!, $method: PullRequestMergeMethod!) {"
+                " enablePullRequestAutoMerge(input: {pullRequestId: $pr, mergeMethod: $method})"
+                " { pullRequest { number } } }"
+            )
+        self._graphql(mutation, variables)
 
     def arm_auto_merge_when_review_required(self, repo: str, number: int) -> bool:
         """Arm auto-merge ONLY when branch protection makes a human review
@@ -457,24 +471,31 @@ class GitHubClient:
             log.warning("auto-merge disarm on %s#%s failed: %s", repo, number, exc)
             return False
 
-    def merge_pull(self, repo: str, number: int, method: str = "merge") -> bool:
+    def merge_pull(
+        self, repo: str, number: int, method: str = "merge", expected_head: str = ""
+    ) -> bool:
         """Directly merge a pull request (REST). Used only by AUTO merge mode
-        when nothing is pending for auto-merge to arm against."""
+        when nothing is pending for auto-merge to arm against. `expected_head`
+        rides the API's `sha` guard: GitHub refuses (409) when the head moved
+        since the caller checked it."""
         if self.dry_run:
             log.info("[dry-run] merge %s#%s", repo, number)
             return True
+        body: dict[str, Any] = {"merge_method": method}
+        if expected_head:
+            body["sha"] = expected_head
         try:
             self._request(
                 "PUT",
                 f"/repos/{urllib.parse.quote(repo)}/pulls/{number}/merge",
-                {"merge_method": method},
+                body,
             )
             return True
         except GitHubError as exc:
             log.warning("direct merge of %s#%s failed: %s", repo, number, exc)
             return False
 
-    def arm_auto_merge_auto_mode(self, repo: str, number: int) -> bool:
+    def arm_auto_merge_auto_mode(self, repo: str, number: int, expected_head: str = "") -> bool:
         """AUTO merge mode (the contract's `merge: auto` dial): arm
         auto-merge so the PR merges when its required checks pass; when
         GitHub declines ONLY because nothing is pending (clean status),
@@ -486,7 +507,7 @@ class GitHubClient:
         opted this repo in, and the gate/panel bound before publish."""
         methods = self.allowed_merge_methods(repo) or ["MERGE"]
         try:
-            self.enable_auto_merge(repo, number, method=methods[0])
+            self.enable_auto_merge(repo, number, method=methods[0], expected_head=expected_head)
             return True
         except GitHubError as exc:
             if "clean status" not in str(exc).casefold():
@@ -503,7 +524,7 @@ class GitHubClient:
                 repo,
                 number,
             )
-        return self.merge_pull(repo, number, method=methods[0].lower())
+        return self.merge_pull(repo, number, method=methods[0].lower(), expected_head=expected_head)
 
     def get_pull_request_diff(self, repo: str, number: int) -> str:
         """Fetch a PR's unified diff (uses the diff media type)."""

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -149,12 +149,14 @@ class RunRecord:
     # head sha the last conflict wake was issued for: a dirty PR wakes the
     # author ONCE per head — a new push (or new conflict) re-arms it
     dirty_wake_head: str = ""
-    # the publish-time consent the auto-arm requires: the PR was published
-    # UNDER merge:auto AND a panel round ran — exactly #171's arming
-    # condition. A manual publish (even with a panel) never opted into
-    # self-merging, and contracts alone cannot prove either fact after a
-    # base dial flip. Default False: legacy records never arm.
-    auto_eligible: bool = False
+    # The exact PR head the auto-arm may merge: set at publish to the pushed
+    # head when the PR was published UNDER merge:auto with a CLEAN panel
+    # (#171's arming condition), carried forward by signature-clean syncs
+    # (same measured bytes), cleared by any code-changing push. Binding the
+    # blessing to a sha — not a flag — means a crashed responder, a live
+    # one, or any unrecorded push simply fails the equality: the tick arms
+    # only when GitHub's head IS this sha. Empty = never arm (legacy too).
+    auto_blessed_head: str = ""
     followup_job_id: str = ""  # slurm job servicing this run's review comments
     issue_number: int = 0  # the requesting issue, when the requested lane started this run
     wake_attempts: int = 0

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -149,10 +149,12 @@ class RunRecord:
     # head sha the last conflict wake was issued for: a dirty PR wakes the
     # author ONCE per head — a new push (or new conflict) re-arms it
     dirty_wake_head: str = ""
-    # whether the publish that opened this run's PR had a panel round —
-    # the provenance the auto re-arm requires (contracts alone cannot
-    # prove it; default False so legacy records never re-arm)
-    panel_ran: bool = False
+    # the publish-time consent the auto-arm requires: the PR was published
+    # UNDER merge:auto AND a panel round ran — exactly #171's arming
+    # condition. A manual publish (even with a panel) never opted into
+    # self-merging, and contracts alone cannot prove either fact after a
+    # base dial flip. Default False: legacy records never arm.
+    auto_eligible: bool = False
     followup_job_id: str = ""  # slurm job servicing this run's review comments
     issue_number: int = 0  # the requesting issue, when the requested lane started this run
     wake_attempts: int = 0

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -149,6 +149,10 @@ class RunRecord:
     # head sha the last conflict wake was issued for: a dirty PR wakes the
     # author ONCE per head — a new push (or new conflict) re-arms it
     dirty_wake_head: str = ""
+    # whether the publish that opened this run's PR had a panel round —
+    # the provenance the auto re-arm requires (contracts alone cannot
+    # prove it; default False so legacy records never re-arm)
+    panel_ran: bool = False
     followup_job_id: str = ""  # slurm job servicing this run's review comments
     issue_number: int = 0  # the requesting issue, when the requested lane started this run
     wake_attempts: int = 0

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -548,6 +548,7 @@ def service_in_review(
                 and getattr(contract, "merge", "manual") == "auto"
                 and pr.get("state") == "open"
                 and not pr.get("merged")
+                and not pr.get("draft")
                 and pr.get("mergeable_state") == "clean"
             ):
                 try:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -553,28 +553,6 @@ def service_in_review(
             # Idempotent auto-arm: once GitHub reports the PR CLEAN (green
             # checks AND up-to-date with the CURRENT base — GitHub's own
             # freshness proof), the kernel-read contract STILL says auto, and
-            # the RECORD says the publish was auto-eligible (published under
-            # merge:auto with a panel round — #171's exact arming condition;
-            # a manual publish never consented to self-merging, and contracts
-            # alone cannot prove either fact after a dial flip), arming
-            # self-merges the PR. Running every tick survives any crash
-            # between a sync push and this step; the helper direct-merges
-            # when nothing is pending to arm against.
-            if (
-                not dry_run
-                and not is_steward
-                and record.auto_eligible
-                and contract is not None
-                and pr.get("state") == "open"
-                and not pr.get("merged")
-                and not pr.get("draft")
-                and pr.get("mergeable_state") == "clean"
-                and _base_dial(github, record.target, pr, contract) == "auto"
-            ):
-                try:
-                    github.arm_auto_merge_auto_mode(record.target, _pr_number(record.pr_url))
-                except Exception as exc:
-                    log.warning("auto-arm failed for %s: %s", record.run_id, exc)
             wake_action = conflict_wake_action(record, pr)
             if wake_action == "clear":
                 # the PR is clean again: re-arm the wake for this head — the
@@ -584,6 +562,33 @@ def service_in_review(
                 except OSError as exc:
                     log.warning("conflict cursor clear failed for %s: %s", record.run_id, exc)
             if not has_new_comments(record, github, spec.bot_login) and wake_action != "wake":
+                # NOTHING awaits servicing — only a fully quiet PR may
+                # self-merge (pending reviewer feedback always wins over
+                # arming: a followup must service it first, and a pushed
+                # change would kill the blessing anyway). The RECORD says the
+                # publish was auto-eligible (published under merge:auto with
+                # a clean panel — #171's exact arming condition; a manual
+                # publish never consented, and contracts alone cannot prove
+                # either fact after a dial flip); GitHub's own CLEAN state is
+                # the freshness proof; the PR's base-branch contract is the
+                # governing dial. Running every tick survives any crash
+                # between a sync push and this step; the helper direct-merges
+                # when nothing is pending to arm against.
+                if (
+                    not dry_run
+                    and not is_steward
+                    and record.auto_eligible
+                    and contract is not None
+                    and pr.get("state") == "open"
+                    and not pr.get("merged")
+                    and not pr.get("draft")
+                    and pr.get("mergeable_state") == "clean"
+                    and _base_dial(github, record.target, pr, contract) == "auto"
+                ):
+                    try:
+                        github.arm_auto_merge_auto_mode(record.target, _pr_number(record.pr_url))
+                    except Exception as exc:
+                        log.warning("auto-arm failed for %s: %s", record.run_id, exc)
                 continue
             if record.followup_job_id:
                 try:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -532,15 +532,18 @@ def service_in_review(
                 continue  # unreadable PR: nothing to decide this tick
             # Idempotent auto-arm: once GitHub reports the PR CLEAN (green
             # checks AND up-to-date with the CURRENT base — GitHub's own
-            # freshness proof), the kernel-read contract says auto, and the
-            # RECORD says the publish had a panel round (contracts alone can
-            # never prove that), arming self-merges the PR. Running every
-            # tick survives any crash between a sync push and this step; the
-            # helper direct-merges when nothing is pending to arm against.
+            # freshness proof), the kernel-read contract STILL says auto, and
+            # the RECORD says the publish was auto-eligible (published under
+            # merge:auto with a panel round — #171's exact arming condition;
+            # a manual publish never consented to self-merging, and contracts
+            # alone cannot prove either fact after a dial flip), arming
+            # self-merges the PR. Running every tick survives any crash
+            # between a sync push and this step; the helper direct-merges
+            # when nothing is pending to arm against.
             if (
                 not dry_run
                 and not is_steward
-                and record.panel_ran
+                and record.auto_eligible
                 and contract is not None
                 and getattr(contract, "merge", "manual") == "auto"
                 and pr.get("state") == "open"

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -475,6 +475,26 @@ def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: A
     return spec
 
 
+def _base_dial(github: Any, target: str, pr: dict, main_contract: Any) -> str:
+    """The merge dial that governs THIS PR: its base branch's contract. The
+    tick's contract is read from main; a PR based elsewhere must be judged
+    by its own base's dial — unreadable or unparsable means "manual"
+    (never arm on doubt)."""
+    base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
+    if base_ref == "main":
+        return str(getattr(main_contract, "merge", "manual"))
+    try:
+        from autoresearch.contract import load_contract
+
+        raw = github.get_file_content(target, ".autoresearch.yaml", base_ref)
+        if raw is None:
+            return "manual"
+        return str(getattr(load_contract(raw, target), "merge", "manual"))
+    except Exception as exc:
+        log.warning("base-contract read failed for %s@%s: %s", target, base_ref, exc)
+        return "manual"
+
+
 def service_in_review(
     root: Path,
     github: Any,  # GitHubClient (Any keeps tick importable without github deps)
@@ -545,11 +565,11 @@ def service_in_review(
                 and not is_steward
                 and record.auto_eligible
                 and contract is not None
-                and getattr(contract, "merge", "manual") == "auto"
                 and pr.get("state") == "open"
                 and not pr.get("merged")
                 and not pr.get("draft")
                 and pr.get("mergeable_state") == "clean"
+                and _base_dial(github, record.target, pr, contract) == "auto"
             ):
                 try:
                     github.arm_auto_merge_auto_mode(record.target, _pr_number(record.pr_url))

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -475,13 +475,16 @@ def shape_followup_spec(spec: FollowupSpec, limits: EffectiveLimits, contract: A
     return spec
 
 
-def _base_dial(github: Any, target: str, pr: dict, main_contract: Any) -> str:
-    """The merge dial that governs THIS PR: its base branch's contract. The
-    tick's contract is read from main; a PR based elsewhere must be judged
-    by its own base's dial — unreadable or unparsable means "manual"
-    (never arm on doubt)."""
+def _base_dial(
+    github: Any, target: str, pr: dict, main_contract: Any, main_target: str = ""
+) -> str:
+    """The merge dial that governs THIS PR: its own target's base-branch
+    contract. The tick's contract is read from ITS configured target's main;
+    it applies only to a main-based PR of that same target — any other
+    target or base is fetched from the PR's own coordinates, and unreadable
+    or unparsable means "manual" (never arm on doubt)."""
     base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
-    if base_ref == "main":
+    if base_ref == "main" and target == main_target:
         return str(getattr(main_contract, "merge", "manual"))
     try:
         from autoresearch.contract import load_contract
@@ -589,13 +592,14 @@ def service_in_review(
                     not dry_run
                     and not is_steward
                     and not followup_live
-                    and record.auto_eligible
+                    and record.auto_blessed_head
+                    and str((pr.get("head") or {}).get("sha", "")) == record.auto_blessed_head
                     and contract is not None
                     and pr.get("state") == "open"
                     and not pr.get("merged")
                     and not pr.get("draft")
                     and pr.get("mergeable_state") == "clean"
-                    and _base_dial(github, record.target, pr, contract) == "auto"
+                    and _base_dial(github, record.target, pr, contract, spec.target) == "auto"
                 ):
                     try:
                         github.arm_auto_merge_auto_mode(record.target, _pr_number(record.pr_url))

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -574,9 +574,21 @@ def service_in_review(
                 # governing dial. Running every tick survives any crash
                 # between a sync push and this step; the helper direct-merges
                 # when nothing is pending to arm against.
+                # ...and no follow-up job may be LIVE: a running responder can
+                # have pushed a code change whose record write (clearing the
+                # blessing) has not landed yet — arming on that head would
+                # merge code the panel never saw (terra #228 r7)
+                followup_live = False
+                if record.followup_job_id:
+                    try:
+                        state = compute.status(record.followup_job_id)
+                        followup_live = not (is_terminal(state) or state == GONE)
+                    except SlurmQueryError:
+                        followup_live = True  # unknown = assume live, never arm
                 if (
                     not dry_run
                     and not is_steward
+                    and not followup_live
                     and record.auto_eligible
                     and contract is not None
                     and pr.get("state") == "open"

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -483,6 +483,7 @@ def service_in_review(
     now: float,
     dry_run: bool = False,
     allow_submit: bool = True,
+    contract: Any = None,
 ) -> tuple[list[tuple[str, str]], list[tuple[str, str]]]:
     """PR-state transitions + follow-up job submission for in-review runs.
 
@@ -495,7 +496,12 @@ def service_in_review(
     duplicate submission no-ops on the lease, and `followup_job_id` keeps the
     tick from queueing duplicates in the first place.
     """
-    from autoresearch.followup import close_if_done, conflict_wake_action, has_new_comments
+    from autoresearch.followup import (
+        _pr_number,
+        close_if_done,
+        conflict_wake_action,
+        has_new_comments,
+    )
 
     ended: list[tuple[str, str]] = []
     submitted: list[tuple[str, str]] = []
@@ -520,7 +526,32 @@ def service_in_review(
             if paused:
                 log.info("follow-up for %s paused (api outage: %s)", record.run_id, paused)
                 continue
-            wake_action = conflict_wake_action(record, github)
+            try:
+                pr = github.get_pull_request(record.target, _pr_number(record.pr_url))
+            except Exception:
+                continue  # unreadable PR: nothing to decide this tick
+            # Idempotent auto-arm: once GitHub reports the PR CLEAN (green
+            # checks AND up-to-date with the CURRENT base — GitHub's own
+            # freshness proof), the kernel-read contract says auto, and the
+            # RECORD says the publish had a panel round (contracts alone can
+            # never prove that), arming self-merges the PR. Running every
+            # tick survives any crash between a sync push and this step; the
+            # helper direct-merges when nothing is pending to arm against.
+            if (
+                not dry_run
+                and not is_steward
+                and record.panel_ran
+                and contract is not None
+                and getattr(contract, "merge", "manual") == "auto"
+                and pr.get("state") == "open"
+                and not pr.get("merged")
+                and pr.get("mergeable_state") == "clean"
+            ):
+                try:
+                    github.arm_auto_merge_auto_mode(record.target, _pr_number(record.pr_url))
+                except Exception as exc:
+                    log.warning("auto-arm failed for %s: %s", record.run_id, exc)
+            wake_action = conflict_wake_action(record, pr)
             if wake_action == "clear":
                 # the PR is clean again: re-arm the wake for this head — the
                 # base can move and conflict the SAME head a second time
@@ -1487,6 +1518,7 @@ def tick(
             now,
             dry_run=followup_dry_run,
             allow_submit=launch_ok,
+            contract=contract,
         )
         try:
             service_research_log(root, github, spec, now)

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -602,7 +602,14 @@ def service_in_review(
                     and _base_dial(github, record.target, pr, contract, spec.target) == "auto"
                 ):
                     try:
-                        github.arm_auto_merge_auto_mode(record.target, _pr_number(record.pr_url))
+                        # the mutation itself is bound to the blessed head: a
+                        # push racing this check is refused by GitHub, not
+                        # merged (terra #228 r9)
+                        github.arm_auto_merge_auto_mode(
+                            record.target,
+                            _pr_number(record.pr_url),
+                            expected_head=record.auto_blessed_head,
+                        )
                     except Exception as exc:
                         log.warning("auto-arm failed for %s: %s", record.run_id, exc)
                 continue

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
 
@@ -958,23 +957,22 @@ def test_conflict_wake_action_lifecycle(review_run) -> None:
 
     root, _ = review_run
     record = load_record(root, "tsp-r1")
-    assert conflict_wake_action(record, cast(Any, FakeGitHub(pr=_dirty_pr()))) == "wake"
-    assert conflict_wake_action(record, cast(Any, FakeGitHub())) == ""  # clean, never woken
+    assert conflict_wake_action(record, _dirty_pr()) == "wake"
+    never_woken = {"state": "open", "merged": False}
+    assert conflict_wake_action(record, never_woken) == ""  # clean, never woken
     woken = replace(record, dirty_wake_head="h" * 40)
-    assert conflict_wake_action(woken, cast(Any, FakeGitHub(pr=_dirty_pr()))) == ""  # once/head
+    assert conflict_wake_action(woken, _dirty_pr()) == ""  # once/head
     # a new head (author pushed, conflicted again) re-arms
-    assert conflict_wake_action(woken, cast(Any, FakeGitHub(pr=_dirty_pr(head="i" * 40)))) == (
-        "wake"
-    )
+    assert conflict_wake_action(woken, _dirty_pr(head="i" * 40)) == ("wake")
     # a PR that turned CLEAN clears the cursor so the SAME head can re-wake
     clean = {"state": "open", "merged": False, "mergeable": True, "mergeable_state": "clean"}
-    assert conflict_wake_action(woken, cast(Any, FakeGitHub(pr=clean))) == "clear"
+    assert conflict_wake_action(woken, clean) == "clear"
     # BEHIND (clean merge, stale base) wakes exactly like a conflict
-    assert conflict_wake_action(record, cast(Any, FakeGitHub(pr=_behind_pr()))) == "wake"
-    assert conflict_wake_action(woken, cast(Any, FakeGitHub(pr=_behind_pr()))) == ""  # once/head
+    assert conflict_wake_action(record, _behind_pr()) == "wake"
+    assert conflict_wake_action(woken, _behind_pr()) == ""  # once/head
     # blocked-but-current does NOT wake (nothing to sync)
     blocked = {"state": "open", "merged": False, "mergeable": True, "mergeable_state": "blocked"}
-    assert conflict_wake_action(record, cast(Any, FakeGitHub(pr=blocked))) == ""
+    assert conflict_wake_action(record, blocked) == ""
 
 
 def test_content_matching_base_is_not_out_of_scope(review_run) -> None:
@@ -1721,75 +1719,3 @@ def test_eval_failed_note_names_paths_and_scrubs_them(review_run) -> None:
 
     tail = note.split("Changed paths:")[1]
     assert not APPROVAL_PATTERN.search(tail.replace("[redacted: approval-like text]", ""))
-
-
-def test_signature_clean_sync_rearms_when_both_worlds_say_auto(review_run) -> None:
-    """Live motivation: gpt-speedrun#5 sat CLEAN-but-unarmed after its
-    signature-clean sync until a human click. When the merge dial is auto in
-    BOTH the measured and merged worlds (auto at publish => the panel ran;
-    auto now => the owner still wants it), the sync push re-arms auto-merge;
-    a manual dial anywhere leaves the merge to a human."""
-    root, bare = review_run
-    head = _ws_head(root)
-    auto_contract = CONTRACT + "merge: auto\n"
-    ws = run_dir(root, "tsp-r1") / "ws"
-    git_id = ["-c", "user.name=t", "-c", "user.email=t@t"]
-    (ws / ".autoresearch.yaml").write_text(auto_contract)
-    _git(ws, *git_id, "add", "-A")
-    _git(ws, *git_id, "commit", "-qm", "branch is auto")
-    head = _ws_head(root)  # the committed tip is what GitHub would serve
-    seed2 = root.parent / "seed2p"
-    _git(root.parent, "clone", "-q", str(bare), str(seed2))
-    # main commits the IDENTICAL auto contract: the merge is topology-only
-    # (tree unchanged), the cleanest signature-clean sync
-    (seed2 / ".autoresearch.yaml").write_text(auto_contract)
-    _git(seed2, *git_id, "add", "-A")
-    _git(seed2, *git_id, "commit", "-qm", "main goes auto identically")
-    _git(seed2, "push", "-q", "origin", "main")
-    _git(ws, "fetch", "-q", "origin", "main")
-    _git(ws, "push", "-q", "origin", "HEAD:feat/auto/agent-01/tsp-r1")
-
-    class ArmingGitHub(FakeGitHub):
-        disarms: int = 0
-        arms: int = 0
-
-        def disable_auto_merge(self, repo, number):
-            ArmingGitHub.disarms += 1
-            return True
-
-        def arm_auto_merge_auto_mode(self, repo, number):
-            ArmingGitHub.arms += 1
-            return True
-
-    github = ArmingGitHub(pr=_behind_pr(head=head))
-    outcome = respond(root, github, ResumingHarness(merge_base=True), QueueEvaluator(values=[]))
-    assert outcome.action == "replied"
-    assert "only the ancestry moved" in github.posted[0]
-    assert "Auto-merge re-armed" in github.posted[0]
-    assert ArmingGitHub.disarms == 1  # push still gated on confirmed disarm
-    assert ArmingGitHub.arms == 1
-
-
-def test_manual_dial_sync_never_rearms(review_run) -> None:
-    """The fixture contract is manual: a signature-clean sync pushes but
-    leaves arming alone — a human merges."""
-    root, bare = review_run
-    head = _ws_head(root)
-    seed2 = root.parent / "seed2q"
-    _git(root.parent, "clone", "-q", str(bare), str(seed2))
-    (seed2 / ".autoresearch.yaml").write_text(CONTRACT + "# lines flip\n")
-    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
-    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "moves")
-    _git(seed2, "push", "-q", "origin", "main")
-    ws = run_dir(root, "tsp-r1") / "ws"
-    _git(ws, "fetch", "-q", "origin", "main")
-
-    class RefusingGitHub(FakeGitHub):
-        def arm_auto_merge_auto_mode(self, repo, number):
-            raise AssertionError("manual dial must never re-arm")
-
-    github = RefusingGitHub(pr=_behind_pr(head=head))
-    outcome = respond(root, github, ResumingHarness(merge_base=True), QueueEvaluator(values=[]))
-    assert outcome.action == "replied"
-    assert "the numbers above stand" in github.posted[0]
-    assert "Auto-merge re-armed" not in github.posted[0]

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1723,24 +1723,24 @@ def test_eval_failed_note_names_paths_and_scrubs_them(review_run) -> None:
 
 def test_a_pushed_code_change_kills_the_auto_blessing(review_run) -> None:
     """A followup that pushes a measured CODE CHANGE replaces the
-    panel-blessed content: auto_eligible dies with it, so the tick can never
+    panel-blessed content: the blessed head dies with it, so the tick can never
     self-merge a head the panel never saw (terra #228 r4). A reply without a
     pushed change keeps the blessing."""
     from dataclasses import replace as dc_replace
 
     root, _bare = review_run
     record = load_record(root, "tsp-r1")
-    save_record(root, dc_replace(record, auto_eligible=True), NOW)
+    save_record(root, dc_replace(record, auto_blessed_head="b" * 40), NOW)
     github = FakeGitHub(comments=[member(901, "please tweak the kick")])
     harness = ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2 tweaked\n"})
     outcome = respond(root, github, harness, QueueEvaluator(values=[10.2]))
     assert outcome.action == "replied"
     assert "Re-measured" in github.posted[0]
-    assert load_record(root, "tsp-r1").auto_eligible is False  # blessing dead
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""  # blessing dead
 
     # a plain reply (no change pushed) keeps the blessing
-    save_record(root, dc_replace(load_record(root, "tsp-r1"), auto_eligible=True), NOW + 1)
+    save_record(root, dc_replace(load_record(root, "tsp-r1"), auto_blessed_head="b" * 40), NOW + 1)
     github2 = FakeGitHub(comments=[member(902, "thanks, just explain")])
     outcome2 = respond(root, github2, ResumingHarness(), QueueEvaluator(values=[]))
     assert outcome2.action == "replied"
-    assert load_record(root, "tsp-r1").auto_eligible is True
+    assert load_record(root, "tsp-r1").auto_blessed_head == "b" * 40

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1721,3 +1721,75 @@ def test_eval_failed_note_names_paths_and_scrubs_them(review_run) -> None:
 
     tail = note.split("Changed paths:")[1]
     assert not APPROVAL_PATTERN.search(tail.replace("[redacted: approval-like text]", ""))
+
+
+def test_signature_clean_sync_rearms_when_both_worlds_say_auto(review_run) -> None:
+    """Live motivation: gpt-speedrun#5 sat CLEAN-but-unarmed after its
+    signature-clean sync until a human click. When the merge dial is auto in
+    BOTH the measured and merged worlds (auto at publish => the panel ran;
+    auto now => the owner still wants it), the sync push re-arms auto-merge;
+    a manual dial anywhere leaves the merge to a human."""
+    root, bare = review_run
+    head = _ws_head(root)
+    auto_contract = CONTRACT + "merge: auto\n"
+    ws = run_dir(root, "tsp-r1") / "ws"
+    git_id = ["-c", "user.name=t", "-c", "user.email=t@t"]
+    (ws / ".autoresearch.yaml").write_text(auto_contract)
+    _git(ws, *git_id, "add", "-A")
+    _git(ws, *git_id, "commit", "-qm", "branch is auto")
+    head = _ws_head(root)  # the committed tip is what GitHub would serve
+    seed2 = root.parent / "seed2p"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    # main commits the IDENTICAL auto contract: the merge is topology-only
+    # (tree unchanged), the cleanest signature-clean sync
+    (seed2 / ".autoresearch.yaml").write_text(auto_contract)
+    _git(seed2, *git_id, "add", "-A")
+    _git(seed2, *git_id, "commit", "-qm", "main goes auto identically")
+    _git(seed2, "push", "-q", "origin", "main")
+    _git(ws, "fetch", "-q", "origin", "main")
+    _git(ws, "push", "-q", "origin", "HEAD:feat/auto/agent-01/tsp-r1")
+
+    class ArmingGitHub(FakeGitHub):
+        disarms: int = 0
+        arms: int = 0
+
+        def disable_auto_merge(self, repo, number):
+            ArmingGitHub.disarms += 1
+            return True
+
+        def arm_auto_merge_auto_mode(self, repo, number):
+            ArmingGitHub.arms += 1
+            return True
+
+    github = ArmingGitHub(pr=_behind_pr(head=head))
+    outcome = respond(root, github, ResumingHarness(merge_base=True), QueueEvaluator(values=[]))
+    assert outcome.action == "replied"
+    assert "only the ancestry moved" in github.posted[0]
+    assert "Auto-merge re-armed" in github.posted[0]
+    assert ArmingGitHub.disarms == 1  # push still gated on confirmed disarm
+    assert ArmingGitHub.arms == 1
+
+
+def test_manual_dial_sync_never_rearms(review_run) -> None:
+    """The fixture contract is manual: a signature-clean sync pushes but
+    leaves arming alone — a human merges."""
+    root, bare = review_run
+    head = _ws_head(root)
+    seed2 = root.parent / "seed2q"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / ".autoresearch.yaml").write_text(CONTRACT + "# lines flip\n")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "moves")
+    _git(seed2, "push", "-q", "origin", "main")
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+
+    class RefusingGitHub(FakeGitHub):
+        def arm_auto_merge_auto_mode(self, repo, number):
+            raise AssertionError("manual dial must never re-arm")
+
+    github = RefusingGitHub(pr=_behind_pr(head=head))
+    outcome = respond(root, github, ResumingHarness(merge_base=True), QueueEvaluator(values=[]))
+    assert outcome.action == "replied"
+    assert "the numbers above stand" in github.posted[0]
+    assert "Auto-merge re-armed" not in github.posted[0]

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1719,3 +1719,28 @@ def test_eval_failed_note_names_paths_and_scrubs_them(review_run) -> None:
 
     tail = note.split("Changed paths:")[1]
     assert not APPROVAL_PATTERN.search(tail.replace("[redacted: approval-like text]", ""))
+
+
+def test_a_pushed_code_change_kills_the_auto_blessing(review_run) -> None:
+    """A followup that pushes a measured CODE CHANGE replaces the
+    panel-blessed content: auto_eligible dies with it, so the tick can never
+    self-merge a head the panel never saw (terra #228 r4). A reply without a
+    pushed change keeps the blessing."""
+    from dataclasses import replace as dc_replace
+
+    root, _bare = review_run
+    record = load_record(root, "tsp-r1")
+    save_record(root, dc_replace(record, auto_eligible=True), NOW)
+    github = FakeGitHub(comments=[member(901, "please tweak the kick")])
+    harness = ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2 tweaked\n"})
+    outcome = respond(root, github, harness, QueueEvaluator(values=[10.2]))
+    assert outcome.action == "replied"
+    assert "Re-measured" in github.posted[0]
+    assert load_record(root, "tsp-r1").auto_eligible is False  # blessing dead
+
+    # a plain reply (no change pushed) keeps the blessing
+    save_record(root, dc_replace(load_record(root, "tsp-r1"), auto_eligible=True), NOW + 1)
+    github2 = FakeGitHub(comments=[member(902, "thanks, just explain")])
+    outcome2 = respond(root, github2, ResumingHarness(), QueueEvaluator(values=[]))
+    assert outcome2.action == "replied"
+    assert load_record(root, "tsp-r1").auto_eligible is True

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -411,20 +411,20 @@ def test_auto_mode_arming_merges_only_on_clean_status(monkeypatch) -> None:
     merged: list = []
     monkeypatch.setattr(client, "allowed_merge_methods", lambda repo: ["MERGE"])
 
-    def _fake_merge(repo, n, method):
+    def _fake_merge(repo, n, method, expected_head=""):
         merged.append(n)
         return True
 
     monkeypatch.setattr(client, "merge_pull", _fake_merge)
 
-    def clean_status(repo, n, method="MERGE"):
+    def clean_status(repo, n, method="MERGE", expected_head=""):
         raise GitHubError(0, "/x", "Pull request is in clean status")
 
     monkeypatch.setattr(client, "enable_auto_merge", clean_status)
     assert client.arm_auto_merge_auto_mode("o/r", 7) is True
     assert merged == [7]
 
-    def not_allowed(repo, n, method="MERGE"):
+    def not_allowed(repo, n, method="MERGE", expected_head=""):
         raise GitHubError(0, "/x", "Auto merge is not allowed for this repository")
 
     monkeypatch.setattr(client, "enable_auto_merge", not_allowed)
@@ -453,3 +453,42 @@ def test_redirect_off_host_loses_the_authorization_header() -> None:
     )
     assert same_host is not None
     assert same_host.headers.get("Authorization") == "Bearer jwt"
+
+
+def test_auto_mode_arming_binds_to_the_expected_head(provider: FileTokenProvider) -> None:
+    """arm_auto_merge_auto_mode threads the blessed head into BOTH paths: the
+    GraphQL arm carries expectedHeadOid, and the clean-status direct merge
+    carries the REST `sha` guard — so a push racing the caller's check is
+    refused by GitHub rather than merged (terra #228 r9)."""
+    import json as _json
+
+    seen: list = []
+
+    class T:
+        def __init__(self, decline_arm: bool) -> None:
+            self.decline_arm = decline_arm
+
+        def __call__(self, request):
+            body = _json.loads(request.data) if request.data else {}
+            seen.append((request.get_method(), request.full_url, body))
+            if request.full_url.endswith("/graphql"):
+                if self.decline_arm:
+                    return {"errors": [{"message": "Pull request is in clean status"}]}
+                return {"data": {"enablePullRequestAutoMerge": {"pullRequest": {"number": 1}}}}
+            if "/pulls/1/merge" in request.full_url:
+                return {"merged": True}
+            if request.full_url.endswith("/pulls/1"):
+                return {"node_id": "PR_x", "number": 1}
+            return {"allow_merge_commit": True}
+
+    client = GitHubClient(auth=provider, transport=T(decline_arm=False))
+    assert client.arm_auto_merge_auto_mode("o/r", 1, expected_head="h" * 40) is True
+    gql = [b for m, u, b in seen if u.endswith("/graphql")][-1]
+    assert gql["variables"]["head"] == "h" * 40
+    assert "expectedHeadOid" in gql["query"]
+
+    seen.clear()
+    client = GitHubClient(auth=provider, transport=T(decline_arm=True))
+    assert client.arm_auto_merge_auto_mode("o/r", 1, expected_head="h" * 40) is True
+    merge = [b for m, u, b in seen if "/pulls/1/merge" in u][-1]
+    assert merge["sha"] == "h" * 40

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3483,7 +3483,7 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
     """The idempotent auto-arm (terra #228's redesign): once GitHub reports
     the PR CLEAN (up-to-date with the CURRENT base + green — GitHub's own
     freshness proof), the kernel-read contract says auto, and the RECORD says
-    the publish was auto-eligible, the service arms/merges. auto_eligible=False,
+    the publish blessed THIS head, the service arms/merges. An empty blessing,
     a manual dial, or a non-clean PR must never arm. Running tick-side (not
     in the sync push) survives a crash between push and arm."""
     from types import SimpleNamespace
@@ -3493,7 +3493,12 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
     from autoresearch.tick import FollowupSpec, service_in_review
 
     spec = FollowupSpec(
-        account="a", partition="p", run_root=tmp_path, image="/img/a.sif", home=Path("/h")
+        account="a",
+        partition="p",
+        run_root=tmp_path,
+        image="/img/a.sif",
+        home=Path("/h"),
+        target="org/pilot",  # the tick's contract applies to ITS target only
     )
 
     from typing import ClassVar
@@ -3536,7 +3541,7 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
                 benchmark="tsp",
                 state=IN_REVIEW,
                 pr_url="https://github.com/org/pilot/pull/7",
-                auto_eligible=panel,
+                auto_blessed_head="h" * 40 if panel else "",
             ),
             now=NOW,
         )
@@ -3611,7 +3616,7 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
             benchmark="tsp",
             state=IN_REVIEW,
             pr_url="https://github.com/org/pilot/pull/7",
-            auto_eligible=True,
+            auto_blessed_head="h" * 40,
             followup_job_id="9000000042",
         ),
         now=NOW,
@@ -3619,6 +3624,36 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
     service_in_review(tmp_path, G(), LiveFollowupCompute(), spec, NOW, contract=auto)
     assert G.arms == []
     rec("r-arm", panel=True)  # back to the plain eligible record
+
+    # the blessing is bound to an exact head (terra #228 r8): a PR whose
+    # head moved past the blessed sha — a crashed responder's push, say —
+    # never arms, whatever the record still says
+    class MovedHeadG(G):
+        def get_pull_request(self, repo, number):
+            return {**super().get_pull_request(repo, number), "head": {"sha": "m" * 40}}
+
+    rec("r-arm", panel=True)
+    service_in_review(tmp_path, MovedHeadG(), LocalCompute(), spec, NOW, contract=auto)
+    assert G.arms == []
+
+    # a record from ANOTHER target is never judged by this tick's contract
+    # (terra #228 r8): its own contract is fetched; unreadable -> manual
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="r-arm",
+            target="org/other",
+            task_title="t",
+            benchmark="tsp",
+            state=IN_REVIEW,
+            pr_url="https://github.com/org/other/pull/7",
+            auto_blessed_head="h" * 40,
+        ),
+        now=NOW,
+    )
+    service_in_review(tmp_path, G(), LocalCompute(), spec, NOW, contract=auto)
+    assert G.arms == []  # G has no get_file_content -> doubt -> manual
+    rec("r-arm", panel=True)
 
     # a DRAFT PR is not a merge candidate, clean or not (terra #228 r3)
     class DraftG(G):

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3483,7 +3483,7 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
     """The idempotent auto-arm (terra #228's redesign): once GitHub reports
     the PR CLEAN (up-to-date with the CURRENT base + green — GitHub's own
     freshness proof), the kernel-read contract says auto, and the RECORD says
-    the publish had a panel round, the service arms/merges. panel_ran=False,
+    the publish was auto-eligible, the service arms/merges. auto_eligible=False,
     a manual dial, or a non-clean PR must never arm. Running tick-side (not
     in the sync push) survives a crash between push and arm."""
     from types import SimpleNamespace
@@ -3536,7 +3536,7 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
                 benchmark="tsp",
                 state=IN_REVIEW,
                 pr_url="https://github.com/org/pilot/pull/7",
-                panel_ran=panel,
+                auto_eligible=panel,
             ),
             now=NOW,
         )

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3579,6 +3579,23 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
     service_in_review(tmp_path, OtherBaseG(), LocalCompute(), spec, NOW, contract=auto)
     assert G.arms == []
 
+    # pending reviewer feedback wins over arming (terra #228 r6): a clean,
+    # eligible PR with a NEW comment services the followup instead
+    class ChattyG(G):
+        def list_comments(self, repo, number, max_pages=20):
+            return [
+                {
+                    "id": 990,
+                    "body": "please adjust",
+                    "user": {"login": "renmengye"},
+                    "author_association": "MEMBER",
+                }
+            ]
+
+    rec("r-arm", panel=True)
+    service_in_review(tmp_path, ChattyG(), LocalCompute(), spec, NOW, contract=auto)
+    assert G.arms == []  # feedback pending: no self-merge
+
     # a DRAFT PR is not a merge candidate, clean or not (terra #228 r3)
     class DraftG(G):
         def get_pull_request(self, repo, number):

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3477,3 +3477,86 @@ def test_loop_cadence_is_clamped_finite(monkeypatch: Any) -> None:
         assert clamped == expect
         assert math.isfinite(clamped)
     assert _loop_cadence_s(0.0) == 45 * 60  # non-positive defers to the env
+
+
+def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
+    """The idempotent auto-arm (terra #228's redesign): once GitHub reports
+    the PR CLEAN (up-to-date with the CURRENT base + green — GitHub's own
+    freshness proof), the kernel-read contract says auto, and the RECORD says
+    the publish had a panel round, the service arms/merges. panel_ran=False,
+    a manual dial, or a non-clean PR must never arm. Running tick-side (not
+    in the sync push) survives a crash between push and arm."""
+    from types import SimpleNamespace
+
+    from autoresearch.compute import LocalCompute
+    from autoresearch.runstate import IN_REVIEW, RunRecord, save_record
+    from autoresearch.tick import FollowupSpec, service_in_review
+
+    spec = FollowupSpec(
+        account="a", partition="p", run_root=tmp_path, image="/img/a.sif", home=Path("/h")
+    )
+
+    from typing import ClassVar
+
+    class G:
+        arms: ClassVar[list[int]] = []
+
+        def __init__(self, state: str = "clean") -> None:
+            self._state = state
+
+        def get_pull_request(self, repo, number):
+            return {
+                "state": "open",
+                "merged": False,
+                "mergeable": True,
+                "mergeable_state": self._state,
+                "head": {"sha": "h" * 40},
+            }
+
+        def arm_auto_merge_auto_mode(self, repo, number):
+            G.arms.append(number)
+            return True
+
+        def list_comments(self, repo, number, max_pages=20):
+            return []
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return []
+
+    def rec(run_id: str, panel: bool) -> None:
+        save_record(
+            tmp_path,
+            RunRecord(
+                run_id=run_id,
+                target="org/pilot",
+                task_title="t",
+                benchmark="tsp",
+                state=IN_REVIEW,
+                pr_url="https://github.com/org/pilot/pull/7",
+                panel_ran=panel,
+            ),
+            now=NOW,
+        )
+
+    auto = SimpleNamespace(merge="auto")
+    manual = SimpleNamespace(merge="manual")
+
+    rec("r-arm", panel=True)
+    service_in_review(tmp_path, G(), LocalCompute(), spec, NOW, contract=auto)
+    assert G.arms == [7]  # armed exactly once
+
+    G.arms.clear()
+    rec("r-arm", panel=False)  # no panel provenance: never arm
+    service_in_review(tmp_path, G(), LocalCompute(), spec, NOW, contract=auto)
+    assert G.arms == []
+
+    rec("r-arm", panel=True)  # manual dial: never arm
+    service_in_review(tmp_path, G(), LocalCompute(), spec, NOW, contract=manual)
+    assert G.arms == []
+
+    # behind (not clean): never arm — freshness comes from GitHub's own check
+    service_in_review(tmp_path, G("behind"), LocalCompute(), spec, NOW, contract=auto)
+    assert G.arms == []

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3561,6 +3561,24 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
     service_in_review(tmp_path, G("behind"), LocalCompute(), spec, NOW, contract=auto)
     assert G.arms == []
 
+    # a non-main base is governed by ITS OWN contract dial (terra #228 r5):
+    # main says auto but the base branch's contract is manual -> never arm
+    class OtherBaseG(G):
+        def get_pull_request(self, repo, number):
+            return {**super().get_pull_request(repo, number), "base": {"ref": "release"}}
+
+        def get_file_content(self, repo, path, ref):
+            assert ref == "release"
+            return (
+                "benchmarks:\n  - name: tsp\n    command: x\n    metric: m\n"
+                "    direction: min\n"
+                "budgets: {gpu_hours_per_run: 1, runs_per_week: 1}\n"
+                "scope: {allowed: [src/]}\nroadmap: docs/roadmap.md\n"
+            )
+
+    service_in_review(tmp_path, OtherBaseG(), LocalCompute(), spec, NOW, contract=auto)
+    assert G.arms == []
+
     # a DRAFT PR is not a merge candidate, clean or not (terra #228 r3)
     class DraftG(G):
         def get_pull_request(self, repo, number):

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3518,7 +3518,8 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
                 "head": {"sha": "h" * 40},
             }
 
-        def arm_auto_merge_auto_mode(self, repo, number):
+        def arm_auto_merge_auto_mode(self, repo, number, expected_head=""):
+            assert expected_head == "h" * 40  # the mutation is bound to the blessed head
             G.arms.append(number)
             return True
 

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3560,3 +3560,11 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
     # behind (not clean): never arm — freshness comes from GitHub's own check
     service_in_review(tmp_path, G("behind"), LocalCompute(), spec, NOW, contract=auto)
     assert G.arms == []
+
+    # a DRAFT PR is not a merge candidate, clean or not (terra #228 r3)
+    class DraftG(G):
+        def get_pull_request(self, repo, number):
+            return {**super().get_pull_request(repo, number), "draft": True}
+
+    service_in_review(tmp_path, DraftG(), LocalCompute(), spec, NOW, contract=auto)
+    assert G.arms == []

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3596,6 +3596,30 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
     service_in_review(tmp_path, ChattyG(), LocalCompute(), spec, NOW, contract=auto)
     assert G.arms == []  # feedback pending: no self-merge
 
+    # a LIVE follow-up job blocks arming (terra #228 r7): its code push may
+    # have landed while the record write clearing the blessing has not
+    class LiveFollowupCompute(LocalCompute):
+        def status(self, job_id):
+            return "RUNNING"
+
+    save_record(
+        tmp_path,
+        RunRecord(
+            run_id="r-arm",
+            target="org/pilot",
+            task_title="t",
+            benchmark="tsp",
+            state=IN_REVIEW,
+            pr_url="https://github.com/org/pilot/pull/7",
+            auto_eligible=True,
+            followup_job_id="9000000042",
+        ),
+        now=NOW,
+    )
+    service_in_review(tmp_path, G(), LiveFollowupCompute(), spec, NOW, contract=auto)
+    assert G.arms == []
+    rec("r-arm", panel=True)  # back to the plain eligible record
+
     # a DRAFT PR is not a merge candidate, clean or not (terra #228 r3)
     class DraftG(G):
         def get_pull_request(self, repo, number):


### PR DESCRIPTION
## What

After a signature-clean base sync push (topology-only or contract-only-with-identical-signatures), `_sync_push` re-arms auto-merge iff the merge dial is `auto` in BOTH the measured (pre-merge) and merged contracts. Auto at publish implies the panel ran (the publish gate enforces it); auto now means the owner still wants self-merging; the clean sync restores exactly the freshness that made `_arm_unless_base_moved` decline at publish. Anything else — manual anywhere, or a dial flip in either direction — keeps the human merge.

## Why (live, this morning)

gpt-speedrun#5 (the 9088 → 8640 record) sat CLEAN-but-unarmed after its kernel-side sync until Mengye's manual click, and his first question was 'why isn't PR #5 auto merged?' — the missing last rung of the base-move self-heal.

## Test / gate

Full gate green. Pins: both-auto topology sync → disarm once, push, re-arm once, note posted; manual-dial sync → the arm call is asserted never to happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)