### PR TITLE
Follow-up re-read: the panel reads a pushed code change before the tick may arm it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- A follow-up that pushes a re-measured code change now has the SAME
+  verification panel re-read the new head, posted on the thread: a clean
+  read under `merge: auto` re-blesses the pushed sha so the tick may arm the
+  merge once GitHub reports the PR clean; blocking findings, a degraded read,
+  a manual dial, or a panel that could not run leave the merge to a human,
+  each named. Author follow-up jobs carry the climb's `--panel` and one
+  read's walltime (`docs/design/orchestrator-verify.md`).
 - A signature-clean base sync re-arms auto-merge when the merge dial is
   `auto` in BOTH the measured and merged worlds (auto at publish means the
   panel ran; auto now means the owner still wants it) — the clean sync

--- a/docs/design/orchestrator-verify.md
+++ b/docs/design/orchestrator-verify.md
@@ -123,6 +123,48 @@ before hibernating (author skill), data-fenced wakes re-ground facts, and
 distillation of reports into lessons is the curator role — nothing
 load-bearing lives only in a compressible medium.
 
+## Re-reading a follow-up
+
+A PR's content changes after publish in exactly one kernel-driven way: a
+follow-up session answers review feedback with a code change, which the
+responder re-measures and pushes. That push replaces the content the panel
+blessed, so the record's `auto_blessed_head` is cleared — the tick arms a
+self-merge only on an exact head match, so a changed PR could only ever be
+merged by a human. The follow-up now closes that gap the same way the climb
+opened the PR: **the same panel reads the new head.**
+
+- The responder posts its reply and writes the record (cursors advanced,
+  blessing cleared) FIRST, then runs the panel. Judges take minutes; a
+  responder killed mid-read must cost an unarmed PR, never a silent push
+  or a repeated wake.
+- The panel's `base/` is the merge-base of the pushed head and the
+  kernel-pinned base sha (after a base sync the two coincide); its contract
+  text is that base's. The claim is a *follow-up re-measure on an open PR*,
+  naming the PR's previous number — never a fresh pre-PR improvement claim.
+- The read is posted on the thread under the follow-up marker, with the
+  panel transcript and one closing line that says who merges.
+- **Bless** — `auto_blessed_head = pushed sha` — only when the read is clean
+  (no blocking finding, no degraded lens), the tree's contract says
+  `merge: auto`, and the workspace HEAD still equals the pushed sha after
+  the judges ran (they hold a shell next to the checkout). The tick then
+  arms once GitHub reports the PR clean and up to date.
+- Everything else is written down and left to a human: blocking findings
+  (the panel's explicit demand), a degraded read, a manual dial (the owner's
+  preference, not doubt), a panel that could not run, no trusted base.
+
+The tick threads the climb's `--panel` to author follow-ups (never the
+steward's — its PRs are not panel-blessed) and adds one read's walltime to
+the job, exactly as the climb's allowance does; the follow-up session's own
+budget is the job minus that read. A panel config that would die at startup
+is left off the follow-up (the reply still goes out; the PR stays
+human-merged; the tick's contract alarm already names the misconfig).
+
+Not yet: the climb's revise loop. A blocking re-read does not wake the
+author inside the same job — the findings sit on the thread, and the author
+addresses them when a maintainer's comment next wakes it. Folding the
+responder's measure-and-push block into a callable so the panel can wake
+the author once is the next rung.
+
 ## What changes on GitHub
 
 - `verify.yml` on targets thins to defense-in-depth (a re-check of the

--- a/docs/design/orchestrator-verify.md
+++ b/docs/design/orchestrator-verify.md
@@ -158,11 +158,12 @@ the job on top of the author's budget, both under the partition cap; it tells
 the follow-up how many minutes the read actually got (`--panel-minutes`), so
 a cap that eats the allowance costs the read — skipped, and said so on the
 thread — never the author's session. The follow-up builds the panel only
-after the run's OWN author is resolved and refuses a judge key that equals
-that author's credential (role separation on the keys themselves, not the
-paths). A panel config that would die at startup is left off the follow-up
-(the reply still goes out; the PR stays human-merged; the tick's contract
-alarm already names the misconfig).
+after the run's OWN author is resolved; a judge key that equals that
+author's credential (role separation on the keys themselves, not the paths)
+drops the panel for this job and posts the skip, the same way — the reply
+never depends on the panel. A panel config that would die at startup is
+left off the follow-up (the reply still goes out; the PR stays
+human-merged; the tick's contract alarm already names the misconfig).
 
 Not yet: the climb's revise loop. A blocking re-read does not wake the
 author inside the same job — the findings sit on the thread, and the author

--- a/docs/design/orchestrator-verify.md
+++ b/docs/design/orchestrator-verify.md
@@ -154,10 +154,15 @@ opened the PR: **the same panel reads the new head.**
 
 The tick threads the climb's `--panel` to author follow-ups (never the
 steward's — its PRs are not panel-blessed) and adds one read's walltime to
-the job, exactly as the climb's allowance does; the follow-up session's own
-budget is the job minus that read. A panel config that would die at startup
-is left off the follow-up (the reply still goes out; the PR stays
-human-merged; the tick's contract alarm already names the misconfig).
+the job on top of the author's budget, both under the partition cap; it tells
+the follow-up how many minutes the read actually got (`--panel-minutes`), so
+a cap that eats the allowance costs the read — skipped, and said so on the
+thread — never the author's session. The follow-up builds the panel only
+after the run's OWN author is resolved and refuses a judge key that equals
+that author's credential (role separation on the keys themselves, not the
+paths). A panel config that would die at startup is left off the follow-up
+(the reply still goes out; the PR stays human-merged; the tick's contract
+alarm already names the misconfig).
 
 Not yet: the climb's revise loop. A blocking re-read does not wake the
 author inside the same job — the findings sit on the thread, and the author

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -2031,6 +2031,7 @@ def build_panel_runner(
     today: str,
     start_round: int = 0,
     exclude: tuple[str, ...] = (),
+    claim_body: Callable[[float, float, str], str] | None = None,
 ) -> Callable[[float, float, str], PanelVerdict]:
     """The git half of the pre-PR panel: prepare the two read-only checkouts
     and the synthetic claim, then hand off to `run_panel` (which owns no git).
@@ -2039,10 +2040,19 @@ def build_panel_runner(
     checks it out as `pr-head/` (sanitized — the candidate is an untrusted
     tree), next to `base/` (the trusted pre-session commit: contract and
     ruler). Worktrees are removed after the read; a fresh pair is built per
-    round because the tree changes with every revision."""
+    round because the tree changes with every revision.
+
+    `claim_body` renders the claim the panel judges from (baseline,
+    candidate, report); the default is the pre-PR improvement claim, a
+    follow-up re-read passes its own wording."""
     from autoresearch.review_agent import sanitize_checkout
 
     reads = {"n": start_round}
+    render_claim = claim_body or (
+        lambda baseline, candidate, report: _panel_claim_body(
+            benchmark, baseline, candidate, report, lines=bool(exclude)
+        )
+    )
 
     def runner(baseline: float, candidate: float, report: str) -> PanelVerdict:
         reads["n"] += 1
@@ -2089,7 +2099,7 @@ def build_panel_runner(
                 repo=target,
                 number=0,
                 title=f"[agent] {benchmark}: {_title_pair(baseline, candidate)}",
-                body=_panel_claim_body(benchmark, baseline, candidate, report, lines=bool(exclude)),
+                body=render_claim(baseline, candidate, report),
                 # base..snapshot, never base..worktree: the snapshot commit
                 # includes newly ADDED files, which a working-tree diff omits
                 diff=ws.git("diff", f"{base_sha}..{snapshot}"),

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
+from typing import Any
 
 from autoresearch.brief import render_review_wake
 from autoresearch.contract import load_contract
@@ -293,7 +295,15 @@ def respond_once(
     secrets: tuple[str, ...] = (),
     created: str = "",
     spec: RoleSpec | None = None,
+    panel_lenses: tuple[Any, ...] = (),
+    panel_builder: Callable[..., Callable[[float, float, str], Any]] | None = None,
 ) -> FollowupOutcome:
+    """Service one in-review run: reply to new maintainer comments (and base
+    moves), re-measure and push any code change the session made.
+
+    `panel_lenses` (the climb's `--panel`) re-reads a PUSHED code change with
+    the same verification panel; `panel_builder` is the runner factory
+    (`build_panel_runner` unless a test injects one)."""
     record = load_record(run_root, run_id)
     if record.state != IN_REVIEW:
         return FollowupOutcome(run_id, "no-op", f"state is {record.state}, not in-review")
@@ -318,6 +328,8 @@ def respond_once(
             secrets,
             created,
             spec,
+            panel_lenses,
+            panel_builder,
         )
     except Exception as exc:
         log.warning("followup failed for %s: %s", run_id, redact(str(exc), secrets))
@@ -341,6 +353,8 @@ def _respond(
     secrets: tuple[str, ...],
     created: str,
     spec: RoleSpec | None = None,
+    panel_lenses: tuple[Any, ...] = (),
+    panel_builder: Callable[..., Callable[[float, float, str], Any]] | None = None,
 ) -> FollowupOutcome:
     # a deployment bug is refused before any GitHub read or contract load —
     # the contained error outcome retries next tick either way, so fail as
@@ -569,6 +583,7 @@ def _respond(
 
     measured_note = ""
     change_pushed = False
+    pushed_head = ""  # the exact sha a code-changing push put on the PR
 
     def _matches_base(path: str) -> bool:
         # content identical to origin/<base> is the base branch's own (a
@@ -960,6 +975,7 @@ def _respond(
                         except NothingToCommit:
                             if not committed:
                                 raise
+                        pushed_head = ws.git("rev-parse", "HEAD").strip()
                         ws.push(branch)
                         change_pushed = True
                         worse = prior is not None and not orch_improved(
@@ -1033,7 +1049,192 @@ def _respond(
         ),
         now,
     )
+    if change_pushed and panel_lenses and not is_steward:
+        # RE-READ: the pushed change replaced the content the panel blessed,
+        # and the write above already cleared the blessing — the tick never
+        # arms a head the panel has not read. Now the SAME panel reads the
+        # new head. A clean read under merge:auto moves the blessing to the
+        # pushed sha (the tick arms once GitHub reports the PR clean);
+        # blocking findings, a degraded read, a manual dial, or a panel that
+        # could not run all leave the merge to a human — named on the thread.
+        # Ordered AFTER the reply and the record write on purpose: judges
+        # take minutes, and a responder killed mid-read must cost an unarmed
+        # PR, never a silent push or a repeated wake.
+        _reread_pushed_change(
+            ws,
+            run_root,
+            run_id,
+            record,
+            number,
+            github,
+            bench,
+            candidate,
+            prior.best if prior is not None else None,
+            reply_body,
+            trusted_base=base_sha_at_fetch if base_fetched else "",
+            pushed_head=pushed_head,
+            dial=str(getattr(post_contract, "merge", "manual")),
+            panel_lenses=panel_lenses,
+            panel_builder=panel_builder,
+            bot_login=bot_login,
+            created=created,
+            now=now,
+            secrets=secrets,
+        )
     return FollowupOutcome(run_id, "replied", f"processed {len(comments)} comment(s)")
+
+
+REREAD_HEADING = "**Verification panel — re-read of the pushed change**"
+
+
+def _followup_claim_body(
+    benchmark: str,
+    number: int,
+    previous: float | None,
+    candidate: float,
+    report: str,
+    *,
+    lines: bool,
+) -> str:
+    """The claim a follow-up re-read judges: a re-measure on an OPEN PR, not
+    a fresh improvement claim — the panel must know the PR already carried
+    a measured number and this is the change made in response to review."""
+    from autoresearch.attempt import MAX_CLAIM_CHARS
+
+    mandate = (
+        "\n\nThis target runs research lines: the PR must stay ONE clean "
+        "contribution. A change that bundles unrelated or unablated work is "
+        "a BLOCKING finding — name the pieces that should be separated."
+        if lines
+        else ""
+    )
+    prev = f"{previous}" if previous is not None else "not recorded"
+    return (
+        f"Follow-up re-measure on open PR #{number}: {benchmark} = {candidate} "
+        f"after a code change made in response to review feedback (the PR's "
+        f"previously measured number: {prev}), measured by the orchestrator."
+        f"{mandate}\n\n## Author's reply\n\n*Session prose, written before "
+        f"the orchestrator measured.*\n\n{report[:MAX_CLAIM_CHARS]}"
+    )
+
+
+def _reread_pushed_change(
+    ws: Workspace,
+    run_root: Path,
+    run_id: str,
+    record: RunRecord,
+    number: int,
+    github: GitHubClient,
+    bench: Any,
+    candidate: float,
+    previous: float | None,
+    report: str,
+    *,
+    trusted_base: str,
+    pushed_head: str,
+    dial: str,
+    panel_lenses: tuple[Any, ...],
+    panel_builder: Callable[..., Callable[[float, float, str], Any]] | None,
+    bot_login: str,
+    created: str,
+    now: float,
+    secrets: tuple[str, ...],
+) -> None:
+    """Run the panel over the head a follow-up just pushed and post the
+    read; bless the head for the tick's auto-arm ONLY on a clean read under
+    merge:auto against a trusted base, with the workspace still exactly the
+    pushed commit. Every other outcome is written down and left to a human.
+    Best-effort throughout: a failure here degrades to an unarmed PR."""
+    transcript = ""
+    clean = False
+    base = ""
+    if trusted_base and pushed_head:
+        # the panel's `base/` is the base the PR actually forks from: the
+        # merge-base of the pushed head and the kernel-pinned base sha (after
+        # a base sync the two coincide) — never a ref name a session can move
+        with contextlib.suppress(GitError):
+            base = ws.git("merge-base", pushed_head, trusted_base).strip()
+    if not base:
+        transcript = "- panel skipped: no trusted base to read against — NOT a clean read"
+    else:
+        try:
+            head_now = ws.git("rev-parse", "HEAD").strip()
+            head_tree = ws.git("rev-parse", "HEAD^{tree}").strip()
+            work_tree = _tree_hash(ws)
+        except GitError:
+            head_now = head_tree = work_tree = ""
+        if not head_now or head_now != pushed_head or work_tree != head_tree:
+            # the panel snapshots the WORKING tree; it must be the pushed commit
+            transcript = (
+                "- panel skipped: the workspace no longer matches the pushed head — "
+                "NOT a clean read"
+            )
+        else:
+            try:
+                from autoresearch.attempt import LINE_MEMORY_PATHS, _utc_date, build_panel_runner
+
+                lines = bool(getattr(bench, "lines", False))
+                try:
+                    contract_text = ws.git("show", f"{base}:.autoresearch.yaml")
+                except GitError:
+                    contract_text = (Path(ws.root) / ".autoresearch.yaml").read_text()
+                runner = (panel_builder or build_panel_runner)(
+                    ws,
+                    run_dir(run_root, run_id),
+                    base,
+                    panel_lenses,
+                    contract_text,
+                    record.target,
+                    bench.name,
+                    bot_login,
+                    created[:10] if created else _utc_date(now),
+                    exclude=LINE_MEMORY_PATHS if lines else (),
+                    claim_body=lambda _b, c, r: _followup_claim_body(
+                        bench.name, number, previous, c, r, lines=lines
+                    ),
+                )
+                verdict = runner(previous if previous is not None else candidate, candidate, report)
+            except Exception as exc:
+                # a panel that cannot run is a NON-read, said plainly
+                transcript = (
+                    f"- panel could not run ({redact(str(exc), secrets)[:160]}) — NOT a clean read"
+                )
+            else:
+                transcript = str(verdict.transcript)
+                clean = not verdict.blocking and not verdict.degraded
+    # judges held a shell next to this checkout: re-pin before trusting
+    try:
+        still_pushed = ws.git("rev-parse", "HEAD").strip() == pushed_head
+    except GitError:
+        still_pushed = False
+    bless = clean and still_pushed and dial == "auto"
+    if bless:
+        closing = (
+            "Clean read under `merge: auto`: the kernel may merge this head once "
+            "GitHub reports the PR clean and up to date with its base."
+        )
+    elif clean and dial != "auto":
+        closing = "Clean read; this repository merges by hand (`merge: manual`)."
+    elif clean:
+        closing = "Clean read, but the workspace moved during it — a human merges this PR."
+    else:
+        closing = "Not a clean read — a human decides this PR."
+    body = APPROVAL_PATTERN.sub(REDACTED, redact(transcript, secrets))[:MAX_REPLY_CHARS]
+    try:
+        github.comment(
+            record.target,
+            number,
+            f"{REPLY_MARKER}\n{REREAD_HEADING} (`{pushed_head[:12]}`)\n{body}\n\n_{closing}_",
+        )
+    except Exception as exc:
+        log.warning("re-read comment failed for %s#%s: %s", record.target, number, exc)
+        return  # an unposted read never blesses: the thread must carry it
+    if bless:
+        try:
+            latest = load_record(run_root, run_id)
+            save_record(run_root, replace(latest, auto_blessed_head=pushed_head), now)
+        except (OSError, ValueError) as exc:
+            log.warning("blessing write failed for %s: %s", run_id, exc)
 
 
 def _changed_paths(ws: Workspace) -> list[str]:
@@ -1113,6 +1314,13 @@ def main() -> int:
         help="author key file; default resolves per backend (config-driven): "
         "AUTORESEARCH_HARNESS_KEY_FILE for claude, AUTORESEARCH_CODEX_KEY_FILE for codex",
     )
+    parser.add_argument(
+        "--panel",
+        default="",
+        help="verification lenses (kind[:backend[:model]], comma-separated) that "
+        "re-read a pushed code change; '' = no re-read, a changed PR stays human-merged",
+    )
+    parser.add_argument("--panel-key-file", default="", help="the claude panel lenses' key file")
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     if not args.image and not args.uncontained:
@@ -1121,10 +1329,21 @@ def main() -> int:
     from datetime import UTC, datetime
 
     from autoresearch.attempt import (
+        PANEL_KEY_DEFAULT,
+        _panel_lenses_from_args,
         codex_author_config_error,
         resolve_author_key_file,
         resume_author,
     )
+    from autoresearch.panel import panel_read_minutes
+
+    args.panel_key_file = args.panel_key_file or PANEL_KEY_DEFAULT
+    try:
+        # the climb's own rules and credentials: judge keys are read only for
+        # the lenses that use them and join the redaction set
+        panel_lenses, panel_secrets = _panel_lenses_from_args(args)
+    except ValueError as exc:
+        parser.error(str(exc))
 
     # a follow-up services ONE run: reproduce THAT run's author (the persisted
     # (backend, model) PAIR), not the current fleet default, so a codex-authored
@@ -1163,11 +1382,14 @@ def main() -> int:
         log.info("self-deadline armed: Terminated in %ds", armed)
     # the manifest first, the harness from it (budget has one source: the
     # args). The session must end before its job does, so the walltime is
-    # bounded by the job minus the self-deadline margin when one is known.
+    # bounded by the job minus the self-deadline margin when one is known —
+    # and minus the panel's read, which runs AFTER the session on the same
+    # clock (the tick added exactly that allowance to the job).
+    session_minutes = max(0, args.job_minutes - panel_read_minutes(args.panel))
     spec = followup_spec(
         max_turns=args.max_turns,
         walltime_s=(
-            min(3600, max(300, args.job_minutes * 60 - 300)) if args.job_minutes > 0 else 3600
+            min(3600, max(300, session_minutes * 60 - 300)) if args.job_minutes > 0 else 3600
         ),
     )
     try:
@@ -1188,8 +1410,9 @@ def main() -> int:
             github=GitHubClient(auth=bot_auth),
             bot_login=args.bot_login,
             now=time.time(),
-            secrets=(api_key, bot_auth.token()),
+            secrets=(api_key, bot_auth.token(), *panel_secrets),
             created=datetime.now(UTC).isoformat(),
+            panel_lenses=panel_lenses,
         )
     finally:
         _signal.alarm(0)

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -1387,15 +1387,17 @@ def main() -> int:
         panel_lenses, panel_secrets = _panel_lenses_from_args(args)
     except ValueError as exc:
         parser.error(str(exc))
-    if api_key and api_key in panel_secrets:
-        parser.error(
-            f"run {args.run_id}: a panel judge key is the run's author key "
-            "(role separation: the judge needs its own key)"
-        )
-    # The read's walltime is what the TICK could add under the partition cap
-    # (--panel-minutes); a read that does not fit is skipped and said so on
-    # the thread rather than starving the author or dying mid-read.
+    # A panel that cannot run in THIS job never costs the reply: the
+    # follow-up runs panel-free and the skip is posted on the thread (the
+    # PR stays human-merged). Two such cases: a judge key that is this run's
+    # author key — the tick preflights against the FLEET key, a run started
+    # under another key is only known here (terra #229 r2) — and a read the
+    # partition cap left no walltime for (--panel-minutes).
     panel_skip = ""
+    if api_key and api_key in panel_secrets:
+        panel_skip = "a panel judge key is this run's author key (role separation)"
+        log.warning("run %s: %s; the follow-up runs without the panel", args.run_id, panel_skip)
+        panel_lenses = ()
     if panel_lenses and args.panel_minutes < panel_read_minutes(args.panel):
         panel_skip = (
             f"the job's walltime cap left {args.panel_minutes} min for a read "

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -297,13 +297,17 @@ def respond_once(
     spec: RoleSpec | None = None,
     panel_lenses: tuple[Any, ...] = (),
     panel_builder: Callable[..., Callable[[float, float, str], Any]] | None = None,
+    panel_skip: str = "",
 ) -> FollowupOutcome:
     """Service one in-review run: reply to new maintainer comments (and base
     moves), re-measure and push any code change the session made.
 
     `panel_lenses` (the climb's `--panel`) re-reads a PUSHED code change with
     the same verification panel; `panel_builder` is the runner factory
-    (`build_panel_runner` unless a test injects one)."""
+    (`build_panel_runner` unless a test injects one). `panel_skip` names why a
+    configured panel cannot run in this job (no walltime for the read): the
+    skip is then posted on the thread instead of a read — silence is never
+    endorsement, and a skipped read never blesses."""
     record = load_record(run_root, run_id)
     if record.state != IN_REVIEW:
         return FollowupOutcome(run_id, "no-op", f"state is {record.state}, not in-review")
@@ -330,6 +334,7 @@ def respond_once(
             spec,
             panel_lenses,
             panel_builder,
+            panel_skip,
         )
     except Exception as exc:
         log.warning("followup failed for %s: %s", run_id, redact(str(exc), secrets))
@@ -355,6 +360,7 @@ def _respond(
     spec: RoleSpec | None = None,
     panel_lenses: tuple[Any, ...] = (),
     panel_builder: Callable[..., Callable[[float, float, str], Any]] | None = None,
+    panel_skip: str = "",
 ) -> FollowupOutcome:
     # a deployment bug is refused before any GitHub read or contract load —
     # the contained error outcome retries next tick either way, so fail as
@@ -1049,7 +1055,7 @@ def _respond(
         ),
         now,
     )
-    if change_pushed and panel_lenses and not is_steward:
+    if change_pushed and (panel_lenses or panel_skip) and not is_steward:
         # RE-READ: the pushed change replaced the content the panel blessed,
         # and the write above already cleared the blessing — the tick never
         # arms a head the panel has not read. Now the SAME panel reads the
@@ -1076,6 +1082,7 @@ def _respond(
             dial=str(getattr(post_contract, "merge", "manual")),
             panel_lenses=panel_lenses,
             panel_builder=panel_builder,
+            panel_skip=panel_skip,
             bot_login=bot_login,
             created=created,
             now=now,
@@ -1135,6 +1142,7 @@ def _reread_pushed_change(
     dial: str,
     panel_lenses: tuple[Any, ...],
     panel_builder: Callable[..., Callable[[float, float, str], Any]] | None,
+    panel_skip: str,
     bot_login: str,
     created: str,
     now: float,
@@ -1148,13 +1156,15 @@ def _reread_pushed_change(
     transcript = ""
     clean = False
     base = ""
-    if trusted_base and pushed_head:
+    if trusted_base and pushed_head and not panel_skip:
         # the panel's `base/` is the base the PR actually forks from: the
         # merge-base of the pushed head and the kernel-pinned base sha (after
         # a base sync the two coincide) — never a ref name a session can move
         with contextlib.suppress(GitError):
             base = ws.git("merge-base", pushed_head, trusted_base).strip()
-    if not base:
+    if panel_skip:
+        transcript = f"- panel skipped: {panel_skip} — NOT a clean read"
+    elif not base:
         transcript = "- panel skipped: no trusted base to read against — NOT a clean read"
     else:
         try:
@@ -1174,10 +1184,9 @@ def _reread_pushed_change(
                 from autoresearch.attempt import LINE_MEMORY_PATHS, _utc_date, build_panel_runner
 
                 lines = bool(getattr(bench, "lines", False))
-                try:
-                    contract_text = ws.git("show", f"{base}:.autoresearch.yaml")
-                except GitError:
-                    contract_text = (Path(ws.root) / ".autoresearch.yaml").read_text()
+                # the judges' rules come from the TRUSTED base only — never the
+                # workspace copy, which the pushed tree controls (terra #229 r1)
+                contract_text = ws.git("show", f"{base}:.autoresearch.yaml")
                 runner = (panel_builder or build_panel_runner)(
                     ws,
                     run_dir(run_root, run_id),
@@ -1321,6 +1330,13 @@ def main() -> int:
         "re-read a pushed code change; '' = no re-read, a changed PR stays human-merged",
     )
     parser.add_argument("--panel-key-file", default="", help="the claude panel lenses' key file")
+    parser.add_argument(
+        "--panel-minutes",
+        type=int,
+        default=0,
+        help="walltime the tick added to this job for the panel's read (0 = none fit: "
+        "the read is skipped and said so; the author's budget is never the panel's)",
+    )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     if not args.image and not args.uncontained:
@@ -1336,14 +1352,6 @@ def main() -> int:
         resume_author,
     )
     from autoresearch.panel import panel_read_minutes
-
-    args.panel_key_file = args.panel_key_file or PANEL_KEY_DEFAULT
-    try:
-        # the climb's own rules and credentials: judge keys are read only for
-        # the lenses that use them and join the redaction set
-        panel_lenses, panel_secrets = _panel_lenses_from_args(args)
-    except ValueError as exc:
-        parser.error(str(exc))
 
     # a follow-up services ONE run: reproduce THAT run's author (the persisted
     # (backend, model) PAIR), not the current fleet default, so a codex-authored
@@ -1368,6 +1376,33 @@ def main() -> int:
     api_key = role_key(args.key_file, author_backend)
     bot_auth = resolve_bot_auth(args.pat_file, args.github_app_file)
 
+    # The panel AFTER the author is resolved: this run's author key is the
+    # RECORDED one (not the fleet default the tick preflights against), so
+    # role separation is checked here on the credentials themselves — one
+    # key never plays author and judge, whatever paths it was read from
+    # (terra #229 r1). Lens rules and judge keys are the climb's own
+    # (_panel_lenses_from_args); every judge key joins the redaction set.
+    args.panel_key_file = args.panel_key_file or PANEL_KEY_DEFAULT
+    try:
+        panel_lenses, panel_secrets = _panel_lenses_from_args(args)
+    except ValueError as exc:
+        parser.error(str(exc))
+    if api_key and api_key in panel_secrets:
+        parser.error(
+            f"run {args.run_id}: a panel judge key is the run's author key "
+            "(role separation: the judge needs its own key)"
+        )
+    # The read's walltime is what the TICK could add under the partition cap
+    # (--panel-minutes); a read that does not fit is skipped and said so on
+    # the thread rather than starving the author or dying mid-read.
+    panel_skip = ""
+    if panel_lenses and args.panel_minutes < panel_read_minutes(args.panel):
+        panel_skip = (
+            f"the job's walltime cap left {args.panel_minutes} min for a read "
+            f"that needs {panel_read_minutes(args.panel)}"
+        )
+        panel_lenses = ()
+
     # Same self-deadline as the climb: Slurm never signals this process,
     # so walltime deaths must be our own clock's job. respond_once contains
     # exceptions per-lane, and its lease/cursor rules keep a Terminated
@@ -1383,9 +1418,10 @@ def main() -> int:
     # the manifest first, the harness from it (budget has one source: the
     # args). The session must end before its job does, so the walltime is
     # bounded by the job minus the self-deadline margin when one is known —
-    # and minus the panel's read, which runs AFTER the session on the same
-    # clock (the tick added exactly that allowance to the job).
-    session_minutes = max(0, args.job_minutes - panel_read_minutes(args.panel))
+    # and minus the panel's minutes, which the tick ADDED for a read that
+    # runs after the session on the same clock: the author keeps exactly the
+    # budget it had without a panel.
+    session_minutes = max(0, args.job_minutes - (args.panel_minutes if panel_lenses else 0))
     spec = followup_spec(
         max_turns=args.max_turns,
         walltime_s=(
@@ -1413,6 +1449,7 @@ def main() -> int:
             secrets=(api_key, bot_auth.token(), *panel_secrets),
             created=datetime.now(UTC).isoformat(),
             panel_lenses=panel_lenses,
+            panel_skip=panel_skip,
         )
     finally:
         _signal.alarm(0)

--- a/src/autoresearch/panel.py
+++ b/src/autoresearch/panel.py
@@ -66,6 +66,18 @@ def parse_lenses(panel: str) -> tuple[tuple[str, str, str], ...]:
     return tuple(entries)
 
 
+def panel_read_minutes(panel: str) -> int:
+    """Walltime one read of every configured lens needs, from the judge role
+    budgets (the same numbers the climb's allowance is built from). 0 when the
+    panel is off. Callers that budget a revision wake add the author's session
+    on top."""
+    lenses = [entry for entry in panel.split(",") if entry.strip()]
+    if not lenses:
+        return 0
+    judge_minutes = max(reviewer_spec().budget.walltime_s, verifier_spec().budget.walltime_s) // 60
+    return len(lenses) * judge_minutes
+
+
 @dataclass(frozen=True)
 class PanelLens:
     """One opinion: a kind (verify = integrity, review = code) on a backend."""

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -635,6 +635,27 @@ def service_in_review(
             if dry_run:
                 submitted.append((record.run_id, "dry-run"))
                 continue
+            # The author follow-up carries the climb's panel so a pushed code
+            # change is RE-READ before the tick may arm it (followup.py). The
+            # panel brings its own walltime, like the climb's allowance — the
+            # contract's followup budget caps the author, not the gate. A
+            # panel that would die at startup is left off: the reply still
+            # goes out, the PR simply stays human-merged (the tick's contract
+            # alarm already names the misconfig).
+            panel_argv: list[str] = []
+            panel_minutes = 0
+            if not is_steward and spec.panel.strip():
+                panel_error = _panel_preflight_error(spec)
+                if panel_error:
+                    log.warning(
+                        "follow-up for %s runs without the panel: %s", record.run_id, panel_error
+                    )
+                else:
+                    from autoresearch.panel import panel_read_minutes
+
+                    panel_argv = _climb_panel_argv(spec)
+                    panel_minutes = panel_read_minutes(spec.panel)
+            job_minutes = min(spec.time_minutes + panel_minutes, spec.max_job_minutes)
             argv = [
                 "uv",
                 "run",
@@ -652,9 +673,10 @@ def service_in_review(
                 "--job-minutes",
                 # the SAME clamped value Slurm gets: a deadline armed past
                 # the real walltime is a Slurm kill before a clean ending
-                str(min(spec.time_minutes, spec.max_job_minutes)),
+                str(job_minutes),
                 "--max-turns",
                 str(spec.max_turns),
+                *panel_argv,
             ]
             if spec.pat_file:
                 argv += ["--pat-file", spec.pat_file]
@@ -668,7 +690,7 @@ def service_in_review(
                     job_name=f"followup-{record.run_id}"[:60],
                     account=spec.account,
                     partition=spec.job_partition or spec.partition,
-                    time_minutes=min(spec.time_minutes, spec.max_job_minutes),
+                    time_minutes=job_minutes,
                     command=_flight_command(spec.home, f"followup-{record.run_id}"[:60], now, argv),
                     cpus=4,
                     mem="8G",
@@ -2678,14 +2700,13 @@ def _wake_panel_minutes(spec: FollowupSpec) -> int:
     author session (the depth-axis wake-to-revise). The revision's re-measure
     only DISPATCHES (then the job ends, parked), so it needs no extra time.
     Grounded in the same judge/author budgets the climb job uses."""
-    lenses = [entry for entry in spec.panel.split(",") if entry.strip()]
-    if not lenses:
-        return 0
-    from autoresearch.roles import author_spec, reviewer_spec, verifier_spec
+    from autoresearch.panel import panel_read_minutes
+    from autoresearch.roles import author_spec
 
-    judge_minutes = max(reviewer_spec().budget.walltime_s, verifier_spec().budget.walltime_s) // 60
-    session_minutes = author_spec().budget.walltime_s // 60
-    return len(lenses) * judge_minutes + session_minutes
+    read_minutes = panel_read_minutes(spec.panel)
+    if not read_minutes:
+        return 0
+    return read_minutes + author_spec().budget.walltime_s // 60
 
 
 def _wake_dispatcher_from_env(

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -655,7 +655,14 @@ def service_in_review(
 
                     panel_argv = _climb_panel_argv(spec)
                     panel_minutes = panel_read_minutes(spec.panel)
-            job_minutes = min(spec.time_minutes + panel_minutes, spec.max_job_minutes)
+            # the author's budget first, the read on top, both under the
+            # partition cap — and the follow-up is told how many minutes the
+            # read actually got (--panel-minutes), so a cap that eats the
+            # allowance costs the READ (skipped, said so), never the author
+            author_minutes = min(spec.time_minutes, spec.max_job_minutes)
+            job_minutes = min(author_minutes + panel_minutes, spec.max_job_minutes)
+            if panel_argv:
+                panel_argv = [*panel_argv, "--panel-minutes", str(job_minutes - author_minutes)]
             argv = [
                 "uv",
                 "run",

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1744,3 +1744,321 @@ def test_a_pushed_code_change_kills_the_auto_blessing(review_run) -> None:
     outcome2 = respond(root, github2, ResumingHarness(), QueueEvaluator(values=[]))
     assert outcome2.action == "replied"
     assert load_record(root, "tsp-r1").auto_blessed_head == "b" * 40
+
+
+# --- the follow-up re-read: a pushed change is read by the panel before the
+# tick may arm it (docs/design/orchestrator-verify.md, "Re-reading a follow-up")
+
+AUTO_CONTRACT = CONTRACT + "merge: auto\n"
+
+
+def _set_contract(root: Path, text: str, leader: float | None = 10.5) -> None:
+    """Commit a contract (and the PR's own measured ledger row) onto the PR
+    branch so the follow-up sees both as the tree's own, not as a change the
+    session made."""
+    from autoresearch.progress import load_leader, update_leader, write_progress
+
+    ws = run_dir(root, "tsp-r1") / "ws"
+    (ws / ".autoresearch.yaml").write_text(text)
+    if leader is not None:
+        entries = update_leader(
+            load_leader(ws),
+            benchmark="tsp",
+            metric="mean_tour_length",
+            direction="min",
+            baseline=leader,
+            candidate=leader,
+            run_id="tsp-r1",
+            date="2026-09-01",
+        )
+        write_progress(ws, entries, "org/pilot")
+    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(ws, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "dial")
+
+
+@dataclass
+class FakePanel:
+    """Stands in for build_panel_runner: records what it was asked to read
+    and returns canned verdicts."""
+
+    verdicts: list = field(default_factory=list)
+    built: list[dict] = field(default_factory=list)
+    reads: list[tuple[float, float, str]] = field(default_factory=list)
+
+    def __call__(
+        self,
+        ws,
+        run_dir_,
+        base_sha,
+        lenses,
+        contract_text,
+        target,
+        benchmark,
+        bot_login,
+        today,
+        exclude=(),
+        claim_body=None,
+    ):
+        self.built.append(
+            {
+                "base": base_sha,
+                "lenses": lenses,
+                "contract": contract_text,
+                "benchmark": benchmark,
+                "claim": claim_body(10.5, 10.2, "why") if claim_body else "",
+            }
+        )
+
+        def runner(baseline, candidate, report):
+            self.reads.append((baseline, candidate, report))
+            verdict = self.verdicts.pop(0)
+            if isinstance(verdict, Exception):
+                raise verdict
+            return verdict
+
+        return runner
+
+
+def _verdict(
+    blocking=(),
+    degraded=False,
+    transcript="**Verification round 1**\n- `claude` (verify): 0 blocking, 0 advisory",
+):
+    from autoresearch.panel import PanelVerdict
+
+    return PanelVerdict(
+        blocking=tuple(blocking), transcript=transcript, wake_text="", degraded=degraded
+    )
+
+
+def _finding(summary="unjustified constant"):
+    from autoresearch.review import Finding
+
+    return Finding(
+        file="src/pilot/solvers/tsp.py",
+        line=1,
+        confidence="high",
+        summary=summary,
+        detail="d",
+        blocking=True,
+    )
+
+
+@dataclass
+class AutoGitHub(FakeGitHub):
+    """An auto-mode PR is disarmed before any push; this fake confirms it."""
+
+    disarmed: list[int] = field(default_factory=list)
+
+    def disable_auto_merge(self, repo, number):
+        self.disarmed.append(number)
+        return True
+
+
+def respond_with_panel(root, github, harness, evaluator, panel):
+    return respond_once(
+        root,
+        "tsp-r1",
+        harness,
+        evaluator,
+        github,
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        panel_lenses=(object(),),
+        panel_builder=panel,
+    )
+
+
+def test_a_clean_reread_under_auto_blesses_the_pushed_head(review_run) -> None:
+    """The consent chain's missing link: after a follow-up pushes a measured
+    code change, the SAME panel reads the new head; clean + merge:auto moves
+    the blessing to exactly that sha, so the tick may arm it once GitHub says
+    the PR is clean. The read is posted on the thread, after the reply."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    github = AutoGitHub(comments=[member(901, "please tweak the kick")])
+    harness = ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2 tweaked\n"})
+    panel = FakePanel(verdicts=[_verdict()])
+    outcome = respond_with_panel(root, github, harness, QueueEvaluator(values=[10.2]), panel)
+    assert outcome.action == "replied"
+    head = _ws_head(root)
+    assert load_record(root, "tsp-r1").auto_blessed_head == head
+    # the reply first (durable before the judges run), then the read
+    assert "Re-measured" in github.posted[0]
+    assert "re-read of the pushed change" in github.posted[1] and head[:12] in github.posted[1]
+    assert "Verification round 1" in github.posted[1]
+    assert "kernel may merge this head" in github.posted[1]
+    # the panel read the pushed tree against the PR's real base, with the
+    # base's contract, under a follow-up claim (not a fresh pre-PR claim)
+    built = panel.built[0]
+    assert built["base"] == _git(run_dir(root, "tsp-r1") / "ws", "rev-parse", "origin/main").strip()
+    assert built["contract"].startswith("benchmarks:") and "merge: auto" not in built["contract"]
+    assert "Follow-up re-measure on open PR #9" in built["claim"]
+    assert "previously measured number: 10.5" in built["claim"]
+    assert panel.reads == [(10.5, 10.2, harness.text)]
+
+
+def test_blocking_or_degraded_rereads_leave_the_merge_to_a_human(review_run) -> None:
+    """Blocking findings are the panel's explicit demand for a human; a
+    degraded read is not a certified pass. Neither blesses; both are named
+    on the thread."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    harness = ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"})
+    panel = FakePanel(
+        verdicts=[
+            _verdict(
+                blocking=(_finding(),),
+                transcript=(
+                    "- `claude` (review): 1 blocking, 0 advisory\n"
+                    "  - **src/pilot/solvers/tsp.py:1** — unjustified constant"
+                ),
+            )
+        ]
+    )
+    respond_with_panel(root, github, harness, QueueEvaluator(values=[10.2]), panel)
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""
+    assert "unjustified constant" in github.posted[1]
+    assert "Not a clean read — a human decides" in github.posted[1]
+
+    github2 = AutoGitHub(comments=[member(902, "again")])
+    panel2 = FakePanel(
+        verdicts=[
+            _verdict(
+                degraded=True,
+                transcript=(
+                    "- `claude` (verify): **no verdict** (timeout) — silence is not endorsement"
+                ),
+            )
+        ]
+    )
+    respond_with_panel(
+        root,
+        github2,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v3\n"}),
+        QueueEvaluator(values=[10.1]),
+        panel2,
+    )
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""
+    assert "silence is not endorsement" in github2.posted[1]
+    assert "human decides" in github2.posted[1]
+
+
+def test_a_clean_reread_never_blesses_under_a_manual_dial(review_run) -> None:
+    """merge:manual is the owner's preference, not doubt: the read is still
+    posted (it is useful review), but nothing is blessed."""
+    root, _bare = review_run  # CONTRACT has no merge key -> manual
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    panel = FakePanel(verdicts=[_verdict()])
+    respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""
+    assert "merges by hand" in github.posted[1]
+
+
+def test_no_reread_without_a_pushed_change_or_without_a_panel(review_run) -> None:
+    """A plain reply spends no judge time; without lenses the change is
+    pushed, the blessing dies, and there is one comment — as before."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    github = AutoGitHub(comments=[member(901, "just explain")])
+    panel = FakePanel(verdicts=[])
+    respond_with_panel(root, github, ResumingHarness(), QueueEvaluator(values=[]), panel)
+    assert panel.built == [] and len(github.posted) == 1
+
+    github2 = AutoGitHub(comments=[member(902, "tweak")])
+    respond(
+        root,
+        github2,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+    )
+    assert len(github2.posted) == 1
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""
+
+
+def test_a_panel_that_cannot_run_is_a_non_read(review_run) -> None:
+    """A judge outage after the push: the reply and the push stand, the
+    thread says the panel did not run, nothing is blessed, and the wake is
+    spent (no repeated push on the next tick)."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    panel = FakePanel(verdicts=[RuntimeError("judge host unreachable sk-x")])
+    outcome = respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    assert outcome.action == "replied"
+    rec = load_record(root, "tsp-r1")
+    assert rec.auto_blessed_head == "" and rec.last_comment_id == 901
+    assert "panel could not run" in github.posted[1] and "sk-x" not in github.posted[1]
+    assert "NOT a clean read" in github.posted[1]
+
+
+def test_a_reread_needs_a_trusted_base(review_run, monkeypatch) -> None:
+    """No pinned base (the fetch failed) means no `base/` for the judges: the
+    read is skipped and said so — never a bless on a base a session could
+    have moved."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    from autoresearch.github import Workspace
+
+    def broken_fetch(self):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(Workspace, "fetch_origin", broken_fetch)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    panel = FakePanel(verdicts=[_verdict()])
+    respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    assert panel.built == []
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""
+    assert "no trusted base" in github.posted[1]
+
+
+def test_a_workspace_that_moves_under_the_judges_is_not_blessed(review_run) -> None:
+    """Judges hold a shell next to the checkout: a HEAD that differs from the
+    pushed sha after the read fails the bless, whatever the verdict said."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    ws = run_dir(root, "tsp-r1") / "ws"
+
+    class MovingPanel(FakePanel):
+        def __call__(self, *a, **kw):
+            runner = super().__call__(*a, **kw)
+
+            def moving(baseline, candidate, report):
+                verdict = runner(baseline, candidate, report)
+                (ws / "src" / "pilot" / "solvers" / "tsp.py").write_text("moved\n")
+                _git(ws, "-c", "user.name=j", "-c", "user.email=j@j", "commit", "-qam", "judge")
+                return verdict
+
+            return moving
+
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    panel = MovingPanel(verdicts=[_verdict()])
+    respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""
+    assert "workspace moved" in github.posted[1]

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2062,3 +2062,60 @@ def test_a_workspace_that_moves_under_the_judges_is_not_blessed(review_run) -> N
     )
     assert load_record(root, "tsp-r1").auto_blessed_head == ""
     assert "workspace moved" in github.posted[1]
+
+
+def test_a_read_that_cannot_fit_the_job_is_posted_as_a_skip(review_run) -> None:
+    """The tick tells the follow-up how many minutes the read got; when the cap
+    ate them the panel is not run, the skip is on the thread (silence is never
+    endorsement), nothing is blessed, and the author's reply stands."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    panel = FakePanel(verdicts=[_verdict()])
+    outcome = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        panel_lenses=(),
+        panel_builder=panel,
+        panel_skip="the job's walltime cap left 10 min for a read that needs 60",
+    )
+    assert outcome.action == "replied"
+    assert panel.built == []
+    assert "panel skipped: the job's walltime cap left 10 min" in github.posted[1]
+    assert "NOT a clean read" in github.posted[1]
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""
+
+
+def test_the_judges_rules_come_from_the_trusted_base_only(review_run, monkeypatch) -> None:
+    """A base whose contract cannot be read is a non-read: the panel never
+    falls back to the workspace copy, which the pushed tree controls."""
+    from autoresearch.github import GitError, Workspace
+
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    real_git = Workspace.git
+
+    def unreadable_base_contract(self, *args):
+        if args and args[0] == "show" and str(args[1]).endswith(":.autoresearch.yaml"):
+            raise GitError("fatal: path '.autoresearch.yaml' does not exist in the base")
+        return real_git(self, *args)
+
+    monkeypatch.setattr(Workspace, "git", unreadable_base_contract)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    panel = FakePanel(verdicts=[_verdict()])
+    respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    assert panel.built == []  # no judges were briefed on a PR-controlled contract
+    assert "panel could not run" in github.posted[1] and "NOT a clean read" in github.posted[1]
+    assert load_record(root, "tsp-r1").auto_blessed_head == ""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3663,3 +3663,98 @@ def test_service_auto_arms_a_clean_panel_backed_auto_pr(tmp_path: Path) -> None:
 
     service_in_review(tmp_path, DraftG(), LocalCompute(), spec, NOW, contract=auto)
     assert G.arms == []
+
+
+def test_author_followups_carry_the_panel_and_its_read_allowance(tmp_path: Path) -> None:
+    """The follow-up re-reads a pushed change with the climb's panel, so the
+    tick threads `--panel` and adds ONE read's walltime to the job (the
+    contract's followup budget caps the author, not the gate). A panel that
+    would die at startup is left off — the reply still goes out — and the
+    steward's follow-up never carries one."""
+    import os
+
+    from autoresearch.compute import CommandResult
+    from autoresearch.panel import panel_read_minutes
+    from autoresearch.runstate import IN_REVIEW, RunRecord, save_record
+    from autoresearch.tick import FollowupSpec, service_in_review
+
+    key = tmp_path / "verifier_key"
+    key.write_text("sk-panel\n")
+    os.chmod(key, 0o600)
+
+    class G:
+        def get_pull_request(self, repo, number):
+            return {"state": "open", "merged": False}
+
+        def list_comments(self, repo, number, max_pages=20):
+            return [
+                {
+                    "id": 9,
+                    "body": "explain",
+                    "user": {"login": "renmengye"},
+                    "author_association": "MEMBER",
+                }
+            ]
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return []
+
+    def run(agent_id: str, panel: str, key_file: str) -> str:
+        root = tmp_path / f"root-{agent_id}-{len(panel)}-{bool(key_file)}"
+        root.mkdir()
+        save_record(
+            root,
+            RunRecord(
+                run_id="r-rev",
+                target="org/pilot",
+                task_title="t",
+                state=IN_REVIEW,
+                pr_url="https://github.com/org/pilot/pull/9",
+                agent_id=agent_id,
+            ),
+            now=NOW,
+        )
+        submits: list[list[str]] = []
+
+        def runner(argv, timeout_s):
+            if argv[0] == "sbatch":
+                submits.append(list(argv))
+                return CommandResult(0, "4242\n", "")
+            if argv[0] == "sacct":
+                return CommandResult(0, "RUNNING\n", "")
+            raise AssertionError(argv)
+
+        spec = FollowupSpec(
+            account="acct",
+            partition="cpu_short",
+            run_root=root,
+            image="/img/a.sif",
+            home=Path("/home/x/autoresearch"),
+            time_minutes=90,
+            panel=panel,
+            panel_key_file=key_file,
+            steward_key_file="/k" if agent_id.startswith("steward") else "",
+        )
+        service_in_review(root, G(), SlurmCompute(runner=runner), spec, NOW)
+        return " ".join(submits[0])
+
+    allowance = panel_read_minutes("verify,review")
+    assert allowance > 0
+    armed = run("agent-01", "verify,review", str(key))
+    assert "--panel verify,review" in armed and f"--panel-key-file {key}" in armed
+    assert f"--time={90 + allowance}" in armed and f"--job-minutes {90 + allowance}" in armed
+
+    # a missing judge key fails the preflight: no panel, plain budget
+    unarmed = run("agent-02", "verify,review", str(tmp_path / "absent"))
+    assert "--panel" not in unarmed and "--time=90" in unarmed and "--job-minutes 90" in unarmed
+
+    # panel off: nothing added
+    off = run("agent-03", "", "")
+    assert "--panel" not in off and "--time=90" in off
+
+    # the steward's PRs are not panel-blessed: never a panel on its follow-up
+    steward = run("steward-01", "verify,review", str(key))
+    assert "--panel" not in steward and "--time=90" in steward

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3702,7 +3702,7 @@ def test_author_followups_carry_the_panel_and_its_read_allowance(tmp_path: Path)
         def list_pr_review_comments(self, repo, number, max_pages=10):
             return []
 
-    def run(agent_id: str, panel: str, key_file: str) -> str:
+    def run(agent_id: str, panel: str, key_file: str, max_job_minutes: int = 600) -> str:
         root = tmp_path / f"root-{agent_id}-{len(panel)}-{bool(key_file)}"
         root.mkdir()
         save_record(
@@ -3736,6 +3736,7 @@ def test_author_followups_carry_the_panel_and_its_read_allowance(tmp_path: Path)
             time_minutes=90,
             panel=panel,
             panel_key_file=key_file,
+            max_job_minutes=max_job_minutes,
             steward_key_file="/k" if agent_id.startswith("steward") else "",
         )
         service_in_review(root, G(), SlurmCompute(runner=runner), spec, NOW)
@@ -3746,6 +3747,13 @@ def test_author_followups_carry_the_panel_and_its_read_allowance(tmp_path: Path)
     armed = run("agent-01", "verify,review", str(key))
     assert "--panel verify,review" in armed and f"--panel-key-file {key}" in armed
     assert f"--time={90 + allowance}" in armed and f"--job-minutes {90 + allowance}" in armed
+    assert f"--panel-minutes {allowance}" in armed  # the read got its full time
+
+    # a partition cap below author+read: the author keeps its 90, the read
+    # gets what fit (10) and the follow-up is told so (it skips, saying why)
+    capped = run("agent-05", "verify,review", str(key), max_job_minutes=100)
+    assert "--time=100" in capped and "--job-minutes 100" in capped
+    assert "--panel-minutes 10" in capped
 
     # a missing judge key fails the preflight: no panel, plain budget
     unarmed = run("agent-02", "verify,review", str(tmp_path / "absent"))


### PR DESCRIPTION
## What

The consent chain's missing link. #228 lets the tick self-merge a PR whose head is exactly the sha a clean, `merge: auto` publish pushed. A follow-up that pushes a re-measured code change kills that blessing — correctly, the panel never saw the new tree — which left every revised PR to a human.

Now the **same panel re-reads the pushed head** inside the follow-up job:

- **Order:** reply posted, record written (cursors advanced, blessing cleared) — *then* the panel runs. Judges take minutes; a responder killed mid-read costs an unarmed PR, never a silent push or a repeated wake.
- **Base:** the merge-base of the pushed head and the kernel-pinned base sha (never a ref name a session can move); the panel's contract text is that base's.
- **Claim:** a *follow-up re-measure on an open PR*, naming the PR's previous number — not a fresh pre-PR improvement claim (`build_panel_runner` grew a `claim_body` seam; default unchanged).
- **Bless** (`auto_blessed_head = pushed sha`) only when: no blocking finding, no degraded lens, the tree's contract says `merge: auto`, and the workspace HEAD still equals the pushed sha after the judges ran (they hold a shell next to the checkout). The tick then arms once GitHub reports the PR clean and up to date — nothing in #228's chain changes.
- **Everything else** is posted on the thread and left to a human: blocking findings (the panel's explicit demand), degraded, manual dial (owner preference, not doubt), no trusted base, moved workspace, panel could not run.
- **Tick:** author follow-ups carry `_climb_panel_argv(spec)` and one read's walltime (`panel_read_minutes`, one owner, also used by the wake allowance); the follow-up session's budget is the job minus that read. Steward follow-ups never carry a panel (their PRs are not blessed). A panel that fails preflight is left off — the reply still goes out.

Not in this PR: the climb's revise loop. A blocking re-read does not wake the author inside the same job; the findings sit on the thread until a maintainer's comment next wakes it. `docs/design/orchestrator-verify.md` names that as the next rung.

## Tests

- `test_followup.py`: clean re-read under auto blesses exactly the pushed head and posts the read after the reply, against the real base with the base's contract and a follow-up claim; blocking and degraded reads leave it to a human (named); clean under manual never blesses; no re-read without a pushed change or without lenses (one comment, as before); a panel that raises is a non-read with the secret redacted and the wake spent; no trusted base → skipped; a workspace that moves under the judges is not blessed.
- `test_tick.py`: author follow-ups carry `--panel`/`--panel-key-file` and `--time`/`--job-minutes` = budget + one read; failed preflight → no panel, plain budget; panel off → nothing added; steward → never.

Full suite 1036 passed; ruff, mypy, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
