### PR TITLE
Relocated means lost only when starving: eligible, unstarted, past the grace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- A job the site relocated off its submitted partition counts as lost only
+  when it is also starving: eligible (dependencies done, slot passed) and not
+  started past the grace window. Relocation alone is routine on Torch and
+  cancelling a relocated job only reset its queue age.
 - `AUTORESEARCH_BOT_ALIASES` names the kernel's former logins, and every
   "is this ours" check (own issues, claims, alarms, own PRs, own comments)
   recognizes them, so an identity flip does not turn the kernel's own

--- a/scripts/requeue_moved_successors.sh
+++ b/scripts/requeue_moved_successors.sh
@@ -1,32 +1,44 @@
 #!/usr/bin/env bash
 # Cancel same-name PENDING jobs of ours that the site moved off the partition
-# we submitted them to. The tick chain keeps two successors queued under
-# `--dependency=singleton`; a successor shifted to a lower-tier catch-all
-# partition starves there AND blocks its twin (singleton waits for same-name
-# jobs to END, and a pending job never ends) — the whole chain stalls
-# (Torch, 2026-09-02). Cancelling the moved job frees the twin, and the
-# chain's top-up queues a fresh successor on the right partition. Prints each
-# cancelled job id. Never fails the caller.
+# we submitted them to AND that are starving there: eligible (past their
+# --begin, no dependency left) and not started for MIN_STARVE_MINUTES. The
+# tick chain keeps two successors queued under `--dependency=singleton`; a
+# successor stuck on a lower-tier partition blocks its twin (singleton waits
+# for same-name jobs to END) and the chain stalls (Torch, 2026-09-02).
 #
-# usage: requeue_moved_successors.sh <job-name> <partition>
+# Relocation ALONE is not a fault: the site moves pending jobs routinely
+# (cpu_short -> cs, 2026-09-02 evening), and cancelling a relocated job that
+# is not yet eligible only resets its queue age. Prints each cancelled job
+# id. Never fails the caller.
+#
+# usage: requeue_moved_successors.sh <job-name> <partition> [min-starve-minutes]
 set -u
-name="${1:?usage: requeue_moved_successors.sh <job-name> <partition>}"
+name="${1:?usage: requeue_moved_successors.sh <job-name> <partition> [min-starve-minutes]}"
 wanted="${2:-}"
+starve_min="${3:-20}"
 [ -n "$wanted" ] || exit 0
-# Both sides may be comma-separated lists (a job may be submitted to several
-# partitions; squeue prints what the job currently holds). A job is MOVED only
-# when none of its partitions is one we asked for; an empty %P is unknown and
-# is never cancelled.
-squeue -u "$USER" --name="$name" -h -t PENDING -o "%i %P" 2>/dev/null | while read -r jid part; do
+now=$(date +%s)
+epoch_of() { date -d "$1" +%s 2>/dev/null || date -j -f %Y-%m-%dT%H:%M:%S "$1" +%s 2>/dev/null || echo ""; }
+# %i id, %P partition(s), %r reason, %S = scheduled/estimated start (N/A when unknown)
+squeue -u "$USER" --name="$name" -h -t PENDING -o "%i|%P|%r" 2>/dev/null | while IFS='|' read -r jid part reason; do
     [ -n "$jid" ] && [ -n "$part" ] || continue
+    # both sides may be comma-separated lists: moved only when the job holds
+    # NONE of the partitions we asked for
     moved=1
     for have in $(printf '%s' "$part" | tr ',' ' '); do
         for want in $(printf '%s' "$wanted" | tr ',' ' '); do
             [ "$have" = "$want" ] && moved=0
         done
     done
-    if [ "$moved" -eq 1 ]; then
-        scancel "$jid" 2>/dev/null && echo "chain: cancelled successor $jid moved to $part (asked for $wanted)"
+    [ "$moved" -eq 1 ] || continue
+    # not yet eligible (waiting for its slot or a dependency): leave it alone
+    case "$reason" in BeginTime|Dependency|DependencyNeverSatisfied) continue ;; esac
+    # eligible: starving only if it has been eligible for a while
+    eligible=$(scontrol show job "$jid" -o 2>/dev/null | tr ' ' '\n' | sed -n 's/^EligibleTime=//p' | head -1)
+    el_epoch=$(epoch_of "$eligible")
+    [ -n "$el_epoch" ] || continue  # unknown = never cancel on doubt
+    if [ $(( now - el_epoch )) -ge $(( starve_min * 60 )) ]; then
+        scancel "$jid" 2>/dev/null && echo "chain: cancelled successor $jid starving on $part since $eligible (asked for $wanted)"
     fi
 done
 exit 0

--- a/scripts/requeue_moved_successors.sh
+++ b/scripts/requeue_moved_successors.sh
@@ -35,8 +35,12 @@ squeue -u "$USER" --name="$name" -h -t PENDING -o "%i|%P|%r" 2>/dev/null | while
     case "$reason" in BeginTime|Dependency|DependencyNeverSatisfied) continue ;; esac
     # eligible: starving only if it has been eligible for a while
     eligible=$(scontrol show job "$jid" -o 2>/dev/null | tr ' ' '\n' | sed -n 's/^EligibleTime=//p' | head -1)
+    # unknown = never cancel on doubt: an absent or non-timestamp value must
+    # not reach date(1), whose GNU form reads "" as today at midnight
+    case "$eligible" in ""|Unknown|N/A|None) continue ;; esac
+    case "$eligible" in [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]) ;; *) continue ;; esac
     el_epoch=$(epoch_of "$eligible")
-    [ -n "$el_epoch" ] || continue  # unknown = never cancel on doubt
+    [ -n "$el_epoch" ] || continue
     if [ $(( now - el_epoch )) -ge $(( starve_min * 60 )) ]; then
         scancel "$jid" 2>/dev/null && echo "chain: cancelled successor $jid starving on $part since $eligible (asked for $wanted)"
     fi

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -951,11 +951,14 @@ def _armed_wake_lost(
     (Slurm reports the dependency as never satisfiable, or the afterany was
     lost). Cancel it so the sweep redelivers; the lease is then reaped.
 
-    A wake the SITE moved off the partition it was submitted to is not
-    coming either — on Torch a pending job can be shifted to a lower-tier
-    catch-all partition and starve there for hours (2026-09-02, wake
-    16787511) — so a holder whose partition is not the one the wake recipe
-    asked for is cancelled the same way and redelivered onto the right one."""
+    A wake the SITE moved off the partition it was submitted to may be
+    starving there — on Torch a pending job can be shifted to a lower-tier
+    partition (2026-09-02, wake 16787511 sat on `all` for hours) — but
+    relocation alone is routine (jobs move to `cs` while still waiting on
+    their dependencies and start on time). So a relocated holder counts as
+    lost only once every job it waited on is terminal AND the grace window
+    has run out without it starting; then it is cancelled and redelivered
+    onto the requested partition."""
     if not lease.holder_job_id:
         return False
     job_ids = _poll_targets(record)

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -970,24 +970,33 @@ def _armed_wake_lost(
     except SlurmQueryError:
         return False
     moved = _moved_off_partition(root, compute, lease.holder_job_id)
-    if moved:
-        log.warning(
-            "armed wake %s for %s was moved to partition %s (asked for %s); redelivering",
-            lease.holder_job_id,
-            record.run_id,
-            moved[0],
-            moved[1],
-        )
-    elif reason == "DependencyNeverSatisfied":
+    if reason == "DependencyNeverSatisfied":
         pass
-    elif reason != "Dependency" or not all(is_terminal(s) for s in states):
+    elif not all(is_terminal(s) for s in states):
+        return False  # its dependencies are still running: nothing to redeliver yet
+    elif reason != "Dependency" and not moved:
         return False
-    elif record.terminal_seen <= 0:
-        if not dry_run:
-            save_record(root, replace(record, terminal_seen=now), now)
-        return False
-    elif now - record.terminal_seen < grace_s:
-        return False
+    else:
+        # Dependency-pending past its dependencies, or RELOCATED and eligible:
+        # both get the grace window. Relocation alone is normal (the site
+        # moves pending jobs routinely); a relocated wake counts as lost only
+        # when every job it waited on is terminal and it still has not
+        # started once the grace has run out — cancelling earlier would only
+        # reset its queue age and burn a wake attempt.
+        if moved:
+            log.info(
+                "armed wake %s for %s sits on partition %s (asked for %s) past its dependencies",
+                lease.holder_job_id,
+                record.run_id,
+                moved[0],
+                moved[1],
+            )
+        if record.terminal_seen <= 0:
+            if not dry_run:
+                save_record(root, replace(record, terminal_seen=now), now)
+            return False
+        if now - record.terminal_seen < grace_s:
+            return False
     if dry_run:
         return True
     try:

--- a/tests/test_requeue_moved_successors.py
+++ b/tests/test_requeue_moved_successors.py
@@ -1,24 +1,41 @@
-"""The chain's pre-top-up sweep: same-name successors moved off our partition
-are cancelled (so the top-up requeues them); the rest are left alone."""
+"""The chain's pre-top-up sweep: a same-name successor relocated off our
+partition is cancelled only when it is STARVING there — eligible and not
+started for a while. Relocation alone (or a job still waiting on its slot or
+a dependency) is left alone: cancelling would only reset its queue age."""
 
 from __future__ import annotations
 
 import os
 import subprocess
+from datetime import datetime, timedelta
 from pathlib import Path
 
 SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "requeue_moved_successors.sh"
 
 
-def _shims(tmp_path: Path, squeue_rows: str) -> tuple[Path, Path]:
-    """Fake squeue/scancel on PATH: squeue prints the given `%i %P` rows,
-    scancel appends its argument to a log file."""
+def _iso(minutes_ago: int) -> str:
+    return (datetime.now() - timedelta(minutes=minutes_ago)).strftime("%Y-%m-%dT%H:%M:%S")
+
+
+def _shims(
+    tmp_path: Path, rows: list[tuple[str, str, str]], eligible: dict[str, str]
+) -> tuple[Path, Path]:
+    """Fake squeue (`%i|%P|%r` rows), scontrol (EligibleTime per job) and
+    scancel (logs its argument) on PATH."""
     bindir = tmp_path / "bin"
     bindir.mkdir(parents=True)
     log = tmp_path / "scancel.log"
-    (bindir / "squeue").write_text(f"#!/bin/sh\nprintf '{squeue_rows}'\n")
+    body = "".join(f"{jid}|{part}|{reason}\\n" for jid, part, reason in rows)
+    (bindir / "squeue").write_text(f"#!/bin/sh\nprintf '{body}'\n")
+    cases = "".join(
+        f'  {jid}) echo "JobId={jid} EligibleTime={t} JobState=PENDING";;\n'
+        for jid, t in eligible.items()
+    )
+    (bindir / "scontrol").write_text(
+        f'#!/bin/sh\ncase "$3" in\n{cases}  *) echo "JobId=$3";;\nesac\n'
+    )
     (bindir / "scancel").write_text(f'#!/bin/sh\necho "$1" >> "{log}"\n')
-    for f in ("squeue", "scancel"):
+    for f in ("squeue", "scontrol", "scancel"):
         os.chmod(bindir / f, 0o755)
     return bindir, log
 
@@ -34,28 +51,32 @@ def _run(bindir: Path, *args: str) -> subprocess.CompletedProcess[str]:
     )
 
 
-def test_moved_successors_are_cancelled_and_named(tmp_path: Path) -> None:
-    bindir, log = _shims(tmp_path, "101 all\\n102 cpu_short\\n103 all\\n")
-    out = _run(bindir, "autoresearch-tick", "cpu_short")
-    assert log.read_text().split() == ["101", "103"]
-    assert "cancelled successor 101 moved to all (asked for cpu_short)" in out.stdout
-    assert "102" not in out.stdout
+def test_only_a_starving_relocated_successor_is_cancelled(tmp_path: Path) -> None:
+    rows = [
+        ("101", "cs", "Priority"),  # relocated, eligible, starving -> cancel
+        ("102", "cs", "BeginTime"),  # relocated but waiting for its slot -> keep
+        ("103", "cs", "Dependency"),  # relocated but singleton-blocked -> keep
+        ("104", "cs", "Priority"),  # relocated, eligible only 5 minutes -> keep
+        ("105", "cpu_short", "Priority"),  # not relocated -> keep
+        ("106", "cs", "Priority"),  # relocated, eligibility unknown -> keep (doubt)
+    ]
+    eligible = {"101": _iso(45), "104": _iso(5)}
+    bindir, log = _shims(tmp_path, rows, eligible)
+    out = _run(bindir, "autoresearch-tick", "cpu_short", "20")
+    assert log.read_text().split() == ["101"]
+    assert "cancelled successor 101 starving on cs" in out.stdout
 
 
-def test_nothing_moved_or_no_partition_is_a_no_op(tmp_path: Path) -> None:
-    bindir, log = _shims(tmp_path, "101 cpu_short\\n102 cpu_short\\n")
-    assert _run(bindir, "autoresearch-tick", "cpu_short").stdout == ""
-    assert not log.exists()
-    # no requested partition known: never cancel on doubt
-    bindir2, log2 = _shims(tmp_path / "two", "101 all\\n")
-    assert _run(bindir2, "autoresearch-tick", "").stdout == ""
-    assert not log2.exists()
-
-
-def test_partition_lists_match_by_membership_and_unknown_is_never_cancelled(tmp_path: Path) -> None:
-    """A job submitted to `cpu_short,all` and now holding `cpu_short` is not
-    moved; one holding `all` alone is; an empty %P is unknown (r1)."""
-    bindir, log = _shims(tmp_path, "101 cpu_short\n102 all\n103 \n104 cpu_short,all\n")
+def test_partition_lists_match_by_membership_and_no_partition_is_a_no_op(tmp_path: Path) -> None:
+    rows = [
+        ("201", "cpu_short,all", "Priority"),
+        ("202", "all", "Priority"),
+        ("203", "", "Priority"),
+    ]
+    eligible = {"201": _iso(60), "202": _iso(60), "203": _iso(60)}
+    bindir, log = _shims(tmp_path, rows, eligible)
     out = _run(bindir, "autoresearch-tick", "cpu_short,cpu_prem")
-    assert log.read_text().split() == ["102"]
-    assert "102" in out.stdout and "101" not in out.stdout and "104" not in out.stdout
+    assert log.read_text().split() == ["202"]
+    assert "201" not in out.stdout and "203" not in out.stdout
+    bindir2, log2 = _shims(tmp_path / "two", rows, eligible)
+    assert _run(bindir2, "autoresearch-tick", "").stdout == "" and not log2.exists()

--- a/tests/test_requeue_moved_successors.py
+++ b/tests/test_requeue_moved_successors.py
@@ -58,9 +58,10 @@ def test_only_a_starving_relocated_successor_is_cancelled(tmp_path: Path) -> Non
         ("103", "cs", "Dependency"),  # relocated but singleton-blocked -> keep
         ("104", "cs", "Priority"),  # relocated, eligible only 5 minutes -> keep
         ("105", "cpu_short", "Priority"),  # not relocated -> keep
-        ("106", "cs", "Priority"),  # relocated, eligibility unknown -> keep (doubt)
+        ("106", "cs", "Priority"),  # relocated, eligibility absent -> keep (doubt)
+        ("107", "cs", "Priority"),  # relocated, EligibleTime=Unknown -> keep (doubt)
     ]
-    eligible = {"101": _iso(45), "104": _iso(5)}
+    eligible = {"101": _iso(45), "104": _iso(5), "107": "Unknown"}
     bindir, log = _shims(tmp_path, rows, eligible)
     out = _run(bindir, "autoresearch-tick", "cpu_short", "20")
     assert log.read_text().split() == ["101"]

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3875,6 +3875,32 @@ def test_sweep_redelivers_an_armed_wake_the_site_moved_off_its_partition(tmp_pat
     assert report.reaped_leases == ("r1",)
     assert dispatcher.dispatched == [("r1", "experiment COMPLETED")]
 
+    # relocated but its dependencies still RUN: nothing to redeliver, no cancel
+    waiting_run(tmp_path, run_id="r3", experiment_job_id="300")
+    acquire_lease(tmp_path, "r3", "wake-job:77", "77", now=NOW - 60)
+    slurm3 = FakeSlurm(
+        states={"300": "RUNNING", "77": "PENDING"},
+        reasons={"77": "Dependency"},
+        partitions={"77": "cs"},
+    )
+    _r3, d3 = run_tick(tmp_path, slurm3, now=NOW + 2, min_tick_s=0)
+    assert "77" not in slurm3.cancelled and d3.dispatched == []
+
+    # relocated, dependencies terminal, but seen terminal only now: the grace
+    # window runs first (stamped), the cancel comes a tick later
+    waiting_run(tmp_path, run_id="r4", terminal_seen=0.0, experiment_job_id="400")
+    acquire_lease(tmp_path, "r4", "wake-job:88", "88", now=NOW - 60)
+    slurm4 = FakeSlurm(
+        states={"400": "COMPLETED", "88": "PENDING"},
+        reasons={"88": "Priority"},
+        partitions={"88": "cs"},
+    )
+    _r4, d4 = run_tick(tmp_path, slurm4, now=NOW + 3, min_tick_s=0)
+    assert "88" not in slurm4.cancelled and d4.dispatched == []
+    assert load_record(tmp_path, "r4").terminal_seen == NOW + 3
+    _r4b, d4b = run_tick(tmp_path, slurm4, now=NOW + 3 + GRACE + 1, min_tick_s=0)
+    assert slurm4.cancelled == ["88"] and d4b.dispatched == [("r4", "experiment COMPLETED")]
+
     # the same partition is not a move: the grace path stands (no cancel yet)
     waiting_run(tmp_path, run_id="r2", terminal_seen=0.0, experiment_job_id="200")
     acquire_lease(tmp_path, "r2", "wake-job:66", "66", now=NOW - 60)


### PR DESCRIPTION
## Why

Tonight every pending job of ours — both tick successors and all four armed wakes — was relocated by the site from `cpu_short` to `cs` **while still ineligible** (waiting on `--begin` or an `afterany`). Relocation is evidently routine, not a fault. #234's rule "off the requested partition = lost" would therefore cancel and resubmit these jobs on every tick: each resubmission resets the job's queue age (making it *less* likely to start under congestion) and each redelivery bills a wake attempt toward `MAX_WAKE_ATTEMPTS` (ending healthy runs as stuck).

## Fix

"Lost" now means relocated **and starving**:

- **Sweep (`_armed_wake_lost`):** a relocated wake is cancelled/redelivered only when every job it waited on is terminal *and* the grace window has run out — the same timing as the `Dependency` case. Dependencies still running → nothing. First sighting → `terminal_seen` stamped, cancel a tick later.
- **Chain (`requeue_moved_successors.sh`):** a relocated successor is cancelled only when it is eligible (reason not `BeginTime`/`Dependency`) and its `EligibleTime` (from `scontrol`) is ≥ 20 minutes ago. Unknown eligibility never cancels.

## Tests

- `test_tick.py`: relocated + dependencies running → no cancel; relocated + terminal + first sighting → stamped, cancelled and redelivered only after the grace; the original starving case still redelivers in one tick; same partition unchanged.
- `test_requeue_moved_successors.py`: six-row table (starving → cancelled; BeginTime / Dependency / freshly eligible / not relocated / unknown eligibility → kept), list membership, empty partition no-op — with `squeue`, `scontrol`, and `scancel` shims.

CHANGELOG under Fixed. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
