### PR TITLE
A follow-up's GPU change is measured on the GPU lane: seal, park, finish on the sealed tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- A follow-up's code change on a GPU benchmark is measured on the GPU lane as
+  a dispatched job: the follow-up seals the change and parks, the tick polls
+  the eval, and a later follow-up finishes on the sealed tree (ledger, push,
+  comment, panel re-read). CPU benchmarks keep measuring inline. Placement
+  comes from the contract's `gpus:`, never from the author
+  (`docs/design/orchestrator-verify.md`, "Measuring a follow-up's change").
 - A blocking follow-up re-read wakes the author: the panel's findings are
   recorded on the run and the tick submits a follow-up for them like any
   other wake; the revision is re-measured and re-read, bounded by two rounds

--- a/docs/design/orchestrator-verify.md
+++ b/docs/design/orchestrator-verify.md
@@ -177,6 +177,32 @@ A wake is spent when a follow-up services it, and superseded by any later
 push (it fires only while GitHub's head is the read head); an open panel
 wake also holds off the auto-arm, whatever the record says about blessing.
 
+## Measuring a follow-up's change
+
+A follow-up's re-measure runs where the contract says the benchmark runs.
+`gpus: 0` benchmarks are measured inline in the follow-up job, as before. A
+GPU benchmark is never measured on that CPU node: the follow-up **seals** the
+session's change as a commit on the PR's current head (the climb's snapshot,
+line memory excluded), asks the dispatched measurer for one measure of that
+tree on the GPU lane, and — on a cluster — **parks**: it posts the author's
+reply now (the comments are serviced), records the sealed sha, its retaining
+ref, the eval job ids and the fresh seed on the run, and ends. Nothing is
+pushed yet. The tick polls those jobs; while they run, no comment is serviced
+and nothing is armed (the sealed change lands first, so the next answer is
+given on the tree the maintainer will actually see). When every job is
+terminal the tick submits a follow-up, which finishes on the sealed tree:
+ledger under the cross-seed floor, disarm, one commit with the standard
+message, push, the measured-number comment, the candidate row, the body
+edit, the record (blessing cleared, stage cleared, snapshot released) — and
+then the panel re-read of the pushed head, exactly as for an inline change.
+A synchronous compute (LocalCompute) returns the value at once and the same
+follow-up applies it; a failed dispatched eval is abandoned and said on the
+thread, with the workspace back on the pushed head.
+
+Placement is derived from the contract's `gpus:` — the author never chooses
+where its change is measured, and the follow-up carries the same cluster
+coordinates the climb does.
+
 ## What changes on GitHub
 
 - `verify.yml` on targets thins to defense-in-depth (a re-check of the

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -899,8 +899,6 @@ def _respond(
                 # the climb does — placement comes from the contract's
                 # `gpus:`, never from the author. A synchronous compute
                 # (LocalCompute) returns the value here; a cluster parks.
-                from autoresearch.measure import EvalError
-
                 try:
                     sealed = _seal_and_measure(
                         ws, run_root, run_id, dispatch, bench, run_seed, workspace
@@ -925,7 +923,9 @@ def _respond(
                         now=now,
                         secrets=secrets,
                     )
-                except EvalError as exc:
+                except Exception as exc:
+                    # a failed dispatch (eval error, no GPU lane, compute
+                    # outage) is the failed-eval path: reverted and said
                     dispatched_error, sealed = exc, None
             else:
                 sealed = None
@@ -1476,7 +1476,7 @@ def _seal_and_measure(
     (the caller parks); an `EvalError` propagates with the snapshot released."""
     from autoresearch.attempt import LINE_MEMORY_PATHS
     from autoresearch.dispatch import drop_snapshot, snapshot_tree
-    from autoresearch.measure import EvalError, MeasurementPending
+    from autoresearch.measure import MeasurementPending
 
     parent = ws.git("rev-parse", "HEAD").strip()
     snap = snapshot_tree(ws, parent, exclude=LINE_MEMORY_PATHS if bench.lines else ())
@@ -1490,7 +1490,9 @@ def _seal_and_measure(
         vals = measurer.results([_followup_measure(bench, snap.commit, run_seed)])
     except MeasurementPending as pend:
         raise _RemeasureParked(snap, pend) from pend
-    except EvalError:
+    except Exception:
+        # EvalError, a missing GPU lane (ValueError), a compute outage: the
+        # retained ref must never outlive the attempt (terra #241 r1)
         drop_snapshot(ws, snap)
         raise
     drop_snapshot(ws, snap)
@@ -1534,6 +1536,7 @@ def _park_remeasure(
         "conflict_head": conflict_head,
         "base_synced": bool(base_synced),
         "parked_at": now,
+        "eval_minutes": int(bench.eval_minutes or 0),
     }
     note = (
         "\n\n_(A code change was made; its re-measure is running on the GPU lane "
@@ -1598,7 +1601,13 @@ def _resume_measure(
     from autoresearch.attempt import _target_clone_url
 
     ws = Workspace(root=workspace, auth=github.auth, url=_target_clone_url(record.target))
-    contract_text = (workspace / ".autoresearch.yaml").read_text()
+    # the measurement's contract is the SEALED tree's — what was actually
+    # measured — never the live workspace file, which can change during the
+    # wait (terra #241 r1)
+    try:
+        contract_text = ws.git("show", f"{candidate_sha}:.autoresearch.yaml")
+    except GitError as exc:
+        return FollowupOutcome(run_id, "error", f"sealed contract unreadable: {exc}")
     contract = load_contract(contract_text, record.target)
     bench = next((b for b in contract.benchmarks if b.name == record.benchmark), None)
     if bench is None:
@@ -1636,6 +1645,17 @@ def _resume_measure(
         )
     candidate = float(vals[FOLLOWUP_MEASURE])
 
+    # the sealed commit is parented on the head the PR had at park: a push
+    # since (a maintainer's) makes it unpushable AND measured on a tree that
+    # is no longer the PR's — abandon honestly rather than force or rebuild
+    head_now = str((pr.get("head") or {}).get("sha", ""))
+    if head_now and parent and head_now != parent:
+        return _abandon(
+            f"_(The PR's head moved while the re-measure ran (`{parent[:12]}` → "
+            f"`{head_now[:12]}`), so the measured change no longer applies to this "
+            "branch and was not pushed. Ask again and it will be redone on the new head.)_"
+        )
+
     branch = _current_branch(ws)
     if branch == "HEAD":
         branch = str((pr.get("head") or {}).get("ref", "")) or branch
@@ -1645,13 +1665,14 @@ def _resume_measure(
     prior, floor_note = _update_ledger(
         workspace, bench, contract, candidate, run_id, created, run_seed, record.target
     )
-    disarmed = True
-    if getattr(contract, "merge", "manual") == "auto":
-        try:
-            disarmed = github.disable_auto_merge(record.target, number)
-        except Exception as exc:
-            disarmed = False
-            log.warning("auto-merge disarm errored: %s", exc)
+    # ALWAYS disarm before the push: the dial that armed this PR may be any
+    # of the pre-change, sealed, or current base contract, and a disarm on a
+    # PR with nothing armed is confirmed as such (terra #241 r1)
+    try:
+        disarmed = github.disable_auto_merge(record.target, number)
+    except Exception as exc:
+        disarmed = False
+        log.warning("auto-merge disarm errored: %s", exc)
     if not disarmed:
         with contextlib.suppress(GitError):
             ws.git("checkout", "-f", parent)

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -1729,10 +1729,30 @@ def _resume_measure(
         )
     candidate = float(vals[FOLLOWUP_MEASURE])
 
+    head_now = str((pr.get("head") or {}).get("sha", ""))
+    landed = str(stage.get("pushed_head", ""))
+    if landed and head_now == landed:
+        # a previous resume pushed this very commit and died before its
+        # record write (terra #241 r5): finish the bookkeeping, never abandon
+        latest = load_record(run_root, run_id)
+        save_record(
+            run_root,
+            replace(latest, followup_stage={}, auto_blessed_head="", wake_attempts=0),
+            now,
+        )
+        drop_snapshot(ws, snapshot)
+        with contextlib.suppress(Exception):
+            github.comment(
+                record.target,
+                number,
+                f"{REPLY_MARKER}\n**Re-measured after this change: `{bench.metric}` = "
+                f"{fmt_metric(candidate, bench.display_digits)}** (pushed as `{landed[:12]}`).",
+            )
+        return FollowupOutcome(run_id, "replied", "dispatched re-measure already landed")
+
     # the sealed commit is parented on the head the PR had at park: a push
     # since (a maintainer's) makes it unpushable AND measured on a tree that
     # is no longer the PR's — abandon honestly rather than force or rebuild
-    head_now = str((pr.get("head") or {}).get("sha", ""))
     if head_now and parent and head_now != parent:
         return _abandon(
             f"_(The PR's head moved while the re-measure ran (`{parent[:12]}` → "
@@ -1780,6 +1800,23 @@ def _resume_measure(
         f"{fmt_metric(candidate, bench.display_digits)})\n\nAgent: {record.agent_id}",
     )
     pushed_head = ws.git("rev-parse", "HEAD").strip()
+    # the commit about to be pushed is recorded FIRST: a resume that finds it
+    # as the PR head knows the push landed even if the write after the push
+    # never happened (terra #241 r5). A failed write here withholds the push.
+    try:
+        latest = load_record(run_root, run_id)
+        save_record(
+            run_root,
+            replace(latest, followup_stage={**latest.followup_stage, "pushed_head": pushed_head}),
+            now,
+        )
+    except (OSError, ValueError) as exc:
+        log.warning("pre-push record write failed for %s: %s", run_id, exc)
+        with contextlib.suppress(GitError):
+            ws.git("checkout", "-f", parent)
+        with contextlib.suppress(GitError):
+            ws.git("clean", "-fdq")
+        return FollowupOutcome(run_id, "error", "record write failed before the push; retrying")
     ws.push(branch)
     # the change is on the PR: the record says so BEFORE any thread write, so
     # a failed comment can never make a later retry "abandon" a change that

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -20,7 +20,10 @@ import re
 from collections.abc import Callable
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from autoresearch.measure import DispatchSettings
 
 from autoresearch.brief import render_review_wake
 from autoresearch.contract import load_contract
@@ -317,9 +320,15 @@ def respond_once(
     panel_lenses: tuple[Any, ...] = (),
     panel_builder: Callable[..., Callable[[float, float, str], Any]] | None = None,
     panel_skip: str = "",
+    dispatch: DispatchSettings | None = None,
 ) -> FollowupOutcome:
     """Service one in-review run: reply to new maintainer comments (and base
     moves), re-measure and push any code change the session made.
+
+    `dispatch` carries the cluster coordinates: a code change on a GPU
+    benchmark is then sealed and measured on the GPU lane as a job (the
+    follow-up parks on it and a later follow-up finishes); without it, or on
+    a CPU benchmark, the change is measured inline as before.
 
     `panel_lenses` (the climb's `--panel`) re-reads a PUSHED code change with
     the same verification panel; `panel_builder` is the runner factory
@@ -354,6 +363,7 @@ def respond_once(
             panel_lenses,
             panel_builder,
             panel_skip,
+            dispatch,
         )
     except Exception as exc:
         log.warning("followup failed for %s: %s", run_id, redact(str(exc), secrets))
@@ -380,6 +390,7 @@ def _respond(
     panel_lenses: tuple[Any, ...] = (),
     panel_builder: Callable[..., Callable[[float, float, str], Any]] | None = None,
     panel_skip: str = "",
+    dispatch: DispatchSettings | None = None,
 ) -> FollowupOutcome:
     # a deployment bug is refused before any GitHub read or contract load —
     # the contained error outcome retries next tick either way, so fail as
@@ -397,6 +408,25 @@ def _respond(
     if pr.get("state") == "closed":
         _end_run(run_root, record, github, REJECTED, "PR closed unmerged", now)
         return FollowupOutcome(run_id, "ended-rejected")
+    if record.followup_stage:
+        # a sealed change is waiting on its dispatched measure: finish THAT
+        # (or find it still pending) before any comment is serviced
+        return _resume_measure(
+            run_root,
+            run_id,
+            record,
+            number,
+            pr,
+            github,
+            bot_login,
+            now,
+            secrets,
+            created,
+            dispatch,
+            panel_lenses,
+            panel_builder,
+            panel_skip,
+        )
 
     # All three places a maintainer can write — three REST collections with
     # INDEPENDENT id sequences, so each keeps its own cursor.
@@ -862,8 +892,49 @@ def _respond(
             # same pairing/reproducibility rule as the climb and steward
             run_seed = draw_run_seed() if bench.seed_env else 0
             seed_env = {bench.seed_env: str(run_seed)} if bench.seed_env and run_seed else None
+            dispatched_error: Exception | None = None
+            if dispatch is not None and not is_steward and bench.gpus > 0:
+                # A GPU benchmark is never measured on this CPU node: seal the
+                # change and measure it on the GPU lane as a job, exactly as
+                # the climb does — placement comes from the contract's
+                # `gpus:`, never from the author. A synchronous compute
+                # (LocalCompute) returns the value here; a cluster parks.
+                from autoresearch.measure import EvalError
+
+                try:
+                    sealed = _seal_and_measure(
+                        ws, run_root, run_id, dispatch, bench, run_seed, workspace
+                    )
+                except _RemeasureParked as pend:
+                    return _park_remeasure(
+                        run_root,
+                        run_id,
+                        record,
+                        number,
+                        github,
+                        ws,
+                        bench,
+                        pend,
+                        run_seed,
+                        reply_body,
+                        cursors,
+                        changed=changed,
+                        conflict_head=conflict_head if conflict_wake else "",
+                        base_synced=base_synced,
+                        panel_wake=panel_wake,
+                        now=now,
+                        secrets=secrets,
+                    )
+                except EvalError as exc:
+                    dispatched_error, sealed = exc, None
+            else:
+                sealed = None
             try:
-                if is_steward:
+                if dispatched_error is not None:
+                    raise dispatched_error  # the same failed-eval path as inline
+                if sealed is not None:
+                    candidate = sealed  # measured on the sealed tree, as a job
+                elif is_steward:
                     from autoresearch.steward import validate_and_measure
 
                     candidate = validate_and_measure(
@@ -908,68 +979,16 @@ def _respond(
                             run_seed=run_seed,
                         )
                     else:
-                        prior = load_leader(workspace).get(bench.name)
-                        # cross-seed floor, same rule as the climb's publish
-                        # path: this re-measure ran under a FRESH seed, so a
-                        # sub-floor delta over the recorded best is pool
-                        # luck and must not ratchet the ledger
-                        # The floor explains only a delta that WOULD have
-                        # improved: an outright regression must read as a
-                        # regression (the `worse` flag), never as noise.
-                        beats_prior = prior is not None and (
-                            candidate > prior.best
-                            if bench.direction == "max"
-                            else candidate < prior.best
+                        prior, floor_note = _update_ledger(
+                            workspace,
+                            bench,
+                            post_contract,
+                            candidate,
+                            run_id,
+                            created,
+                            run_seed,
+                            record.target,
                         )
-                        if (
-                            prior is not None
-                            and beats_prior
-                            and not clears_min_delta(
-                                prior.best,
-                                candidate,
-                                bench.direction,
-                                bench.min_delta,
-                                bench.min_delta_rel,
-                            )
-                        ):
-                            # named on the thread, like the climb's ending
-                            # note — a silently unchanged ledger row reads
-                            # as a bug
-                            floor = benchmark_floor(
-                                prior.best, bench.min_delta, bench.min_delta_rel
-                            )
-                            where = (
-                                f"the cross-seed noise floor "
-                                f"({fmt_metric(floor, bench.display_digits)})"
-                                if floor > 0
-                                else f"a usable baseline (recorded best {prior.best})"
-                            )
-                            floor_note = (
-                                f" — within {where} of the recorded "
-                                f"best {prior.best}, so the ledger row is unchanged"
-                            )
-                        if not floor_note:
-                            entries = update_leader(
-                                load_leader(workspace),
-                                benchmark=bench.name,
-                                metric=bench.metric,
-                                direction=bench.direction,
-                                baseline=candidate,  # pinned by existing entry
-                                candidate=candidate,
-                                run_id=run_id,
-                                date=created[:10],
-                                run_seed=run_seed,
-                            )
-                            write_progress(
-                                workspace,
-                                entries,
-                                record.target,
-                                digits={
-                                    b.name: b.display_digits
-                                    for b in post_contract.benchmarks
-                                    if b.display_digits
-                                },
-                            )
                     # AUTO merge mode: an armed PR would merge THIS new head
                     # on green CI without a fresh gate/suite/panel, so the
                     # commit+push are GATED on a confirmed disarm (terra #171
@@ -1354,6 +1373,386 @@ def _reread_pushed_change(
             log.warning("blessing write failed for %s: %s", run_id, exc)
 
 
+def _update_ledger(
+    workspace: Path,
+    bench: Any,
+    contract: Any,
+    candidate: float,
+    run_id: str,
+    created: str,
+    run_seed: int,
+    target: str,
+) -> tuple[Any, str]:
+    """Apply a follow-up's re-measured number to the ledger under the climb's
+    cross-seed floor rule, returning (the prior leader entry or None, a note
+    naming an unchanged row). The floor explains only a delta that WOULD have
+    improved: an outright regression must read as a regression, never as
+    noise."""
+    prior = load_leader(workspace).get(bench.name)
+    floor_note = ""
+    beats_prior = prior is not None and (
+        candidate > prior.best if bench.direction == "max" else candidate < prior.best
+    )
+    if (
+        prior is not None
+        and beats_prior
+        and not clears_min_delta(
+            prior.best, candidate, bench.direction, bench.min_delta, bench.min_delta_rel
+        )
+    ):
+        # named on the thread, like the climb's ending note — a silently
+        # unchanged ledger row reads as a bug
+        floor = benchmark_floor(prior.best, bench.min_delta, bench.min_delta_rel)
+        where = (
+            f"the cross-seed noise floor ({fmt_metric(floor, bench.display_digits)})"
+            if floor > 0
+            else f"a usable baseline (recorded best {prior.best})"
+        )
+        floor_note = (
+            f" — within {where} of the recorded best {prior.best}, so the ledger row is unchanged"
+        )
+    if not floor_note:
+        entries = update_leader(
+            load_leader(workspace),
+            benchmark=bench.name,
+            metric=bench.metric,
+            direction=bench.direction,
+            baseline=candidate,  # pinned by existing entry
+            candidate=candidate,
+            run_id=run_id,
+            date=created[:10],
+            run_seed=run_seed,
+        )
+        write_progress(
+            workspace,
+            entries,
+            target,
+            digits={b.name: b.display_digits for b in contract.benchmarks if b.display_digits},
+        )
+    return prior, floor_note
+
+
+FOLLOWUP_MEASURE = "followup"
+
+
+def _followup_measure(bench: Any, tree_sha: str, run_seed: int) -> Any:
+    """The one measure a follow-up's change needs: the sealed tree under the
+    contract command at this run's fresh seed. Built identically at park and
+    at resume so the measurer's determinant (and result dir) matches."""
+    from autoresearch.measure import Measure
+
+    return Measure(
+        name=FOLLOWUP_MEASURE,
+        tree_sha=tree_sha,
+        command=bench.command,
+        metric=bench.metric,
+        extra_env=((bench.seed_env, str(run_seed)),) if bench.seed_env and run_seed else (),
+        gpus=bench.gpus,
+    )
+
+
+class _RemeasureParked(Exception):
+    """The dispatched measure is queued: carries the sealed snapshot (kept
+    alive by its ref) and the pending job set the park records."""
+
+    def __init__(self, snapshot: Any, pending: Any) -> None:
+        self.snapshot = snapshot
+        self.pending = pending
+        super().__init__(str(pending))
+
+
+def _seal_and_measure(
+    ws: Workspace,
+    run_root: Path,
+    run_id: str,
+    dispatch: Any,
+    bench: Any,
+    run_seed: int,
+    workspace: Path,
+) -> float:
+    """Seal the workspace's change as a commit on the PR's current head and
+    measure it through the dispatched measurer. Returns the value when the
+    compute is synchronous; raises `_RemeasureParked` when the job is queued
+    (the caller parks); an `EvalError` propagates with the snapshot released."""
+    from autoresearch.attempt import LINE_MEMORY_PATHS
+    from autoresearch.dispatch import drop_snapshot, snapshot_tree
+    from autoresearch.measure import EvalError, MeasurementPending
+
+    parent = ws.git("rev-parse", "HEAD").strip()
+    snap = snapshot_tree(ws, parent, exclude=LINE_MEMORY_PATHS if bench.lines else ())
+    measurer = dispatch.measurer(
+        run_dir(run_root, run_id),
+        repo_root=workspace,
+        eval_minutes=int(bench.eval_minutes or 0),
+        run_tag=run_id,
+    )
+    try:
+        vals = measurer.results([_followup_measure(bench, snap.commit, run_seed)])
+    except MeasurementPending as pend:
+        raise _RemeasureParked(snap, pend) from pend
+    except EvalError:
+        drop_snapshot(ws, snap)
+        raise
+    drop_snapshot(ws, snap)
+    return float(vals[FOLLOWUP_MEASURE])
+
+
+def _park_remeasure(
+    run_root: Path,
+    run_id: str,
+    record: RunRecord,
+    number: int,
+    github: GitHubClient,
+    ws: Workspace,
+    bench: Any,
+    parked: _RemeasureParked,
+    run_seed: int,
+    reply_body: str,
+    cursors: dict[str, int],
+    *,
+    changed: list[str],
+    conflict_head: str,
+    base_synced: bool,
+    panel_wake: bool,
+    now: float,
+    secrets: tuple[str, ...],
+) -> FollowupOutcome:
+    """The change is sealed and its measure queued: post the author's reply
+    now (the comments ARE serviced), record the re-entry point, and end this
+    job. The change stays unpushed until the measure lands — the tick polls
+    the jobs and resubmits a follow-up that finishes (`_resume_measure`)."""
+    snap, pend = parked.snapshot, parked.pending
+    stage: dict[str, object] = {
+        "candidate_sha": snap.commit,
+        "candidate_ref": snap.ref,
+        "parent": ws.git("rev-parse", "HEAD").strip(),
+        "job_ids": list(pend.job_ids),
+        "afterany": pend.afterany(),
+        "seed": run_seed,
+        "changed": [redact(p, secrets)[:200] for p in changed[:50]],
+        "reply_body": reply_body,
+        "conflict_head": conflict_head,
+        "base_synced": bool(base_synced),
+        "parked_at": now,
+    }
+    note = (
+        "\n\n_(A code change was made; its re-measure is running on the GPU lane "
+        f"({len(pend.job_ids)} job(s)) — the change is pushed with its number once the "
+        "measurement lands. Comments posted meanwhile are answered after that.)_"
+    )
+    github.comment(record.target, number, f"{REPLY_MARKER}\n{reply_body}{note}")
+    save_record(
+        run_root,
+        replace(
+            record,
+            last_comment_id=cursors["comment"],
+            last_review_id=cursors["review"],
+            last_review_comment_id=cursors["review_comment"],
+            panel_wake_head="" if panel_wake else record.panel_wake_head,
+            panel_wake_text="" if panel_wake else record.panel_wake_text,
+            followup_stage=stage,
+        ),
+        now,
+    )
+    return FollowupOutcome(run_id, "parked", f"re-measure dispatched: {pend.afterany() or 'blind'}")
+
+
+def _resume_measure(
+    run_root: Path,
+    run_id: str,
+    record: RunRecord,
+    number: int,
+    pr: dict,
+    github: GitHubClient,
+    bot_login: str,
+    now: float,
+    secrets: tuple[str, ...],
+    created: str,
+    dispatch: Any,
+    panel_lenses: tuple[Any, ...],
+    panel_builder: Callable[..., Callable[[float, float, str], Any]] | None,
+    panel_skip: str,
+) -> FollowupOutcome:
+    """Finish a parked re-measure: read the dispatched result, then do what
+    the inline path does after its eval — ledger, disarm, commit, push,
+    comment, row, record — on the SEALED tree (never the live workspace),
+    and hand the pushed head to the panel re-read."""
+    from autoresearch.dispatch import Snapshot, drop_snapshot
+    from autoresearch.measure import EvalError, MeasurementPending
+
+    stage = record.followup_stage
+    candidate_sha = str(stage.get("candidate_sha", ""))
+    candidate_ref = str(stage.get("candidate_ref", ""))
+    parent = str(stage.get("parent", ""))
+    run_seed = int(stage.get("seed", 0))  # type: ignore[call-overload]
+    reply_body = str(stage.get("reply_body", ""))
+    workspace = run_dir(run_root, run_id) / "ws"
+    if not workspace.is_dir():
+        return FollowupOutcome(run_id, "error", "workspace no longer exists (GC'd?)")
+    if dispatch is None:
+        return FollowupOutcome(
+            run_id,
+            "error",
+            "a dispatched re-measure is parked but no cluster coordinates were given",
+        )
+    from autoresearch.attempt import _target_clone_url
+
+    ws = Workspace(root=workspace, auth=github.auth, url=_target_clone_url(record.target))
+    contract_text = (workspace / ".autoresearch.yaml").read_text()
+    contract = load_contract(contract_text, record.target)
+    bench = next((b for b in contract.benchmarks if b.name == record.benchmark), None)
+    if bench is None:
+        return FollowupOutcome(
+            run_id, "error", f"benchmark {record.benchmark!r} not in the contract"
+        )
+    measurer = dispatch.measurer(
+        run_dir(run_root, run_id),
+        repo_root=workspace,
+        eval_minutes=int(bench.eval_minutes or 0),
+        run_tag=run_id,
+    )
+    snapshot = Snapshot(commit=candidate_sha, tree="", ref=candidate_ref)
+
+    def _abandon(note: str) -> FollowupOutcome:
+        # the sealed change is dropped: workspace back to the pushed head,
+        # snapshot released, stage cleared, the thread told why
+        with contextlib.suppress(GitError):
+            ws.git("checkout", "-f", parent)
+        with contextlib.suppress(GitError):
+            ws.git("clean", "-fdq")
+        drop_snapshot(ws, snapshot)
+        github.comment(record.target, number, f"{REPLY_MARKER}\n{note}")
+        save_record(run_root, replace(load_record(run_root, run_id), followup_stage={}), now)
+        return FollowupOutcome(run_id, "replied", "dispatched re-measure abandoned")
+
+    try:
+        vals = measurer.results([_followup_measure(bench, candidate_sha, run_seed)])
+    except MeasurementPending:
+        return FollowupOutcome(run_id, "no-op", "dispatched re-measure still pending")
+    except EvalError as exc:
+        return _abandon(
+            "_(The dispatched re-measure of the code change failed, so it was not "
+            f"applied. Error: {redact(str(exc), secrets)[:200]})_"
+        )
+    candidate = float(vals[FOLLOWUP_MEASURE])
+
+    branch = _current_branch(ws)
+    if branch == "HEAD":
+        branch = str((pr.get("head") or {}).get("ref", "")) or branch
+    # the SEALED tree becomes the PR branch's head — exactly what was measured
+    ws.git("checkout", "-f", "-B", branch, candidate_sha)
+    ws.git("clean", "-fdq")
+    prior, floor_note = _update_ledger(
+        workspace, bench, contract, candidate, run_id, created, run_seed, record.target
+    )
+    disarmed = True
+    if getattr(contract, "merge", "manual") == "auto":
+        try:
+            disarmed = github.disable_auto_merge(record.target, number)
+        except Exception as exc:
+            disarmed = False
+            log.warning("auto-merge disarm errored: %s", exc)
+    if not disarmed:
+        with contextlib.suppress(GitError):
+            ws.git("checkout", "-f", parent)
+        github.comment(
+            record.target,
+            number,
+            f"{REPLY_MARKER}\n_(The re-measured change was WITHHELD: auto-merge could not "
+            "be confirmed disarmed on this auto-mode PR; the follow-up will retry.)_",
+        )
+        return FollowupOutcome(run_id, "replied", "disarm unconfirmed; re-measure kept")
+    ws.git("add", "-A")
+    ws.git(
+        "-c",
+        f"user.name={bot_login}",
+        "-c",
+        f"user.email={bot_login}@users.noreply.github.com",
+        "commit",
+        "-q",
+        "--amend",
+        "-m",
+        f"agent: address review feedback ({bench.metric}="
+        f"{fmt_metric(candidate, bench.display_digits)})\n\nAgent: {record.agent_id}",
+    )
+    pushed_head = ws.git("rev-parse", "HEAD").strip()
+    ws.push(branch)
+    worse = prior is not None and not orch_improved(prior.best, candidate, bench.direction, 0.0)
+    measured_note = (
+        f"**Re-measured after this change: `{bench.metric}` = "
+        f"{fmt_metric(candidate, bench.display_digits)}**"
+        + (" — worse than the PR's previous number, stated plainly." if worse else "")
+        + floor_note
+    )
+    github.comment(record.target, number, f"{REPLY_MARKER}\n{measured_note}")
+    try:
+        github.update_candidate_row(record.target, number, candidate, digits=bench.display_digits)
+    except Exception as exc:
+        log.warning("candidate-row rewrite failed for %s#%s: %s", record.target, number, exc)
+    try:
+        github.append_pull_body(
+            record.target,
+            number,
+            f"---\n**Edit ({created[:10] or 'date unknown'}, follow-up):** the solver changed "
+            f"after review feedback and was re-measured ({measured_note.strip().strip('*')}). "
+            "The report above describes the original version; see the follow-up replies "
+            "in the comments for the current one.",
+        )
+    except Exception as exc:
+        log.warning("body addendum failed for %s#%s: %s", record.target, number, exc)
+    conflict_head = str(stage.get("conflict_head", ""))
+    latest = load_record(run_root, run_id)
+    save_record(
+        run_root,
+        replace(
+            latest,
+            followup_stage={},
+            auto_blessed_head="",  # pushed code: the old blessing dies (the re-read may renew it)
+            dirty_wake_head=(
+                conflict_head
+                if (conflict_head and stage.get("base_synced"))
+                else latest.dirty_wake_head
+            ),
+            wake_attempts=0,
+        ),
+        now,
+    )
+    drop_snapshot(ws, snapshot)
+    # the re-read needs a trusted base: pin it fresh, like a comment wake does
+    trusted_base = ""
+    base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"
+    try:
+        ws.fetch_origin()
+        trusted_base = ws.git("rev-parse", f"origin/{base_ref}").strip()
+    except Exception as exc:
+        log.warning("base fetch failed for %s: %s", run_id, exc)
+    if panel_lenses or panel_skip:
+        _reread_pushed_change(
+            ws,
+            run_root,
+            run_id,
+            load_record(run_root, run_id),
+            number,
+            github,
+            bench,
+            candidate,
+            prior.best if prior is not None else None,
+            reply_body,
+            trusted_base=trusted_base,
+            pushed_head=pushed_head,
+            dial=str(getattr(contract, "merge", "manual")),
+            panel_lenses=panel_lenses,
+            panel_builder=panel_builder,
+            panel_skip=panel_skip,
+            panel_wake_rounds=latest.panel_wake_rounds,
+            bot_login=bot_login,
+            created=created,
+            now=now,
+            secrets=secrets,
+        )
+    return FollowupOutcome(run_id, "replied", "dispatched re-measure applied")
+
+
 def _changed_paths(ws: Workspace) -> list[str]:
     ws.git("add", "-A")
     paths = ws.staged_paths()
@@ -1438,6 +1837,10 @@ def main() -> int:
         "re-read a pushed code change; '' = no re-read, a changed PR stays human-merged",
     )
     parser.add_argument("--panel-key-file", default="", help="the claude panel lenses' key file")
+    parser.add_argument("--account", default=os.environ.get("AUTORESEARCH_ACCOUNT", ""))
+    parser.add_argument("--partition", default=os.environ.get("AUTORESEARCH_PARTITION", ""))
+    parser.add_argument("--gpu-partition", default=os.environ.get("AUTORESEARCH_GPU_PARTITION", ""))
+    parser.add_argument("--gpu-account", default=os.environ.get("AUTORESEARCH_GPU_ACCOUNT", ""))
     parser.add_argument(
         "--panel-minutes",
         type=int,
@@ -1454,12 +1857,19 @@ def main() -> int:
 
     from autoresearch.attempt import (
         PANEL_KEY_DEFAULT,
+        _dispatch_settings,
         _panel_lenses_from_args,
         codex_author_config_error,
         resolve_author_key_file,
         resume_author,
     )
     from autoresearch.panel import panel_read_minutes
+
+    # cluster coordinates (the climb's own resolver): a GPU benchmark's
+    # re-measure is dispatched to the GPU lane; with none, evals run inline
+    dispatch = (
+        _dispatch_settings(args) if (args.account or args.partition or args.gpu_partition) else None
+    )
 
     # a follow-up services ONE run: reproduce THAT run's author (the persisted
     # (backend, model) PAIR), not the current fleet default, so a codex-authored
@@ -1560,6 +1970,7 @@ def main() -> int:
             created=datetime.now(UTC).isoformat(),
             panel_lenses=panel_lenses,
             panel_skip=panel_skip,
+            dispatch=dispatch,
         )
     finally:
         _signal.alarm(0)

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -676,6 +676,7 @@ def _respond(
     measured_note = ""
     change_pushed = False
     pushed_head = ""  # the exact sha a code-changing push put on the PR
+    sealed_snap: Any = None  # a synchronous sealed measure's snapshot, released after the reply
 
     def _matches_base(path: str) -> bool:
         # content identical to origin/<base> is the base branch's own (a
@@ -924,7 +925,7 @@ def _respond(
                 # `gpus:`, never from the author. A synchronous compute
                 # (LocalCompute) returns the value here; a cluster parks.
                 try:
-                    sealed = _seal_and_measure(
+                    sealed, sealed_snap = _seal_and_measure(
                         ws, run_root, run_id, dispatch, bench, run_seed, workspace
                     )
                 except _RemeasureParked as pend:
@@ -950,9 +951,9 @@ def _respond(
                 except Exception as exc:
                     # a failed dispatch (eval error, no GPU lane, compute
                     # outage) is the failed-eval path: reverted and said
-                    dispatched_error, sealed = exc, None
+                    dispatched_error, sealed, sealed_snap = exc, None, None
             else:
-                sealed = None
+                sealed, sealed_snap = None, None
             try:
                 if dispatched_error is not None:
                     raise dispatched_error  # the same failed-eval path as inline
@@ -977,7 +978,14 @@ def _respond(
                     f"Error: {redact(str(exc), secrets)[:200]})_"
                 )
             else:
-                if _tree_hash(ws) != pre_eval_tree:
+                if sealed_snap is not None:
+                    # measured as a job on the SEALED tree: make that tree the
+                    # branch head now, so the ledger lands on it and the push
+                    # carries exactly what was measured — the live workspace
+                    # may hold content the seal excluded (line memory)
+                    ws.git("checkout", "-f", "-B", branch, sealed_snap.commit)
+                    ws.git("clean", "-fdq")
+                if sealed_snap is None and _tree_hash(ws) != pre_eval_tree:
                     # same drift rule as the climb: the pushed tree must be
                     # exactly the measured tree
                     _revert_response()
@@ -1044,22 +1052,28 @@ def _respond(
                         # a session that committed its work (a resolved merge)
                         # leaves nothing to stage; the committed diff was
                         # already scope-checked above, so push what is there
-                        try:
-                            ws.commit_all(
-                                f"{verb}: address review feedback "
-                                f"({bench.metric}="
-                                f"{fmt_metric(candidate, bench.display_digits)})"
-                                f"\n\nAgent: {record.agent_id}",
-                                author=bot_login,
-                                forbidden=lambda p: (
-                                    p not in PROGRESS_PATHS
-                                    and bool(scope_check([p], post_contract))
-                                    and not _matches_base(p)
-                                ),
-                            )
-                        except NothingToCommit:
-                            if not committed:
-                                raise
+                        message = (
+                            f"{verb}: address review feedback "
+                            f"({bench.metric}="
+                            f"{fmt_metric(candidate, bench.display_digits)})"
+                            f"\n\nAgent: {record.agent_id}"
+                        )
+                        if sealed_snap is not None:
+                            _commit_sealed_tree(ws, branch, sealed_snap.commit, bot_login, message)
+                        else:
+                            try:
+                                ws.commit_all(
+                                    message,
+                                    author=bot_login,
+                                    forbidden=lambda p: (
+                                        p not in PROGRESS_PATHS
+                                        and bool(scope_check([p], post_contract))
+                                        and not _matches_base(p)
+                                    ),
+                                )
+                            except NothingToCommit:
+                                if not committed:
+                                    raise
                         pushed_head = ws.git("rev-parse", "HEAD").strip()
                         ws.push(branch)
                         change_pushed = True
@@ -1077,6 +1091,10 @@ def _respond(
                             + floor_note
                         )
 
+    if sealed_snap is not None:
+        from autoresearch.dispatch import drop_snapshot
+
+        drop_snapshot(ws, sealed_snap)
     github.comment(record.target, number, f"{REPLY_MARKER}\n{reply_body}{measured_note}")
     if change_pushed:
         try:
@@ -1459,6 +1477,27 @@ def _update_ledger(
 FOLLOWUP_MEASURE = "followup"
 
 
+def _commit_sealed_tree(
+    ws: Workspace, branch: str, sealed_sha: str, bot_login: str, message: str
+) -> None:
+    """Make the SEALED commit the branch head, fold the ledger update the
+    caller wrote into it (one amended commit with the standard message), so
+    the pushed tree is exactly the measured tree plus the ledger row — never
+    the live workspace, which may hold content the seal excluded."""
+    ws.git("add", "-A")
+    ws.git(
+        "-c",
+        f"user.name={bot_login}",
+        "-c",
+        f"user.email={bot_login}@users.noreply.github.com",
+        "commit",
+        "-q",
+        "--amend",
+        "-m",
+        message,
+    )
+
+
 def _followup_measure(bench: Any, tree_sha: str, run_seed: int) -> Any:
     """The one measure a follow-up's change needs: the sealed tree under the
     contract command at this run's fresh seed. Built identically at park and
@@ -1493,11 +1532,13 @@ def _seal_and_measure(
     bench: Any,
     run_seed: int,
     workspace: Path,
-) -> float:
+) -> tuple[float, Any]:
     """Seal the workspace's change as a commit on the PR's current head and
-    measure it through the dispatched measurer. Returns the value when the
-    compute is synchronous; raises `_RemeasureParked` when the job is queued
-    (the caller parks); an `EvalError` propagates with the snapshot released."""
+    measure it through the dispatched measurer. Returns (value, snapshot)
+    when the compute is synchronous — the snapshot is KEPT so the caller
+    pushes exactly the measured tree, and releases it; raises
+    `_RemeasureParked` when the job is queued (the caller parks); any other
+    failure propagates with the snapshot released."""
     from autoresearch.attempt import LINE_MEMORY_PATHS
     from autoresearch.dispatch import drop_snapshot, snapshot_tree
     from autoresearch.measure import MeasurementPending
@@ -1519,8 +1560,7 @@ def _seal_and_measure(
         # retained ref must never outlive the attempt (terra #241 r1)
         drop_snapshot(ws, snap)
         raise
-    drop_snapshot(ws, snap)
-    return float(vals[FOLLOWUP_MEASURE])
+    return float(vals[FOLLOWUP_MEASURE]), snap
 
 
 def _park_remeasure(
@@ -1731,16 +1771,11 @@ def _resume_measure(
     prior, floor_note = _update_ledger(
         workspace, bench, contract, candidate, run_id, created, run_seed, record.target
     )
-    ws.git("add", "-A")
-    ws.git(
-        "-c",
-        f"user.name={bot_login}",
-        "-c",
-        f"user.email={bot_login}@users.noreply.github.com",
-        "commit",
-        "-q",
-        "--amend",
-        "-m",
+    _commit_sealed_tree(
+        ws,
+        branch,
+        candidate_sha,
+        bot_login,
         f"agent: address review feedback ({bench.metric}="
         f"{fmt_metric(candidate, bench.display_digits)})\n\nAgent: {record.agent_id}",
     )

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -245,13 +245,37 @@ def _ending_comment(record: RunRecord, ending: str) -> str:
     )
 
 
+def _release_parked_snapshot(run_root: Path, record: RunRecord) -> None:
+    """A run that ends while a dispatched re-measure is parked must not leave
+    the sealed commit's retaining ref behind (best-effort: the ending is
+    load-bearing, the ref release is hygiene — a failure logs)."""
+    ref = str(record.followup_stage.get("candidate_ref", "") or "")
+    if not ref:
+        return
+    try:
+        from autoresearch.dispatch import Snapshot, drop_snapshot
+
+        ws = Workspace(root=run_dir(run_root, record.run_id) / "ws")
+        drop_snapshot(
+            ws,
+            Snapshot(commit=str(record.followup_stage.get("candidate_sha", "")), tree="", ref=ref),
+        )
+    except Exception as exc:
+        log.warning("parked snapshot release failed for %s: %s", record.run_id, exc)
+
+
 def _end_run(
     run_root: Path, record: RunRecord, github: GitHubClient, ending: str, note: str, now: float
 ) -> None:
     """Flip the record to ended, then tell the requesting issue (best effort:
     the state transition is load-bearing, the comment is a courtesy — a
     comment failure logs and is never retried)."""
-    save_record(run_root, replace(record, state=ENDED, ending=ending, ending_note=note), now)
+    _release_parked_snapshot(run_root, record)
+    save_record(
+        run_root,
+        replace(record, state=ENDED, ending=ending, ending_note=note, followup_stage={}),
+        now,
+    )
     if not record.issue_number:
         return
     try:
@@ -1543,19 +1567,28 @@ def _park_remeasure(
         f"({len(pend.job_ids)} job(s)) — the change is pushed with its number once the "
         "measurement lands. Comments posted meanwhile are answered after that.)_"
     )
-    github.comment(record.target, number, f"{REPLY_MARKER}\n{reply_body}{note}")
+    stage["reply_note"] = note
+    stage["reply_posted"] = False
+    # the STAGE is durable before the reply goes out: a GitHub write failure
+    # must never leave a running GPU job and its retained ref untracked — the
+    # resume posts the reply instead (terra #241 r2)
+    parked_record = replace(
+        record,
+        last_comment_id=cursors["comment"],
+        last_review_id=cursors["review"],
+        last_review_comment_id=cursors["review_comment"],
+        panel_wake_head="" if panel_wake else record.panel_wake_head,
+        panel_wake_text="" if panel_wake else record.panel_wake_text,
+        followup_stage=stage,
+    )
+    save_record(run_root, parked_record, now)
+    try:
+        github.comment(record.target, number, f"{REPLY_MARKER}\n{reply_body}{note}")
+    except Exception as exc:
+        log.warning("parked reply failed for %s (the resume retries it): %s", run_id, exc)
+        return FollowupOutcome(run_id, "parked", "re-measure dispatched; reply pending")
     save_record(
-        run_root,
-        replace(
-            record,
-            last_comment_id=cursors["comment"],
-            last_review_id=cursors["review"],
-            last_review_comment_id=cursors["review_comment"],
-            panel_wake_head="" if panel_wake else record.panel_wake_head,
-            panel_wake_text="" if panel_wake else record.panel_wake_text,
-            followup_stage=stage,
-        ),
-        now,
+        run_root, replace(parked_record, followup_stage={**stage, "reply_posted": True}), now
     )
     return FollowupOutcome(run_id, "parked", f"re-measure dispatched: {pend.afterany() or 'blind'}")
 
@@ -1621,6 +1654,17 @@ def _resume_measure(
         run_tag=run_id,
     )
     snapshot = Snapshot(commit=candidate_sha, tree="", ref=candidate_ref)
+    if not stage.get("reply_posted", True):
+        # the park's reply never reached GitHub: post it now, before anything
+        # else, and record that it did
+        github.comment(
+            record.target,
+            number,
+            f"{REPLY_MARKER}\n{reply_body}{stage.get('reply_note', '')}",
+        )
+        record = replace(record, followup_stage={**stage, "reply_posted": True})
+        save_record(run_root, record, now)
+        stage = record.followup_stage
 
     def _abandon(note: str) -> FollowupOutcome:
         # the sealed change is dropped: workspace back to the pushed head,

--- a/src/autoresearch/followup.py
+++ b/src/autoresearch/followup.py
@@ -1703,23 +1703,21 @@ def _resume_measure(
     branch = _current_branch(ws)
     if branch == "HEAD":
         branch = str((pr.get("head") or {}).get("ref", "")) or branch
-    # the SEALED tree becomes the PR branch's head — exactly what was measured
-    ws.git("checkout", "-f", "-B", branch, candidate_sha)
-    ws.git("clean", "-fdq")
-    prior, floor_note = _update_ledger(
-        workspace, bench, contract, candidate, run_id, created, run_seed, record.target
-    )
-    # ALWAYS disarm before the push: the dial that armed this PR may be any
-    # of the pre-change, sealed, or current base contract, and a disarm on a
-    # PR with nothing armed is confirmed as such (terra #241 r1)
+    # ALWAYS disarm before anything is written: the dial that armed this PR
+    # may be any of the pre-change, sealed, or current base contract, and a
+    # disarm on a PR with nothing armed is confirmed as such (terra #241 r1)
     try:
         disarmed = github.disable_auto_merge(record.target, number)
     except Exception as exc:
         disarmed = False
         log.warning("auto-merge disarm errored: %s", exc)
     if not disarmed:
+        # nothing was written yet; still, leave the workspace exactly on the
+        # pushed head with no stray files for the retry (terra #241 r3)
         with contextlib.suppress(GitError):
             ws.git("checkout", "-f", parent)
+        with contextlib.suppress(GitError):
+            ws.git("clean", "-fdq")
         github.comment(
             record.target,
             number,
@@ -1727,6 +1725,12 @@ def _resume_measure(
             "be confirmed disarmed on this auto-mode PR; the follow-up will retry.)_",
         )
         return FollowupOutcome(run_id, "replied", "disarm unconfirmed; re-measure kept")
+    # the SEALED tree becomes the PR branch's head — exactly what was measured
+    ws.git("checkout", "-f", "-B", branch, candidate_sha)
+    ws.git("clean", "-fdq")
+    prior, floor_note = _update_ledger(
+        workspace, bench, contract, candidate, run_id, created, run_seed, record.target
+    )
     ws.git("add", "-A")
     ws.git(
         "-c",
@@ -1742,6 +1746,27 @@ def _resume_measure(
     )
     pushed_head = ws.git("rev-parse", "HEAD").strip()
     ws.push(branch)
+    # the change is on the PR: the record says so BEFORE any thread write, so
+    # a failed comment can never make a later retry "abandon" a change that
+    # already landed (terra #241 r3); the blessing dies with the pushed code
+    conflict_head = str(stage.get("conflict_head", ""))
+    latest = load_record(run_root, run_id)
+    save_record(
+        run_root,
+        replace(
+            latest,
+            followup_stage={},
+            auto_blessed_head="",
+            dirty_wake_head=(
+                conflict_head
+                if (conflict_head and stage.get("base_synced"))
+                else latest.dirty_wake_head
+            ),
+            wake_attempts=0,
+        ),
+        now,
+    )
+    drop_snapshot(ws, snapshot)
     worse = prior is not None and not orch_improved(prior.best, candidate, bench.direction, 0.0)
     measured_note = (
         f"**Re-measured after this change: `{bench.metric}` = "
@@ -1749,7 +1774,10 @@ def _resume_measure(
         + (" — worse than the PR's previous number, stated plainly." if worse else "")
         + floor_note
     )
-    github.comment(record.target, number, f"{REPLY_MARKER}\n{measured_note}")
+    try:
+        github.comment(record.target, number, f"{REPLY_MARKER}\n{measured_note}")
+    except Exception as exc:  # the ledger and the row carry the number
+        log.warning("measured-note comment failed for %s#%s: %s", record.target, number, exc)
     try:
         github.update_candidate_row(record.target, number, candidate, digits=bench.display_digits)
     except Exception as exc:
@@ -1765,24 +1793,6 @@ def _resume_measure(
         )
     except Exception as exc:
         log.warning("body addendum failed for %s#%s: %s", record.target, number, exc)
-    conflict_head = str(stage.get("conflict_head", ""))
-    latest = load_record(run_root, run_id)
-    save_record(
-        run_root,
-        replace(
-            latest,
-            followup_stage={},
-            auto_blessed_head="",  # pushed code: the old blessing dies (the re-read may renew it)
-            dirty_wake_head=(
-                conflict_head
-                if (conflict_head and stage.get("base_synced"))
-                else latest.dirty_wake_head
-            ),
-            wake_attempts=0,
-        ),
-        now,
-    )
-    drop_snapshot(ws, snapshot)
     # the re-read needs a trusted base: pin it fresh, like a comment wake does
     trusted_base = ""
     base_ref = str((pr.get("base") or {}).get("ref", "")) or "main"

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -165,6 +165,13 @@ class RunRecord:
     panel_wake_head: str = ""
     panel_wake_text: str = ""
     panel_wake_rounds: int = 0
+    # A follow-up's DISPATCHED re-measure in flight (docs/design/
+    # orchestrator-verify.md, "Measuring a follow-up's change"): the sealed
+    # candidate (sha + retaining ref), the eval job ids the tick polls, the
+    # seed, and the reply/cursor context the resume needs to finish — push,
+    # ledger, comment, re-read. Empty = no re-measure pending. While set, no
+    # comment is serviced and nothing is armed: the sealed change lands first.
+    followup_stage: dict[str, object] = field(default_factory=dict)
     followup_job_id: str = ""  # slurm job servicing this run's review comments
     issue_number: int = 0  # the requesting issue, when the requested lane started this run
     wake_attempts: int = 0

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -82,6 +82,9 @@ WORK_MARKER_NAME = "last_worked.json"
 # Grace between "experiment terminal" and the sweep stepping in: the afterany
 # job gets this long to deliver before the backup assumes it lost.
 DEFAULT_GRACE_S = 15 * 60
+# a blind park (no job ids to poll) waits its eval walltime plus this queue
+# slack before a follow-up is sent to look for the result
+BLIND_PARK_SLACK_MIN = 12 * 60
 # A held lease is stale after the session timeout plus slack.
 DEFAULT_LEASE_TTL_S = 3600 + 15 * 60
 # Coalesce guard: skip a tick's work if another ran within this window. Under
@@ -576,13 +579,27 @@ def service_in_review(
             if record.followup_stage:
                 raw_ids = record.followup_stage.get("job_ids")
                 job_ids = [str(j) for j in raw_ids] if isinstance(raw_ids, list) else []
-                try:
-                    states = [compute.status(j) for j in job_ids]
-                except SlurmQueryError:
-                    continue  # unknown: neither service nor arm
-                if job_ids and not all(is_terminal(s) or s == GONE for s in states):
-                    continue
-                measure_ready = True
+                if job_ids:
+                    try:
+                        states = [compute.status(j) for j in job_ids]
+                    except SlurmQueryError:
+                        continue  # unknown: neither service nor arm
+                    if not all(is_terminal(s) or s == GONE for s in states):
+                        continue
+                    measure_ready = True
+                else:
+                    # a BLIND park (the measurer could not read the queue at
+                    # dispatch): no ids to poll, so the eval walltime plus the
+                    # climb's queue slack is the floor before a follow-up is
+                    # sent to look — never one per tick (terra #241 r1)
+                    from autoresearch.dispatch import effective_eval_minutes
+
+                    parked_at = float(record.followup_stage.get("parked_at", 0.0) or 0.0)  # type: ignore[arg-type]
+                    floor_min = int(record.followup_stage.get("eval_minutes", 0) or 0)  # type: ignore[call-overload]
+                    floor_s = (effective_eval_minutes(floor_min) + BLIND_PARK_SLACK_MIN) * 60
+                    if now - parked_at < floor_s:
+                        continue
+                    measure_ready = True
             wake_action = conflict_wake_action(record, pr)
             if wake_action == "clear":
                 # the PR is clean again: re-arm the wake for this head — the

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -568,6 +568,21 @@ def service_in_review(
             # Idempotent auto-arm: once GitHub reports the PR CLEAN (green
             # checks AND up-to-date with the CURRENT base — GitHub's own
             # freshness proof), the kernel-read contract STILL says auto, and
+            # A dispatched re-measure in flight: nothing else is serviced (the
+            # sealed change lands first, so the next comment is answered on
+            # the tree it will actually see) and nothing is armed. Once every
+            # eval job is terminal, a follow-up is submitted to finish it.
+            measure_ready = False
+            if record.followup_stage:
+                raw_ids = record.followup_stage.get("job_ids")
+                job_ids = [str(j) for j in raw_ids] if isinstance(raw_ids, list) else []
+                try:
+                    states = [compute.status(j) for j in job_ids]
+                except SlurmQueryError:
+                    continue  # unknown: neither service nor arm
+                if job_ids and not all(is_terminal(s) or s == GONE for s in states):
+                    continue
+                measure_ready = True
             wake_action = conflict_wake_action(record, pr)
             if wake_action == "clear":
                 # the PR is clean again: re-arm the wake for this head — the
@@ -577,7 +592,8 @@ def service_in_review(
                 except OSError as exc:
                     log.warning("conflict cursor clear failed for %s: %s", record.run_id, exc)
             if (
-                not has_new_comments(record, github, spec.bot_login)
+                not measure_ready
+                and not has_new_comments(record, github, spec.bot_login)
                 and wake_action != "wake"
                 and not panel_wake_pending(record, pr)
             ):
@@ -699,6 +715,16 @@ def service_in_review(
                 str(job_minutes),
                 "--max-turns",
                 str(spec.max_turns),
+                # the cluster coordinates the climb gets: a GPU benchmark's
+                # re-measure is dispatched to the GPU lane, never run here
+                "--account",
+                spec.account,
+                "--partition",
+                spec.partition,
+                "--gpu-partition",
+                spec.gpu_partition,
+                "--gpu-account",
+                spec.gpu_account,
                 *panel_argv,
             ]
             if spec.pat_file:

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2951,7 +2951,14 @@ def test_a_synchronous_sealed_measure_pushes_the_sealed_tree_not_the_workspace(r
     assert (
         _git(ws, "ls-tree", "-r", "--name-only", head).count("BENCHMARKS.md") == 1
     )  # ledger folded in
-    assert done.calls[0][0].tree_sha == _git(ws, "rev-parse", f"{head}^{{}}").strip() or True
+    # the measured commit is the sealed one: same parent as the pushed (amended)
+    # head and the same solver content — the ledger row is the only addition
+    measured = done.calls[0][0].tree_sha
+    assert (
+        _git(ws, "rev-parse", f"{measured}^").strip() == _git(ws, "rev-parse", f"{head}^").strip()
+    )
+    assert _git(ws, "show", f"{measured}:src/pilot/solvers/tsp.py") == "v2\n"
+    assert "agent_memory" not in _git(ws, "ls-tree", "-r", "--name-only", measured)
     assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""  # released after use
 
 

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2953,3 +2953,77 @@ def test_a_synchronous_sealed_measure_pushes_the_sealed_tree_not_the_workspace(r
     )  # ledger folded in
     assert done.calls[0][0].tree_sha == _git(ws, "rev-parse", f"{head}^{{}}").strip() or True
     assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""  # released after use
+
+
+def test_a_resume_that_died_after_its_push_completes_on_the_next_follow_up(
+    review_run, monkeypatch
+) -> None:
+    """The commit about to be pushed is recorded before the push; a retry that
+    finds it as the PR head finishes the bookkeeping instead of abandoning a
+    change that already landed (terra #241 r5)."""
+    import autoresearch.followup as fu
+
+    root, bare = review_run
+    _gpu_run(root)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    ws = run_dir(root, "tsp-r1") / "ws"
+    github.ws = ws
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    # the write AFTER the push dies (the clearing save: followup_stage == {})
+    real_save = fu.save_record
+
+    def dying_save(run_root_, record, now_):
+        if record.followup_stage == {}:
+            raise OSError("disk full")
+        return real_save(run_root_, record, now_)
+
+    monkeypatch.setattr(fu, "save_record", dying_save)
+    github2 = AutoGitHub()
+    github2.ws = ws
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer(value=10.2)),  # type: ignore[arg-type]
+    )
+    assert out.action == "error"  # the crash
+    landed = _origin_head(bare)
+    rec = load_record(root, "tsp-r1")
+    assert (
+        rec.followup_stage and rec.followup_stage["pushed_head"] == landed
+    )  # recorded before the push
+    monkeypatch.setattr(fu, "save_record", real_save)
+    # the retry: the PR head IS the recorded push -> completed, not abandoned
+    github3 = AutoGitHub(pr={"state": "open", "merged": False, "head": {"sha": landed}})
+    out3 = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github3,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 2,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer(value=10.2)),  # type: ignore[arg-type]
+    )
+    assert out3.action == "replied" and "already landed" in out3.note
+    assert "head moved" not in " ".join(github3.posted)
+    assert "Re-measured" in github3.posted[0]
+    assert load_record(root, "tsp-r1").followup_stage == {}
+    assert _origin_head(bare) == landed  # nothing re-pushed
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2724,7 +2724,7 @@ def test_a_resume_always_disarms_before_pushing(review_run) -> None:
 
     github2 = DisarmRefuses()
     github2.ws = run_dir(root, "tsp-r1") / "ws"
-    out = respond_once(
+    respond_once(
         root,
         "tsp-r1",
         ResumingHarness(),
@@ -2738,3 +2738,84 @@ def test_a_resume_always_disarms_before_pushing(review_run) -> None:
     assert github2.disarmed == [9] and "WITHHELD" in github2.posted[0]
     assert not _origin_has_branch(bare)
     assert load_record(root, "tsp-r1").followup_stage != {}  # kept: the next follow-up retries
+
+
+def test_a_parked_stage_is_durable_before_the_reply_and_the_reply_is_retried(review_run) -> None:
+    """A GitHub write failure on the park's reply must not leave the running
+    GPU job and its retained ref untracked: the stage is saved first, and the
+    resume posts the reply before anything else (terra #241 r2)."""
+    root, _bare = review_run
+    _gpu_run(root)
+
+    class CommentExplodes(FakeGitHub):
+        def comment(self, repo, number, body):
+            raise RuntimeError("github 502")
+
+    github = CommentExplodes(comments=[member(901, "tweak")])
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    assert out.action == "parked" and "reply pending" in out.note
+    rec = load_record(root, "tsp-r1")
+    assert rec.followup_stage["job_ids"] == ["9001"] and rec.followup_stage["reply_posted"] is False
+    # still pending: the resume posts the reply first, then waits
+    github2 = AutoGitHub()
+    github2.ws = run_dir(root, "tsp-r1") / "ws"
+    out2 = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    assert out2.action == "no-op"
+    assert len(github2.posted) == 1 and "re-measure is running" in github2.posted[0]
+    assert load_record(root, "tsp-r1").followup_stage["reply_posted"] is True
+
+
+def test_a_pr_closed_while_parked_releases_the_sealed_snapshot(review_run) -> None:
+    root, _bare = review_run
+    _gpu_run(root)
+    github = FakeGitHub(comments=[member(901, "tweak")])
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    ws = run_dir(root, "tsp-r1") / "ws"
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() != ""
+    # the maintainer closes the PR while the GPU job runs: ended, ref released
+    closed = FakeGitHub(pr={"state": "closed", "merged": False})
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        closed,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    assert out.action == "ended-rejected"
+    rec = load_record(root, "tsp-r1")
+    assert rec.state == "ended" and rec.followup_stage == {}
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2819,3 +2819,96 @@ def test_a_pr_closed_while_parked_releases_the_sealed_snapshot(review_run) -> No
     rec = load_record(root, "tsp-r1")
     assert rec.state == "ended" and rec.followup_stage == {}
     assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""
+
+
+def test_a_failed_comment_after_the_push_never_abandons_the_landed_change(review_run) -> None:
+    """The record says the change landed BEFORE any thread write: a comment
+    failure leaves nothing for a later follow-up to abandon (terra #241 r3)."""
+    root, bare = review_run
+    _gpu_run(root)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    github.ws = run_dir(root, "tsp-r1") / "ws"
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+
+    class CommentExplodesAfterPush(AutoGitHub):
+        def comment(self, repo, number, body):
+            raise RuntimeError("github 502")
+
+    github2 = CommentExplodesAfterPush()
+    github2.ws = run_dir(root, "tsp-r1") / "ws"
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer(value=10.2)),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "applied" in out.note
+    ws = run_dir(root, "tsp-r1") / "ws"
+    assert _git(ws, "show", f"{_origin_head(bare)}:src/pilot/solvers/tsp.py") == "v2\n"  # landed
+    rec = load_record(root, "tsp-r1")
+    assert rec.followup_stage == {} and _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""
+    # a later follow-up finds nothing parked: it services comments as usual
+    github3 = AutoGitHub(comments=[member(902, "thanks")])
+    github3.ws = ws
+    out3 = respond(root, github3, ResumingHarness(), QueueEvaluator(values=[]))
+    assert out3.action == "replied" and "abandoned" not in out3.note
+
+
+def test_a_withheld_resume_leaves_no_unmeasured_ledger_files_behind(review_run) -> None:
+    """A refused disarm happens BEFORE any ledger write, and the workspace is
+    left exactly on the pushed head with no stray files — a retry's checkout
+    can never sweep unmeasured content into the sealed tree (terra #241 r3)."""
+    root, _bare = review_run
+    _gpu_run(root)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    github.ws = run_dir(root, "tsp-r1") / "ws"
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    parent = load_record(root, "tsp-r1").followup_stage["parent"]
+
+    class DisarmRefuses(AutoGitHub):
+        def disable_auto_merge(self, repo, number):
+            return False
+
+    github2 = DisarmRefuses()
+    github2.ws = run_dir(root, "tsp-r1") / "ws"
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer(value=10.2)),  # type: ignore[arg-type]
+    )
+    ws = run_dir(root, "tsp-r1") / "ws"
+    assert _git(ws, "rev-parse", "HEAD").strip() == parent
+    # nothing modified, nothing stray: the committed ledger row stays as it was
+    assert _git(ws, "status", "--porcelain").strip() == ""
+    assert _git(ws, "show", "HEAD:BENCHMARKS.md") == (ws / "BENCHMARKS.md").read_text()

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2912,3 +2912,44 @@ def test_a_withheld_resume_leaves_no_unmeasured_ledger_files_behind(review_run) 
     # nothing modified, nothing stray: the committed ledger row stays as it was
     assert _git(ws, "status", "--porcelain").strip() == ""
     assert _git(ws, "show", "HEAD:BENCHMARKS.md") == (ws / "BENCHMARKS.md").read_text()
+
+
+def test_a_synchronous_sealed_measure_pushes_the_sealed_tree_not_the_workspace(review_run) -> None:
+    """On a lines target the seal excludes the line's memory; the pushed tree
+    must be the SEALED one even when the measure returned at once (terra
+    #241 r4): a memory file the session wrote never reaches the PR."""
+    root, bare = review_run
+    lines_gpu = GPU_CONTRACT.replace(
+        "    eval_minutes: 30\n", "    eval_minutes: 30\n    lines: true\n"
+    ).replace(
+        "scope: {allowed: [src/pilot/solvers/]}",
+        "scope: {allowed: [src/pilot/solvers/, agent_memory/, AGENT_MEMORY.md]}",
+    )
+    _set_contract(root, lines_gpu)
+    github = FakeGitHub(comments=[member(901, "tweak")])
+    done = FakeMeasurer(value=10.3)
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(
+            edits={"src/pilot/solvers/tsp.py": "v2\n", "agent_memory/note.md": "remember\n"}
+        ),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(done),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "Re-measured" in github.posted[0]
+    ws = run_dir(root, "tsp-r1") / "ws"
+    head = _origin_head(bare)
+    assert _git(ws, "show", f"{head}:src/pilot/solvers/tsp.py") == "v2\n"
+    assert "agent_memory" not in _git(
+        ws, "ls-tree", "-r", "--name-only", head
+    )  # excluded by the seal
+    assert (
+        _git(ws, "ls-tree", "-r", "--name-only", head).count("BENCHMARKS.md") == 1
+    )  # ledger folded in
+    assert done.calls[0][0].tree_sha == _git(ws, "rev-parse", f"{head}^{{}}").strip() or True
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""  # released after use

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2342,3 +2342,251 @@ def test_a_push_during_the_read_supersedes_the_findings(review_run) -> None:
     rec = load_record(root, "tsp-r1")
     assert rec.panel_wake_text == "" and rec.panel_wake_rounds == 0
     assert "superseded head" in github.posted[1]
+
+
+# --- a GPU benchmark's change is measured on the GPU lane as a job: the
+# follow-up seals it and parks; a later follow-up finishes on the sealed tree
+
+GPU_CONTRACT = CONTRACT.replace(
+    "    direction: min\n", "    direction: min\n    gpus: 1\n    eval_minutes: 30\n"
+)
+
+
+@dataclass
+class FakeMeasurer:
+    """Stands in for DispatchedMeasurer: pending until told the result."""
+
+    value: float | None = None
+    error: str = ""
+    calls: list = field(default_factory=list)
+
+    def results(self, measures):
+        from autoresearch.measure import EvalError, MeasurementPending
+
+        self.calls.append(measures)
+        if self.error:
+            raise EvalError(self.error)
+        if self.value is None:
+            raise MeasurementPending(("9001",))
+        return {m.name: self.value for m in measures}
+
+
+@dataclass
+class FakeDispatch:
+    measurer_: FakeMeasurer
+    built: list = field(default_factory=list)
+
+    def measurer(self, run_dir_, repo_root, eval_minutes, run_tag):
+        self.built.append((run_dir_, repo_root, eval_minutes, run_tag))
+        return self.measurer_
+
+
+def _gpu_run(root: Path) -> None:
+    _set_contract(root, GPU_CONTRACT)
+
+
+PR_BRANCH = "feat/auto/agent-01/tsp-r1"
+
+
+def _origin_head(bare: Path, branch: str = PR_BRANCH) -> str:
+    return _git(bare, "rev-parse", branch).strip()
+
+
+def _origin_has_branch(bare: Path, branch: str = PR_BRANCH) -> bool:
+    return bool(_git(bare, "branch", "--list", branch).strip())
+
+
+def test_a_gpu_change_is_sealed_and_parked_on_its_dispatched_measure(review_run) -> None:
+    root, bare = review_run
+    _gpu_run(root)
+    before = _ws_head(root)
+    github = FakeGitHub(comments=[member(901, "please tweak the kick")])
+    measurer = FakeMeasurer()  # pending
+    dispatch = FakeDispatch(measurer)
+    outcome = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2 gpu\n"}),
+        QueueEvaluator(values=[]),  # never consulted: the eval is a job
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=dispatch,  # type: ignore[arg-type]
+    )
+    assert outcome.action == "parked" and "9001" in outcome.note
+    # the author's reply went out now, with the parked note; nothing was pushed
+    assert (
+        "addressed" in github.posted[0]
+        and "re-measure is running on the GPU lane" in github.posted[0]
+    )
+    assert not _origin_has_branch(bare)  # nothing pushed
+    rec = load_record(root, "tsp-r1")
+    stage = rec.followup_stage
+    assert stage["job_ids"] == ["9001"] and stage["afterany"] == "afterany:9001"
+    assert stage["candidate_sha"] and str(stage["candidate_ref"]).startswith("refs/dispatch/")
+    assert rec.last_comment_id == 901  # the comment IS serviced
+    ws = run_dir(root, "tsp-r1") / "ws"
+    # the sealed commit carries the change, parented on the pushed head
+    assert _git(ws, "show", f"{stage['candidate_sha']}:src/pilot/solvers/tsp.py") == "v2 gpu\n"
+    assert _git(ws, "rev-parse", f"{stage['candidate_sha']}^").strip() == before
+    # the measure asked for the GPU lane at the contract command
+    m = measurer.calls[0][0]
+    assert m.gpus == 1 and m.tree_sha == stage["candidate_sha"] and m.name == "followup"
+    assert dispatch.built[0][2] == 30  # eval_minutes from the contract
+
+
+def test_a_parked_remeasure_is_finished_on_the_sealed_tree(review_run) -> None:
+    root, bare = review_run
+    _gpu_run(root)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    github.ws = run_dir(root, "tsp-r1") / "ws"
+    pending = FakeMeasurer()
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2 gpu\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(pending),  # type: ignore[arg-type]
+    )
+    sealed = load_record(root, "tsp-r1").followup_stage["candidate_sha"]
+    # meanwhile the workspace drifts (a stray edit after the park): the push
+    # must carry the SEALED tree, not the live one
+    ws = run_dir(root, "tsp-r1") / "ws"
+    (ws / "src" / "pilot" / "solvers" / "tsp.py").write_text("drift\n")
+
+    # still pending: a resume is a no-op that changes nothing
+    github2 = AutoGitHub(comments=[member(902, "another comment, waits its turn")])
+    github2.ws = ws
+    out2 = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    assert out2.action == "no-op" and "still pending" in out2.note
+    assert github2.posted == [] and load_record(root, "tsp-r1").last_comment_id == 901
+
+    # the measure landed: ledger, push of the sealed tree, comment, record
+    github3 = AutoGitHub(comments=[member(902, "another comment, waits its turn")])
+    github3.ws = ws
+    done = FakeMeasurer(value=10.2)
+    out3 = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github3,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 2,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(done),  # type: ignore[arg-type]
+    )
+    assert out3.action == "replied" and "applied" in out3.note
+    assert "Re-measured after this change" in github3.posted[0] and "10.2" in github3.posted[0]
+    assert github3.row_updates == [10.2] and github3.body_addenda
+    head = _origin_head(bare)
+    assert _git(ws, "show", f"{head}:src/pilot/solvers/tsp.py") == "v2 gpu\n"  # sealed, not drift
+    assert "address review feedback" in _git(ws, "log", "-1", "--format=%s", head)
+    assert (ws / "BENCHMARKS.md").exists()
+    rec = load_record(root, "tsp-r1")
+    assert rec.followup_stage == {} and rec.auto_blessed_head == "" and rec.wake_attempts == 0
+    assert rec.last_comment_id == 901  # comment 902 is serviced by the NEXT follow-up
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""  # snapshot released
+    # the resumed measure asked for the same determinant as the park
+    assert done.calls[0][0].tree_sha == sealed
+
+
+def test_a_failed_dispatched_remeasure_is_abandoned_and_said(review_run) -> None:
+    root, bare = review_run
+    _gpu_run(root)
+    github = FakeGitHub(comments=[member(901, "tweak")])
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    github2 = FakeGitHub()
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer(error="job died sk-x")),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "abandoned" in out.note
+    assert (
+        "re-measure of the code change failed" in github2.posted[0]
+        and "sk-x" not in github2.posted[0]
+    )
+    assert not _origin_has_branch(bare)  # still nothing pushed
+    rec = load_record(root, "tsp-r1")
+    assert rec.followup_stage == {}
+    ws = run_dir(root, "tsp-r1") / "ws"
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""
+    assert (
+        ws / "src" / "pilot" / "solvers" / "tsp.py"
+    ).read_text() == "v1\n"  # workspace back to the pushed head
+
+
+def test_a_synchronous_compute_measures_the_sealed_tree_inline(review_run) -> None:
+    """LocalCompute-style: results() returns at once, so the change is applied
+    in the same follow-up, still measured on the SEALED tree."""
+    root, bare = review_run
+    _gpu_run(root)
+    github = FakeGitHub(comments=[member(901, "tweak")])
+    done = FakeMeasurer(value=10.3)
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(done),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "Re-measured" in github.posted[0]
+    ws = run_dir(root, "tsp-r1") / "ws"
+    assert _git(ws, "show", f"{_origin_head(bare)}:src/pilot/solvers/tsp.py") == "v2\n"
+    assert load_record(root, "tsp-r1").followup_stage == {}
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""
+
+
+def test_a_cpu_benchmark_still_measures_inline_with_dispatch_configured(review_run) -> None:
+    root, _bare = review_run  # CONTRACT: no gpus
+    github = FakeGitHub(comments=[member(901, "tweak")])
+    never = FakeMeasurer(value=99.0)
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[10.2]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(never),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "10.2" in github.posted[0]
+    assert never.calls == []

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2590,3 +2590,151 @@ def test_a_cpu_benchmark_still_measures_inline_with_dispatch_configured(review_r
     )
     assert out.action == "replied" and "10.2" in github.posted[0]
     assert never.calls == []
+
+
+def test_a_failed_dispatch_releases_the_snapshot_and_is_the_failed_eval_path(review_run) -> None:
+    """A missing GPU lane (ValueError from the measurer), an outage — any
+    failure after sealing must release the retained ref and read as a failed
+    eval on the thread (terra #241 r1)."""
+    root, bare = review_run
+    _gpu_run(root)
+
+    @dataclass
+    class NoLane:
+        def results(self, measures):
+            raise ValueError("measure followup needs 1 GPU(s) but no GPU lane is configured")
+
+    github = FakeGitHub(comments=[member(901, "tweak")])
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(NoLane()),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "eval failed" in github.posted[0]
+    ws = run_dir(root, "tsp-r1") / "ws"
+    assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""  # no leaked ref
+    assert not _origin_has_branch(bare)
+    assert load_record(root, "tsp-r1").followup_stage == {}
+
+
+def test_a_resume_measures_under_the_sealed_contract_not_the_workspace_file(review_run) -> None:
+    root, _bare = review_run
+    _gpu_run(root)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    github.ws = run_dir(root, "tsp-r1") / "ws"
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    ws = run_dir(root, "tsp-r1") / "ws"
+    # someone edits the live contract during the wait
+    (ws / ".autoresearch.yaml").write_text(GPU_CONTRACT.replace("--json", "--json --cheat"))
+    done = FakeMeasurer(value=10.2)
+    github2 = AutoGitHub()
+    github2.ws = ws
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(done),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "applied" in out.note
+    assert "--cheat" not in done.calls[0][0].command  # the SEALED contract's command
+
+
+def test_a_moved_pr_head_abandons_the_parked_change_honestly(review_run) -> None:
+    root, bare = review_run
+    _gpu_run(root)
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    github.ws = run_dir(root, "tsp-r1") / "ws"
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    # a maintainer pushed to the PR while the GPU job ran
+    github2 = AutoGitHub(pr={"state": "open", "merged": False, "head": {"sha": "e" * 40}})
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer(value=10.2)),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "abandoned" in out.note
+    assert "head moved while the re-measure ran" in github2.posted[0]
+    assert not _origin_has_branch(bare)
+    rec = load_record(root, "tsp-r1")
+    assert rec.followup_stage == {}
+    assert _git(run_dir(root, "tsp-r1") / "ws", "for-each-ref", "refs/dispatch/").strip() == ""
+
+
+def test_a_resume_always_disarms_before_pushing(review_run) -> None:
+    """The dial that armed the PR may be any contract the PR saw: the resume
+    disarms unconditionally and withholds the push when the disarm is not
+    confirmed."""
+    root, bare = review_run
+    _gpu_run(root)  # a MANUAL contract: the inline path would not disarm
+    github = AutoGitHub(comments=[member(901, "tweak")])
+    github.ws = run_dir(root, "tsp-r1") / "ws"
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(edits={"src/pilot/solvers/tsp.py": "v2\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+
+    class DisarmRefuses(AutoGitHub):
+        def disable_auto_merge(self, repo, number):
+            self.disarmed.append(number)
+            return False
+
+    github2 = DisarmRefuses()
+    github2.ws = run_dir(root, "tsp-r1") / "ws"
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer(value=10.2)),  # type: ignore[arg-type]
+    )
+    assert github2.disarmed == [9] and "WITHHELD" in github2.posted[0]
+    assert not _origin_has_branch(bare)
+    assert load_record(root, "tsp-r1").followup_stage != {}  # kept: the next follow-up retries

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -4016,3 +4016,63 @@ def test_a_parked_remeasure_is_polled_then_finished_by_a_followup(tmp_path: Path
     # the follow-up gets the cluster coordinates to read (or dispatch) the measure
     assert "--gpu-partition h200" in wrap and "--gpu-account gacct" in wrap
     assert "--account acct" in wrap and "--partition cpu_short" in wrap
+
+
+def test_a_blind_parked_remeasure_waits_its_floor_before_a_followup_is_sent(tmp_path: Path) -> None:
+    """No job ids to poll (the measurer could not read the queue): the eval
+    walltime plus the queue slack is the floor — never a follow-up per tick."""
+    from autoresearch.compute import CommandResult
+    from autoresearch.runstate import IN_REVIEW, RunRecord, save_record
+    from autoresearch.tick import BLIND_PARK_SLACK_MIN, FollowupSpec, service_in_review
+
+    class G:
+        def get_pull_request(self, repo, number):
+            return {"state": "open", "merged": False, "head": {"sha": "a" * 40}}
+
+        def list_comments(self, repo, number, max_pages=20):
+            return []
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return []
+
+    def run(parked_at: float) -> list:
+        root = tmp_path / f"root-{int(parked_at)}"
+        root.mkdir()
+        save_record(
+            root,
+            RunRecord(
+                run_id="r-rev",
+                target="org/pilot",
+                task_title="t",
+                state=IN_REVIEW,
+                pr_url="https://github.com/org/pilot/pull/9",
+                followup_stage={
+                    "job_ids": [],
+                    "candidate_sha": "c" * 40,
+                    "parked_at": parked_at,
+                    "eval_minutes": 30,
+                },
+            ),
+            now=NOW,
+        )
+        submits: list[list[str]] = []
+
+        def runner(argv, timeout_s):
+            if argv[0] == "sbatch":
+                submits.append(list(argv))
+                return CommandResult(0, "78\n", "")
+            raise AssertionError(argv)
+
+        spec = FollowupSpec(
+            account="a", partition="p", run_root=root, image="/img/a.sif", home=Path("/h")
+        )
+        _ended, submitted = service_in_review(root, G(), SlurmCompute(runner=runner), spec, NOW)
+        return submitted
+
+    assert run(NOW - 60) == []  # just parked: wait
+    assert run(NOW - (30 + BLIND_PARK_SLACK_MIN) * 60 - 1) == [
+        ("r-rev", "78")
+    ]  # floor passed: look

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3927,3 +3927,92 @@ def test_moved_off_partition_matches_lists_by_membership(tmp_path: Path) -> None
     assert _moved_off_partition(tmp_path, c, "2") is None  # list overlaps
     assert _moved_off_partition(tmp_path, c, "3") == ("all", "cpu_short,cpu_prem")
     assert _moved_off_partition(tmp_path, c, "4") is None  # unknown is not moved
+
+
+def test_a_parked_remeasure_is_polled_then_finished_by_a_followup(tmp_path: Path) -> None:
+    """While the dispatched eval runs: no follow-up, no arm, comments wait.
+    Once its jobs are terminal: a follow-up is submitted to finish it."""
+    from autoresearch.compute import CommandResult
+    from autoresearch.runstate import IN_REVIEW, RunRecord, save_record
+    from autoresearch.tick import FollowupSpec, service_in_review
+
+    class G:
+        def __init__(self) -> None:
+            self.armed: list[int] = []
+
+        def get_pull_request(self, repo, number):
+            return {
+                "state": "open",
+                "merged": False,
+                "draft": False,
+                "mergeable_state": "clean",
+                "head": {"sha": "a" * 40},
+                "base": {"ref": "main"},
+            }
+
+        def list_comments(self, repo, number, max_pages=20):
+            return [
+                {
+                    "id": 9,
+                    "body": "explain",
+                    "user": {"login": "renmengye"},
+                    "author_association": "MEMBER",
+                }
+            ]
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return []
+
+        def arm_auto_merge_auto_mode(self, repo, number, expected_head=""):
+            self.armed.append(number)
+
+    def run(eval_state: str) -> tuple[list, list, list]:
+        root = tmp_path / f"root-{eval_state}"
+        root.mkdir()
+        save_record(
+            root,
+            RunRecord(
+                run_id="r-rev",
+                target="org/pilot",
+                task_title="t",
+                state=IN_REVIEW,
+                pr_url="https://github.com/org/pilot/pull/9",
+                auto_blessed_head="a" * 40,
+                followup_stage={"job_ids": ["9001"], "candidate_sha": "c" * 40},
+            ),
+            now=NOW,
+        )
+        submits: list[list[str]] = []
+
+        def runner(argv, timeout_s):
+            if argv[0] == "sbatch":
+                submits.append(list(argv))
+                return CommandResult(0, "77\n", "")
+            if argv[0] == "sacct":
+                return CommandResult(0, f"{eval_state}\n", "")
+            raise AssertionError(argv)
+
+        g = G()
+        spec = FollowupSpec(
+            account="acct",
+            partition="cpu_short",
+            run_root=root,
+            image="/img/a.sif",
+            home=Path("/home/x/autoresearch"),
+            gpu_partition="h200",
+            gpu_account="gacct",
+        )
+        _ended, submitted = service_in_review(root, g, SlurmCompute(runner=runner), spec, NOW)
+        return submitted, g.armed, submits
+
+    submitted, armed, _ = run("RUNNING")
+    assert submitted == [] and armed == []  # comments wait; nothing armed
+    submitted2, armed2, submits2 = run("COMPLETED")
+    assert submitted2 == [("r-rev", "77")] and armed2 == []
+    wrap = " ".join(submits2[0])
+    # the follow-up gets the cluster coordinates to read (or dispatch) the measure
+    assert "--gpu-partition h200" in wrap and "--gpu-account gacct" in wrap
+    assert "--account acct" in wrap and "--partition cpu_short" in wrap


### PR DESCRIPTION
## Why

A follow-up job runs on `cpu_short`. On the CPU pilot that was fine; on gpt-speedrun a follow-up's code change could never be measured (no GPU on the node), so a review-driven change could not be applied — and the #229 re-read had nothing real to bless. Placement should come from the contract, as the climb's does.

## What

- **Seal + dispatch (`_seal_and_measure`)**: for `bench.gpus > 0` with cluster coordinates, the change is sealed as a commit parented on the PR's current head (line memory excluded), and the dispatched measurer is asked for one measure (`followup`, contract command, this run's fresh seed, `gpus` from the contract). Synchronous compute → value now; cluster → `MeasurementPending`.
- **Park (`_park_remeasure`)**: the author's reply is posted now with a parked note (comments ARE serviced, cursors advance, a serviced panel wake is spent); `record.followup_stage` records `candidate_sha`, `candidate_ref`, `parent`, `job_ids`/`afterany`, `seed`, the reply text and conflict context. Nothing pushed.
- **Tick**: a record with a stage polls its jobs each tick; while any runs → no comment serviced, no arm; when all terminal/gone → a follow-up is submitted (the usual billing). Follow-up argv now carries `--account/--partition/--gpu-partition/--gpu-account`.
- **Resume (`_resume_measure`)**: reads the result (still pending → no-op; `EvalError` → abandon: workspace back to `parent`, snapshot released, stage cleared, said on the thread); otherwise `checkout -B <branch> <sealed>` (never the live tree — a drift test proves it), ledger via the shared `_update_ledger` (extracted from the inline path), disarm under `merge: auto`, one amended commit with the standard message, push, measured-number comment, candidate row, body edit, record (stage cleared, blessing cleared, wake attempts reset, conflict cursor per the sync rule), snapshot released, then the panel re-read of the pushed head with a fresh trusted base.
- CPU benchmarks and stewards keep the inline path; without coordinates everything is as before.

## Tests

`test_followup.py` (fake measurer/dispatch): park records the stage and pushes nothing, the sealed commit carries the change parented on the pushed head, the measure asks for the GPU lane at the contract's eval minutes; pending resume is a no-op that consumes no comment; landing applies the SEALED tree despite workspace drift, updates the ledger, comments, clears the stage and releases the ref; a failed eval is abandoned with the secret redacted and the branch unpushed; a synchronous compute applies in one pass; a CPU benchmark never touches the measurer. `test_tick.py`: RUNNING → no submit, no arm; COMPLETED → submit with the coordinates.

Full suite green (1075); ruff, mypy, pre-commit clean. Design note section added; CHANGELOG under Changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
