### PR TITLE
The significance floor is inclusive: a delta equal to min_delta is credited

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The significance floor is inclusive: a candidate whose delta over the base
+  (paired gate) or the recorded best (follow-up re-measure) EQUALS the
+  contract's `min_delta` is credited. The floor is the smallest movement the
+  contract calls real; on a quantized metric the old strict bar silently
+  demanded the next quantum (gpt-speedrun: three exact-floor wins discarded
+  in one night).
 - A follow-up's code change on a GPU benchmark is measured on the GPU lane as
   a dispatched job: the follow-up seals the change and parks, the tick polls
   the eval, and a later follow-up finishes on the sealed tree (ledger, push,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Versions follow [SemVer](https://semver.org).
 
 - A candidate is now credited when its improvement equals the contract's
   `min_delta`, in both the paired gate and the follow-up re-measure; before,
-  it had to beat the floor outright. Floor comparisons also tolerate
-  binary-float rounding, so a 0.1 improvement clears a 0.1 floor.
+  it had to beat the floor outright. Floor comparisons are made in exact
+  decimal arithmetic on the values as written, so a 0.1 improvement clears
+  a 0.1 floor and nothing short of the floor is credited.
 - A follow-up's code change on a GPU benchmark is measured on the GPU lane as
   a dispatched job: the follow-up seals the change and parks, the tick polls
   the eval, and a later follow-up finishes on the sealed tree (ledger, push,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
-- The significance floor is inclusive: a candidate whose delta over the base
-  (paired gate) or the recorded best (follow-up re-measure) EQUALS the
-  contract's `min_delta` is credited. The floor is the smallest movement the
-  contract calls real; on a quantized metric the old strict bar silently
-  demanded the next quantum (gpt-speedrun: three exact-floor wins discarded
-  in one night).
+- A candidate is now credited when its improvement equals the contract's
+  `min_delta`, in both the paired gate and the follow-up re-measure; before,
+  it had to beat the floor outright. Floor comparisons also tolerate
+  binary-float rounding, so a 0.1 improvement clears a 0.1 floor.
 - A follow-up's code change on a GPU benchmark is measured on the GPU lane as
   a dispatched job: the follow-up seals the change and parks, the tick polls
   the eval, and a later follow-up finishes on the sealed tree (ledger, push,

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -634,6 +634,14 @@ def benchmark_floor(
     return max(floors) if floors else 0.0
 
 
+def reaches_floor(delta: float, floor: float) -> bool:
+    """Inclusive floor test that survives binary floats: 0.3 - 0.2 is
+    0.09999999999999998, which must still clear a 0.1 floor. Relative
+    tolerance only — an absolute one would let a genuinely short delta
+    through on a tiny floor."""
+    return delta >= floor or math.isclose(delta, floor, rel_tol=1e-9, abs_tol=0.0)
+
+
 def clears_min_delta(
     prior_best: float,
     candidate: float,
@@ -656,7 +664,7 @@ def clears_min_delta(
         return False  # a declared floor with non-finite inputs fails closed
     floor = benchmark_floor(prior_best, min_delta, min_delta_rel)
     delta = candidate - prior_best if direction == "max" else prior_best - candidate
-    return delta >= floor
+    return reaches_floor(delta, floor)
 
 
 def suite_regressed(
@@ -916,7 +924,7 @@ def measure_and_decide(
         delta = (candidate - baseline) if bench.direction == "max" else (baseline - candidate)
         # INCLUSIVE, matching clears_min_delta: the floor is the smallest
         # movement the contract calls real, so a delta equal to it clears
-        if delta < floor:
+        if not reaches_floor(delta, floor):
             return AttemptResult(
                 outcome="no-improvement",
                 note=(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -636,10 +636,11 @@ def benchmark_floor(
 
 def reaches_floor(delta: float, floor: float) -> bool:
     """Inclusive floor test that survives binary floats: 0.3 - 0.2 is
-    0.09999999999999998, which must still clear a 0.1 floor. Relative
-    tolerance only — an absolute one would let a genuinely short delta
-    through on a tiny floor."""
-    return delta >= floor or math.isclose(delta, floor, rel_tol=1e-9, abs_tol=0.0)
+    0.09999999999999998, which must still clear a 0.1 floor. The tolerance
+    is relative and sized to rounding only (subtraction error is ~1e-16 of
+    the operands, so 1e-12 of the floor covers values up to thousands of
+    floors wide); a genuinely short delta is never rescued, at any scale."""
+    return delta >= floor or math.isclose(delta, floor, rel_tol=1e-12, abs_tol=0.0)
 
 
 def clears_min_delta(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -20,6 +20,7 @@ import subprocess
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from dataclasses import replace as dc_replace
+from fractions import Fraction
 from pathlib import Path
 from secrets import randbits
 from typing import TYPE_CHECKING, Protocol
@@ -634,13 +635,27 @@ def benchmark_floor(
     return max(floors) if floors else 0.0
 
 
-def reaches_floor(delta: float, floor: float) -> bool:
-    """Inclusive floor test that survives binary floats: 0.3 - 0.2 is
-    0.09999999999999998, which must still clear a 0.1 floor. The tolerance
-    is relative and sized to rounding only (subtraction error is ~1e-16 of
-    the operands, so 1e-12 of the floor covers values up to thousands of
-    floors wide); a genuinely short delta is never rescued, at any scale."""
-    return delta >= floor or math.isclose(delta, floor, rel_tol=1e-12, abs_tol=0.0)
+def reaches_floor(
+    prior: float,
+    candidate: float,
+    direction: str,
+    min_delta: float | None,
+    min_delta_rel: float | None,
+) -> bool:
+    """Inclusive floor test in exact decimal arithmetic. Metric values and
+    floors arrive as decimal text (eval JSON, the contract's YAML), so the
+    comparison is made on the decimals that were written, not on their
+    binary approximations: 0.3 - 0.2 is exactly 0.1 here, and there is no
+    tolerance for a short delta to hide in at any scale. Callers check
+    finiteness first; the caller's own float floor is only for messages."""
+    p, c = Fraction(repr(prior)), Fraction(repr(candidate))
+    delta = c - p if direction == "max" else p - c
+    floors = []
+    if min_delta:
+        floors.append(Fraction(repr(min_delta)))
+    if min_delta_rel:
+        floors.append(Fraction(repr(min_delta_rel)) * abs(p))
+    return delta >= max(floors) if floors else True
 
 
 def clears_min_delta(
@@ -663,9 +678,7 @@ def clears_min_delta(
         return True  # no floor declared
     if not (math.isfinite(prior_best) and math.isfinite(candidate)):
         return False  # a declared floor with non-finite inputs fails closed
-    floor = benchmark_floor(prior_best, min_delta, min_delta_rel)
-    delta = candidate - prior_best if direction == "max" else prior_best - candidate
-    return reaches_floor(delta, floor)
+    return reaches_floor(prior_best, candidate, direction, min_delta, min_delta_rel)
 
 
 def suite_regressed(
@@ -925,7 +938,9 @@ def measure_and_decide(
         delta = (candidate - baseline) if bench.direction == "max" else (baseline - candidate)
         # INCLUSIVE, matching clears_min_delta: the floor is the smallest
         # movement the contract calls real, so a delta equal to it clears
-        if not reaches_floor(delta, floor):
+        if not reaches_floor(
+            baseline, candidate, bench.direction, bench.min_delta, bench.min_delta_rel
+        ):
             return AttemptResult(
                 outcome="no-improvement",
                 note=(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -641,17 +641,22 @@ def clears_min_delta(
     min_delta: float | None,
     min_delta_rel: float | None = None,
 ) -> bool:
-    """Cross-seed comparisons on a resampled pool must clear the
+    """Cross-seed comparisons on a resampled pool must reach the
     benchmark's noise floor: the recorded best was measured under a
-    different seed, so a delta inside the floor is pool luck, not progress.
-    Same-seed paired comparisons never call this."""
+    different seed, so a delta below the floor is pool luck, not progress.
+    The floor is INCLUSIVE — a delta equal to it is credited: the contract
+    declares the smallest movement it calls real, and on a quantized metric
+    (a step count measured every N steps) the floor IS a reachable value,
+    so a strict bar silently demands the next quantum (gpt-speedrun,
+    2026-09-03: three candidates measured exactly one floor better than the
+    base were all discarded). Same-seed paired comparisons never call this."""
     if not (min_delta or min_delta_rel):
         return True  # no floor declared
     if not (math.isfinite(prior_best) and math.isfinite(candidate)):
         return False  # a declared floor with non-finite inputs fails closed
     floor = benchmark_floor(prior_best, min_delta, min_delta_rel)
     delta = candidate - prior_best if direction == "max" else prior_best - candidate
-    return delta > floor
+    return delta >= floor
 
 
 def suite_regressed(
@@ -909,9 +914,9 @@ def measure_and_decide(
     floor = benchmark_floor(baseline, bench.min_delta, bench.min_delta_rel)
     if floor:
         delta = (candidate - baseline) if bench.direction == "max" else (baseline - candidate)
-        # STRICTLY greater, matching clears_min_delta: a delta exactly at the
-        # floor is indistinguishable from the noise the floor models
-        if delta <= floor:
+        # INCLUSIVE, matching clears_min_delta: the floor is the smallest
+        # movement the contract calls real, so a delta equal to it clears
+        if delta < floor:
             return AttemptResult(
                 outcome="no-improvement",
                 note=(

--- a/src/autoresearch/orchestrator.py
+++ b/src/autoresearch/orchestrator.py
@@ -646,8 +646,12 @@ def reaches_floor(
     floors arrive as decimal text (eval JSON, the contract's YAML), so the
     comparison is made on the decimals that were written, not on their
     binary approximations: 0.3 - 0.2 is exactly 0.1 here, and there is no
-    tolerance for a short delta to hide in at any scale. Callers check
-    finiteness first; the caller's own float floor is only for messages."""
+    tolerance for a short delta to hide in at any scale. Non-finite inputs
+    fail closed: an infinite floor (`min_delta: .inf` is valid YAML) is
+    never reached, and a NaN anywhere is not a measurement. The caller's
+    float floor is only for messages."""
+    if not all(math.isfinite(v) for v in (prior, candidate, min_delta or 0, min_delta_rel or 0)):
+        return False
     p, c = Fraction(repr(prior)), Fraction(repr(candidate))
     delta = c - p if direction == "max" else p - c
     floors = []

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -753,6 +753,14 @@ def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
 
     assert clears_min_delta(12.0, 11.4, "min", 0.5)  # 0.6 > 0.5
     assert clears_min_delta(12.0, 11.5, "min", 0.5)  # exactly at the floor: credited
+    # binary floats: 0.3 - 0.2 is 0.09999999999999998, still an exact-floor
+    # improvement in the contract's decimal terms (absolute and relative)
+    assert clears_min_delta(0.3, 0.2, "min", 0.1)
+    assert clears_min_delta(0.2, 0.3, "max", 0.1)
+    assert clears_min_delta(0.3, 0.27, "min", None, 0.1)  # floor 0.03 vs 0.02999…
+    # a delta genuinely short of the floor is not rescued by the tolerance
+    assert not clears_min_delta(0.3, 0.2000001, "min", 0.1)
+    assert not clears_min_delta(0.3, 0.2700001, "min", None, 0.1)
     assert not clears_min_delta(12.0, 11.6, "min", 0.5)  # 0.4 < 0.5: pool luck
     assert clears_min_delta(0.54, 0.65, "max", 0.10)
     assert not clears_min_delta(0.54, 0.60, "max", 0.10)  # inside pool luck
@@ -1701,6 +1709,22 @@ def test_gate_credits_an_exact_floor_delta_and_rejects_below_it(tmp_path: Path) 
     result, _, _ = run_climb(tmp_path, [13.876, 13.4], contract=FLOOR_CONTRACT)
     assert result.outcome == "no-improvement"
     assert "inside the contract's significance floor" in (result.note or "")
+
+
+DECIMAL_FLOOR_CONTRACT = CONTRACT.replace(
+    "    direction: min\n",
+    "    direction: min\n    min_delta: 0.1\n",
+    1,
+)
+
+
+def test_gate_credits_an_exact_decimal_floor_despite_binary_rounding(tmp_path: Path) -> None:
+    # 0.3 - 0.2 is 0.09999999999999998 in binary; the contract said 0.1 and
+    # the candidate moved 0.1, so the gate must credit it
+    result, _, _ = run_climb(tmp_path, [0.3, 0.2], contract=DECIMAL_FLOOR_CONTRACT)
+    assert result.outcome == "improved"
+    result, _, _ = run_climb(tmp_path, [0.3, 0.2001], contract=DECIMAL_FLOOR_CONTRACT)
+    assert result.outcome == "no-improvement"
 
 
 def test_branch_prefix_derives_from_the_agent_id() -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -752,7 +752,8 @@ def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
     from autoresearch.orchestrator import clears_min_delta
 
     assert clears_min_delta(12.0, 11.4, "min", 0.5)  # 0.6 > 0.5
-    assert not clears_min_delta(12.0, 11.5, "min", 0.5)  # exactly at the floor
+    assert clears_min_delta(12.0, 11.5, "min", 0.5)  # exactly at the floor: credited
+    assert not clears_min_delta(12.0, 11.6, "min", 0.5)  # 0.4 < 0.5: pool luck
     assert clears_min_delta(0.54, 0.65, "max", 0.10)
     assert not clears_min_delta(0.54, 0.60, "max", 0.10)  # inside pool luck
     assert clears_min_delta(12.0, 11.9, "min", None)  # no floor declared
@@ -1691,11 +1692,15 @@ def test_gate_publishes_a_floor_clearing_delta(tmp_path: Path) -> None:
     assert result.outcome == "improved"
 
 
-def test_gate_rejects_an_exact_floor_delta(tmp_path: Path) -> None:
-    # boundary matches clears_min_delta: STRICTLY greater publishes — a
-    # delta exactly at the floor is the noise the floor models (terra #169)
+def test_gate_credits_an_exact_floor_delta_and_rejects_below_it(tmp_path: Path) -> None:
+    # boundary matches clears_min_delta: the floor is INCLUSIVE — the
+    # contract's floor is the smallest movement it calls real, so a delta
+    # equal to it publishes; anything below it is the noise the floor models
     result, _, _ = run_climb(tmp_path, [13.876, 13.376], contract=FLOOR_CONTRACT)
+    assert result.outcome == "improved"
+    result, _, _ = run_climb(tmp_path, [13.876, 13.4], contract=FLOOR_CONTRACT)
     assert result.outcome == "no-improvement"
+    assert "inside the contract's significance floor" in (result.note or "")
 
 
 def test_branch_prefix_derives_from_the_agent_id() -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -761,9 +761,10 @@ def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
     # a delta genuinely short of the floor is not rescued by the tolerance
     assert not clears_min_delta(0.3, 0.2000001, "min", 0.1)
     assert not clears_min_delta(0.3, 0.2700001, "min", None, 0.1)
-    # the tolerance absorbs rounding, not a measurable shortfall at any scale
-    assert not reaches_floor(999_999_999.5, 1_000_000_000.0)
-    assert reaches_floor(1_000_000_000.0, 1_000_000_000.0)
+    # exact decimal arithmetic: no tolerance for a short delta at any scale
+    assert not clears_min_delta(1_000_000_000.0, 0.0009, "min", 999_999_999.9991 + 0.0009)
+    assert clears_min_delta(1_000_000_000.0, 0.0, "min", 1_000_000_000.0)
+    assert not reaches_floor(1_000_000_000.0, 0.0009, "min", 1_000_000_000.0, None)
     assert not clears_min_delta(12.0, 11.6, "min", 0.5)  # 0.4 < 0.5: pool luck
     assert clears_min_delta(0.54, 0.65, "max", 0.10)
     assert not clears_min_delta(0.54, 0.60, "max", 0.10)  # inside pool luck

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -765,6 +765,10 @@ def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
     assert not clears_min_delta(1_000_000_000.0, 0.0009, "min", 999_999_999.9991 + 0.0009)
     assert clears_min_delta(1_000_000_000.0, 0.0, "min", 1_000_000_000.0)
     assert not reaches_floor(1_000_000_000.0, 0.0009, "min", 1_000_000_000.0, None)
+    # an infinite floor (`min_delta: .inf` parses) is never reached, never a crash
+    assert not clears_min_delta(10.0, 0.0, "min", float("inf"))
+    assert not reaches_floor(10.0, 0.0, "min", float("inf"), None)
+    assert not reaches_floor(10.0, 0.0, "min", float("nan"), None)
     assert not clears_min_delta(12.0, 11.6, "min", 0.5)  # 0.4 < 0.5: pool luck
     assert clears_min_delta(0.54, 0.65, "max", 0.10)
     assert not clears_min_delta(0.54, 0.60, "max", 0.10)  # inside pool luck
@@ -1720,6 +1724,19 @@ DECIMAL_FLOOR_CONTRACT = CONTRACT.replace(
     "    direction: min\n    min_delta: 0.1\n",
     1,
 )
+
+
+INF_FLOOR_CONTRACT = CONTRACT.replace(
+    "    direction: min\n",
+    "    direction: min\n    min_delta: .inf\n",
+    1,
+)
+
+
+def test_gate_rejects_under_an_infinite_floor_instead_of_crashing(tmp_path: Path) -> None:
+    result, _, _ = run_climb(tmp_path, [13.876, 1.0], contract=INF_FLOOR_CONTRACT)
+    assert result.outcome == "no-improvement"
+    assert "inside the contract's significance floor" in (result.note or "")
 
 
 def test_gate_credits_an_exact_decimal_floor_despite_binary_rounding(tmp_path: Path) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -749,7 +749,7 @@ def test_relative_floor_scales_with_the_level() -> None:
 
 
 def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
-    from autoresearch.orchestrator import clears_min_delta
+    from autoresearch.orchestrator import clears_min_delta, reaches_floor
 
     assert clears_min_delta(12.0, 11.4, "min", 0.5)  # 0.6 > 0.5
     assert clears_min_delta(12.0, 11.5, "min", 0.5)  # exactly at the floor: credited
@@ -761,6 +761,9 @@ def test_clears_min_delta_is_direction_aware_and_absolute() -> None:
     # a delta genuinely short of the floor is not rescued by the tolerance
     assert not clears_min_delta(0.3, 0.2000001, "min", 0.1)
     assert not clears_min_delta(0.3, 0.2700001, "min", None, 0.1)
+    # the tolerance absorbs rounding, not a measurable shortfall at any scale
+    assert not reaches_floor(999_999_999.5, 1_000_000_000.0)
+    assert reaches_floor(1_000_000_000.0, 1_000_000_000.0)
     assert not clears_min_delta(12.0, 11.6, "min", 0.5)  # 0.4 < 0.5: pool luck
     assert clears_min_delta(0.54, 0.65, "max", 0.10)
     assert not clears_min_delta(0.54, 0.60, "max", 0.10)  # inside pool luck


### PR DESCRIPTION
## Why

Owner's call (2026-09-03): "change to >=". Last night three gpt-speedrun candidates (agent-03 width960: 8640 → 8384; agent-04's re-run; agent-02's warmdown) measured **exactly one floor** (256 steps) better than the base and were all discarded by the strict `delta > floor`, so their authors restored the tree and ended as negatives.

The step count is quantized: `bench_eval.py` checks val loss every 128 steps, so `steps_to_target` is always a multiple of 128 and `min_delta: 256` means "two intervals". A strict bar therefore silently demands **three** intervals (384). The contract's own comment reads inclusively already: "a candidate must cross at <= 9216 to be credited over 9472" is `delta >= 256`.

## What

- `clears_min_delta` (follow-up / cross-seed rule): `delta >= floor`.
- The paired gate in `measure_and_decide`: rejects `delta < floor` instead of `<= floor`.
- Docstrings and comments say why the floor is inclusive; tests updated: an exact-floor delta is credited at both sites, one quantum below stays "inside the contract's significance floor".
- CHANGELOG under Changed. No contract change needed on gpt-speedrun (its comment already matches; a follow-up nit could drop the words "Strictly greater").

Full suite green; ruff, mypy, pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
