### PR TITLE
Wake on a line: the line's memory is never the run's change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,13 +51,9 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- A dispatched wake on a research-lines target no longer reads the line's
-  memory files as out-of-scope deletions: the run's base is the line tip that
-  carries them and the sealed candidate excludes them by design, so the
-  base..candidate diff listed them as the run's change and aborted a run whose
-  paired eval had already finished (live: gpt-speedrun, 11 GPU-hours). The
-  wake now applies the climb's own line-memory rule, and the panel's claim diff
-  excludes those paths too.
+- Dispatched wakes on research lines no longer read the line's memory files
+  as out-of-scope deletions (the run's base is the line tip that carries them;
+  the sealed candidate excludes them); the panel's claim diff omits them too.
 - GPU-hours for an author's launches are charged at the declared walltime when dispatched and reconciled when the wake gathers them: unused walltime is refunded (a sweep that dies in its first minutes no longer costs its full declared hours).
 - An author that concludes after an errored gate eval ends the attempt on that error; only a resubmit runs the eval again.
 - A tree the gate already turned down in this attempt is never measured again: when the woken author concludes (or resubmits untouched), that verdict stands and the attempt ends on it — no second eval pair, no GPU-hours. An errored eval is still retried.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Versions follow [SemVer](https://semver.org).
   paired eval had already finished (live: gpt-speedrun, 11 GPU-hours). The
   wake now applies the climb's own line-memory rule, and the panel's claim diff
   excludes those paths too.
+- GPU-hours for an author's launches are charged at the declared walltime when dispatched and reconciled when the wake gathers them: unused walltime is refunded (a sweep that dies in its first minutes no longer costs its full declared hours).
 - An author that concludes after an errored gate eval ends the attempt on that error; only a resubmit runs the eval again.
 - A tree the gate already turned down in this attempt is never measured again: when the woken author concludes (or resubmits untouched), that verdict stands and the attempt ends on it — no second eval pair, no GPU-hours. An errored eval is still retried.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- GPU-hours for an author's launches are charged at the declared walltime when dispatched and reconciled when the wake gathers them: unused walltime is refunded (a sweep that dies in its first minutes no longer costs its full declared hours).
+- A dispatched wake on a research-lines target no longer reads the line's
+  memory files as out-of-scope deletions: the run's base is the line tip that
+  carries them and the sealed candidate excludes them by design, so the
+  base..candidate diff listed them as the run's change and aborted a run whose
+  paired eval had already finished (live: gpt-speedrun, 11 GPU-hours). The
+  wake now applies the climb's own line-memory rule, and the panel's claim diff
+  excludes those paths too.
 - An author that concludes after an errored gate eval ends the attempt on that error; only a resubmit runs the eval again.
 - A tree the gate already turned down in this attempt is never measured again: when the woken author concludes (or resubmits untouched), that verdict stands and the attempt ends on it — no second eval pair, no GPU-hours. An errored eval is still retried.
 

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -18,7 +18,7 @@ import logging
 import os
 import re
 import shutil
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from dataclasses import replace as dc_replace
 from functools import partial
@@ -796,9 +796,7 @@ def _wake_author_sleep(
         ws.git("add", "-A")
         paths = ws.staged_paths()
         ws.git("reset")
-        if wake_line:
-            paths = [p for p in paths if not _is_line_memory(p)]
-        return paths
+        return _without_line_memory(paths, wake_line)
 
     panel_runner = (
         build_panel_runner(
@@ -1061,6 +1059,16 @@ LINE_MEMORY_PATHS = ("AGENT_MEMORY.md", "agent_memory")
 
 def _is_line_memory(path: str) -> bool:
     return path in LINE_MEMORY_PATHS or path.startswith("agent_memory/")
+
+
+def _without_line_memory(paths: Iterable[str], line: str) -> list[str]:
+    """The run's OWN changes: with a line active, its memory paths are dropped.
+    Every sealed tree excludes them by construction, and the run's base is the
+    line tip that carries them — so a base..candidate diff lists them as
+    deletions that are not the run's change (live: a dispatched wake on
+    gpt-speedrun read eight memory files as out of scope and aborted a run
+    whose paired eval had already finished)."""
+    return [p for p in paths if not (line and _is_line_memory(p))]
 
 
 def _line_ref_for(bench: Benchmark | None, agent_id: str) -> str:
@@ -1327,9 +1335,18 @@ def resume_run(
     # measured_paths from the COMMITTED base..candidate diff — the sealed
     # candidate, never `changed_paths()` on a live tree that may have drifted.
     # NUL-delimited (like Workspace.staged_paths) so a path with a space is one
-    # entry, not two that could each slip past the scope check.
+    # entry, not two that could each slip past the scope check. The same
+    # line-memory rule as the climb's changed_paths(): the base is the line
+    # tip, the seal excluded the memory, the diff must not read it as a change.
     measured_paths = tuple(
-        p for p in ws.git("diff", "--name-only", "-z", base_sha, candidate_sha).split("\0") if p
+        _without_line_memory(
+            (
+                p
+                for p in ws.git("diff", "--name-only", "-z", base_sha, candidate_sha).split("\0")
+                if p
+            ),
+            _line_ref_for(bench, config.agent_id),
+        )
     )
     seed = int(stage["seed"])  # type: ignore[call-overload]
     suite_seed = int(stage["suite_seed"])  # type: ignore[call-overload]
@@ -2091,8 +2108,15 @@ def build_panel_runner(
                 title=f"[agent] {benchmark}: {_title_pair(baseline, candidate)}",
                 body=_panel_claim_body(benchmark, baseline, candidate, report, lines=bool(exclude)),
                 # base..snapshot, never base..worktree: the snapshot commit
-                # includes newly ADDED files, which a working-tree diff omits
-                diff=ws.git("diff", f"{base_sha}..{snapshot}"),
+                # includes newly ADDED files, which a working-tree diff omits.
+                # Excluded (line-memory) paths are excluded from the diff too:
+                # the snapshot dropped them, so against a line-tip base they
+                # would read as deletions the author never made
+                diff=ws.git(
+                    "diff",
+                    f"{base_sha}..{snapshot}",
+                    *(["--", ".", *(f":(exclude){p}" for p in exclude)] if exclude else []),
+                ),
                 author=bot_login,
             )
             return run_panel(lenses, panel_ws, claim, contract_text, today, reads["n"])

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4201,3 +4201,140 @@ def test_wake_re_establishes_the_merge_artifact_exclude(tmp_path, monkeypatch) -
         now=1_000_100.0,
     )
     assert "*.orig" in exclude.read_text()  # re-established on the wake
+
+
+# --- a line's memory is never the run's change (live incident 2026-09-02:
+# a dispatched wake on a lines target read the line tip's memory files as
+# out-of-scope deletions and aborted a run whose paired eval had finished)
+
+CONTRACT_LINES_DISPATCH = CONTRACT.replace(
+    "    direction: min\n", "    direction: min\n    lines: true\n    eval_minutes: 30\n"
+)
+
+
+def _write_parked_line_candidate(tmp_path, monkeypatch, *, values, run_id="tsp-line-1"):
+    """Like _write_parked_candidate, but the run's base is a LINE TIP that
+    carries memory files, and the candidate was sealed with the line-memory
+    exclude — exactly the park a lines run reaches."""
+    from autoresearch.attempt import LINE_MEMORY_PATHS
+    from autoresearch.dispatch import snapshot_tree
+    from autoresearch.github import Workspace
+    from autoresearch.measure import DispatchSettings
+
+    state = tmp_path / "state"
+    wsroot = state / "runs" / run_id / "ws"
+    (wsroot / "src" / "pilot" / "solvers").mkdir(parents=True)
+    (wsroot / "agent_memory").mkdir()
+    (wsroot / ".autoresearch.yaml").write_text(CONTRACT_LINES_DISPATCH)
+    (wsroot / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): ...\n")
+    (wsroot / "AGENT_MEMORY.md").write_text("# memory\n- [warmdown](agent_memory/warmdown.md)\n")
+    (wsroot / "agent_memory" / "warmdown.md").write_text("longer warmdown helped\n")
+    _git(wsroot, "init", "-q", "-b", "main")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "line tip")
+    base_sha = _git(wsroot, "rev-parse", "HEAD").strip()
+    (wsroot / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): return 'better'\n")
+    ws = Workspace(root=wsroot)
+    snap = snapshot_tree(ws, base_sha, exclude=LINE_MEMORY_PATHS)
+    # the seal really dropped the memory: the base..candidate diff lists it as deleted
+    assert "AGENT_MEMORY.md" in _git(wsroot, "diff", "--name-only", base_sha, snap.commit)
+    bare = tmp_path / f"origin-{run_id}.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(wsroot), str(bare))
+    _git(wsroot, "remote", "add", "origin", str(bare))
+    _git(wsroot, "branch", "agents/agent-02", base_sha)
+    record = RunRecord(
+        run_id=run_id,
+        target="org/pilot",
+        task_title="improve tsp",
+        benchmark="tsp",
+        state="waiting",
+        resume_session_id="s1",
+        agent_id="agent-02",
+        stage={
+            "phase": "candidate",
+            "base_sha": base_sha,
+            "candidate_sha": snap.commit,
+            "candidate_ref": snap.ref,
+            "seed": 7,
+            "suite_seed": 9,
+            "afterany": "afterany:501",
+            "report": "longer warmdown",
+            "base_branch": "main",
+        },
+    )
+    save_record(state, record, 1_000_000.0)
+    fake = _FakeMeasurer(values=values)
+    monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: fake)
+    monkeypatch.setattr("autoresearch.attempt._target_clone_url", lambda target: str(bare))
+    return state, run_id
+
+
+def test_wake_on_a_line_never_reads_the_lines_memory_as_out_of_scope(tmp_path, monkeypatch):
+    """The base is the line tip (memory on it), the sealed candidate excludes
+    the memory: the wake's measured paths are the run's OWN change only, so
+    the gate decides on the numbers instead of aborting on phantom deletions."""
+    state, run_id = _write_parked_line_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),
+        now=1_000_100.0,
+    )
+    assert outcome.outcome == "no-improvement", outcome
+    record = load_record(state, run_id)
+    assert record.ending == "negative-result" and "out-of-scope" not in record.ending_note
+
+
+def test_without_line_memory_drops_memory_only_when_a_line_is_active() -> None:
+    from autoresearch.attempt import _without_line_memory
+
+    paths = ["AGENT_MEMORY.md", "agent_memory/x.md", "train.py", "agent_memory"]
+    assert _without_line_memory(paths, "agents/agent-02") == ["train.py"]
+    assert _without_line_memory(paths, "") == paths  # no line: nothing is special
+
+
+def test_panel_claim_diff_excludes_the_lines_memory(tmp_path, monkeypatch) -> None:
+    """Judges read the claim's diff: against a line-tip base it must not show
+    the memory the seal dropped as deletions the author never made."""
+    from autoresearch.attempt import LINE_MEMORY_PATHS, build_panel_runner
+    from autoresearch.github import Workspace
+    from autoresearch.panel import PanelVerdict
+
+    wsroot = tmp_path / "ws"
+    (wsroot / "agent_memory").mkdir(parents=True)
+    (wsroot / ".autoresearch.yaml").write_text(CONTRACT_LINES_DISPATCH)
+    (wsroot / "train.py").write_text("v1\n")
+    (wsroot / "AGENT_MEMORY.md").write_text("# memory\n")
+    (wsroot / "agent_memory" / "a.md").write_text("note\n")
+    _git(wsroot, "init", "-q", "-b", "main")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "line tip")
+    base_sha = _git(wsroot, "rev-parse", "HEAD").strip()
+    (wsroot / "train.py").write_text("v2\n")
+    seen: dict = {}
+
+    def fake_run_panel(lenses, panel_ws, claim, contract_text, today, round_no):
+        seen["diff"] = claim.diff
+        return PanelVerdict(blocking=(), transcript="ok", wake_text="")
+
+    monkeypatch.setattr("autoresearch.attempt.run_panel", fake_run_panel)
+    monkeypatch.setattr("autoresearch.review_agent.sanitize_checkout", lambda p: (0, 0))
+    runner = build_panel_runner(
+        Workspace(root=wsroot),
+        tmp_path / "run",
+        base_sha,
+        (object(),),  # type: ignore[arg-type]
+        CONTRACT_LINES_DISPATCH,
+        "org/pilot",
+        "tsp",
+        "bot",
+        "2026-09-02",
+        exclude=LINE_MEMORY_PATHS,
+    )
+    runner(13.0, 12.0, "report")
+    assert "train.py" in seen["diff"]
+    assert "AGENT_MEMORY" not in seen["diff"] and "agent_memory" not in seen["diff"]


### PR DESCRIPTION
## Incident

`speedrun-20260902-084609-agent-02` (gpt-speedrun, codex author) launched three experiments, submitted `warmdown3072`, and parked on a dispatched paired eval. When the eval pair finished (~3.5 h), the wake aborted the run:

```
out-of-scope paths: AGENT_MEMORY.md, agent_memory/adamw_beta2_098.md, agent_memory/attention_residual_scale.md, ...
```

11.4 GPU-hours spent; the numbers were in the eval dirs (base 9088 → candidate 8832; main is already 8640, so no win was lost — but the run should have ended as an honest negative, not an abort).

## Cause

On a research-lines target the run's `base_sha` is the **line tip**, which carries the memory files (8 of them on agent-02's line). Every sealed candidate excludes those paths by design (`snapshot_tree(..., exclude=LINE_MEMORY_PATHS)`). The climb's own `changed_paths()` filters `_is_line_memory` — but `resume_run` took `measured_paths` straight from `git diff base_sha candidate_sha`, where the memory shows up as **deletions**, and the gate's scope check flagged them. Verified on Torch: `git diff --name-status <line tip> <candidate>` = 8 × `D agent_memory/...` + `M train.py`.

This was the first dispatched candidate wake on a line that already carried memory. Every agent's line carries memory now, so **every dispatched wake on gpt-speedrun would hit it** after burning its paired eval.

## Fix

- `_without_line_memory(paths, line)` — one owner for "a line's memory is never the run's change"; used by both `changed_paths()` closures and by `resume_run`'s `measured_paths`.
- `build_panel_runner`: the claim diff excludes the same paths (`-- . :(exclude)AGENT_MEMORY.md :(exclude)agent_memory`) so judges never read eight phantom deletions against a line-tip base.

## Tests

- A parked lines run whose base is a line tip with memory files and whose candidate was sealed with the exclude: the wake decides on the numbers (`no-improvement`), never `scope-violation`.
- `_without_line_memory` drops memory only when a line is active.
- The panel's claim diff shows the code change and no memory path.

CHANGELOG under Fixed. `test_attempt.py` 129 passed; ruff, mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
