### PR TITLE
Jobs the site moves off their partition no longer stall the kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- Jobs the site moves off their submitted partition no longer stall the kernel:
+  the tick chain cancels and requeues a moved successor (it starved on a
+  lower-tier partition and blocked its twin through `singleton`), and the
+  sweep treats an armed wake sitting on a foreign partition as lost and
+  redelivers it.
 - Before each deploy, the tick job removes git lock files older than ten
   minutes when no git process is working in the checkout.
 - Dispatched wakes on research lines no longer read the line's memory files

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,6 +6,6 @@ Operational scripts, always committed.
 | --- | --- |
 | `setup_branch_protection.sh` | Apply/refresh branch protection on `main`. Solo-phase default: 0 approvals, checks required, admins enforced. Re-run with `1` once a second code owner joins. |
 | `tick_chain.sbatch` | The self-resubmitting Slurm tick: deploys `main` into its checkout, syncs deps, runs one tick, schedules the next (`docs/design/architecture.md`). |
-| `requeue_moved_successors.sh` | Cancel same-name pending jobs the site moved off the requested partition (a moved tick successor starves and blocks its twin); the chain runs it before topping up. |
+| `requeue_moved_successors.sh` | Cancel pending same-name jobs that are no longer on the requested partition. The tick chain runs this before adding successors. |
 | `sweep_git_locks.sh` | Remove stale `.git/*.lock` files from a checkout (older than N minutes, no live git process); the chain runs it before each deploy. |
 | `install_codex.sh`, `install_hermes.sh` | Pin and install the non-claude author/judge backends on the tick host. |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,5 +6,6 @@ Operational scripts, always committed.
 | --- | --- |
 | `setup_branch_protection.sh` | Apply/refresh branch protection on `main`. Solo-phase default: 0 approvals, checks required, admins enforced. Re-run with `1` once a second code owner joins. |
 | `tick_chain.sbatch` | The self-resubmitting Slurm tick: deploys `main` into its checkout, syncs deps, runs one tick, schedules the next (`docs/design/architecture.md`). |
+| `requeue_moved_successors.sh` | Cancel same-name pending jobs the site moved off the requested partition (a moved tick successor starves and blocks its twin); the chain runs it before topping up. |
 | `sweep_git_locks.sh` | Remove stale `.git/*.lock` files from a checkout (older than N minutes, no live git process); the chain runs it before each deploy. |
 | `install_codex.sh`, `install_hermes.sh` | Pin and install the non-claude author/judge backends on the tick host. |

--- a/scripts/requeue_moved_successors.sh
+++ b/scripts/requeue_moved_successors.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Cancel same-name PENDING jobs of ours that the site moved off the partition
+# we submitted them to. The tick chain keeps two successors queued under
+# `--dependency=singleton`; a successor shifted to a lower-tier catch-all
+# partition starves there AND blocks its twin (singleton waits for same-name
+# jobs to END, and a pending job never ends) — the whole chain stalls
+# (Torch, 2026-09-02). Cancelling the moved job frees the twin, and the
+# chain's top-up queues a fresh successor on the right partition. Prints each
+# cancelled job id. Never fails the caller.
+#
+# usage: requeue_moved_successors.sh <job-name> <partition>
+set -u
+name="${1:?usage: requeue_moved_successors.sh <job-name> <partition>}"
+wanted="${2:-}"
+[ -n "$wanted" ] || exit 0
+squeue -u "$USER" --name="$name" -h -t PENDING -o "%i %P" 2>/dev/null | while read -r jid part; do
+    [ -n "$jid" ] || continue
+    if [ "$part" != "$wanted" ]; then
+        scancel "$jid" 2>/dev/null && echo "chain: cancelled successor $jid moved to $part (asked for $wanted)"
+    fi
+done
+exit 0

--- a/scripts/requeue_moved_successors.sh
+++ b/scripts/requeue_moved_successors.sh
@@ -13,9 +13,19 @@ set -u
 name="${1:?usage: requeue_moved_successors.sh <job-name> <partition>}"
 wanted="${2:-}"
 [ -n "$wanted" ] || exit 0
+# Both sides may be comma-separated lists (a job may be submitted to several
+# partitions; squeue prints what the job currently holds). A job is MOVED only
+# when none of its partitions is one we asked for; an empty %P is unknown and
+# is never cancelled.
 squeue -u "$USER" --name="$name" -h -t PENDING -o "%i %P" 2>/dev/null | while read -r jid part; do
-    [ -n "$jid" ] || continue
-    if [ "$part" != "$wanted" ]; then
+    [ -n "$jid" ] && [ -n "$part" ] || continue
+    moved=1
+    for have in $(printf '%s' "$part" | tr ',' ' '); do
+        for want in $(printf '%s' "$wanted" | tr ',' ' '); do
+            [ "$have" = "$want" ] && moved=0
+        done
+    done
+    if [ "$moved" -eq 1 ]; then
         scancel "$jid" 2>/dev/null && echo "chain: cancelled successor $jid moved to $part (asked for $wanted)"
     fi
 done

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -37,6 +37,9 @@ for var in AUTORESEARCH_HOME AUTORESEARCH_ROOT AUTORESEARCH_ACCOUNT AUTORESEARCH
 done
 
 # --- 1. keep two successors queued (singleton serializes same-name jobs) ---
+# A successor the SITE moved off our partition starves there and blocks its
+# twin through singleton; cancel it first so the top-up below requeues it.
+bash "${AUTORESEARCH_HOME:-.}/scripts/requeue_moved_successors.sh" "$JOB_NAME" "${AUTORESEARCH_PARTITION:-}" || true
 # Successors land on slots AFTER the ones already-queued jobs occupy —
 # otherwise every top-up doubles the tick rate on the next slot.
 if squeue_out=$(squeue -u "$USER" --name="$JOB_NAME" -h -t PENDING 2>/dev/null); then

--- a/src/autoresearch/compute.py
+++ b/src/autoresearch/compute.py
@@ -139,6 +139,7 @@ class Compute(Protocol):
     def submit(self, spec: JobSpec) -> str: ...
     def status(self, job_id: str) -> str: ...
     def pending_reason(self, job_id: str) -> str: ...
+    def job_partition(self, job_id: str) -> str: ...
     def active_job_names(self) -> list[str]: ...
     def job_id_for_name(self, name: str) -> str: ...
     def cancel(self, job_id: str) -> None: ...
@@ -218,6 +219,21 @@ class SlurmCompute:
             raise ValueError(f"not a job id: {job_id!r}")
         try:
             result = self.runner(["squeue", "-j", job_id, "-h", "-o", "%r"], self.command_timeout_s)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SlurmQueryError(f"squeue did not run: {exc}") from exc
+        if result.returncode != 0:
+            raise SlurmQueryError(f"squeue failed ({result.returncode}): {result.stderr.strip()}")
+        return result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
+
+    def job_partition(self, job_id: str) -> str:
+        """The partition(s) a queued job currently sits in, as squeue prints
+        them, or "" when squeue no longer lists it. A site can MOVE a pending
+        job off the partition it was submitted to (Torch does, under
+        congestion); callers compare this with what they asked for."""
+        if not job_id.isdigit():
+            raise ValueError(f"not a job id: {job_id!r}")
+        try:
+            result = self.runner(["squeue", "-j", job_id, "-h", "-o", "%P"], self.command_timeout_s)
         except (OSError, subprocess.TimeoutExpired) as exc:
             raise SlurmQueryError(f"squeue did not run: {exc}") from exc
         if result.returncode != 0:
@@ -412,6 +428,9 @@ class LocalCompute:
 
     def pending_reason(self, job_id: str) -> str:
         return ""  # synchronous jobs are terminal at submit — never pending
+
+    def job_partition(self, job_id: str) -> str:
+        return ""  # no scheduler, no partitions
 
     def active_job_names(self) -> list[str]:
         return []  # synchronous: nothing is ever pending or running

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -947,7 +947,13 @@ def _armed_wake_lost(
     """An armed wake that is still PENDING on its dependency after every job
     it waits on has been terminal for a full grace window is not coming
     (Slurm reports the dependency as never satisfiable, or the afterany was
-    lost). Cancel it so the sweep redelivers; the lease is then reaped."""
+    lost). Cancel it so the sweep redelivers; the lease is then reaped.
+
+    A wake the SITE moved off the partition it was submitted to is not
+    coming either — on Torch a pending job can be shifted to a lower-tier
+    catch-all partition and starve there for hours (2026-09-02, wake
+    16787511) — so a holder whose partition is not the one the wake recipe
+    asked for is cancelled the same way and redelivered onto the right one."""
     if not lease.holder_job_id:
         return False
     job_ids = _poll_targets(record)
@@ -961,7 +967,16 @@ def _armed_wake_lost(
         states = [compute.status(jid) for jid in job_ids]
     except SlurmQueryError:
         return False
-    if reason == "DependencyNeverSatisfied":
+    moved = _moved_off_partition(root, compute, lease.holder_job_id)
+    if moved:
+        log.warning(
+            "armed wake %s for %s was moved to partition %s (asked for %s); redelivering",
+            lease.holder_job_id,
+            record.run_id,
+            moved[0],
+            moved[1],
+        )
+    elif reason == "DependencyNeverSatisfied":
         pass
     elif reason != "Dependency" or not all(is_terminal(s) for s in states):
         return False
@@ -1339,6 +1354,26 @@ def _sweep_implementing(root: Path, compute: Compute, now: float, grace_s: float
         except Exception as exc:  # per-record isolation, like the waiting sweep
             log.warning("implementing-sweep failed on %s: %s", record.run_id, exc)
     return ended
+
+
+def _moved_off_partition(root: Path, compute: Compute, job_id: str) -> tuple[str, str] | None:
+    """(actual, wanted) when a queued kernel job no longer sits in the
+    partition the wake recipe asks for, else None. Unknown either way —
+    no recipe, a compute without partitions, a failed query — is None:
+    never cancel on doubt."""
+    spec = load_wake_spec(root)
+    if spec is None:
+        return None
+    wanted = spec.job_partition or spec.partition
+    if not wanted:
+        return None
+    try:
+        actual = compute.job_partition(job_id)
+    except (SlurmQueryError, ValueError, AttributeError):
+        return None
+    if not actual or actual == wanted:
+        return None
+    return actual, wanted
 
 
 def _poll_targets(record: RunRecord) -> list[str]:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1371,7 +1371,11 @@ def _moved_off_partition(root: Path, compute: Compute, job_id: str) -> tuple[str
         actual = compute.job_partition(job_id)
     except (SlurmQueryError, ValueError, AttributeError):
         return None
-    if not actual or actual == wanted:
+    # both sides may be comma-separated lists: moved only when the job holds
+    # NONE of the partitions the recipe asked for; empty is unknown, not moved
+    have = {p.strip() for p in actual.split(",") if p.strip()}
+    want = {p.strip() for p in wanted.split(",") if p.strip()}
+    if not have or have & want:
         return None
     return actual, wanted
 

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -191,6 +191,9 @@ def test_job_terminal_without_a_result_fails_instead_of_parking(tmp_path: Path) 
         def pending_reason(self, job_id: str) -> str:
             return ""
 
+        def job_partition(self, job_id: str) -> str:
+            return ""
+
         def active_job_names(self) -> list:
             return []
 

--- a/tests/test_requeue_moved_successors.py
+++ b/tests/test_requeue_moved_successors.py
@@ -1,0 +1,52 @@
+"""The chain's pre-top-up sweep: same-name successors moved off our partition
+are cancelled (so the top-up requeues them); the rest are left alone."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "requeue_moved_successors.sh"
+
+
+def _shims(tmp_path: Path, squeue_rows: str) -> tuple[Path, Path]:
+    """Fake squeue/scancel on PATH: squeue prints the given `%i %P` rows,
+    scancel appends its argument to a log file."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(parents=True)
+    log = tmp_path / "scancel.log"
+    (bindir / "squeue").write_text(f"#!/bin/sh\nprintf '{squeue_rows}'\n")
+    (bindir / "scancel").write_text(f'#!/bin/sh\necho "$1" >> "{log}"\n')
+    for f in ("squeue", "scancel"):
+        os.chmod(bindir / f, 0o755)
+    return bindir, log
+
+
+def _run(bindir: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "USER": os.environ.get("USER", "u"),
+    }
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args], check=True, capture_output=True, text=True, env=env
+    )
+
+
+def test_moved_successors_are_cancelled_and_named(tmp_path: Path) -> None:
+    bindir, log = _shims(tmp_path, "101 all\\n102 cpu_short\\n103 all\\n")
+    out = _run(bindir, "autoresearch-tick", "cpu_short")
+    assert log.read_text().split() == ["101", "103"]
+    assert "cancelled successor 101 moved to all (asked for cpu_short)" in out.stdout
+    assert "102" not in out.stdout
+
+
+def test_nothing_moved_or_no_partition_is_a_no_op(tmp_path: Path) -> None:
+    bindir, log = _shims(tmp_path, "101 cpu_short\\n102 cpu_short\\n")
+    assert _run(bindir, "autoresearch-tick", "cpu_short").stdout == ""
+    assert not log.exists()
+    # no requested partition known: never cancel on doubt
+    bindir2, log2 = _shims(tmp_path / "two", "101 all\\n")
+    assert _run(bindir2, "autoresearch-tick", "").stdout == ""
+    assert not log2.exists()

--- a/tests/test_requeue_moved_successors.py
+++ b/tests/test_requeue_moved_successors.py
@@ -50,3 +50,12 @@ def test_nothing_moved_or_no_partition_is_a_no_op(tmp_path: Path) -> None:
     bindir2, log2 = _shims(tmp_path / "two", "101 all\\n")
     assert _run(bindir2, "autoresearch-tick", "").stdout == ""
     assert not log2.exists()
+
+
+def test_partition_lists_match_by_membership_and_unknown_is_never_cancelled(tmp_path: Path) -> None:
+    """A job submitted to `cpu_short,all` and now holding `cpu_short` is not
+    moved; one holding `all` alone is; an empty %P is unknown (r1)."""
+    bindir, log = _shims(tmp_path, "101 cpu_short\n102 all\n103 \n104 cpu_short,all\n")
+    out = _run(bindir, "autoresearch-tick", "cpu_short,cpu_prem")
+    assert log.read_text().split() == ["102"]
+    assert "102" in out.stdout and "101" not in out.stdout and "104" not in out.stdout

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -42,6 +42,7 @@ class FakeSlurm:
     states: dict[str, str] = field(default_factory=dict)
     cancelled: list[str] = field(default_factory=list)
     reasons: dict[str, str] = field(default_factory=dict)  # squeue %r by job id
+    partitions: dict[str, str] = field(default_factory=dict)  # squeue %P by job id
     cancel_sticks: bool = True  # scancel moves the job to CANCELLED, like Slurm
 
     def _runner(self, argv, timeout_s):
@@ -58,8 +59,10 @@ class FakeSlurm:
             return CommandResult(0, "", "")
         if argv[0] == "squeue":
             if "-j" in argv:
-                reason = self.reasons.get(argv[argv.index("-j") + 1], "")
-                return CommandResult(0, reason + "\n" if reason else "", "")
+                jid = argv[argv.index("-j") + 1]
+                table = self.partitions if "%P" in argv else self.reasons
+                value = table.get(jid, "")
+                return CommandResult(0, value + "\n" if value else "", "")
             return CommandResult(0, "", "")  # no live jobs
         raise AssertionError(f"unexpected command {argv}")
 
@@ -3846,3 +3849,39 @@ def test_a_pending_panel_wake_submits_a_followup_and_holds_off_the_arm(tmp_path:
     assert submitted == [("r-rev", "77")] and armed == []
     submitted2, _armed2 = run("b" * 40, "c" * 40)
     assert submitted2 == []
+
+
+def test_sweep_redelivers_an_armed_wake_the_site_moved_off_its_partition(tmp_path: Path) -> None:
+    """Torch can shift a pending job to a lower-tier catch-all partition where
+    it starves (2026-09-02: wake 16787511 sat on `all` for hours). A holder
+    whose partition is not the recipe's is treated as lost: cancelled, lease
+    reaped, redelivered onto the right partition — in the same tick."""
+    from dataclasses import replace as dc_replace
+
+    from autoresearch.tick import write_wake_spec
+
+    waiting_run(tmp_path)
+    acquire_lease(tmp_path, "r1", "wake-job:55", "55", now=NOW - 60)
+    write_wake_spec(
+        tmp_path, dc_replace(_wake_spec(tmp_path), partition="cpu_short", job_partition="")
+    )
+    slurm = FakeSlurm(
+        states={"100": "COMPLETED", "55": "PENDING"},
+        reasons={"55": "Priority"},
+        partitions={"55": "all"},
+    )
+    report, dispatcher = run_tick(tmp_path, slurm)
+    assert slurm.cancelled == ["55"]
+    assert report.reaped_leases == ("r1",)
+    assert dispatcher.dispatched == [("r1", "experiment COMPLETED")]
+
+    # the same partition is not a move: the grace path stands (no cancel yet)
+    waiting_run(tmp_path, run_id="r2", terminal_seen=0.0, experiment_job_id="200")
+    acquire_lease(tmp_path, "r2", "wake-job:66", "66", now=NOW - 60)
+    slurm2 = FakeSlurm(
+        states={"200": "COMPLETED", "66": "PENDING"},
+        reasons={"66": "Dependency"},
+        partitions={"66": "cpu_short"},
+    )
+    _report2, dispatcher2 = run_tick(tmp_path, slurm2, now=NOW + 1, min_tick_s=0)
+    assert "66" not in slurm2.cancelled and dispatcher2.dispatched == []

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3885,3 +3885,19 @@ def test_sweep_redelivers_an_armed_wake_the_site_moved_off_its_partition(tmp_pat
     )
     _report2, dispatcher2 = run_tick(tmp_path, slurm2, now=NOW + 1, min_tick_s=0)
     assert "66" not in slurm2.cancelled and dispatcher2.dispatched == []
+
+
+def test_moved_off_partition_matches_lists_by_membership(tmp_path: Path) -> None:
+    from dataclasses import replace as dc_replace
+
+    from autoresearch.tick import _moved_off_partition, write_wake_spec
+
+    write_wake_spec(
+        tmp_path, dc_replace(_wake_spec(tmp_path), partition="cpu_short,cpu_prem", job_partition="")
+    )
+    slurm = FakeSlurm(partitions={"1": "cpu_short", "2": "cpu_short,all", "3": "all", "4": ""})
+    c = slurm.compute()
+    assert _moved_off_partition(tmp_path, c, "1") is None  # holds one we asked for
+    assert _moved_off_partition(tmp_path, c, "2") is None  # list overlaps
+    assert _moved_off_partition(tmp_path, c, "3") == ("all", "cpu_short,cpu_prem")
+    assert _moved_off_partition(tmp_path, c, "4") is None  # unknown is not moved


### PR DESCRIPTION
## Incident

Today Torch moved two pending kernel jobs from `cpu_short` (where they were submitted; `SubmitLine` proves it) to the lower-tier catch-all partition `all`, where they starved on priority for hours:

- an armed wake (`16787511`, agent-04) — the kernel correctly waited (its rule cancels a pending wake only on `Dependency`/`DependencyNeverSatisfied`), the owner cancelled it by hand and the sweep redelivered;
- the 14:15 ET tick successor (`16795803`) — worse: the chain keeps two successors under `--dependency=singleton`, which waits for same-name jobs to **end**, and a pending job never ends, so the twin on `cpu_short` was blocked too. **No ticks from 17:45Z until the owner cancelled the moved job.**

`scontrol update Partition=cpu_short` is refused by the site ("Unspecified error").

## Fix

- **Chain:** `scripts/requeue_moved_successors.sh <name> <partition>` cancels same-name PENDING jobs whose `%P` is not the requested partition; `tick_chain.sbatch` runs it before the top-up, so a fresh successor lands on the right partition. No-op when no partition is configured (never cancel on doubt).
- **Sweep:** `Compute.job_partition(job_id)` (squeue `%P`; `""` for local compute). `_armed_wake_lost` treats a pending holder whose partition differs from the wake recipe's (`job_partition or partition`) as lost — cancelled, lease reaped, redelivered in the same tick, with a warning naming the move. Unknown (no recipe, failed query, backend without partitions) is never a move.

## Tests

- `tests/test_requeue_moved_successors.py`: PATH shims for `squeue`/`scancel` — moved successors are cancelled and named, unmoved ones untouched, empty partition is a no-op.
- `tests/test_tick.py`: a pending armed wake on `all` while the recipe says `cpu_short` is cancelled and redelivered in the same tick; the same partition keeps the existing grace path. `FakeSlurm` answers `%P` and `%r` separately.

Full suite green; ruff, mypy, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
