### PR TITLE
The resident tick: one six-hour job that loops, with a single afterany:self successor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The tick can run RESIDENT (`AUTORESEARCH_RESIDENT=1`, its own job name):
+  one six-hour job that loops deploy → tick → sleep with a single
+  `afterany:self` successor, so the chain needs four scheduling events a day
+  instead of one per cadence (`docs/design/resident-tick.md`). The per-cadence
+  chain drains itself once a resident job exists. The deploy step is shared
+  (`scripts/tick_deploy.sh`).
 - A blocking follow-up re-read wakes the author: the panel's findings are
   recorded on the run and the tick submits a follow-up for them like any
   other wake; the revision is re-measured and re-read, bounded by two rounds

--- a/docs/design/resident-tick.md
+++ b/docs/design/resident-tick.md
@@ -1,7 +1,8 @@
 # The resident tick
 
-*Design note, 2026-09-02. Status: proposed — the chain restarts of 2026-09-02
-are the evidence.*
+*Design note, 2026-09-02. Status: built as the opt-in mode
+(`AUTORESEARCH_RESIDENT=1`, `scripts/tick_resident.sh`); the chain restarts of
+2026-09-02 are the evidence.*
 
 ## The problem
 
@@ -87,15 +88,26 @@ covers it.
 ## Rollout
 
 1. Opt-in mode in `scripts/tick_chain.sbatch`: `AUTORESEARCH_RESIDENT=1` in
-   the chain's environment selects the loop; unset keeps today's per-cadence
-   chain, byte for byte. The walltime is fixed by Slurm before the script
-   runs, so the resident chain is STARTED with an explicit
-   `sbatch --time=06:00:00 …` (the `#SBATCH --time=15` header stays the
-   per-cadence default) and its successors are submitted the same way. The
-   loop's slot arithmetic and the tick timeout are small helpers with tests
-   (PATH shims), like the lock sweep.
-2. Start one resident chain beside nothing else (singleton makes the two
-   modes exclusive); watch a day of handovers in the tick log.
+   the chain's environment selects the loop; unset keeps the per-cadence
+   chain. The walltime is fixed by Slurm before the script runs, so the
+   resident chain is STARTED with an explicit walltime and its own job name:
+
+   ```
+   sbatch --time=360 --job-name=autoresearch-resident --dependency=singleton \
+     --account=… --partition=cpu_short \
+     --export=ALL,AUTORESEARCH_RESIDENT=1,AUTORESEARCH_HOME=…,AUTORESEARCH_ROOT=…,\
+   AUTORESEARCH_ACCOUNT=…,AUTORESEARCH_PARTITION=cpu_short,AUTORESEARCH_PAT_FILE=… \
+     scripts/tick_chain.sbatch
+   ```
+
+   The two modes have different job names, so the switch needs no cancel:
+   the per-cadence chain stops topping up as soon as a resident job exists
+   and drains within a cadence (the resident also cancels its pending
+   successors on start; a still-running one finishes its tick, and the
+   tick's coalescing guard makes an overlap a no-op). Switching back: set the
+   pause sentinel (the resident cancels its successor and exits), clear it,
+   start a per-cadence chain.
+2. Watch a day of handovers in the tick log (four, at six-hour walltime).
 3. Make resident the default; keep the per-cadence mode as the LocalCompute /
    dev path.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,9 @@ Operational scripts, always committed.
 | Script | Purpose |
 | --- | --- |
 | `setup_branch_protection.sh` | Apply/refresh branch protection on `main`. Solo-phase default: 0 approvals, checks required, admins enforced. Re-run with `1` once a second code owner joins. |
-| `tick_chain.sbatch` | The self-resubmitting Slurm tick: deploys `main` into its checkout, syncs deps, runs one tick, schedules the next (`docs/design/architecture.md`). |
+| `tick_chain.sbatch` | The Slurm tick entry: per-cadence chain (deploy, one tick, schedule the next) or, with `AUTORESEARCH_RESIDENT=1`, the resident loop (`docs/design/resident-tick.md`). |
+| `tick_deploy.sh` | The deploy step both modes source: stale-lock sweep, pull `main`, sync deps, read the operator's `.env` knobs, install backends. |
+| `tick_resident.sh` | The resident loop: deploy → one tick under a timeout → sleep to the slot, one `afterany:self` successor, pause exits clean, shim changes resubmit the successor. |
 | `requeue_moved_successors.sh` | Cancel pending same-name jobs that are no longer on the requested partition. The tick chain runs this before adding successors. |
 | `sweep_git_locks.sh` | Remove stale `.git/*.lock` files from a checkout (older than N minutes, no live git process); the chain runs it before each deploy. |
 | `install_codex.sh`, `install_hermes.sh` | Pin and install the non-claude author/judge backends on the tick host. |

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -15,6 +15,14 @@
 #   AUTORESEARCH_CADENCE_MIN  tick cadence, default 30
 #   AUTORESEARCH_PAT_FILE     bot PAT for the deploy pull (optional; no file
 #                             means run whatever code is already deployed)
+#   AUTORESEARCH_RESIDENT=1   run as the RESIDENT tick (design/resident-tick.md):
+#                             one long-lived job that loops deploy -> tick ->
+#                             sleep, with a single afterany:self successor.
+#                             Start it with an explicit walltime, e.g.
+#                             `sbatch --time=360 --job-name=autoresearch-resident
+#                             --export=ALL,AUTORESEARCH_RESIDENT=1,...`; the
+#                             per-cadence chain drains itself once a resident
+#                             job exists. Unset = the per-cadence chain below.
 # Further config also loads from ~/.config/autoresearch/.env (0600) each tick, so
 # a live config change (e.g. AUTORESEARCH_AUTHOR_BACKEND=codex + its key file)
 # needs no chain restart — just an edit to that file.
@@ -30,13 +38,27 @@
 # vars are checked by hand instead.
 CADENCE_MIN="${AUTORESEARCH_CADENCE_MIN:-30}"
 JOB_NAME="autoresearch-tick"
+RESIDENT_JOB_NAME="autoresearch-resident"
 missing=""
 for var in AUTORESEARCH_HOME AUTORESEARCH_ROOT AUTORESEARCH_ACCOUNT AUTORESEARCH_PARTITION; do
     eval "val=\${$var:-}"
     [ -z "$val" ] && missing="$missing $var"
 done
 
+# --- 0. the resident tick: hand the whole job to the loop ---
+if [ "${AUTORESEARCH_RESIDENT:-}" = "1" ]; then
+    . "${AUTORESEARCH_HOME:-.}/scripts/tick_resident.sh"
+    exit $?
+fi
+
 # --- 1. keep two successors queued (singleton serializes same-name jobs) ---
+# A resident tick (design/resident-tick.md) supersedes this chain: while one
+# is queued or running, stop topping up so the per-cadence chain drains.
+if squeue -u "$USER" --name="$RESIDENT_JOB_NAME" -h 2>/dev/null | grep -q '[0-9]'; then
+    echo "chain: a resident tick exists; not queuing successors (draining)"
+    need=0
+    pending=0
+else
 # A successor the SITE moved off our partition starves there and blocks its
 # twin through singleton; cancel it first so the top-up below requeues it.
 bash "${AUTORESEARCH_HOME:-.}/scripts/requeue_moved_successors.sh" "$JOB_NAME" "${AUTORESEARCH_PARTITION:-}" || true
@@ -53,10 +75,13 @@ else
     pending=0
     need=0
 fi
+fi
 epoch_now=$(date +%s)
 cadence_s=$((CADENCE_MIN * 60))
 next_slot=$(( (epoch_now / cadence_s + 1) * cadence_s ))
-for i in $(seq 1 "$need"); do
+# a while loop, not `seq 1 $need`: BSD seq counts DOWN for `seq 1 0`
+i=1
+while [ "$i" -le "$need" ]; do
     begin_epoch=$((next_slot + (pending + i - 1) * cadence_s))
     begin=$(date -d "@$begin_epoch" +%Y-%m-%dT%H:%M:%S 2>/dev/null \
             || date -r "$begin_epoch" +%Y-%m-%dT%H:%M:%S)
@@ -69,6 +94,7 @@ for i in $(seq 1 "$need"); do
         echo "sbatch retry $attempt failed; backing off"
         sleep $((attempt * 20))
     done
+    i=$((i + 1))
 done
 
 # Only NOW may configuration problems kill this tick — successors are queued.
@@ -84,101 +110,9 @@ if [ -w "$LOG_DIR" ]; then
 fi
 echo "=== tick $(date -Is) on $(hostname -s) job=${SLURM_JOB_ID:-none}"
 
-# --- 2. deploy: pull main with the bot PAT, sync deps (best-effort) ---
-# A tick killed mid-fetch leaves .git/*.lock files that make every later
-# deploy fail and the chain run stale code; sweep locks older than a few
-# minutes (a live git op holds one for seconds) before touching the checkout.
-bash "$AUTORESEARCH_HOME/scripts/sweep_git_locks.sh" "$AUTORESEARCH_HOME" 10 || true
-# The PAT never appears in argv (argv is world-readable via /proc on shared
-# nodes): git asks for it through GIT_ASKPASS instead.
-if [ -n "${AUTORESEARCH_PAT_FILE:-}" ] && [ -r "$AUTORESEARCH_PAT_FILE" ]; then
-    ASKPASS=$(mktemp 2>/dev/null || echo "") && [ -n "$ASKPASS" ] && chmod 700 "$ASKPASS"
-    printf '#!/bin/sh\ncat "%s"\n' "$AUTORESEARCH_PAT_FILE" > "$ASKPASS"
-    if GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 git -C "$AUTORESEARCH_HOME" fetch --quiet \
-        "https://x-access-token@github.com/agentic-learning-ai-lab/autoresearch.git" main; then
-        git -C "$AUTORESEARCH_HOME" reset --hard --quiet FETCH_HEAD || echo "deploy: reset failed"
-    else
-        echo "deploy: fetch failed; running previous code"
-    fi
-    rm -f "$ASKPASS"
-fi
-# Host-side caches must never land in $HOME: home quotas are tiny on many
-# clusters and invisible until EDQUOT (verified on Torch — a full home took
-# down a live run). Default them under the state root (scratch-class
-# storage); explicit env wins. Submitted jobs inherit these via sbatch.
-export UV_CACHE_DIR="${UV_CACHE_DIR:-$AUTORESEARCH_ROOT/cache/uv}"
-export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-$AUTORESEARCH_ROOT/cache/apptainer}"
-mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
-
-(cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet) || echo "deploy: uv sync failed"
-
-# --- config knobs: read the config-driven AUTHOR knobs from the operator .env so
-# live config changes need no chain restart. These are where
-# AUTORESEARCH_AUTHOR_BACKEND/_MODEL and the per-backend key files live; the
-# config-driven climb/followup default from them and the tick preflights them.
-#
-# We do NOT source .env: sourcing would execute it and let it set ANY variable
-# (the chain's own HOME/ROOT/PATH/cadence, arbitrary code). Instead we extract
-# only an ALLOWLIST of author knobs — so .env is structurally per-tick author
-# config and can never hijack the chain's identity or scheduling. And only from a
-# file that is ours and not group/world-writable (a writable one could still
-# inject a malicious VALUE, e.g. a bad codex binary path).
-ENV_FILE="$HOME/.config/autoresearch/.env"
-if [ -r "$ENV_FILE" ]; then
-    perms=$(stat -c "%a" "$ENV_FILE" 2>/dev/null || echo 777)
-    owner=$(stat -c "%u" "$ENV_FILE" 2>/dev/null || echo -1)
-    if [ "$owner" = "$(id -u)" ] && [ $((8#$perms & 8#022)) -eq 0 ]; then
-        for _k in AUTORESEARCH_AUTHOR_BACKEND AUTORESEARCH_AUTHOR_MODEL \
-                  AUTORESEARCH_CODEX_BIN AUTORESEARCH_CODEX_KEY_FILE \
-                  AUTORESEARCH_HARNESS_KEY_FILE \
-                  AUTORESEARCH_VERTEX_PROJECT AUTORESEARCH_VERTEX_REGION \
-                  AUTORESEARCH_VERTEX_ADC \
-                  AUTORESEARCH_TARGET \
-                  AUTORESEARCH_GITHUB_APP_FILE AUTORESEARCH_BOT_LOGIN AUTORESEARCH_BOT_ALIASES \
-                  AUTORESEARCH_GPU_PARTITION AUTORESEARCH_GPU_ACCOUNT \
-                  AUTORESEARCH_PANEL AUTORESEARCH_PANEL_KEY_FILE \
-                  AUTORESEARCH_PANEL_CODEX_KEY_FILE \
-                  AUTORESEARCH_PANEL_HERMES_KEY_FILE \
-                  REVIEW_HERMES_REPO REVIEW_HERMES_PROVIDER; do
-            _line=$(grep -E "^${_k}=" "$ENV_FILE" 2>/dev/null | tail -1)
-            # PRESENCE-based, not value-based: a key set to "" in .env is a
-            # live OFF-SWITCH (AUTORESEARCH_PANEL="" disables the panel,
-            # VERTEX_PROJECT="" reverts to API-key billing) and must override
-            # an inherited chain value; an ABSENT key changes nothing.
-            if [ -n "$_line" ]; then
-                _v=${_line#*=}
-                _v=${_v%$'\r'}                     # CRLF-edited file
-                _v=${_v#[\"\']}; _v=${_v%[\"\']}   # optional surrounding quote
-                export "$_k=$_v"
-            fi
-        done
-    else
-        echo "deploy: refusing to read $ENV_FILE (owner=$owner perms=$perms;" \
-             "needs to be yours and not group/world-writable)"
-    fi
-fi
-
-# The codex author binary is a host prerequisite; install it (idempotent, fast
-# path is a local version check) when ANY codex role is deployed — the fleet
-# author, or a codex panel lens (a claude-author/codex-panel rollout still
-# bind-mounts the binary into every judge container). Best-effort: a failure
-# here must never break the chain — the climb will report a missing codex
-# clearly if it comes to that.
-case "${AUTORESEARCH_AUTHOR_BACKEND:-}:${AUTORESEARCH_PANEL:-}" in
-    codex:*|*:*codex*)
-        bash "$AUTORESEARCH_HOME/scripts/install_codex.sh" || echo "deploy: codex install failed"
-        ;;
-esac
-case "${AUTORESEARCH_PANEL:-}" in
-    *hermes*)
-        # the default install location IS the default config: exporting it
-        # here connects the provisioned clone to the preflight/climb without
-        # requiring the operator to name a path they didn't choose
-        export REVIEW_HERMES_REPO="${REVIEW_HERMES_REPO:-$HOME/hermes-agent}"
-        bash "$AUTORESEARCH_HOME/scripts/install_hermes.sh" "$REVIEW_HERMES_REPO" \
-            || echo "deploy: hermes install failed"
-        ;;
-esac
+# --- 2. deploy: pull main, sync deps, read the operator's knobs (best-effort;
+#        scripts/tick_deploy.sh, sourced so its exports reach the tick) ---
+. "$AUTORESEARCH_HOME/scripts/tick_deploy.sh"
 
 # --- 3. the tick itself (scrubbed of the PAT path; sessions are scrubbed
 #        further down in the harness) ---

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -46,7 +46,14 @@ for var in AUTORESEARCH_HOME AUTORESEARCH_ROOT AUTORESEARCH_ACCOUNT AUTORESEARCH
 done
 
 # --- 0. the resident tick: hand the whole job to the loop ---
+# A resident job has no queued successor to protect yet, so a misconfigured
+# start fails LOUDLY here (the per-cadence chain below checks after its
+# top-up on purpose: its successors are already queued and must stay so).
 if [ "${AUTORESEARCH_RESIDENT:-}" = "1" ]; then
+    if [ -n "$missing" ]; then
+        echo "resident tick misconfigured; missing:$missing" >&2
+        exit 1
+    fi
     . "${AUTORESEARCH_HOME:-.}/scripts/tick_resident.sh"
     exit $?
 fi

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# The chain's deploy step, SOURCED by tick_chain.sbatch (it exports the
+# operator's config knobs into the tick's environment): sweep stale git locks,
+# pull main with the bot PAT, sync deps, read the allowlisted .env knobs,
+# install the non-claude backends. Every step is best-effort — a bad merge
+# crashes the tick, never the chain. Shared by the per-cadence chain (once per
+# job) and the resident loop (once per iteration).
+#
+# Expects: AUTORESEARCH_HOME, AUTORESEARCH_ROOT; optional AUTORESEARCH_PAT_FILE.
+
+# --- 2. deploy: pull main with the bot PAT, sync deps (best-effort) ---
+# A tick killed mid-fetch leaves .git/*.lock files that make every later
+# deploy fail and the chain run stale code; sweep locks older than a few
+# minutes (a live git op holds one for seconds) before touching the checkout.
+bash "$AUTORESEARCH_HOME/scripts/sweep_git_locks.sh" "$AUTORESEARCH_HOME" 10 || true
+# The PAT never appears in argv (argv is world-readable via /proc on shared
+# nodes): git asks for it through GIT_ASKPASS instead.
+if [ -n "${AUTORESEARCH_PAT_FILE:-}" ] && [ -r "$AUTORESEARCH_PAT_FILE" ]; then
+    ASKPASS=$(mktemp 2>/dev/null || echo "") && [ -n "$ASKPASS" ] && chmod 700 "$ASKPASS"
+    printf '#!/bin/sh\ncat "%s"\n' "$AUTORESEARCH_PAT_FILE" > "$ASKPASS"
+    if GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 git -C "$AUTORESEARCH_HOME" fetch --quiet \
+        "https://x-access-token@github.com/agentic-learning-ai-lab/autoresearch.git" main; then
+        git -C "$AUTORESEARCH_HOME" reset --hard --quiet FETCH_HEAD || echo "deploy: reset failed"
+    else
+        echo "deploy: fetch failed; running previous code"
+    fi
+    rm -f "$ASKPASS"
+fi
+# Host-side caches must never land in $HOME: home quotas are tiny on many
+# clusters and invisible until EDQUOT (verified on Torch — a full home took
+# down a live run). Default them under the state root (scratch-class
+# storage); explicit env wins. Submitted jobs inherit these via sbatch.
+export UV_CACHE_DIR="${UV_CACHE_DIR:-$AUTORESEARCH_ROOT/cache/uv}"
+export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-$AUTORESEARCH_ROOT/cache/apptainer}"
+mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
+
+(cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet) || echo "deploy: uv sync failed"
+
+# --- config knobs: read the config-driven AUTHOR knobs from the operator .env so
+# live config changes need no chain restart. These are where
+# AUTORESEARCH_AUTHOR_BACKEND/_MODEL and the per-backend key files live; the
+# config-driven climb/followup default from them and the tick preflights them.
+#
+# We do NOT source .env: sourcing would execute it and let it set ANY variable
+# (the chain's own HOME/ROOT/PATH/cadence, arbitrary code). Instead we extract
+# only an ALLOWLIST of author knobs — so .env is structurally per-tick author
+# config and can never hijack the chain's identity or scheduling. And only from a
+# file that is ours and not group/world-writable (a writable one could still
+# inject a malicious VALUE, e.g. a bad codex binary path).
+ENV_FILE="$HOME/.config/autoresearch/.env"
+if [ -r "$ENV_FILE" ]; then
+    perms=$(stat -c "%a" "$ENV_FILE" 2>/dev/null || echo 777)
+    owner=$(stat -c "%u" "$ENV_FILE" 2>/dev/null || echo -1)
+    if [ "$owner" = "$(id -u)" ] && [ $((8#$perms & 8#022)) -eq 0 ]; then
+        for _k in AUTORESEARCH_AUTHOR_BACKEND AUTORESEARCH_AUTHOR_MODEL \
+                  AUTORESEARCH_CODEX_BIN AUTORESEARCH_CODEX_KEY_FILE \
+                  AUTORESEARCH_HARNESS_KEY_FILE \
+                  AUTORESEARCH_VERTEX_PROJECT AUTORESEARCH_VERTEX_REGION \
+                  AUTORESEARCH_VERTEX_ADC \
+                  AUTORESEARCH_TARGET \
+                  AUTORESEARCH_GITHUB_APP_FILE AUTORESEARCH_BOT_LOGIN AUTORESEARCH_BOT_ALIASES \
+                  AUTORESEARCH_GPU_PARTITION AUTORESEARCH_GPU_ACCOUNT \
+                  AUTORESEARCH_PANEL AUTORESEARCH_PANEL_KEY_FILE \
+                  AUTORESEARCH_PANEL_CODEX_KEY_FILE \
+                  AUTORESEARCH_PANEL_HERMES_KEY_FILE \
+                  REVIEW_HERMES_REPO REVIEW_HERMES_PROVIDER; do
+            _line=$(grep -E "^${_k}=" "$ENV_FILE" 2>/dev/null | tail -1)
+            # PRESENCE-based, not value-based: a key set to "" in .env is a
+            # live OFF-SWITCH (AUTORESEARCH_PANEL="" disables the panel,
+            # VERTEX_PROJECT="" reverts to API-key billing) and must override
+            # an inherited chain value; an ABSENT key changes nothing.
+            if [ -n "$_line" ]; then
+                _v=${_line#*=}
+                _v=${_v%$'\r'}                     # CRLF-edited file
+                _v=${_v#[\"\']}; _v=${_v%[\"\']}   # optional surrounding quote
+                export "$_k=$_v"
+            fi
+        done
+    else
+        echo "deploy: refusing to read $ENV_FILE (owner=$owner perms=$perms;" \
+             "needs to be yours and not group/world-writable)"
+    fi
+fi
+
+# The codex author binary is a host prerequisite; install it (idempotent, fast
+# path is a local version check) when ANY codex role is deployed — the fleet
+# author, or a codex panel lens (a claude-author/codex-panel rollout still
+# bind-mounts the binary into every judge container). Best-effort: a failure
+# here must never break the chain — the climb will report a missing codex
+# clearly if it comes to that.
+case "${AUTORESEARCH_AUTHOR_BACKEND:-}:${AUTORESEARCH_PANEL:-}" in
+    codex:*|*:*codex*)
+        bash "$AUTORESEARCH_HOME/scripts/install_codex.sh" || echo "deploy: codex install failed"
+        ;;
+esac
+case "${AUTORESEARCH_PANEL:-}" in
+    *hermes*)
+        # the default install location IS the default config: exporting it
+        # here connects the provisioned clone to the preflight/climb without
+        # requiring the operator to name a path they didn't choose
+        export REVIEW_HERMES_REPO="${REVIEW_HERMES_REPO:-$HOME/hermes-agent}"
+        bash "$AUTORESEARCH_HOME/scripts/install_hermes.sh" "$REVIEW_HERMES_REPO" \
+            || echo "deploy: hermes install failed"
+        ;;
+esac

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# The resident tick (docs/design/resident-tick.md), SOURCED by tick_chain.sbatch
+# when AUTORESEARCH_RESIDENT=1: one long-lived job that loops
+#   deploy -> one tick as a child under a hard timeout -> sleep to the next slot
+# and keeps exactly ONE successor queued, dependent on its own end
+# (afterany:self + singleton), so the chain needs a handful of scheduling
+# events a day instead of one per cadence. The pause sentinel cancels the
+# successor and exits without resubmitting; a deploy that changed the shim
+# resubmits the successor so handover runs the current script (Slurm spools
+# batch scripts at submission). The tick itself is unchanged: records,
+# leases, markers and the coalescing guard make a late or repeated tick safe.
+#
+# Knobs (chain environment): AUTORESEARCH_RESIDENT_MINUTES (walltime the job
+# was started with; default 360 = cpu_short's maximum), AUTORESEARCH_CADENCE_MIN,
+# AUTORESEARCH_TICK_TIMEOUT (default 15m), AUTORESEARCH_RESIDENT_MARGIN_S
+# (stop this many seconds before walltime; default 1200),
+# AUTORESEARCH_RESIDENT_CADENCE_S (tests: override the cadence in seconds).
+
+resident_minutes="${AUTORESEARCH_RESIDENT_MINUTES:-360}"
+cadence_s="${AUTORESEARCH_RESIDENT_CADENCE_S:-$((${AUTORESEARCH_CADENCE_MIN:-30} * 60))}"
+tick_timeout="${AUTORESEARCH_TICK_TIMEOUT:-15m}"
+margin_s="${AUTORESEARCH_RESIDENT_MARGIN_S:-1200}"
+self="${SLURM_JOB_ID:-}"
+shim="$AUTORESEARCH_HOME/scripts/tick_chain.sbatch"
+sentinel="$AUTORESEARCH_ROOT/PAUSE"
+
+epoch_of() { date -d "$1" +%s 2>/dev/null || date -j -f %Y-%m-%dT%H:%M:%S "$1" +%s 2>/dev/null || echo ""; }
+
+# the job's real end (Slurm's EndTime), else start + the configured minutes
+started=$(date +%s)
+end_epoch=$((started + resident_minutes * 60))
+if [ -n "$self" ]; then
+    et=$(scontrol show job "$self" -o 2>/dev/null | tr ' ' '\n' | sed -n 's/^EndTime=//p' | head -1)
+    case "$et" in [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]) e=$(epoch_of "$et"); [ -n "$e" ] && end_epoch=$e ;; esac
+fi
+
+submit_successor() {
+    # one successor, ineligible until this job ends: afterany:self keeps it
+    # off the scheduler's eligible list (never a candidate to starve), and
+    # singleton keeps two residents from ever running together
+    local dep="singleton"
+    [ -n "$self" ] && dep="afterany:${self},singleton"
+    local out="" attempt
+    for attempt in 1 2 3; do
+        if out=$(sbatch --parsable --dependency="$dep" --time="$resident_minutes" \
+                    --job-name="$RESIDENT_JOB_NAME" --export=ALL \
+                    --account="${AUTORESEARCH_ACCOUNT:-}" --partition="${AUTORESEARCH_PARTITION:-}" \
+                    "$shim" 2>/dev/null); then
+            printf '%s' "${out%%;*}"
+            return 0
+        fi
+        sleep $((attempt * 20))
+    done
+    return 1
+}
+
+drain_per_cadence_chain() {
+    # the per-cadence chain's queued successors are superseded; cancel the
+    # PENDING ones so the two modes never tick side by side for long (a
+    # running one finishes its tick and, seeing us, queues no more)
+    squeue -u "$USER" --name="$JOB_NAME" -h -t PENDING -o "%i" 2>/dev/null | while read -r jid; do
+        [ -n "$jid" ] && scancel "$jid" 2>/dev/null && echo "resident: cancelled per-cadence successor $jid"
+    done
+}
+
+successor=""
+shim_sum=""
+LOG_DIR="$AUTORESEARCH_ROOT/logs"
+mkdir -p "$LOG_DIR" || true
+while :; do
+    # the log file rolls daily: reopen it every iteration
+    if [ -w "$LOG_DIR" ]; then exec >>"$LOG_DIR/tick-$(date +%Y%m%d).log" 2>&1; fi
+    now=$(date +%s)
+    if [ $((end_epoch - now)) -le "$margin_s" ]; then
+        echo "resident: walltime margin reached; handing over to successor ${successor:-none}"
+        exit 0
+    fi
+    if [ -e "$sentinel" ]; then
+        echo "resident: pause sentinel present; cancelling successor ${successor:-none} and exiting"
+        [ -n "$successor" ] && scancel "$successor" 2>/dev/null
+        exit 0
+    fi
+    if [ -z "$successor" ]; then
+        if successor=$(submit_successor); then
+            echo "resident: successor $successor queued (afterany:${self:-none})"
+            drain_per_cadence_chain
+        else
+            successor=""
+            echo "resident: successor submit failed; retrying next iteration"
+        fi
+    fi
+    # deploy + operator knobs, fresh every iteration (exports reach the tick)
+    . "$AUTORESEARCH_HOME/scripts/tick_deploy.sh"
+    new_sum=$(cksum "$shim" 2>/dev/null | cut -d' ' -f1)
+    if [ -n "$shim_sum" ] && [ "$new_sum" != "$shim_sum" ] && [ -n "$successor" ]; then
+        # Slurm spooled the successor's script at submission: resubmit so
+        # handover runs the shim the deploy just installed
+        scancel "$successor" 2>/dev/null
+        if successor=$(submit_successor); then
+            echo "resident: shim changed; successor resubmitted as $successor"
+        else
+            successor=""
+            echo "resident: shim changed but resubmit failed; retrying next iteration"
+        fi
+    fi
+    shim_sum="$new_sum"
+    echo "=== tick $(date -Is) on $(hostname -s) job=${self:-none} (resident)"
+    (cd "$AUTORESEARCH_HOME" && timeout --kill-after=60s "$tick_timeout" \
+        uv run python -m autoresearch.tick --root "$AUTORESEARCH_ROOT")
+    rc=$?
+    [ "$rc" -ne 0 ] && echo "resident: tick exited $rc; the loop continues"
+    now=$(date +%s)
+    next=$(( (now / cadence_s + 1) * cadence_s ))
+    sleep $((next - now))
+done

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -73,6 +73,13 @@ while :; do
     # the log file rolls daily: reopen it every iteration
     if [ -w "$LOG_DIR" ]; then exec >>"$LOG_DIR/tick-$(date +%Y%m%d).log" 2>&1; fi
     now=$(date +%s)
+    # the sentinel is read FIRST on every iteration, the handover included: a
+    # paused chain ends with nothing queued, whatever brought the loop here
+    if [ -e "$sentinel" ]; then
+        echo "resident: pause sentinel present; cancelling successor ${successor:-none} and exiting"
+        [ -n "$successor" ] && scancel "$successor" 2>/dev/null
+        exit 0
+    fi
     if [ $((end_epoch - now)) -le "$margin_s" ]; then
         # never end without a successor: one more attempt on the way out
         if [ -z "$successor" ] && successor=$(submit_successor); then
@@ -83,11 +90,6 @@ while :; do
         else
             echo "resident: walltime margin reached with NO successor queued — the chain needs a restart"
         fi
-        exit 0
-    fi
-    if [ -e "$sentinel" ]; then
-        echo "resident: pause sentinel present; cancelling successor ${successor:-none} and exiting"
-        [ -n "$successor" ] && scancel "$successor" 2>/dev/null
         exit 0
     fi
     if [ -z "$successor" ]; then

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -63,8 +63,10 @@ drain_per_cadence_chain() {
     done
 }
 
+shim_checksum() { cksum "$shim" 2>/dev/null | cut -d' ' -f1; }
+
 successor=""
-shim_sum=""
+successor_sum=""  # the shim checksum the queued successor was submitted under
 LOG_DIR="$AUTORESEARCH_ROOT/logs"
 mkdir -p "$LOG_DIR" || true
 while :; do
@@ -72,7 +74,15 @@ while :; do
     if [ -w "$LOG_DIR" ]; then exec >>"$LOG_DIR/tick-$(date +%Y%m%d).log" 2>&1; fi
     now=$(date +%s)
     if [ $((end_epoch - now)) -le "$margin_s" ]; then
-        echo "resident: walltime margin reached; handing over to successor ${successor:-none}"
+        # never end without a successor: one more attempt on the way out
+        if [ -z "$successor" ] && successor=$(submit_successor); then
+            echo "resident: successor $successor queued at handover"
+        fi
+        if [ -n "$successor" ]; then
+            echo "resident: walltime margin reached; handing over to successor $successor"
+        else
+            echo "resident: walltime margin reached with NO successor queued — the chain needs a restart"
+        fi
         exit 0
     fi
     if [ -e "$sentinel" ]; then
@@ -81,6 +91,7 @@ while :; do
         exit 0
     fi
     if [ -z "$successor" ]; then
+        successor_sum=$(shim_checksum)
         if successor=$(submit_successor); then
             echo "resident: successor $successor queued (afterany:${self:-none})"
             drain_per_cadence_chain
@@ -91,25 +102,38 @@ while :; do
     fi
     # deploy + operator knobs, fresh every iteration (exports reach the tick)
     . "$AUTORESEARCH_HOME/scripts/tick_deploy.sh"
-    new_sum=$(cksum "$shim" 2>/dev/null | cut -d' ' -f1)
-    if [ -n "$shim_sum" ] && [ "$new_sum" != "$shim_sum" ] && [ -n "$successor" ]; then
+    new_sum=$(shim_checksum)
+    if [ -n "$successor" ] && [ "$new_sum" != "$successor_sum" ]; then
         # Slurm spooled the successor's script at submission: resubmit so
-        # handover runs the shim the deploy just installed
-        scancel "$successor" 2>/dev/null
-        if successor=$(submit_successor); then
-            echo "resident: shim changed; successor resubmitted as $successor"
+        # handover runs the shim the deploy just installed. The REPLACEMENT is
+        # queued first (a moment with two singleton successors is harmless —
+        # they serialize), and the stale one is cancelled only then; a
+        # cancellation Slurm refuses keeps the stale one and drops the
+        # replacement, so the chain can never fork or go successor-less here
+        if replacement=$(submit_successor); then
+            if scancel "$successor" 2>/dev/null; then
+                echo "resident: shim changed; successor $successor replaced by $replacement"
+                successor="$replacement"
+                successor_sum="$new_sum"
+            else
+                scancel "$replacement" 2>/dev/null || true
+                echo "resident: could not cancel stale successor $successor; keeping it (retry next iteration)"
+            fi
         else
-            successor=""
             echo "resident: shim changed but resubmit failed; retrying next iteration"
         fi
     fi
-    shim_sum="$new_sum"
     echo "=== tick $(date -Is) on $(hostname -s) job=${self:-none} (resident)"
     (cd "$AUTORESEARCH_HOME" && timeout --kill-after=60s "$tick_timeout" \
         uv run python -m autoresearch.tick --root "$AUTORESEARCH_ROOT")
     rc=$?
     [ "$rc" -ne 0 ] && echo "resident: tick exited $rc; the loop continues"
+    # sleep to the next slot, but never past the walltime margin: the loop
+    # must wake to hand over, not be killed asleep
     now=$(date +%s)
     next=$(( (now / cadence_s + 1) * cadence_s ))
-    sleep $((next - now))
+    wait=$((next - now))
+    limit=$((end_epoch - margin_s - now))
+    [ "$limit" -lt "$wait" ] && wait="$limit"
+    [ "$wait" -gt 0 ] && sleep "$wait"
 done

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -20,6 +20,7 @@ resident_minutes="${AUTORESEARCH_RESIDENT_MINUTES:-360}"
 cadence_s="${AUTORESEARCH_RESIDENT_CADENCE_S:-$((${AUTORESEARCH_CADENCE_MIN:-30} * 60))}"
 tick_timeout="${AUTORESEARCH_TICK_TIMEOUT:-15m}"
 margin_s="${AUTORESEARCH_RESIDENT_MARGIN_S:-1200}"
+retry_s="${AUTORESEARCH_RESIDENT_RETRY_S:-20}"  # backoff unit for submit retries (tests: 0)
 self="${SLURM_JOB_ID:-}"
 shim="$AUTORESEARCH_HOME/scripts/tick_chain.sbatch"
 sentinel="$AUTORESEARCH_ROOT/PAUSE"
@@ -49,7 +50,7 @@ submit_successor() {
             printf '%s' "${out%%;*}"
             return 0
         fi
-        sleep $((attempt * 20))
+        sleep $((attempt * retry_s))
     done
     return 1
 }
@@ -81,10 +82,18 @@ while :; do
         exit 0
     fi
     if [ $((end_epoch - now)) -le "$margin_s" ]; then
-        # never end without a successor: one more attempt on the way out
-        if [ -z "$successor" ] && successor=$(submit_successor); then
-            echo "resident: successor $successor queued at handover"
-        fi
+        # never end without a successor: keep trying through the margin (a
+        # scheduler outage that clears before walltime still gets a
+        # successor), giving up only two minutes before the job is killed
+        while [ -z "$successor" ] && [ $((end_epoch - $(date +%s))) -gt 120 ]; do
+            if successor=$(submit_successor); then
+                echo "resident: successor $successor queued at handover"
+            else
+                successor=""
+                echo "resident: successor submit failed at handover; retrying"
+                sleep $((retry_s + retry_s / 2))
+            fi
+        done
         if [ -n "$successor" ]; then
             echo "resident: walltime margin reached; handing over to successor $successor"
         else

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -246,3 +246,32 @@ def test_pause_wins_over_the_walltime_margin(tmp_path: Path) -> None:
     assert not (shimlog / "sbatch").exists() and not (shimlog / "ticks").exists()
     log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
     assert "pause sentinel present" in log and "handing over" not in log
+
+
+def test_the_handover_keeps_retrying_a_failed_submission_through_the_margin(tmp_path: Path) -> None:
+    """A scheduler outage inside the margin that clears before walltime still
+    yields a successor: the handover retries instead of giving up (r3)."""
+    from datetime import datetime, timedelta
+
+    home, root, bindir, shimlog = _install(tmp_path)
+    soon = (datetime.now() + timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S")
+    (bindir / "scontrol").write_text(
+        f'#!/bin/sh\necho "JobId=42 EndTime={soon} JobState=RUNNING"\n'
+    )
+    # sbatch fails its first four calls (the loop's 3 attempts + 1), then works
+    (bindir / "sbatch").write_text(
+        f"""#!/bin/sh
+echo "$@" >> "{shimlog}/sbatch"
+n=$(wc -l < "{shimlog}/sbatch" | tr -d " ")
+[ "$n" -le 4 ] && exit 1
+echo "$((500 + n))"
+"""
+    )
+    proc = _run_chain(
+        home, _resident_env(home, root, bindir, AUTORESEARCH_RESIDENT_RETRY_S="0"), timeout=120
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert len((shimlog / "sbatch").read_text().splitlines()) == 5
+    log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
+    assert "submit failed at handover; retrying" in log
+    assert "handing over to successor 505" in log

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -1,0 +1,151 @@
+"""The chain end to end with Slurm and uv shimmed on PATH: the per-cadence
+path still queues two singleton successors and execs the tick; the resident
+path loops deploy → tick → sleep, keeps one afterany:self successor,
+resubmits it when the shim changes, and exits clean on the pause sentinel."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _install(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
+    """A fake checkout (scripts/ copied), a state root, a PATH of shims and the
+    shims' log directory."""
+    home = tmp_path / "home"
+    (home / "scripts").mkdir(parents=True)
+    for f in ROOT.joinpath("scripts").glob("*"):
+        if f.is_file():
+            shutil.copy(f, home / "scripts" / f.name)
+    root = tmp_path / "root"
+    root.mkdir()
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    shimlog = tmp_path / "shimlog"
+    shimlog.mkdir()
+    shims = {
+        # sbatch prints a fresh id per call and logs its argv
+        "sbatch": (
+            f'#!/bin/sh\necho "$@" >> "{shimlog}/sbatch"\n'
+            f'n=$(wc -l < "{shimlog}/sbatch" | tr -d " ")\necho "$((500 + n))"\n'
+        ),
+        "scancel": f'#!/bin/sh\necho "$1" >> "{shimlog}/scancel"\n',
+        "squeue": "#!/bin/sh\nexit 0\n",  # nothing of ours queued
+        "scontrol": '#!/bin/sh\necho "JobId=42 EndTime=2030-01-01T00:00:00 JobState=RUNNING"\n',
+        "timeout": '#!/bin/sh\nshift 2\nexec "$@"\n',  # --kill-after=.. 15m cmd...
+        # uv: `sync` is a no-op; `run ... tick` is the fake tick — it counts
+        # its calls, appends to the shim on the 2nd call, sets PAUSE on the 3rd
+        "uv": f'''#!/bin/sh
+case "$1" in
+  sync) exit 0 ;;
+  run)
+    echo "tick $(date +%s)" >> "{shimlog}/ticks"
+    n=$(wc -l < "{shimlog}/ticks" | tr -d " ")
+    [ "$n" -eq 2 ] && echo "# shim edited by a deploy" >> "{home}/scripts/tick_chain.sbatch"
+    [ "$n" -eq 3 ] && touch "{root}/PAUSE"
+    exit 0 ;;
+esac
+exit 0
+''',
+    }
+    for name, body in shims.items():
+        p = bindir / name
+        p.write_text(body)
+        os.chmod(p, 0o755)
+    return home, root, bindir, shimlog
+
+
+def _env(home: Path, root: Path, bindir: Path, **extra: str) -> dict[str, str]:
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "USER": os.environ.get("USER", "u"),
+        "AUTORESEARCH_HOME": str(home),
+        "AUTORESEARCH_ROOT": str(root),
+        "AUTORESEARCH_ACCOUNT": "acct",
+        "AUTORESEARCH_PARTITION": "cpu_short",
+        "HOME": str(home),  # no ~/.config/autoresearch/.env
+    }
+    env.pop("AUTORESEARCH_PAT_FILE", None)
+    env.pop("AUTORESEARCH_RESIDENT", None)
+    env.update(extra)
+    return env
+
+
+def _run_chain(
+    home: Path, env: dict[str, str], timeout: int = 60
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(home / "scripts" / "tick_chain.sbatch")],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_per_cadence_chain_queues_two_successors_and_execs_the_tick(tmp_path: Path) -> None:
+    home, root, bindir, shimlog = _install(tmp_path)
+    proc = _run_chain(home, _env(home, root, bindir))
+    assert proc.returncode == 0, proc.stderr
+    sbatch = (shimlog / "sbatch").read_text().splitlines()
+    assert len(sbatch) == 2
+    for line in sbatch:
+        assert "--dependency=singleton" in line and "--begin=" in line
+        assert "--partition=cpu_short" in line and "--deadline" not in line
+        assert "afterany" not in line
+    assert (shimlog / "ticks").read_text().count("tick") == 1
+    log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
+    assert "=== tick" in log and "(resident)" not in log
+
+
+def test_resident_loop_keeps_one_successor_resubmits_on_shim_change_and_pauses_clean(
+    tmp_path: Path,
+) -> None:
+    home, root, bindir, shimlog = _install(tmp_path)
+    env = _env(
+        home,
+        root,
+        bindir,
+        AUTORESEARCH_RESIDENT="1",
+        AUTORESEARCH_RESIDENT_CADENCE_S="1",
+        AUTORESEARCH_RESIDENT_MINUTES="360",
+        SLURM_JOB_ID="42",
+    )
+    proc = _run_chain(home, env)
+    assert proc.returncode == 0, proc.stderr
+    ticks = (shimlog / "ticks").read_text().count("tick")
+    assert ticks == 3  # ran until the fake tick raised the sentinel
+    sbatch = (shimlog / "sbatch").read_text().splitlines()
+    # one successor at start, one resubmit after the shim changed — never two queued
+    assert len(sbatch) == 2
+    for line in sbatch:
+        assert "--dependency=afterany:42,singleton" in line
+        assert "--time=360" in line and "--job-name=autoresearch-resident" in line
+        assert "--export=ALL" in line and "--begin" not in line
+    scancel = (shimlog / "scancel").read_text().split()
+    assert scancel == ["501", "502"]  # the shim-change resubmit, then the pause
+    log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
+    assert log.count("(resident)") == 3
+    assert "successor 501 queued (afterany:42)" in log
+    assert "shim changed; successor resubmitted as 502" in log
+    assert "pause sentinel present; cancelling successor 502" in log
+
+
+def test_per_cadence_chain_drains_when_a_resident_exists(tmp_path: Path) -> None:
+    home, root, bindir, shimlog = _install(tmp_path)
+    # squeue reports a resident job of ours
+    (bindir / "squeue").write_text(
+        '#!/bin/sh\ncase "$*" in *autoresearch-resident*) echo "777";; esac\nexit 0\n'
+    )
+    proc = _run_chain(home, _env(home, root, bindir))
+    assert proc.returncode == 0, proc.stderr
+    assert not (shimlog / "sbatch").exists()  # no successors queued
+    # the top-up runs BEFORE the log redirect (successors first, always), so
+    # its note goes to the job's stdout
+    assert "a resident tick exists; not queuing successors" in proc.stdout
+    assert (shimlog / "ticks").read_text().count("tick") == 1  # this tick still ran

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -275,3 +275,15 @@ echo "$((500 + n))"
     log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
     assert "submit failed at handover; retrying" in log
     assert "handing over to successor 505" in log
+
+
+def test_a_misconfigured_resident_start_fails_loudly_before_queuing_anything(
+    tmp_path: Path,
+) -> None:
+    home, root, bindir, shimlog = _install(tmp_path)
+    env = _resident_env(home, root, bindir)
+    env.pop("AUTORESEARCH_ROOT")
+    proc = _run_chain(home, env)
+    assert proc.returncode == 1
+    assert "resident tick misconfigured; missing: AUTORESEARCH_ROOT" in proc.stderr
+    assert not (shimlog / "sbatch").exists() and not (shimlog / "ticks").exists()

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -228,3 +228,21 @@ def test_the_walltime_margin_hands_over_with_a_successor_and_never_sleeps_past_i
     log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
     assert "successor 501 queued at handover" in log
     assert "walltime margin reached; handing over to successor 501" in log
+
+
+def test_pause_wins_over_the_walltime_margin(tmp_path: Path) -> None:
+    """PAUSE set while the loop slept up to the margin: the handover branch
+    must not run — the successor is cancelled and nothing is queued (r2)."""
+    from datetime import datetime, timedelta
+
+    home, root, bindir, shimlog = _install(tmp_path)
+    soon = (datetime.now() + timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S")
+    (bindir / "scontrol").write_text(
+        f'#!/bin/sh\necho "JobId=42 EndTime={soon} JobState=RUNNING"\n'
+    )
+    (root / "PAUSE").touch()
+    proc = _run_chain(home, _resident_env(home, root, bindir))
+    assert proc.returncode == 0, proc.stderr
+    assert not (shimlog / "sbatch").exists() and not (shimlog / "ticks").exists()
+    log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
+    assert "pause sentinel present" in log and "handing over" not in log

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -132,7 +132,7 @@ def test_resident_loop_keeps_one_successor_resubmits_on_shim_change_and_pauses_c
     log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
     assert log.count("(resident)") == 3
     assert "successor 501 queued (afterany:42)" in log
-    assert "shim changed; successor resubmitted as 502" in log
+    assert "shim changed; successor 501 replaced by 502" in log
     assert "pause sentinel present; cancelling successor 502" in log
 
 
@@ -149,3 +149,82 @@ def test_per_cadence_chain_drains_when_a_resident_exists(tmp_path: Path) -> None
     # its note goes to the job's stdout
     assert "a resident tick exists; not queuing successors" in proc.stdout
     assert (shimlog / "ticks").read_text().count("tick") == 1  # this tick still ran
+
+
+def _resident_env(home: Path, root: Path, bindir: Path, **extra: str) -> dict[str, str]:
+    return _env(
+        home,
+        root,
+        bindir,
+        AUTORESEARCH_RESIDENT="1",
+        AUTORESEARCH_RESIDENT_CADENCE_S="1",
+        AUTORESEARCH_RESIDENT_MINUTES="360",
+        SLURM_JOB_ID="42",
+        **extra,
+    )
+
+
+def test_a_shim_change_on_the_first_deploy_replaces_the_successor(tmp_path: Path) -> None:
+    """The successor is queued before the first deploy; a deploy that changes
+    the shim on that very iteration must still replace it (r1)."""
+    home, root, bindir, shimlog = _install(tmp_path)
+    # the deploy's `uv sync` edits the shim (a deploy that pulled a new shim);
+    # the fake tick pauses on its first call
+    (bindir / "uv").write_text(
+        f"""#!/bin/sh
+case "$1" in
+  sync) echo "# shim edited by the first deploy" >> "{home}/scripts/tick_chain.sbatch"; exit 0 ;;
+  run) echo tick >> "{shimlog}/ticks"; touch "{root}/PAUSE"; exit 0 ;;
+esac
+"""
+    )
+    proc = _run_chain(home, _resident_env(home, root, bindir))
+    assert proc.returncode == 0, proc.stderr
+    sbatch = (shimlog / "sbatch").read_text().splitlines()
+    assert len(sbatch) == 2  # initial + the replacement, before the first tick
+    assert (shimlog / "scancel").read_text().split() == ["501", "502"]  # stale, then pause
+    log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
+    assert "shim changed; successor 501 replaced by 502" in log
+    assert log.index("replaced by 502") < log.index("(resident)")
+
+
+def test_a_refused_cancellation_keeps_the_stale_successor_and_drops_the_replacement(
+    tmp_path: Path,
+) -> None:
+    """Never two successors, never none: if Slurm refuses to cancel the stale
+    successor, the replacement is withdrawn and the stale one kept (r1)."""
+    home, root, bindir, shimlog = _install(tmp_path)
+    (bindir / "scancel").write_text(
+        f'#!/bin/sh\ncase "$1" in 501) exit 1 ;; esac\necho "$1" >> "{shimlog}/scancel"\n'
+    )
+    proc = _run_chain(home, _resident_env(home, root, bindir))
+    assert proc.returncode == 0, proc.stderr
+    sbatch = (shimlog / "sbatch").read_text().splitlines()
+    assert len(sbatch) == 2  # initial + one replacement attempt
+    # the replacement (502) was withdrawn; at PAUSE the stale 501 is cancelled
+    # (refused again by the shim, so it does not appear in the log)
+    assert (shimlog / "scancel").read_text().split() == ["502"]
+    log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
+    assert "could not cancel stale successor 501; keeping it" in log
+    assert "cancelling successor 501 and exiting" in log
+
+
+def test_the_walltime_margin_hands_over_with_a_successor_and_never_sleeps_past_it(
+    tmp_path: Path,
+) -> None:
+    """Inside the margin the loop queues a successor if it has none and
+    exits at once — no tick, no sleep (r1)."""
+    from datetime import datetime, timedelta
+
+    home, root, bindir, shimlog = _install(tmp_path)
+    soon = (datetime.now() + timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%S")
+    (bindir / "scontrol").write_text(
+        f'#!/bin/sh\necho "JobId=42 EndTime={soon} JobState=RUNNING"\n'
+    )
+    proc = _run_chain(home, _resident_env(home, root, bindir))
+    assert proc.returncode == 0, proc.stderr
+    assert not (shimlog / "ticks").exists()
+    assert len((shimlog / "sbatch").read_text().splitlines()) == 1
+    log = next(root.joinpath("logs").glob("tick-*.log")).read_text()
+    assert "successor 501 queued at handover" in log
+    assert "walltime margin reached; handing over to successor 501" in log


### PR DESCRIPTION
Implements `docs/design/resident-tick.md` (#238) as the opt-in mode.

## What

- **`scripts/tick_resident.sh`** (sourced when `AUTORESEARCH_RESIDENT=1`): loop until 20 min before walltime — pause sentinel → cancel successor, exit; ensure one successor is queued (`--dependency=afterany:<self>,singleton --time=<minutes> --job-name=autoresearch-resident --export=ALL`, 3 retries, retried next iteration on failure); source the deploy; if the shim's checksum changed → cancel + resubmit the successor; run one tick as a child under `timeout --kill-after=60s 15m`; sleep to the next cadence slot. Log file reopened per iteration (daily roll). End time from Slurm's `EndTime` (fallback: start + minutes).
- **`scripts/tick_deploy.sh`**: the deploy body moved out of the chain verbatim (lock sweep, PAT fetch/reset, caches, `uv sync`, allowlisted `.env` knobs, backend installs) and sourced by both modes.
- **`scripts/tick_chain.sbatch`**: hands off to the loop in resident mode; otherwise unchanged behaviour, plus: stops topping up while a resident job exists (drain), and the top-up loop no longer uses `seq 1 $need` (BSD seq counts down for 0 — only bit macOS tests, but it was a latent portability bug).
- Job names differ (`autoresearch-tick` vs `autoresearch-resident`), so the switch needs no `scancel`: the resident cancels pending per-cadence successors on start, a running one finishes and queues nothing more, and the tick's coalescing guard makes any overlap a no-op. Switch back: PAUSE sentinel → resident exits clean → clear → start a per-cadence chain.

## Tests (`tests/test_tick_resident.py`)

The **whole chain script** runs under shims for `sbatch`/`scancel`/`squeue`/`scontrol`/`timeout`/`uv`:
- per-cadence: two singleton successors on the grid, no deadline, tick runs once;
- resident (cadence 1 s): three ticks, exactly one successor at a time, `afterany:42,singleton --time=360`, resubmitted (501→502) after the fake tick edits the shim, cancelled on PAUSE, exit 0;
- per-cadence drains when a resident job is listed.

Full suite green (1072); ruff, mypy, pre-commit clean. CHANGELOG, `scripts/README.md`, design-note status updated.

## Rollout

After merge and the next per-cadence deploy, start one resident job with `--time=360` on `cpu_short` and watch a day of handovers before making it the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
