### PR TITLE
Design note: the resident tick

### DIFF
--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -57,6 +57,9 @@ needs inbound access is a human with the runbook.
   + absolute `--begin` times on a fixed cadence grid, so the schedule doesn't
   drift), submitted with retry/backoff. One failed submit doesn't kill the loop;
   two consecutive failures leave the watchdog alert as the signal.
+  Under scheduler congestion this per-cadence chain is fragile (a moved
+  successor can stall it); **design/resident-tick.md** proposes one long-lived
+  looping job with a single `afterany:self` successor instead.
 - **Tick order**: (1) read the pause sentinel on the state branch — if set, exit
   *without resubmitting*; (2) acquire the lease by compare-and-swap commit to the
   state branch — a non-fast-forward push means another tick is alive: exit;

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -58,8 +58,9 @@ needs inbound access is a human with the runbook.
   drift), submitted with retry/backoff. One failed submit doesn't kill the loop;
   two consecutive failures leave the watchdog alert as the signal.
   Under scheduler congestion this per-cadence chain is fragile (a moved
-  successor can stall it); **design/resident-tick.md** proposes one long-lived
-  looping job with a single `afterany:self` successor instead.
+  successor can stall it); **design/resident-tick.md** proposes a six-hour
+  looping job with a single `afterany:self` successor instead — four
+  scheduling events a day instead of 48.
 - **Tick order**: (1) read the pause sentinel on the state branch — if set, exit
   *without resubmitting*; (2) acquire the lease by compare-and-swap commit to the
   state branch — a non-fast-forward push means another tick is alive: exit;

--- a/docs/design/resident-tick.md
+++ b/docs/design/resident-tick.md
@@ -22,8 +22,8 @@ to do something we cannot control. On Torch, 2026-09-02, it did:
   deadline against its own *estimated* start, which under congestion sits
   hours out, so it **cancelled every successor within minutes** (#237 reverted).
 - At 19:02 ET the scheduler also cancelled every pending job of ours at once,
-  armed wakes included — cause unknown, but a reminder that pending jobs are
-  hostage to the site.
+  armed wakes included — cause unknown, but a reminder that pending jobs depend
+  on the site scheduler.
 
 Mitigations shipped (#234: a running tick requeues a moved successor; the
 sweep redelivers a moved wake) only help while a tick runs. The root cause is
@@ -33,30 +33,41 @@ job every thirty minutes.
 ## The design
 
 **One long-lived tick job that loops** — deploy, tick, sleep to the next slot —
-so the chain needs one scheduling event per *day*, not per cadence:
+so the chain needs a handful of scheduling events per *day*, not one per
+cadence. `cpu_short` accepts at most six hours (`sbatch --test-only`: 06:00:00
+accepted, 06:01:00 rejected — the partition's QoS), so a resident job lives
+six hours and hands over four times a day: twelve times fewer scheduling
+events than the 48 per-cadence jobs.
 
 ```
-resident job (cpu_short, --time=1-00:00:00, singleton)
+resident job (cpu_short, --time=06:00:00 passed at start, singleton)
   submit ONE successor: --dependency=afterany:<self>,singleton   # continuity
   loop until 20 minutes before walltime:
+    if the pause sentinel is set: cancel the successor, exit     # no resubmit
     deploy (fetch main + reset, uv sync, re-read .env)            # as today
-    run one tick as a CHILD process with a 15-minute timeout      # never exec
+    if the shim's hash changed: cancel + resubmit the successor   # fresh shim
+    run one tick as a CHILD: timeout --kill-after=60s 15m         # never exec
     sleep until the next cadence slot
 ```
 
 - **Continuity.** The single successor waits on `afterany:self`, so it is
   ineligible (not a candidate for the site's moves) until this job ends —
   walltime, node death, or preemption — and then starts as soon as the
-  scheduler gives it a node. One handover per day; during it, the armed
+  scheduler gives it a node. Four handovers a day; during one, the armed
   per-run wakes keep firing on their own, exactly as they did today.
+- **Pause exits without resubmitting.** The sentinel is read at the top of
+  every iteration; when set, the loop cancels its queued successor and exits,
+  which is the architecture's rule for the pause and what a paused chain must
+  mean: nothing queued.
 - **Deploy-at-tick stays.** Each iteration re-deploys and re-reads the operator
   `.env` before the tick, so merges to `main` and live config changes still
-  land at the next cadence. The successor also runs the script from the
-  checkout, so shim changes propagate at handover instead of one generation
-  later.
+  land at the next cadence. Slurm spools a batch script at submission, so the
+  queued successor carries the shim as it was when queued: after a deploy that
+  changed `tick_chain.sbatch` (hash compare), the loop cancels and resubmits
+  the successor, and handover runs the current shim — no extra generation.
 - **A hung or crashed tick never takes the loop with it.** The tick runs as a
-  child under `timeout`; the loop logs the exit and sleeps to the next slot.
-  The pause sentinel is honored per iteration.
+  child under `timeout --kill-after=60s 15m` (TERM, then KILL a minute later
+  if it ignores TERM); the loop logs the exit and sleeps to the next slot.
 - **Idempotent by construction.** Nothing in the tick changes: same records,
   leases, markers, coalescing guard. A tick that runs twice or late is already
   safe (the lease makes restarts safe); the resident loop only changes *who
@@ -68,16 +79,20 @@ resident job (cpu_short, --time=1-00:00:00, singleton)
 
 If the resident job itself is pending (first start, or a handover during
 congestion) the chain is down until it starts — the same exposure as today,
-once a day instead of 48 times. `cpu_short` has `PreemptMode=OFF`, so a running
+four times a day instead of 48. `cpu_short` has `PreemptMode=OFF`, so a running
 resident job is not preempted. A dead node kills the job; the successor
 covers it.
 
 ## Rollout
 
-1. Opt-in mode in `scripts/tick_chain.sbatch`: `AUTORESEARCH_RESIDENT_HOURS=24`
-   selects the loop; unset keeps today's per-cadence chain, byte for byte.
-   The loop's slot arithmetic and the tick timeout are small helpers with
-   tests (PATH shims), like the lock sweep.
+1. Opt-in mode in `scripts/tick_chain.sbatch`: `AUTORESEARCH_RESIDENT=1` in
+   the chain's environment selects the loop; unset keeps today's per-cadence
+   chain, byte for byte. The walltime is fixed by Slurm before the script
+   runs, so the resident chain is STARTED with an explicit
+   `sbatch --time=06:00:00 …` (the `#SBATCH --time=15` header stays the
+   per-cadence default) and its successors are submitted the same way. The
+   loop's slot arithmetic and the tick timeout are small helpers with tests
+   (PATH shims), like the lock sweep.
 2. Start one resident chain beside nothing else (singleton makes the two
    modes exclusive); watch a day of handovers in the tick log.
 3. Make resident the default; keep the per-cadence mode as the LocalCompute /

--- a/docs/design/resident-tick.md
+++ b/docs/design/resident-tick.md
@@ -5,8 +5,9 @@ are the evidence.*
 
 ## The problem
 
-The tick chain schedules **one Slurm job per cadence**: every tick queues two
-successors (`--dependency=singleton`, `--begin` on the cadence grid) and exits.
+The tick chain schedules **one Slurm job per cadence**: each tick maintains two
+queued successors (`--dependency=singleton`, `--begin` on the cadence grid) and
+exits.
 That is 48 scheduling events a day, each one an opportunity for the scheduler
 to do something we cannot control. On Torch, 2026-09-02, it did:
 

--- a/docs/design/resident-tick.md
+++ b/docs/design/resident-tick.md
@@ -1,0 +1,86 @@
+# The resident tick
+
+*Design note, 2026-09-02. Status: proposed — the chain restarts of 2026-09-02
+are the evidence.*
+
+## The problem
+
+The tick chain schedules **one Slurm job per cadence**: every tick queues two
+successors (`--dependency=singleton`, `--begin` on the cadence grid) and exits.
+That is 48 scheduling events a day, each one an opportunity for the scheduler
+to do something we cannot control. On Torch, 2026-09-02, it did:
+
+- Under `cpu_short` congestion the site **moved eligible pending jobs into the
+  lower-tier catch-all partition `all`**, where they starved for hours. Our
+  jobs may request only `cpu_short`; `all` and `cpu_prem` are rejected at
+  submit, and `scontrol update Partition` is refused. We cannot route around
+  the move.
+- A moved successor never starts and never ends, so its twin waits on
+  `singleton` forever: **the chain stopped for five hours** until a human
+  cancelled the moved job.
+- Giving successors a `--deadline` (#235) made it worse: Slurm enforces the
+  deadline against its own *estimated* start, which under congestion sits
+  hours out, so it **cancelled every successor within minutes** (#237 reverted).
+- At 19:02 ET the scheduler also cancelled every pending job of ours at once,
+  armed wakes included — cause unknown, but a reminder that pending jobs are
+  hostage to the site.
+
+Mitigations shipped (#234: a running tick requeues a moved successor; the
+sweep redelivers a moved wake) only help while a tick runs. The root cause is
+structural: the chain's liveness depends on the scheduler starting a fresh
+job every thirty minutes.
+
+## The design
+
+**One long-lived tick job that loops** — deploy, tick, sleep to the next slot —
+so the chain needs one scheduling event per *day*, not per cadence:
+
+```
+resident job (cpu_short, --time=1-00:00:00, singleton)
+  submit ONE successor: --dependency=afterany:<self>,singleton   # continuity
+  loop until 20 minutes before walltime:
+    deploy (fetch main + reset, uv sync, re-read .env)            # as today
+    run one tick as a CHILD process with a 15-minute timeout      # never exec
+    sleep until the next cadence slot
+```
+
+- **Continuity.** The single successor waits on `afterany:self`, so it is
+  ineligible (not a candidate for the site's moves) until this job ends —
+  walltime, node death, or preemption — and then starts as soon as the
+  scheduler gives it a node. One handover per day; during it, the armed
+  per-run wakes keep firing on their own, exactly as they did today.
+- **Deploy-at-tick stays.** Each iteration re-deploys and re-reads the operator
+  `.env` before the tick, so merges to `main` and live config changes still
+  land at the next cadence. The successor also runs the script from the
+  checkout, so shim changes propagate at handover instead of one generation
+  later.
+- **A hung or crashed tick never takes the loop with it.** The tick runs as a
+  child under `timeout`; the loop logs the exit and sleeps to the next slot.
+  The pause sentinel is honored per iteration.
+- **Idempotent by construction.** Nothing in the tick changes: same records,
+  leases, markers, coalescing guard. A tick that runs twice or late is already
+  safe (the lease makes restarts safe); the resident loop only changes *who
+  starts it*.
+- **Logs.** The loop reopens `logs/tick-YYYYMMDD.log` per iteration, so the
+  daily files keep their shape and the watchdog keeps its heartbeat.
+
+## What it does not fix
+
+If the resident job itself is pending (first start, or a handover during
+congestion) the chain is down until it starts — the same exposure as today,
+once a day instead of 48 times. `cpu_short` has `PreemptMode=OFF`, so a running
+resident job is not preempted. A dead node kills the job; the successor
+covers it.
+
+## Rollout
+
+1. Opt-in mode in `scripts/tick_chain.sbatch`: `AUTORESEARCH_RESIDENT_HOURS=24`
+   selects the loop; unset keeps today's per-cadence chain, byte for byte.
+   The loop's slot arithmetic and the tick timeout are small helpers with
+   tests (PATH shims), like the lock sweep.
+2. Start one resident chain beside nothing else (singleton makes the two
+   modes exclusive); watch a day of handovers in the tick log.
+3. Make resident the default; keep the per-cadence mode as the LocalCompute /
+   dev path.
+
+Related: `docs/design/architecture.md` (Scheduling), #234, #235/#237.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,6 +93,11 @@ standing instruction they supersede — a resumed agent honors stale constraints
 - [ ] Ops runbook: manual restart, `scancel` procedures, PAT rotation calendar
 - [ ] Transcript storage on project space with stated retention
 
+- [ ] Resident tick (design/resident-tick.md): one long-lived looping job with a
+      single `afterany:self` successor, one scheduling event per day — the
+      structural answer to the 2026-09-02 chain stalls (site partition moves;
+      the #235 deadline reverted in #237). Opt-in mode first, then default.
+
 ## Phase 5 — Benchmark-climb pilot
 
 Target: [autoresearch-pilot](https://github.com/agentic-learning-ai-lab/autoresearch-pilot)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -93,8 +93,8 @@ standing instruction they supersede — a resumed agent honors stale constraints
 - [ ] Ops runbook: manual restart, `scancel` procedures, PAT rotation calendar
 - [ ] Transcript storage on project space with stated retention
 
-- [ ] Resident tick (design/resident-tick.md): one long-lived looping job with a
-      single `afterany:self` successor, one scheduling event per day — the
+- [ ] Resident tick (design/resident-tick.md): a six-hour looping job with a
+      single `afterany:self` successor, four scheduling events a day — the
       structural answer to the 2026-09-02 chain stalls (site partition moves;
       the #235 deadline reverted in #237). Opt-in mode first, then default.
 


### PR DESCRIPTION
Design note only (no code): `docs/design/resident-tick.md`, a pointer from the architecture note's Scheduling section, and a roadmap item.

**Why now.** Today the chain stalled twice: the site moved eligible `cpu_short` successors into the starved `all` partition (we may request only `cpu_short`; moves cannot be undone by us), and a moved successor holds `singleton` forever. The `--deadline` attempt (#235) made Slurm cancel every successor within minutes on its own start estimate (#237 reverted). The per-cadence chain hands the scheduler 48 chances a day to do this.

**Proposal.** One long-lived tick job (cpu_short, 24h, singleton) that loops deploy → one tick as a child under `timeout` → sleep to the next slot, and queues a single `afterany:self` successor for continuity. One scheduling event per day; the successor is ineligible (so not movable) until handover; armed per-run wakes are unaffected. Deploy-at-tick and `.env` re-read stay per iteration; nothing in the tick itself changes. Rollout: opt-in `AUTORESEARCH_RESIDENT_HOURS`, a day of watched handovers, then default.

Owner's review wanted before code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
