### PR TITLE
Tick chain sweeps stale git locks before each deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,10 +58,8 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- The tick chain sweeps stale `.git/*.lock` files (older than ten minutes,
-  no live git process) from its checkout before each deploy, so a tick killed
-  mid-fetch no longer freezes deploys on old code until someone clears the
-  lock by hand (`scripts/sweep_git_locks.sh`).
+- Before each deploy, the tick job removes git lock files older than ten
+  minutes when no git process is working in the checkout.
 - Dispatched wakes on research lines no longer read the line's memory files
   as out-of-scope deletions (the run's base is the line tip that carries them;
   the sealed candidate excludes them); the panel's claim diff omits them too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- The tick chain sweeps stale `.git/*.lock` files (older than ten minutes,
+  no live git process) from its checkout before each deploy, so a tick killed
+  mid-fetch no longer freezes deploys on old code until someone clears the
+  lock by hand (`scripts/sweep_git_locks.sh`).
 - Dispatched wakes on research lines no longer read the line's memory files
   as out-of-scope deletions (the run's base is the line tip that carries them;
   the sealed candidate excludes them); the panel's claim diff omits them too.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,6 @@ Operational scripts, always committed.
 | Script | Purpose |
 | --- | --- |
 | `setup_branch_protection.sh` | Apply/refresh branch protection on `main`. Solo-phase default: 0 approvals, checks required, admins enforced. Re-run with `1` once a second code owner joins. |
-
-Planned (docs/roadmap.md): the Torch tick job (`scrontab` entry + self-resubmitting
-fallback) and the orchestrator launcher.
+| `tick_chain.sbatch` | The self-resubmitting Slurm tick: deploys `main` into its checkout, syncs deps, runs one tick, schedules the next (`docs/cluster.md`). |
+| `sweep_git_locks.sh` | Remove stale `.git/*.lock` files from a checkout (older than N minutes, no live git process); the chain runs it before each deploy. |
+| `install_codex.sh`, `install_hermes.sh` | Pin and install the non-claude author/judge backends on the tick host. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,6 +5,6 @@ Operational scripts, always committed.
 | Script | Purpose |
 | --- | --- |
 | `setup_branch_protection.sh` | Apply/refresh branch protection on `main`. Solo-phase default: 0 approvals, checks required, admins enforced. Re-run with `1` once a second code owner joins. |
-| `tick_chain.sbatch` | The self-resubmitting Slurm tick: deploys `main` into its checkout, syncs deps, runs one tick, schedules the next (`docs/cluster.md`). |
+| `tick_chain.sbatch` | The self-resubmitting Slurm tick: deploys `main` into its checkout, syncs deps, runs one tick, schedules the next (`docs/design/architecture.md`). |
 | `sweep_git_locks.sh` | Remove stale `.git/*.lock` files from a checkout (older than N minutes, no live git process); the chain runs it before each deploy. |
 | `install_codex.sh`, `install_hermes.sh` | Pin and install the non-claude author/judge backends on the tick host. |

--- a/scripts/sweep_git_locks.sh
+++ b/scripts/sweep_git_locks.sh
@@ -60,13 +60,15 @@ live_git() {
         done <<EOF_WT
 $worktrees
 EOF_WT
-        # a RELATIVE -C / --git-dir / --work-tree naming the checkout by its
-        # basename (started from the parent directory): matched by name,
-        # conservatively — over-matching only delays the sweep a cadence
+        # a RELATIVE path naming the checkout by its basename (a git started
+        # from the parent directory), whatever option carries it — -C,
+        # --git-dir, --work-tree, split or '=' form: any argument token that
+        # is the bare name, ./-prefixed, or a path component before a '/'.
+        # Matched by name, conservatively — over-matching only delays the
+        # sweep a cadence; a sibling named with this one as a PREFIX does
+        # not match (the token must end at a space or a '/')
         case " $args " in
-            *" -C $base "*|*" -C ./$base "*|*" -C $base/"*|*" -C ./$base/"*) return 0 ;;
-            *"--git-dir=$base/"*|*"--git-dir=./$base/"*) return 0 ;;
-            *"--work-tree=$base"*|*"--work-tree=./$base"*) return 0 ;;
+            *" $base "*|*" $base/"*|*"=$base "*|*"=$base/"*|*"/$base "*|*"/$base/"*) return 0 ;;
         esac
         if [ -d /proc ]; then
             cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null) || continue

--- a/scripts/sweep_git_locks.sh
+++ b/scripts/sweep_git_locks.sh
@@ -25,10 +25,15 @@ uid=$(id -u)
 # locks in the shared dir too, and must count as live for this sweep
 worktrees=$(git -C "$checkout" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
 [ -n "$worktrees" ] || worktrees="$checkout"
-# find truncates ages to whole minutes, so "+N" would skip a lock N minutes
-# and 30 seconds old; "+N-1" selects everything at least N minutes old
-[ "$min_age" -ge 1 ] 2>/dev/null || min_age=1
-age_arg=$((min_age - 1))
+# ages are compared exactly, in seconds: find's -mmin truncates on GNU and
+# rounds UP on BSD, so neither says "at least N minutes old" the same way
+[ "$min_age" -ge 0 ] 2>/dev/null || min_age=10
+min_age_s=$((min_age * 60))
+now=$(date +%s)
+
+mtime_of() {
+    stat -c %Y -- "$1" 2>/dev/null || stat -f %m -- "$1" 2>/dev/null || echo "$now"
+}
 
 live_git() {
     # only REAL git processes of ours (comm == git — never this bash script,
@@ -63,8 +68,10 @@ if live_git; then
 fi
 for dir in "$gitdir" "$common"; do
     [ -d "$dir" ] || continue
-    find "$dir" -type f -name '*.lock' -mmin "+$age_arg" 2>/dev/null
+    find "$dir" -type f -name '*.lock' 2>/dev/null
 done | sort -u | while IFS= read -r lock; do
+    age=$(( now - $(mtime_of "$lock") ))
+    [ "$age" -ge "$min_age_s" ] || continue
     rm -f -- "$lock" && echo "deploy: swept stale git lock $lock"
 done
 exit 0

--- a/scripts/sweep_git_locks.sh
+++ b/scripts/sweep_git_locks.sh
@@ -21,6 +21,14 @@ gitdir=$(git -C "$checkout" rev-parse --absolute-git-dir 2>/dev/null) || exit 0
 common=$(git -C "$checkout" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "$gitdir")
 [ -d "$gitdir" ] || exit 0
 uid=$(id -u)
+# every worktree sharing $common: a git working in a SIBLING worktree holds
+# locks in the shared dir too, and must count as live for this sweep
+worktrees=$(git -C "$checkout" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
+[ -n "$worktrees" ] || worktrees="$checkout"
+# find truncates ages to whole minutes, so "+N" would skip a lock N minutes
+# and 30 seconds old; "+N-1" selects everything at least N minutes old
+[ "$min_age" -ge 1 ] 2>/dev/null || min_age=1
+age_arg=$((min_age - 1))
 
 live_git() {
     # only REAL git processes of ours (comm == git — never this bash script,
@@ -30,7 +38,10 @@ live_git() {
     # reason enough to wait a cadence
     for pid in $(pgrep -u "$uid" -x git 2>/dev/null); do
         args=$(ps -o args= -p "$pid" 2>/dev/null || echo "")
-        case "$args" in *"$checkout"*|*"$gitdir"*|*"$common"*) return 0 ;; esac
+        case "$args" in *"$gitdir"*|*"$common"*) return 0 ;; esac
+        for wt in $worktrees; do
+            case "$args" in *"$wt"*) return 0 ;; esac
+        done
         if [ -d /proc ]; then
             cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null) || continue
         elif command -v lsof >/dev/null 2>&1; then
@@ -39,7 +50,10 @@ live_git() {
         else
             return 0
         fi
-        case "$cwd" in "$checkout"|"$checkout"/*|"$common"|"$common"/*) return 0 ;; esac
+        case "$cwd" in "$common"|"$common"/*) return 0 ;; esac
+        for wt in $worktrees; do
+            case "$cwd" in "$wt"|"$wt"/*) return 0 ;; esac
+        done
     done
     return 1
 }
@@ -49,7 +63,7 @@ if live_git; then
 fi
 for dir in "$gitdir" "$common"; do
     [ -d "$dir" ] || continue
-    find "$dir" -type f -name '*.lock' -mmin "+$min_age" 2>/dev/null
+    find "$dir" -type f -name '*.lock' -mmin "+$age_arg" 2>/dev/null
 done | sort -u | while IFS= read -r lock; do
     rm -f -- "$lock" && echo "deploy: swept stale git lock $lock"
 done

--- a/scripts/sweep_git_locks.sh
+++ b/scripts/sweep_git_locks.sh
@@ -23,14 +23,14 @@ common=$(git -C "$checkout" rev-parse --path-format=absolute --git-common-dir 2>
 uid=$(id -u)
 
 live_git() {
-    # a git of ours that NAMES this checkout or its git dir on its command line
-    if pgrep -u "$uid" -f -- "git.*($checkout|$gitdir|$common)" >/dev/null 2>&1; then
-        return 0
-    fi
-    # a git of ours started AFTER cd into the checkout names nothing: read its
-    # cwd (/proc on Linux, lsof elsewhere); with neither, any git of ours is
+    # only REAL git processes of ours (comm == git — never this bash script,
+    # whose own argv names the checkout): live when one names the checkout
+    # or its git dir on its command line, or works inside it (cwd via /proc
+    # on Linux, lsof elsewhere); with no cwd source, any git of ours is
     # reason enough to wait a cadence
     for pid in $(pgrep -u "$uid" -x git 2>/dev/null); do
+        args=$(ps -o args= -p "$pid" 2>/dev/null || echo "")
+        case "$args" in *"$checkout"*|*"$gitdir"*|*"$common"*) return 0 ;; esac
         if [ -d /proc ]; then
             cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null) || continue
         elif command -v lsof >/dev/null 2>&1; then

--- a/scripts/sweep_git_locks.sh
+++ b/scripts/sweep_git_locks.sh
@@ -6,20 +6,51 @@
 # File exists" — the chain keeps running OLD code until someone clears them by
 # hand (twice on Torch, 2026-09-01). A lock is stale when it is older than
 # MIN_AGE_MINUTES (default 10 — a live git op holds one for seconds) AND no
-# git process is running against the checkout. Only *.lock files are touched;
-# git recreates them as needed. Every removed path is printed.
+# git process of ours is working in the checkout. Only *.lock files are
+# touched, at any depth (slash-named branches nest their ref locks); git
+# recreates them as needed. Linked worktrees are followed to their real git
+# dir. Every removed path is printed. Never fails the caller.
 #
 # usage: sweep_git_locks.sh <checkout> [min-age-minutes]
 set -u
 checkout="${1:?usage: sweep_git_locks.sh <checkout> [min-age-minutes]}"
 min_age="${2:-10}"
-gitdir="$checkout/.git"
+# resolve the git dir through git itself (a linked worktree's .git is a FILE
+# naming it); rev-parse takes no locks, so stale ones cannot block this
+gitdir=$(git -C "$checkout" rev-parse --absolute-git-dir 2>/dev/null) || exit 0
+common=$(git -C "$checkout" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || echo "$gitdir")
 [ -d "$gitdir" ] || exit 0
-# a live git process on this checkout owns its locks — never race it
-if pgrep -f "git -C $checkout" >/dev/null 2>&1 || pgrep -f "git.*--git-dir=$gitdir" >/dev/null 2>&1; then
+uid=$(id -u)
+
+live_git() {
+    # a git of ours that NAMES this checkout or its git dir on its command line
+    if pgrep -u "$uid" -f -- "git.*($checkout|$gitdir|$common)" >/dev/null 2>&1; then
+        return 0
+    fi
+    # a git of ours started AFTER cd into the checkout names nothing: read its
+    # cwd (/proc on Linux, lsof elsewhere); with neither, any git of ours is
+    # reason enough to wait a cadence
+    for pid in $(pgrep -u "$uid" -x git 2>/dev/null); do
+        if [ -d /proc ]; then
+            cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null) || continue
+        elif command -v lsof >/dev/null 2>&1; then
+            cwd=$(lsof -a -p "$pid" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p' | head -1)
+            [ -n "$cwd" ] || return 0
+        else
+            return 0
+        fi
+        case "$cwd" in "$checkout"|"$checkout"/*|"$common"|"$common"/*) return 0 ;; esac
+    done
+    return 1
+}
+
+if live_git; then
     exit 0
 fi
-find "$gitdir" -maxdepth 4 -type f -name '*.lock' -mmin "+$min_age" 2>/dev/null | while IFS= read -r lock; do
+for dir in "$gitdir" "$common"; do
+    [ -d "$dir" ] || continue
+    find "$dir" -type f -name '*.lock' -mmin "+$min_age" 2>/dev/null
+done | sort -u | while IFS= read -r lock; do
     rm -f -- "$lock" && echo "deploy: swept stale git lock $lock"
 done
 exit 0

--- a/scripts/sweep_git_locks.sh
+++ b/scripts/sweep_git_locks.sh
@@ -25,6 +25,7 @@ uid=$(id -u)
 # locks in the shared dir too, and must count as live for this sweep
 worktrees=$(git -C "$checkout" worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
 [ -n "$worktrees" ] || worktrees="$checkout"
+base=$(basename "$checkout")
 # ages are compared exactly, in seconds: find's -mmin truncates on GNU and
 # rounds UP on BSD, so neither says "at least N minutes old" the same way
 [ "$min_age" -ge 0 ] 2>/dev/null || min_age=10
@@ -47,6 +48,14 @@ live_git() {
         for wt in $worktrees; do
             case "$args" in *"$wt"*) return 0 ;; esac
         done
+        # a RELATIVE -C / --git-dir / --work-tree naming the checkout by its
+        # basename (started from the parent directory): matched by name,
+        # conservatively — over-matching only delays the sweep a cadence
+        case " $args " in
+            *" -C $base "*|*" -C ./$base "*|*" -C $base/"*|*" -C ./$base/"*) return 0 ;;
+            *"--git-dir=$base/"*|*"--git-dir=./$base/"*) return 0 ;;
+            *"--work-tree=$base"*|*"--work-tree=./$base"*) return 0 ;;
+        esac
         if [ -d /proc ]; then
             cwd=$(readlink "/proc/$pid/cwd" 2>/dev/null) || continue
         elif command -v lsof >/dev/null 2>&1; then

--- a/scripts/sweep_git_locks.sh
+++ b/scripts/sweep_git_locks.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Remove STALE git lock files from a checkout before the tick deploys into it.
+#
+# A tick job killed mid-fetch (walltime, node death) leaves .git/*.lock files
+# behind, and every later deploy then fails with "Unable to create ...lock:
+# File exists" — the chain keeps running OLD code until someone clears them by
+# hand (twice on Torch, 2026-09-01). A lock is stale when it is older than
+# MIN_AGE_MINUTES (default 10 — a live git op holds one for seconds) AND no
+# git process is running against the checkout. Only *.lock files are touched;
+# git recreates them as needed. Every removed path is printed.
+#
+# usage: sweep_git_locks.sh <checkout> [min-age-minutes]
+set -u
+checkout="${1:?usage: sweep_git_locks.sh <checkout> [min-age-minutes]}"
+min_age="${2:-10}"
+gitdir="$checkout/.git"
+[ -d "$gitdir" ] || exit 0
+# a live git process on this checkout owns its locks — never race it
+if pgrep -f "git -C $checkout" >/dev/null 2>&1 || pgrep -f "git.*--git-dir=$gitdir" >/dev/null 2>&1; then
+    exit 0
+fi
+find "$gitdir" -maxdepth 4 -type f -name '*.lock' -mmin "+$min_age" 2>/dev/null | while IFS= read -r lock; do
+    rm -f -- "$lock" && echo "deploy: swept stale git lock $lock"
+done
+exit 0

--- a/scripts/sweep_git_locks.sh
+++ b/scripts/sweep_git_locks.sh
@@ -44,10 +44,22 @@ live_git() {
     # reason enough to wait a cadence
     for pid in $(pgrep -u "$uid" -x git 2>/dev/null); do
         args=$(ps -o args= -p "$pid" 2>/dev/null || echo "")
-        case "$args" in *"$gitdir"*|*"$common"*) return 0 ;; esac
-        for wt in $worktrees; do
-            case "$args" in *"$wt"*) return 0 ;; esac
-        done
+        # paths match at argument boundaries (space or '=' before, space or
+        # '/' after) so a sibling checkout named with this one as a prefix
+        # never counts; worktree paths are read one per line (spaces inside
+        # a path survive)
+        case " $args " in
+            *" $gitdir "*|*" $gitdir/"*|*"=$gitdir "*|*"=$gitdir/"*) return 0 ;;
+            *" $common "*|*" $common/"*|*"=$common "*|*"=$common/"*) return 0 ;;
+        esac
+        while IFS= read -r wt; do
+            [ -n "$wt" ] || continue
+            case " $args " in
+                *" $wt "*|*" $wt/"*|*"=$wt "*|*"=$wt/"*) return 0 ;;
+            esac
+        done <<EOF_WT
+$worktrees
+EOF_WT
         # a RELATIVE -C / --git-dir / --work-tree naming the checkout by its
         # basename (started from the parent directory): matched by name,
         # conservatively — over-matching only delays the sweep a cadence
@@ -65,9 +77,12 @@ live_git() {
             return 0
         fi
         case "$cwd" in "$common"|"$common"/*) return 0 ;; esac
-        for wt in $worktrees; do
+        while IFS= read -r wt; do
+            [ -n "$wt" ] || continue
             case "$cwd" in "$wt"|"$wt"/*) return 0 ;; esac
-        done
+        done <<EOF_WT
+$worktrees
+EOF_WT
     done
     return 1
 }

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -82,6 +82,10 @@ fi
 echo "=== tick $(date -Is) on $(hostname -s) job=${SLURM_JOB_ID:-none}"
 
 # --- 2. deploy: pull main with the bot PAT, sync deps (best-effort) ---
+# A tick killed mid-fetch leaves .git/*.lock files that make every later
+# deploy fail and the chain run stale code; sweep locks older than a few
+# minutes (a live git op holds one for seconds) before touching the checkout.
+bash "$AUTORESEARCH_HOME/scripts/sweep_git_locks.sh" "$AUTORESEARCH_HOME" 10 || true
 # The PAT never appears in argv (argv is world-readable via /proc on shared
 # nodes): git asks for it through GIT_ASKPASS instead.
 if [ -n "${AUTORESEARCH_PAT_FILE:-}" ] && [ -r "$AUTORESEARCH_PAT_FILE" ]; then

--- a/tests/test_sweep_git_locks.py
+++ b/tests/test_sweep_git_locks.py
@@ -1,0 +1,59 @@
+"""The tick chain's pre-deploy lock sweep: stale locks go, fresh ones stay."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "sweep_git_locks.sh"
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "checkout"
+    repo.mkdir()
+    subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], check=True)
+    return repo
+
+
+def _sweep(repo: Path, min_age: str = "10") -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), str(repo), min_age], check=True, capture_output=True, text=True
+    )
+
+
+def test_stale_locks_are_swept_and_named(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    old = time.time() - 3600
+    stale = [repo / ".git" / "index.lock", repo / ".git" / "refs" / "heads" / "main.lock"]
+    for lock in stale:
+        lock.parent.mkdir(parents=True, exist_ok=True)
+        lock.write_text("")
+        os.utime(lock, (old, old))
+    out = _sweep(repo)
+    assert not any(lock.exists() for lock in stale)
+    for lock in stale:
+        assert f"swept stale git lock {lock}" in out.stdout
+
+
+def test_a_fresh_lock_is_left_alone(tmp_path: Path) -> None:
+    """A live git op holds its lock for seconds — never race it."""
+    repo = _repo(tmp_path)
+    fresh = repo / ".git" / "HEAD.lock"
+    fresh.write_text("")
+    out = _sweep(repo)
+    assert fresh.exists() and out.stdout == ""
+
+
+def test_only_lock_files_are_touched_and_no_git_dir_is_a_no_op(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    old = time.time() - 3600
+    keep = repo / ".git" / "FETCH_HEAD"
+    keep.write_text("abc")
+    os.utime(keep, (old, old))
+    _sweep(repo)
+    assert keep.read_text() == "abc"
+    plain = tmp_path / "not-a-checkout"
+    plain.mkdir()
+    assert _sweep(plain).returncode == 0

--- a/tests/test_sweep_git_locks.py
+++ b/tests/test_sweep_git_locks.py
@@ -70,10 +70,13 @@ def test_an_aged_lock_under_a_live_git_process_is_left_alone(tmp_path: Path) -> 
     reads stdin until we close it; swept once it is gone."""
     repo = _repo(tmp_path)
     lock = _aged_lock(repo / ".git" / "index.lock")
+    # the RELATIVE form, started from the parent: argv names the checkout by
+    # basename only and cwd is outside it (terra #231 r4)
     proc = subprocess.Popen(
-        ["git", "-C", str(repo), "hash-object", "--stdin"],
+        ["git", "-C", repo.name, "hash-object", "--stdin"],
         stdin=subprocess.PIPE,
         stdout=subprocess.DEVNULL,
+        cwd=tmp_path,
     )
     try:
         time.sleep(0.3)

--- a/tests/test_sweep_git_locks.py
+++ b/tests/test_sweep_git_locks.py
@@ -1,4 +1,4 @@
-"""The tick chain's pre-deploy lock sweep: stale locks go, fresh ones stay."""
+"""The tick chain's pre-deploy lock sweep: stale locks go, fresh or live ones stay."""
 
 from __future__ import annotations
 
@@ -8,29 +8,47 @@ import time
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "sweep_git_locks.sh"
+HOUR_AGO = time.time() - 3600
 
 
-def _repo(tmp_path: Path) -> Path:
-    repo = tmp_path / "checkout"
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _repo(tmp_path: Path, name: str = "checkout") -> Path:
+    repo = tmp_path / name
     repo.mkdir()
-    subprocess.run(["git", "-C", str(repo), "init", "-q", "-b", "main"], check=True)
+    _git(repo, "init", "-q", "-b", "main")
+    (repo / "f").write_text("x\n")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(repo, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "seed")
     return repo
 
 
-def _sweep(repo: Path, min_age: str = "10") -> subprocess.CompletedProcess[str]:
+def _aged_lock(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("")
+    os.utime(path, (HOUR_AGO, HOUR_AGO))
+    return path
+
+
+def _sweep(checkout: Path, min_age: str = "10") -> subprocess.CompletedProcess[str]:
     return subprocess.run(
-        ["bash", str(SCRIPT), str(repo), min_age], check=True, capture_output=True, text=True
+        ["bash", str(SCRIPT), str(checkout), min_age], check=True, capture_output=True, text=True
     )
 
 
-def test_stale_locks_are_swept_and_named(tmp_path: Path) -> None:
+def test_stale_locks_are_swept_at_any_depth_and_named(tmp_path: Path) -> None:
     repo = _repo(tmp_path)
-    old = time.time() - 3600
-    stale = [repo / ".git" / "index.lock", repo / ".git" / "refs" / "heads" / "main.lock"]
-    for lock in stale:
-        lock.parent.mkdir(parents=True, exist_ok=True)
-        lock.write_text("")
-        os.utime(lock, (old, old))
+    stale = [
+        _aged_lock(repo / ".git" / "index.lock"),
+        _aged_lock(repo / ".git" / "refs" / "heads" / "main.lock"),
+        # slash-named branches nest their ref locks (terra #231 r1)
+        _aged_lock(repo / ".git" / "refs" / "remotes" / "origin" / "release" / "v1" / "x.lock"),
+        _aged_lock(repo / ".git" / "logs" / "refs" / "heads" / "a" / "b" / "c" / "d.lock"),
+    ]
     out = _sweep(repo)
     assert not any(lock.exists() for lock in stale)
     for lock in stale:
@@ -38,7 +56,7 @@ def test_stale_locks_are_swept_and_named(tmp_path: Path) -> None:
 
 
 def test_a_fresh_lock_is_left_alone(tmp_path: Path) -> None:
-    """A live git op holds its lock for seconds — never race it."""
+    """A live git op holds its lock for seconds — age alone never qualifies."""
     repo = _repo(tmp_path)
     fresh = repo / ".git" / "HEAD.lock"
     fresh.write_text("")
@@ -46,12 +64,48 @@ def test_a_fresh_lock_is_left_alone(tmp_path: Path) -> None:
     assert fresh.exists() and out.stdout == ""
 
 
-def test_only_lock_files_are_touched_and_no_git_dir_is_a_no_op(tmp_path: Path) -> None:
+def test_an_aged_lock_under_a_live_git_process_is_left_alone(tmp_path: Path) -> None:
+    """A git command working in the checkout owns its locks, however old: the
+    sweep waits (a cadence later it runs again). Held live via a git that
+    reads stdin until we close it; swept once it is gone."""
     repo = _repo(tmp_path)
-    old = time.time() - 3600
+    lock = _aged_lock(repo / ".git" / "index.lock")
+    proc = subprocess.Popen(
+        ["git", "-C", str(repo), "hash-object", "--stdin"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+    )
+    try:
+        time.sleep(0.3)
+        out = _sweep(repo)
+        assert lock.exists() and out.stdout == ""
+    finally:
+        assert proc.stdin is not None
+        proc.stdin.close()
+        proc.wait(timeout=30)
+    out = _sweep(repo)
+    assert not lock.exists() and "swept stale git lock" in out.stdout
+
+
+def test_a_linked_worktree_is_followed_to_its_git_dir(tmp_path: Path) -> None:
+    """In a linked worktree `.git` is a FILE naming the real git dir; stale
+    locks live there and in the common dir (terra #231 r1)."""
+    repo = _repo(tmp_path)
+    linked = tmp_path / "linked"
+    _git(repo, "worktree", "add", "-q", "-b", "wt", str(linked))
+    assert (linked / ".git").is_file()
+    wt_lock = _aged_lock(repo / ".git" / "worktrees" / "linked" / "HEAD.lock")
+    common_lock = _aged_lock(repo / ".git" / "refs" / "heads" / "wt.lock")
+    out = _sweep(linked)
+    assert not wt_lock.exists() and not common_lock.exists()
+    assert out.stdout.count("swept stale git lock") == 2
+
+
+def test_only_lock_files_are_touched_and_a_non_repo_is_a_no_op(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
     keep = repo / ".git" / "FETCH_HEAD"
     keep.write_text("abc")
-    os.utime(keep, (old, old))
+    os.utime(keep, (HOUR_AGO, HOUR_AGO))
     _sweep(repo)
     assert keep.read_text() == "abc"
     plain = tmp_path / "not-a-checkout"

--- a/tests/test_sweep_git_locks.py
+++ b/tests/test_sweep_git_locks.py
@@ -141,3 +141,46 @@ def test_only_lock_files_are_touched_and_a_non_repo_is_a_no_op(tmp_path: Path) -
     plain = tmp_path / "not-a-checkout"
     plain.mkdir()
     assert _sweep(plain).returncode == 0
+
+
+def test_a_prefix_named_sibling_checkout_never_blocks_the_sweep(tmp_path: Path) -> None:
+    """A live git in `<checkout>-old` is unrelated work: paths match at
+    argument boundaries, so the sweep of `<checkout>` proceeds (r5)."""
+    repo = _repo(tmp_path, "app")
+    sibling = _repo(tmp_path, "app-old")
+    lock = _aged_lock(repo / ".git" / "index.lock")
+    proc = subprocess.Popen(
+        ["git", "-C", str(sibling), "hash-object", "--stdin"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+    )
+    try:
+        time.sleep(0.3)
+        out = _sweep(repo)
+        assert not lock.exists() and "swept stale git lock" in out.stdout
+    finally:
+        assert proc.stdin is not None
+        proc.stdin.close()
+        proc.wait(timeout=30)
+
+
+def test_a_worktree_path_with_spaces_still_counts_as_live(tmp_path: Path) -> None:
+    repo = _repo(tmp_path)
+    linked = tmp_path / "linked work tree"
+    _git(repo, "worktree", "add", "-q", "-b", "sp", str(linked))
+    common_lock = _aged_lock(repo / ".git" / "refs" / "heads" / "sp.lock")
+    proc = subprocess.Popen(
+        ["git", "hash-object", "--stdin"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        cwd=linked,
+    )
+    try:
+        time.sleep(0.3)
+        assert _sweep(repo).stdout == "" and common_lock.exists()
+    finally:
+        assert proc.stdin is not None
+        proc.stdin.close()
+        proc.wait(timeout=30)
+    _sweep(repo)
+    assert not common_lock.exists()

--- a/tests/test_sweep_git_locks.py
+++ b/tests/test_sweep_git_locks.py
@@ -96,9 +96,36 @@ def test_a_linked_worktree_is_followed_to_its_git_dir(tmp_path: Path) -> None:
     assert (linked / ".git").is_file()
     wt_lock = _aged_lock(repo / ".git" / "worktrees" / "linked" / "HEAD.lock")
     common_lock = _aged_lock(repo / ".git" / "refs" / "heads" / "wt.lock")
+    # a git working in the SIBLING (main) worktree owns shared locks too (r3)
+    proc = subprocess.Popen(
+        ["git", "-C", str(repo), "hash-object", "--stdin"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+    )
+    try:
+        time.sleep(0.3)
+        assert _sweep(linked).stdout == "" and common_lock.exists()
+    finally:
+        assert proc.stdin is not None
+        proc.stdin.close()
+        proc.wait(timeout=30)
     out = _sweep(linked)
     assert not wt_lock.exists() and not common_lock.exists()
     assert out.stdout.count("swept stale git lock") == 2
+
+
+def test_the_age_threshold_means_at_least_that_old(tmp_path: Path) -> None:
+    """find truncates ages to whole minutes: a lock 10m30s old must count as
+    older than ten minutes (r3), while one 9m30s old must not."""
+    repo = _repo(tmp_path)
+    just_over = _aged_lock(repo / ".git" / "index.lock")
+    t = time.time() - 630
+    os.utime(just_over, (t, t))
+    just_under = _aged_lock(repo / ".git" / "HEAD.lock")
+    t = time.time() - 570
+    os.utime(just_under, (t, t))
+    _sweep(repo, "10")
+    assert not just_over.exists() and just_under.exists()
 
 
 def test_only_lock_files_are_touched_and_a_non_repo_is_a_no_op(tmp_path: Path) -> None:

--- a/tests/test_sweep_git_locks.py
+++ b/tests/test_sweep_git_locks.py
@@ -184,3 +184,24 @@ def test_a_worktree_path_with_spaces_still_counts_as_live(tmp_path: Path) -> Non
         proc.wait(timeout=30)
     _sweep(repo)
     assert not common_lock.exists()
+
+
+def test_split_form_git_dir_and_work_tree_from_the_parent_count_as_live(tmp_path: Path) -> None:
+    """`--git-dir checkout/.git --work-tree checkout` (split form, relative,
+    from the parent) names the checkout only by basename tokens (r6)."""
+    repo = _repo(tmp_path, "app")
+    lock = _aged_lock(repo / ".git" / "index.lock")
+    proc = subprocess.Popen(
+        ["git", "--git-dir", "app/.git", "--work-tree", "app", "hash-object", "--stdin"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.DEVNULL,
+        cwd=tmp_path,
+    )
+    try:
+        time.sleep(0.3)
+        assert _sweep(repo).stdout == "" and lock.exists()
+    finally:
+        assert proc.stdin is not None
+        proc.stdin.close()
+        proc.wait(timeout=30)
+    assert "swept stale git lock" in _sweep(repo).stdout


### PR DESCRIPTION
## What

A tick job killed mid-fetch (walltime, node death) leaves `.git/*.lock` files in the chain's checkout. Every later deploy then fails with "Unable to create ...lock: File exists", and the chain keeps running **old code** until someone clears the locks by hand — which happened twice on Torch this week.

`scripts/sweep_git_locks.sh <checkout> [min-age-minutes]` removes `*.lock` files under `.git/` that are older than the threshold (default 10 min — a live git op holds a lock for seconds) when no git process is running against the checkout, and names each removed path in the tick log. Only `*.lock` files are touched; git recreates them. The chain calls it right before its fetch/reset, best-effort.

## Tests

`tests/test_sweep_git_locks.py`: stale locks (index, refs/heads) are removed and named; a fresh lock is left alone; non-lock files are untouched; a directory without `.git` is a no-op.

`scripts/README.md` gained rows for the chain, the sweep, and the installers (it still said the tick job was "planned").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
