### PR TITLE
The revise loop as a wake type: a blocking re-read wakes the author

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- A blocking follow-up re-read wakes the author: the panel's findings are
+  recorded on the run and the tick submits a follow-up for them like any
+  other wake; the revision is re-measured and re-read, bounded by two rounds
+  before the findings are left to a human.
 - `AUTORESEARCH_BOT_LOGIN` names the login the kernel posts as; every role
   defaults to it (the bot account's name when unset), so a GitHub App cutover
   flips identity and credential together.

--- a/docs/design/orchestrator-verify.md
+++ b/docs/design/orchestrator-verify.md
@@ -165,11 +165,17 @@ never depends on the panel. A panel config that would die at startup is
 left off the follow-up (the reply still goes out; the PR stays
 human-merged; the tick's contract alarm already names the misconfig).
 
-Not yet: the climb's revise loop. A blocking re-read does not wake the
-author inside the same job — the findings sit on the thread, and the author
-addresses them when a maintainer's comment next wakes it. Folding the
-responder's measure-and-push block into a callable so the panel can wake
-the author once is the next rung.
+**The revise loop is a wake type.** A blocking re-read (findings, not a
+degraded lens) is recorded on the run — the panel's data-fenced findings and
+the pushed head they were read on — and the tick submits a follow-up for it
+exactly as it does for a maintainer's comment or a base move: every step a
+job, on the one follow-up channel. The woken author addresses or rebuts the
+findings; a code change is re-measured and re-read, and a read that still
+blocks sets the wake again. Bounded by `PANEL_WAKE_CAP` revisions, after
+which the findings are left to a human (the panel's explicit demand stands).
+A wake is spent when a follow-up services it, and superseded by any later
+push (it fires only while GitHub's head is the read head); an open panel
+wake also holds off the auto-arm, whatever the record says about blessing.
 
 ## What changes on GitHub
 

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -665,7 +665,11 @@ def _respond(
         committed = []
         history_known = False
 
+    response_reverted = False
+
     def _revert_response() -> None:
+        nonlocal response_reverted
+        response_reverted = True
         # drop working-tree edits AND any local commits past the pushed tip;
         # abort first — a conflicted, uncommitted merge leaves MERGE_HEAD and
         # unmerged paths that checkout/clean do not clear, and the next wake
@@ -1079,9 +1083,16 @@ def _respond(
             # before this write can never bless the pushed code (#228 r4/r8)
             auto_blessed_head="" if change_pushed else blessed_head,
             # a serviced panel wake is spent (the re-read below may set a new
-            # one for the head it just pushed); an unserviced one stands
-            panel_wake_head="" if panel_wake else record.panel_wake_head,
-            panel_wake_text="" if panel_wake else record.panel_wake_text,
+            # one for the head it just pushed) — unless the response was
+            # REVERTED (out of scope, failed eval, failed sync): the author
+            # never got to answer the findings, so the wake stands for the
+            # next job, bounded by the tick's wake_attempts billing
+            panel_wake_head=(
+                "" if (panel_wake and not response_reverted) else record.panel_wake_head
+            ),
+            panel_wake_text=(
+                "" if (panel_wake and not response_reverted) else record.panel_wake_text
+            ),
             wake_attempts=(
                 record.wake_attempts
                 if (conflict_wake and not (sync_pushed or (base_synced and change_pushed)))
@@ -1255,14 +1266,24 @@ def _reread_pushed_change(
     except GitError:
         still_pushed = False
     bless = clean and still_pushed and dial == "auto"
-    # blocking findings on a head that is still the pushed one go back to the
-    # AUTHOR (the climb's revise loop as a wake type), bounded; a degraded
+    # blocking findings on a head that is still the pushed one — in the
+    # workspace AND on GitHub (a push during the read supersedes the
+    # findings; a wake for the old sha could never be serviced) — go back to
+    # the AUTHOR (the climb's revise loop as a wake type), bounded; a degraded
     # read is not findings, and a capped-out author leaves them to a human
+    try:
+        gh_head = str(
+            (github.get_pull_request(record.target, number).get("head") or {}).get("sha", "")
+        )
+    except Exception:
+        gh_head = ""
+    superseded = bool(verdict is not None and verdict.blocking) and gh_head != pushed_head
     wake_author = (
         verdict is not None
         and bool(verdict.blocking)
         and not verdict.degraded
         and still_pushed
+        and gh_head == pushed_head
         and panel_wake_rounds < PANEL_WAKE_CAP
     )
     if bless:
@@ -1279,11 +1300,34 @@ def _reread_pushed_change(
             f"Blocking findings: the author is woken to address them (revision "
             f"{panel_wake_rounds + 1} of {PANEL_WAKE_CAP}); a human decides if they stand."
         )
+    elif superseded:
+        closing = (
+            "Blocking findings, but the PR moved during the read — they describe a "
+            "superseded head; the new head gets its own read when a follow-up pushes it."
+        )
     elif verdict is not None and verdict.blocking and not verdict.degraded:
         closing = f"Blocking findings after {PANEL_WAKE_CAP} revisions — a human decides this PR."
     else:
         closing = "Not a clean read — a human decides this PR."
     body = APPROVAL_PATTERN.sub(REDACTED, redact(transcript, secrets))[:MAX_REPLY_CHARS]
+    # the WAKE is persisted before the comment: a responder that dies between
+    # the two costs a thread without the transcript (the woken author still
+    # carries the findings in its prompt), never a lost wake (terra #233 r1)
+    if wake_author:
+        try:
+            latest = load_record(run_root, run_id)
+            save_record(
+                run_root,
+                replace(
+                    latest,
+                    panel_wake_head=pushed_head,
+                    panel_wake_text=str(verdict.wake_text),
+                    panel_wake_rounds=latest.panel_wake_rounds + 1,
+                ),
+                now,
+            )
+        except (OSError, ValueError) as exc:
+            log.warning("panel wake write failed for %s: %s", run_id, exc)
     try:
         github.comment(
             record.target,
@@ -1293,21 +1337,12 @@ def _reread_pushed_change(
     except Exception as exc:
         log.warning("re-read comment failed for %s#%s: %s", record.target, number, exc)
         return  # an unposted read never blesses: the thread must carry it
-    if bless or wake_author:
+    if bless:
         try:
             latest = load_record(run_root, run_id)
-            if bless:
-                latest = replace(latest, auto_blessed_head=pushed_head)
-            if wake_author:
-                latest = replace(
-                    latest,
-                    panel_wake_head=pushed_head,
-                    panel_wake_text=str(verdict.wake_text),
-                    panel_wake_rounds=latest.panel_wake_rounds + 1,
-                )
-            save_record(run_root, latest, now)
+            save_record(run_root, replace(latest, auto_blessed_head=pushed_head), now)
         except (OSError, ValueError) as exc:
-            log.warning("re-read record write failed for %s: %s", run_id, exc)
+            log.warning("blessing write failed for %s: %s", run_id, exc)
 
 
 def _changed_paths(ws: Workspace) -> list[str]:

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -1093,9 +1093,17 @@ def _respond(
             panel_wake_text=(
                 "" if (panel_wake and not response_reverted) else record.panel_wake_text
             ),
+            # the count is KEPT (never advanced here, never reset) whenever a
+            # wake stays pending without progress — a base sync that did not
+            # reach GitHub, or a panel wake whose response was reverted — so
+            # the tick's submit-time billing still reaches MAX_WAKE_ATTEMPTS
+            # instead of resubmitting a failing job forever (terra #233 r2)
             wake_attempts=(
                 record.wake_attempts
-                if (conflict_wake and not (sync_pushed or (base_synced and change_pushed)))
+                if (
+                    (conflict_wake and not (sync_pushed or (base_synced and change_pushed)))
+                    or (panel_wake and response_reverted)
+                )
                 else 0
             ),
         ),

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -70,6 +70,9 @@ from autoresearch.verifier import VERIFY_MARKER
 log = logging.getLogger(__name__)
 
 QUALIFYING_ASSOCIATIONS = ("OWNER", "MEMBER", "COLLABORATOR")
+# revisions a blocking re-read may ask of the author before the findings are
+# left to a human — the climb's depth axis, bounded the same way
+PANEL_WAKE_CAP = 2
 MAX_COMMENTS_PER_WAKE = 5
 MAX_REPLY_CHARS = 20_000
 
@@ -272,6 +275,15 @@ def close_if_done(run_root: Path, record: RunRecord, github: GitHubClient, now: 
     return ""
 
 
+def panel_wake_pending(record: RunRecord, pr: dict) -> bool:
+    """A blocking re-read is waiting for the author, and the PR still shows
+    the head it was read on (a later push supersedes the findings). Pure — the
+    tick and the follow-up decide from the same rule."""
+    return bool(record.panel_wake_text) and (
+        str((pr.get("head") or {}).get("sha", "")) == record.panel_wake_head
+    )
+
+
 def has_new_comments(record: RunRecord, github: GitHubClient, bot_login: str) -> bool:
     """Cheap read-only check the tick can afford every cycle."""
     number = _pr_number(record.pr_url)
@@ -421,7 +433,8 @@ def _respond(
     is_conflict = bool(dirty_pr_head(pr))
     conflict_head = base_sync_head(pr)
     conflict_wake = bool(conflict_head) and conflict_head != record.dirty_wake_head
-    if not merged and not conflict_wake:
+    panel_wake = panel_wake_pending(record, pr)
+    if not merged and not conflict_wake and not panel_wake:
         return FollowupOutcome(run_id, "no-op", "no new qualifying comments")
     # oldest first WITHIN each source (ids are monotonic per source); cap the
     # wake, and advance each cursor only to the max id actually processed
@@ -516,6 +529,18 @@ def _respond(
             "contribution is superseded, say so plainly instead of pushing "
             "on. The merged result is re-measured before it is pushed, and "
             "a human merges the updated PR.\n\n"
+        ) + prompt
+    if panel_wake:
+        # the verification panel's read of the author's last push — the same
+        # data-fenced findings the climb's revise loop delivers, framed for a
+        # PR that already exists
+        prompt = (
+            "# The verification panel read your last push\n"
+            "Your change was pushed and re-measured; then the panel read it and "
+            "found BLOCKING findings. Address them in the workspace, or leave the "
+            "code alone and rebut them in your reply. Any change is re-measured "
+            "and re-read; the PR merges only on a clean read.\n\n"
+            f"{record.panel_wake_text}\n\n"
         ) + prompt
     if is_steward:
         from autoresearch.steward import STEWARD_WAKE_PREAMBLE
@@ -1053,6 +1078,10 @@ def _respond(
             # the tick arms only on an exact head match, so even a crash
             # before this write can never bless the pushed code (#228 r4/r8)
             auto_blessed_head="" if change_pushed else blessed_head,
+            # a serviced panel wake is spent (the re-read below may set a new
+            # one for the head it just pushed); an unserviced one stands
+            panel_wake_head="" if panel_wake else record.panel_wake_head,
+            panel_wake_text="" if panel_wake else record.panel_wake_text,
             wake_attempts=(
                 record.wake_attempts
                 if (conflict_wake and not (sync_pushed or (base_synced and change_pushed)))
@@ -1089,6 +1118,7 @@ def _respond(
             panel_lenses=panel_lenses,
             panel_builder=panel_builder,
             panel_skip=panel_skip,
+            panel_wake_rounds=record.panel_wake_rounds,
             bot_login=bot_login,
             created=created,
             now=now,
@@ -1149,6 +1179,7 @@ def _reread_pushed_change(
     panel_lenses: tuple[Any, ...],
     panel_builder: Callable[..., Callable[[float, float, str], Any]] | None,
     panel_skip: str,
+    panel_wake_rounds: int,
     bot_login: str,
     created: str,
     now: float,
@@ -1161,6 +1192,7 @@ def _reread_pushed_change(
     Best-effort throughout: a failure here degrades to an unarmed PR."""
     transcript = ""
     clean = False
+    verdict: Any = None
     base = ""
     if trusted_base and pushed_head and not panel_skip:
         # the panel's `base/` is the base the PR actually forks from: the
@@ -1223,6 +1255,16 @@ def _reread_pushed_change(
     except GitError:
         still_pushed = False
     bless = clean and still_pushed and dial == "auto"
+    # blocking findings on a head that is still the pushed one go back to the
+    # AUTHOR (the climb's revise loop as a wake type), bounded; a degraded
+    # read is not findings, and a capped-out author leaves them to a human
+    wake_author = (
+        verdict is not None
+        and bool(verdict.blocking)
+        and not verdict.degraded
+        and still_pushed
+        and panel_wake_rounds < PANEL_WAKE_CAP
+    )
     if bless:
         closing = (
             "Clean read under `merge: auto`: the kernel may merge this head once "
@@ -1232,6 +1274,13 @@ def _reread_pushed_change(
         closing = "Clean read; this repository merges by hand (`merge: manual`)."
     elif clean:
         closing = "Clean read, but the workspace moved during it — a human merges this PR."
+    elif wake_author:
+        closing = (
+            f"Blocking findings: the author is woken to address them (revision "
+            f"{panel_wake_rounds + 1} of {PANEL_WAKE_CAP}); a human decides if they stand."
+        )
+    elif verdict is not None and verdict.blocking and not verdict.degraded:
+        closing = f"Blocking findings after {PANEL_WAKE_CAP} revisions — a human decides this PR."
     else:
         closing = "Not a clean read — a human decides this PR."
     body = APPROVAL_PATTERN.sub(REDACTED, redact(transcript, secrets))[:MAX_REPLY_CHARS]
@@ -1244,12 +1293,21 @@ def _reread_pushed_change(
     except Exception as exc:
         log.warning("re-read comment failed for %s#%s: %s", record.target, number, exc)
         return  # an unposted read never blesses: the thread must carry it
-    if bless:
+    if bless or wake_author:
         try:
             latest = load_record(run_root, run_id)
-            save_record(run_root, replace(latest, auto_blessed_head=pushed_head), now)
+            if bless:
+                latest = replace(latest, auto_blessed_head=pushed_head)
+            if wake_author:
+                latest = replace(
+                    latest,
+                    panel_wake_head=pushed_head,
+                    panel_wake_text=str(verdict.wake_text),
+                    panel_wake_rounds=latest.panel_wake_rounds + 1,
+                )
+            save_record(run_root, latest, now)
         except (OSError, ValueError) as exc:
-            log.warning("blessing write failed for %s: %s", run_id, exc)
+            log.warning("re-read record write failed for %s: %s", run_id, exc)
 
 
 def _changed_paths(ws: Workspace) -> list[str]:

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -157,6 +157,14 @@ class RunRecord:
     # one, or any unrecorded push simply fails the equality: the tick arms
     # only when GitHub's head IS this sha. Empty = never arm (legacy too).
     auto_blessed_head: str = ""
+    # A BLOCKING follow-up re-read wakes the author (docs/design/orchestrator-
+    # verify.md): the panel's findings, data-fenced, and the pushed head they
+    # were read on. The wake fires only while GitHub's head IS that sha, is
+    # cleared when a follow-up services it, and is set again by the next read
+    # if findings remain — bounded by `panel_wake_rounds`.
+    panel_wake_head: str = ""
+    panel_wake_text: str = ""
+    panel_wake_rounds: int = 0
     followup_job_id: str = ""  # slurm job servicing this run's review comments
     issue_number: int = 0  # the requesting issue, when the requested lane started this run
     wake_attempts: int = 0

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -533,6 +533,7 @@ def service_in_review(
         close_if_done,
         conflict_wake_action,
         has_new_comments,
+        panel_wake_pending,
     )
 
     ended: list[tuple[str, str]] = []
@@ -573,7 +574,11 @@ def service_in_review(
                     save_record(root, replace(record, dirty_wake_head=""), now)
                 except OSError as exc:
                     log.warning("conflict cursor clear failed for %s: %s", record.run_id, exc)
-            if not has_new_comments(record, github, spec.bot_login) and wake_action != "wake":
+            if (
+                not has_new_comments(record, github, spec.bot_login)
+                and wake_action != "wake"
+                and not panel_wake_pending(record, pr)
+            ):
                 # NOTHING awaits servicing — only a fully quiet PR may
                 # self-merge (pending reviewer feedback always wins over
                 # arming: a followup must service it first, and a pushed

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1824,10 +1824,14 @@ def _verdict(
     degraded=False,
     transcript="**Verification round 1**\n- `claude` (verify): 0 blocking, 0 advisory",
 ):
-    from autoresearch.panel import PanelVerdict
+    from autoresearch.panel import PanelVerdict, _render_wake
 
     return PanelVerdict(
-        blocking=tuple(blocking), transcript=transcript, wake_text="", degraded=degraded
+        blocking=tuple(blocking),
+        transcript=transcript,
+        # the real panel renders a data-fenced wake for blocking findings
+        wake_text=_render_wake(tuple(blocking)) if blocking else "",
+        degraded=degraded,
     )
 
 
@@ -1846,16 +1850,27 @@ def _finding(summary="unjustified constant"):
 
 @dataclass
 class AutoGitHub(FakeGitHub):
-    """An auto-mode PR is disarmed before any push; this fake confirms it."""
+    """An auto-mode PR is disarmed before any push; this fake confirms it.
+    With `ws` set, the PR's head follows the workspace HEAD — what GitHub
+    reports right after the follow-up's own push."""
 
     disarmed: list[int] = field(default_factory=list)
+    ws: Path | None = None
 
     def disable_auto_merge(self, repo, number):
         self.disarmed.append(number)
         return True
 
+    def get_pull_request(self, repo, number):
+        pr = dict(self.pr)
+        if self.ws is not None and "head" not in pr:
+            pr["head"] = {"sha": _git(self.ws, "rev-parse", "HEAD").strip()}
+        return pr
+
 
 def respond_with_panel(root, github, harness, evaluator, panel):
+    if isinstance(github, AutoGitHub) and github.ws is None:
+        github.ws = run_dir(root, "tsp-r1") / "ws"
     return respond_once(
         root,
         "tsp-r1",
@@ -2153,6 +2168,7 @@ def test_a_blocking_reread_records_a_panel_wake_for_the_pushed_head(review_run) 
     rec = load_record(root, "tsp-r1")
     assert rec.panel_wake_head == _ws_head(root)
     assert rec.panel_wake_text == verdict_text.wake_text and rec.panel_wake_rounds == 1
+    assert "unjustified constant" in rec.panel_wake_text  # deliverable: the findings themselves
     assert rec.auto_blessed_head == ""
     assert f"revision 1 of {PANEL_WAKE_CAP}" in github.posted[1]
     assert "author is woken" in github.posted[1]
@@ -2234,3 +2250,86 @@ def test_a_pending_panel_wake_is_serviced_without_new_comments(review_run) -> No
     )
     github2 = FakeGitHub(pr={"state": "open", "merged": False, "head": {"sha": head}})
     assert respond(root, github2, ResumingHarness(), QueueEvaluator(values=[])).action == "no-op"
+
+
+def test_the_wake_is_saved_before_the_reread_comment_and_survives_its_failure(review_run) -> None:
+    """A responder that dies between the two costs a thread without the
+    transcript, never a lost wake (terra #233 r1)."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+
+    class SecondCommentExplodes(AutoGitHub):
+        def comment(self, repo, number, body):
+            if self.posted:  # the reply went out; the re-read comment fails
+                raise RuntimeError("github 502")
+            super().comment(repo, number, body)
+
+    github = SecondCommentExplodes(comments=[member(901, "tweak")])
+    panel = FakePanel(verdicts=[_verdict(blocking=(_finding(),), transcript="- 1 blocking")])
+    outcome = respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    assert outcome.action == "replied" and len(github.posted) == 1
+    rec = load_record(root, "tsp-r1")
+    assert rec.panel_wake_head == _ws_head(root) and "unjustified constant" in rec.panel_wake_text
+
+
+def test_a_reverted_response_keeps_the_panel_wake_pending(review_run) -> None:
+    """The author was woken for the findings but its change was reverted (out
+    of scope here): it never answered them, so the wake stands for the next
+    job instead of being spent."""
+    from dataclasses import replace as dc_replace
+
+    root, _bare = review_run
+    head = _ws_head(root)
+    save_record(
+        root,
+        dc_replace(
+            load_record(root, "tsp-r1"),
+            panel_wake_head=head,
+            panel_wake_text="PANEL FINDINGS",
+            panel_wake_rounds=1,
+        ),
+        NOW,
+    )
+    github = FakeGitHub(pr={"state": "open", "merged": False, "head": {"sha": head}})
+    outcome = respond(
+        root, github, ResumingHarness(edits={"docs/roadmap.md": "widened\n"}), QueueEvaluator()
+    )
+    assert outcome.action == "replied" and "not applied" in github.posted[0]
+    rec = load_record(root, "tsp-r1")
+    assert rec.panel_wake_text == "PANEL FINDINGS" and rec.panel_wake_head == head
+
+
+def test_a_push_during_the_read_supersedes_the_findings(review_run) -> None:
+    """GitHub's head moved while the judges read: a wake for the old sha could
+    never be serviced, so none is recorded and the thread says why."""
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+
+    class MovingHeadGitHub(AutoGitHub):
+        reads = 0
+
+        def get_pull_request(self, repo, number):
+            self.reads += 1
+            pr = dict(self.pr)
+            if self.reads > 1:  # after the push: someone else pushed again
+                pr["head"] = {"sha": "e" * 40}
+            return pr
+
+    github = MovingHeadGitHub(comments=[member(901, "tweak")])
+    panel = FakePanel(verdicts=[_verdict(blocking=(_finding(),), transcript="- 1 blocking")])
+    respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    rec = load_record(root, "tsp-r1")
+    assert rec.panel_wake_text == "" and rec.panel_wake_rounds == 0
+    assert "superseded head" in github.posted[1]

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -1921,7 +1921,8 @@ def test_blocking_or_degraded_rereads_leave_the_merge_to_a_human(review_run) -> 
     respond_with_panel(root, github, harness, QueueEvaluator(values=[10.2]), panel)
     assert load_record(root, "tsp-r1").auto_blessed_head == ""
     assert "unjustified constant" in github.posted[1]
-    assert "Not a clean read — a human decides" in github.posted[1]
+    # blocking findings go back to the author first; a human decides if they stand
+    assert "author is woken" in github.posted[1] and "a human decides" in github.posted[1]
 
     github2 = AutoGitHub(comments=[member(902, "again")])
     panel2 = FakePanel(
@@ -2119,3 +2120,117 @@ def test_the_judges_rules_come_from_the_trusted_base_only(review_run, monkeypatc
     assert panel.built == []  # no judges were briefed on a PR-controlled contract
     assert "panel could not run" in github.posted[1] and "NOT a clean read" in github.posted[1]
     assert load_record(root, "tsp-r1").auto_blessed_head == ""
+
+
+# --- the revise loop as a wake type: a blocking re-read wakes the author
+
+
+def test_a_blocking_reread_records_a_panel_wake_for_the_pushed_head(review_run) -> None:
+    """Findings (not a degraded lens) on a head that is still the pushed one
+    go back to the author: the record carries the fenced findings and the
+    head they were read on, the thread says a revision is asked."""
+    from autoresearch.followup import PANEL_WAKE_CAP
+
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    panel = FakePanel(
+        verdicts=[
+            _verdict(
+                blocking=(_finding(),),
+                transcript="- `claude` (review): 1 blocking, 0 advisory",
+            )
+        ]
+    )
+    verdict_text = panel.verdicts[0]
+    respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    rec = load_record(root, "tsp-r1")
+    assert rec.panel_wake_head == _ws_head(root)
+    assert rec.panel_wake_text == verdict_text.wake_text and rec.panel_wake_rounds == 1
+    assert rec.auto_blessed_head == ""
+    assert f"revision 1 of {PANEL_WAKE_CAP}" in github.posted[1]
+    assert "author is woken" in github.posted[1]
+
+
+def test_a_capped_out_or_degraded_reread_leaves_the_findings_to_a_human(review_run) -> None:
+    from dataclasses import replace as dc_replace
+
+    from autoresearch.followup import PANEL_WAKE_CAP
+
+    root, _bare = review_run
+    _set_contract(root, AUTO_CONTRACT)
+    save_record(
+        root, dc_replace(load_record(root, "tsp-r1"), panel_wake_rounds=PANEL_WAKE_CAP), NOW
+    )
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    panel = FakePanel(verdicts=[_verdict(blocking=(_finding(),), transcript="- 1 blocking")])
+    respond_with_panel(
+        root,
+        github,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        panel,
+    )
+    rec = load_record(root, "tsp-r1")
+    assert rec.panel_wake_text == "" and rec.panel_wake_rounds == PANEL_WAKE_CAP
+    assert f"after {PANEL_WAKE_CAP} revisions" in github.posted[1]
+
+    # degraded is not findings: no wake, no revision counted
+    github2 = AutoGitHub(comments=[member(902, "again")])
+    panel2 = FakePanel(verdicts=[_verdict(degraded=True, transcript="- no verdict")])
+    save_record(root, dc_replace(load_record(root, "tsp-r1"), panel_wake_rounds=0), NOW + 1)
+    respond_with_panel(
+        root,
+        github2,
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v3\n"}),
+        QueueEvaluator(values=[10.1]),
+        panel2,
+    )
+    rec2 = load_record(root, "tsp-r1")
+    assert rec2.panel_wake_text == "" and rec2.panel_wake_rounds == 0
+
+
+def test_a_pending_panel_wake_is_serviced_without_new_comments(review_run) -> None:
+    """The findings reach the author as the wake's prompt; servicing spends the
+    wake (cleared on the record, cursors untouched); a head that moved since
+    the read supersedes the findings (no-op)."""
+    from dataclasses import replace as dc_replace
+
+    root, _bare = review_run
+    head = _ws_head(root)
+    fenced = "PANEL FINDINGS\n```\n- src/pilot/solvers/tsp.py:1 — unjustified constant\n```"
+    save_record(
+        root,
+        dc_replace(
+            load_record(root, "tsp-r1"),
+            panel_wake_head=head,
+            panel_wake_text=fenced,
+            panel_wake_rounds=1,
+        ),
+        NOW,
+    )
+    github = FakeGitHub(pr={"state": "open", "merged": False, "head": {"sha": head}})
+    harness = ResumingHarness(text="Rebutted: the constant is the paper's value.")
+    outcome = respond(root, github, harness, QueueEvaluator(values=[]))
+    assert outcome.action == "replied"
+    assert "verification panel read your last push" in harness.calls[0][0]
+    assert "unjustified constant" in harness.calls[0][0]
+    rec = load_record(root, "tsp-r1")
+    assert rec.panel_wake_text == "" and rec.panel_wake_head == ""
+    assert rec.last_comment_id == 100  # no comment was consumed
+    assert "Rebutted" in github.posted[0]
+
+    # a later push moved the head: the findings are stale, nothing to service
+    save_record(
+        root,
+        dc_replace(load_record(root, "tsp-r1"), panel_wake_head="f" * 40, panel_wake_text=fenced),
+        NOW + 1,
+    )
+    github2 = FakeGitHub(pr={"state": "open", "merged": False, "head": {"sha": head}})
+    assert respond(root, github2, ResumingHarness(), QueueEvaluator(values=[])).action == "no-op"

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2297,12 +2297,21 @@ def test_a_reverted_response_keeps_the_panel_wake_pending(review_run) -> None:
         NOW,
     )
     github = FakeGitHub(pr={"state": "open", "merged": False, "head": {"sha": head}})
+    save_record(root, dc_replace(load_record(root, "tsp-r1"), wake_attempts=3), NOW)
     outcome = respond(
         root, github, ResumingHarness(edits={"docs/roadmap.md": "widened\n"}), QueueEvaluator()
     )
     assert outcome.action == "replied" and "not applied" in github.posted[0]
     rec = load_record(root, "tsp-r1")
     assert rec.panel_wake_text == "PANEL FINDINGS" and rec.panel_wake_head == head
+    # ...and the retry count is KEPT, so the tick's billing still caps the loop (r2)
+    assert rec.wake_attempts == 3
+
+    # a serviced, non-reverted panel wake is progress: the count resets
+    github2 = FakeGitHub(pr={"state": "open", "merged": False, "head": {"sha": head}})
+    respond(root, github2, ResumingHarness(text="Rebutted."), QueueEvaluator())
+    rec2 = load_record(root, "tsp-r1")
+    assert rec2.panel_wake_text == "" and rec2.wake_attempts == 0
 
 
 def test_a_push_during_the_read_supersedes_the_findings(review_run) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3766,3 +3766,83 @@ def test_author_followups_carry_the_panel_and_its_read_allowance(tmp_path: Path)
     # the steward's PRs are not panel-blessed: never a panel on its follow-up
     steward = run("steward-01", "verify,review", str(key))
     assert "--panel" not in steward and "--time=90" in steward
+
+
+def test_a_pending_panel_wake_submits_a_followup_and_holds_off_the_arm(tmp_path: Path) -> None:
+    """No new comments, no base move — but the panel's blocking findings wait
+    for the author on the PR's current head: the tick submits a follow-up
+    (never arms, whatever the blessing says). A stale wake (head moved) is
+    nothing to service."""
+    from autoresearch.compute import CommandResult
+    from autoresearch.runstate import IN_REVIEW, RunRecord, save_record
+    from autoresearch.tick import FollowupSpec, service_in_review
+
+    class G:
+        def __init__(self, head: str) -> None:
+            self.head = head
+            self.armed: list[int] = []
+
+        def get_pull_request(self, repo, number):
+            return {
+                "state": "open",
+                "merged": False,
+                "draft": False,
+                "mergeable_state": "clean",
+                "head": {"sha": self.head},
+                "base": {"ref": "main"},
+            }
+
+        def list_comments(self, repo, number, max_pages=20):
+            return []
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return []
+
+        def arm_auto_merge_auto_mode(self, repo, number, expected_head=""):
+            self.armed.append(number)
+
+    def run(wake_head: str, pr_head: str) -> tuple[list, list]:
+        root = tmp_path / f"root-{wake_head[:2]}-{pr_head[:2]}"
+        root.mkdir()
+        save_record(
+            root,
+            RunRecord(
+                run_id="r-rev",
+                target="org/pilot",
+                task_title="t",
+                state=IN_REVIEW,
+                pr_url="https://github.com/org/pilot/pull/9",
+                auto_blessed_head=pr_head,
+                panel_wake_head=wake_head,
+                panel_wake_text="findings",
+            ),
+            now=NOW,
+        )
+        submits: list[list[str]] = []
+
+        def runner(argv, timeout_s):
+            if argv[0] == "sbatch":
+                submits.append(list(argv))
+                return CommandResult(0, "77\n", "")
+            if argv[0] == "sacct":
+                return CommandResult(0, "RUNNING\n", "")
+            raise AssertionError(argv)
+
+        g = G(pr_head)
+        spec = FollowupSpec(
+            account="acct",
+            partition="cpu_short",
+            run_root=root,
+            image="/img/a.sif",
+            home=Path("/home/x/autoresearch"),
+        )
+        _ended, submitted = service_in_review(root, g, SlurmCompute(runner=runner), spec, NOW)
+        return submitted, g.armed
+
+    submitted, armed = run("a" * 40, "a" * 40)
+    assert submitted == [("r-rev", "77")] and armed == []
+    submitted2, _armed2 = run("b" * 40, "c" * 40)
+    assert submitted2 == []


### PR DESCRIPTION
## What

The rung after #229. A blocking follow-up re-read used to sit on the thread until a maintainer's next comment woke the author. Now it is a **wake type** on the existing follow-up channel, next to comment, conflict, and behind wakes — every step a job, one dispatcher, no in-job loop:

- `_reread_pushed_change`: blocking findings (not a degraded lens) on a head that is still the pushed one write `panel_wake_head` / `panel_wake_text` (the panel's data-fenced `wake_text`) on the record and bump `panel_wake_rounds`; the closing line says a revision is asked (`revision N of PANEL_WAKE_CAP`). At the cap the findings are left to a human, said so.
- `panel_wake_pending(record, pr)` — one pure rule for the tick and the follow-up: the wake is live only while GitHub's head **is** the read head (a later push supersedes the findings).
- Tick: a pending panel wake counts as "awaiting service" — it submits a follow-up and, being inside the nothing-awaits gate, holds off the auto-arm regardless of blessing.
- Follow-up: services the wake without new comments; the prompt frames the findings for a PR that already exists ("address them, or leave the code alone and rebut"); servicing spends the wake (cleared on the record, cursors untouched). A code change is re-measured and re-read as before, and a still-blocking read sets a new wake.

`PANEL_WAKE_CAP = 2`, the climb's depth-axis bound applied to revisions.

## Tests

- follow-up: blocking read records the wake for the pushed head with the fenced findings and round 1; at the cap → no wake, "after N revisions — a human decides"; degraded → no wake and no round counted; a pending wake is serviced with no comments (findings in the prompt, wake cleared, cursor untouched); a stale wake (head moved) is a no-op. The #229 blocking-read test's expectation updated (findings now go to the author first).
- tick: a pending panel wake submits a follow-up and never arms; a stale one submits nothing.

Design note updated (`docs/design/orchestrator-verify.md`); CHANGELOG under Changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
