### PR TITLE
autoresearch start: the one launch command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- `autoresearch start`, the one launch command: with `sbatch` on PATH it
+  submits the resident tick (walltime, job name, and exports filled in from
+  flags, the environment, or `~/.config/autoresearch/.env`); otherwise, or
+  with `AUTORESEARCH_COMPUTE=local`, it runs the local loop in the
+  foreground. `autoresearch tick` forwards to the tick entry.
+
 ### Changed
 
 - A candidate is now credited when its improvement equals the contract's

--- a/docs/design/onboarding.md
+++ b/docs/design/onboarding.md
@@ -45,7 +45,10 @@ non-interactive use):
   writable, Slurm placement accepted, contract readable on the target.
   The doctor is re-runnable on its own (`init --doctor`) and is the first
   thing support asks for.
-- **Print the start command.** Nothing starts implicitly.
+- **Print the start command.** Nothing starts implicitly. The command is
+  `autoresearch start` on both paths: it submits the resident tick where
+  `sbatch` exists and runs the local loop elsewhere, taking the root and
+  placement from flags, the environment, or the `.env` the wizard wrote.
 
 The wizard invents no new validation: every check calls the same functions
 the tick preflights with, so the doctor and the tick cannot disagree
@@ -69,8 +72,8 @@ simultaneously the zero-Slurm on-ramp and the paper's Karpathy-loop
 ablation cell (width 1 × serialized) — the same kernel, the compute seam
 swapped, nothing else different.
 
-- **The chain is a loop.** No sbatch → `python -m autoresearch.tick --loop`
-  runs a tick every cadence in the foreground. State stays in records on
+- **The chain is a loop.** No sbatch → `autoresearch start` runs
+  `tick --loop`, a tick every cadence in the foreground. State stays in records on
   disk, so killing and restarting the loop resumes exactly like the Slurm
   chain surviving a dead tick.
 - **Serialization is the semantics, not a bug.** A tick that launches a
@@ -93,7 +96,8 @@ swapped, nothing else different.
 1. **Kernel enablement** (this note's PR series, part 1):
    `AUTORESEARCH_COMPUTE` selection at the two `SlurmCompute()` sites,
    `tick --loop`, local-mode wake-arming skip, per-mode required-env
-   relaxation (no account/partition in local mode).
+   relaxation (no account/partition in local mode), and the one launch
+   command `autoresearch start` (`src/autoresearch/cli.py`). Done.
 2. **The wizard**: `autoresearch.init` — detection, prompts, `.env` writer,
    doctor (PAT path first).
 3. **The manifest flow**: App mint + installation discovery inside the

--- a/docs/design/resident-tick.md
+++ b/docs/design/resident-tick.md
@@ -77,6 +77,10 @@ resident job (cpu_short, --time=06:00:00 passed at start, singleton)
 - **Logs.** The loop reopens `logs/tick-YYYYMMDD.log` per iteration, so the
   daily files keep their shape and the watchdog keeps its heartbeat.
 
+Starting it is `autoresearch start` (`src/autoresearch/cli.py`): it fills in the
+walltime, job name, placement, and exports from flags, the environment, or
+`~/.config/autoresearch/.env`, and refuses to submit beside a live resident.
+
 ## What it does not fix
 
 If the resident job itself is pending (first start, or a handover during

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
 #   github   : PyGithub or gh-CLI wrappers
 #   compute  : (stdlib subprocess over sbatch/squeue; no dep expected)
 
+[project.scripts]
+autoresearch = "autoresearch.cli:main"
+
 [project.optional-dependencies]
 # GitHub App auth: RS256 signing for App JWTs (docs/design/github-app-auth.md).
 # Install where AUTORESEARCH_GITHUB_APP_FILE is set; the PAT path needs nothing.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,6 +1,8 @@
 # scripts/
 
-Operational scripts, always committed.
+Operational scripts, always committed. Start the loop with `autoresearch start`:
+it submits `tick_chain.sbatch` as the resident tick where `sbatch` exists and
+runs the local loop elsewhere, reading placement from `~/.config/autoresearch/.env`.
 
 | Script | Purpose |
 | --- | --- |

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -18,9 +18,10 @@
 #   AUTORESEARCH_RESIDENT=1   run as the RESIDENT tick (design/resident-tick.md):
 #                             one long-lived job that loops deploy -> tick ->
 #                             sleep, with a single afterany:self successor.
-#                             Start it with an explicit walltime, e.g.
+#                             `autoresearch start` submits it (walltime,
+#                             name, and exports filled in); by hand:
 #                             `sbatch --time=360 --job-name=autoresearch-resident
-#                             --export=ALL,AUTORESEARCH_RESIDENT=1,...`; the
+#                             --export=ALL,AUTORESEARCH_RESIDENT=1,...`. The
 #                             per-cadence chain drains itself once a resident
 #                             job exists. Unset = the per-cadence chain below.
 # Further config also loads from ~/.config/autoresearch/.env (0600) each tick, so

--- a/src/autoresearch/__main__.py
+++ b/src/autoresearch/__main__.py
@@ -1,0 +1,3 @@
+from autoresearch.cli import main
+
+raise SystemExit(main())

--- a/src/autoresearch/cli.py
+++ b/src/autoresearch/cli.py
@@ -81,8 +81,12 @@ def env_file_values(path: Path = ENV_FILE, keys: tuple[str, ...] = START_KEYS) -
         raise StartError(
             f"refusing to read {path}: it must be owned by you and not group/world-writable"
         )
+    try:
+        text = path.read_text()
+    except OSError as e:
+        raise StartError(f"cannot read {path}: {e}") from None
     out: dict[str, str] = {}
-    for raw in path.read_text().splitlines():
+    for raw in text.splitlines():
         line = raw.rstrip("\r").strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
@@ -119,6 +123,7 @@ class StartPlan:
             f"AUTORESEARCH_ROOT={self.root}",
             f"AUTORESEARCH_ACCOUNT={self.account}",
             f"AUTORESEARCH_PARTITION={self.partition}",
+            f"AUTORESEARCH_RESIDENT_MINUTES={self.resident_minutes}",  # successors reuse it
         ]
         if self.cadence_min:
             exports.append(f"AUTORESEARCH_CADENCE_MIN={self.cadence_min}")
@@ -127,6 +132,7 @@ class StartPlan:
         return [
             "sbatch",
             "--parsable",
+            "--dependency=singleton",  # two starts can both submit; only one ever runs
             f"--time={self.resident_minutes}",
             f"--job-name={RESIDENT_JOB_NAME}",
             f"--account={self.account}",
@@ -173,9 +179,14 @@ def plan_start(
     compute = _setting("AUTORESEARCH_COMPUTE", "local" if local else "", environ, from_file)
     mode = "local" if compute.strip().lower() == "local" or not sbatch_on_path else "slurm"
     root_s = _setting("AUTORESEARCH_ROOT", root, environ, from_file)
+    cadence = _setting("AUTORESEARCH_CADENCE_MIN", "", environ, from_file)
+    pat = _setting("AUTORESEARCH_PAT_FILE", "", environ, from_file)
     if mode == "local":
         return StartPlan(
-            mode="local", root=Path(root_s).expanduser() if root_s else DEFAULT_LOCAL_ROOT
+            mode="local",
+            root=Path(root_s).expanduser() if root_s else DEFAULT_LOCAL_ROOT,
+            cadence_min=cadence,
+            pat_file=pat,
         )
     home = _home(environ, cwd)
     if not root_s:
@@ -195,7 +206,6 @@ def plan_start(
     ]
     if missing:
         raise StartError("Slurm mode needs " + " and ".join(missing))
-    cadence = _setting("AUTORESEARCH_CADENCE_MIN", "", environ, from_file)
     minutes_s = _setting("AUTORESEARCH_RESIDENT_MINUTES", "", environ, from_file)
     try:
         minutes = int(minutes_s) if minutes_s else DEFAULT_RESIDENT_MINUTES
@@ -205,7 +215,6 @@ def plan_start(
         ) from None
     if minutes <= 0:
         raise StartError("AUTORESEARCH_RESIDENT_MINUTES must be positive")
-    pat = _setting("AUTORESEARCH_PAT_FILE", "", environ, from_file)
     for name, value in (
         ("root", root_s),
         ("account", acc),
@@ -230,10 +239,11 @@ def plan_start(
     )
 
 
-def _resident_job() -> str:
-    """The id of a queued or running resident tick, or ''. Unknown on error."""
+def _resident_jobs() -> list[str] | None:
+    """Ids of queued or running resident ticks, lowest first; None when the
+    scheduler could not be asked (a failed lookup must never read as 'none')."""
     try:
-        out = subprocess.run(
+        proc = subprocess.run(
             [
                 "squeue",
                 "-u",
@@ -246,10 +256,17 @@ def _resident_job() -> str:
             capture_output=True,
             text=True,
             timeout=30,
-        ).stdout
+        )
     except (OSError, subprocess.SubprocessError):
-        return ""
-    return out.split()[0] if out.split() else ""
+        return None
+    if proc.returncode != 0:
+        return None
+    ids = [line.strip() for line in proc.stdout.splitlines() if line.strip()]
+    return sorted(ids, key=lambda s: (len(s), s))
+
+
+def _cancel(job: str) -> None:
+    subprocess.run(["scancel", job], capture_output=True, text=True, timeout=30)
 
 
 def _exec(cmd: list[str], env: dict[str, str]) -> int:
@@ -290,15 +307,27 @@ def start(args: argparse.Namespace) -> int:
             env.setdefault(key, value)
         env["AUTORESEARCH_COMPUTE"] = "local"
         env["AUTORESEARCH_ROOT"] = str(plan.root)
+        if plan.cadence_min:
+            env["AUTORESEARCH_CADENCE_MIN"] = plan.cadence_min
+        if plan.pat_file:
+            env["AUTORESEARCH_PAT_FILE"] = plan.pat_file
         print(
             f"local loop: state in {plan.root}; Ctrl-C stops it, the records resume it",
             file=sys.stderr,
         )
         return _exec(cmd, env)
-    existing = _resident_job()
+    existing = _resident_jobs()
+    if existing is None:
+        print(
+            "autoresearch start: could not ask the scheduler whether a resident tick "
+            "exists (squeue failed); nothing submitted. Retry, or check "
+            f"`squeue --name {RESIDENT_JOB_NAME}`.",
+            file=sys.stderr,
+        )
+        return 1
     if existing:
         print(
-            f"a resident tick is already queued or running (job {existing}); nothing "
+            f"a resident tick is already queued or running (job {existing[0]}); nothing "
             f"submitted. Stop it with `scancel --name {RESIDENT_JOB_NAME}`, or pause it "
             f"with `touch {plan.root}/PAUSE`.",
             file=sys.stderr,
@@ -312,6 +341,17 @@ def start(args: argparse.Namespace) -> int:
         )
         return 1
     job = proc.stdout.strip().split(";")[0]
+    # two starts can pass the check above together; singleton keeps them from
+    # running at once, and the later submission withdraws so one chain remains
+    after = _resident_jobs()
+    if after and after[0] != job and job in after:
+        _cancel(job)
+        print(
+            f"another resident tick (job {after[0]}) was submitted at the same time; "
+            f"withdrew this one (job {job}).",
+            file=sys.stderr,
+        )
+        return 0
     print(
         f"resident tick submitted: job {job} on {plan.partition}, "
         f"{plan.resident_minutes} min walltime, hands over to itself. "

--- a/src/autoresearch/cli.py
+++ b/src/autoresearch/cli.py
@@ -268,8 +268,12 @@ def _resident_jobs() -> list[str] | None:
     return sorted(ids, key=lambda s: (len(s), s))
 
 
-def _cancel(job: str) -> None:
-    subprocess.run(["scancel", job], capture_output=True, text=True, timeout=30)
+def _cancel(job: str) -> bool:
+    try:
+        proc = subprocess.run(["scancel", job], capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return proc.returncode == 0
 
 
 def _exec(cmd: list[str], env: dict[str, str]) -> int:
@@ -279,7 +283,8 @@ def _exec(cmd: list[str], env: dict[str, str]) -> int:
 
 def start(args: argparse.Namespace) -> int:
     try:
-        from_file = env_file_values(ENV_FILE)
+        values = env_file_values(ENV_FILE, START_KEYS + TICK_ENV_KEYS)  # one read for everything
+        from_file = {k: v for k, v in values.items() if k in START_KEYS}
         plan = plan_start(
             root=args.root or "",
             account=args.account or "",
@@ -301,13 +306,9 @@ def start(args: argparse.Namespace) -> int:
         # the loop has no deploy step, so the author knobs the chain would
         # export from .env each tick are exported here once; the shell wins
         env = dict(os.environ)
-        try:
-            knobs = env_file_values(ENV_FILE, TICK_ENV_KEYS)
-        except StartError as e:
-            print(f"autoresearch start: {e}", file=sys.stderr)
-            return 2
-        for key, value in knobs.items():
-            env.setdefault(key, value)
+        for key, value in values.items():
+            if key in TICK_ENV_KEYS:
+                env.setdefault(key, value)
         env["AUTORESEARCH_COMPUTE"] = "local"
         env["AUTORESEARCH_ROOT"] = str(plan.root)
         env["AUTORESEARCH_HOME"] = str(plan.home)
@@ -349,13 +350,20 @@ def start(args: argparse.Namespace) -> int:
     # running at once, and the later submission withdraws so one chain remains
     after = _resident_jobs()
     if after and after[0] != job and job in after:
-        _cancel(job)
+        if _cancel(job):
+            print(
+                f"another resident tick (job {after[0]}) was submitted at the same time; "
+                f"withdrew this one (job {job}).",
+                file=sys.stderr,
+            )
+            return 0
+        # a queued loser would run after the winner and start a second chain
         print(
-            f"another resident tick (job {after[0]}) was submitted at the same time; "
-            f"withdrew this one (job {job}).",
+            f"another resident tick (job {after[0]}) was submitted at the same time and "
+            f"this one (job {job}) could not be cancelled; cancel it by hand: scancel {job}",
             file=sys.stderr,
         )
-        return 0
+        return 1
     print(
         f"resident tick submitted: job {job} on {plan.partition}, "
         f"{plan.resident_minutes} min walltime, hands over to itself. "

--- a/src/autoresearch/cli.py
+++ b/src/autoresearch/cli.py
@@ -105,7 +105,7 @@ def env_file_values(path: Path = ENV_FILE, keys: tuple[str, ...] = START_KEYS) -
 class StartPlan:
     mode: str  # "slurm" | "local"
     root: Path
-    home: Path | None = None
+    home: Path = Path(".")
     account: str = ""
     partition: str = ""
     cadence_min: str = ""
@@ -115,7 +115,6 @@ class StartPlan:
     def command(self) -> list[str]:
         if self.mode == "local":
             return [sys.executable, "-m", "autoresearch.tick", "--root", str(self.root), "--loop"]
-        assert self.home is not None
         exports = [
             "ALL",
             "AUTORESEARCH_RESIDENT=1",
@@ -152,8 +151,9 @@ def _setting(key: str, flag: str, environ: dict[str, str], from_file: dict[str, 
 
 
 def _home(environ: dict[str, str], cwd: Path) -> Path:
-    """The checkout the chain deploys from: AUTORESEARCH_HOME, else the
-    current directory when it is one."""
+    """The checkout the loop runs from: AUTORESEARCH_HOME, else the current
+    directory when it is one. Both modes need it; the tick's launch lanes
+    and GitHub servicing switch off without it."""
     home = (
         Path(environ["AUTORESEARCH_HOME"]).expanduser() if environ.get("AUTORESEARCH_HOME") else cwd
     )
@@ -181,14 +181,17 @@ def plan_start(
     root_s = _setting("AUTORESEARCH_ROOT", root, environ, from_file)
     cadence = _setting("AUTORESEARCH_CADENCE_MIN", "", environ, from_file)
     pat = _setting("AUTORESEARCH_PAT_FILE", "", environ, from_file)
+    # both modes run from a checkout: the tick's launch lanes and GitHub
+    # servicing switch off without AUTORESEARCH_HOME
+    home = _home(environ, cwd)
     if mode == "local":
         return StartPlan(
             mode="local",
             root=Path(root_s).expanduser() if root_s else DEFAULT_LOCAL_ROOT,
+            home=home,
             cadence_min=cadence,
             pat_file=pat,
         )
-    home = _home(environ, cwd)
     if not root_s:
         raise StartError(
             "Slurm mode needs the state root on the shared filesystem: "
@@ -307,6 +310,7 @@ def start(args: argparse.Namespace) -> int:
             env.setdefault(key, value)
         env["AUTORESEARCH_COMPUTE"] = "local"
         env["AUTORESEARCH_ROOT"] = str(plan.root)
+        env["AUTORESEARCH_HOME"] = str(plan.home)
         if plan.cadence_min:
             env["AUTORESEARCH_CADENCE_MIN"] = plan.cadence_min
         if plan.pat_file:

--- a/src/autoresearch/cli.py
+++ b/src/autoresearch/cli.py
@@ -180,6 +180,17 @@ def plan_start(
     mode = "local" if compute.strip().lower() == "local" or not sbatch_on_path else "slurm"
     root_s = _setting("AUTORESEARCH_ROOT", root, environ, from_file)
     cadence = _setting("AUTORESEARCH_CADENCE_MIN", "", environ, from_file)
+    if cadence:
+        # the chain divides by it and the loop sleeps on it: a bad value would
+        # only surface after the job started
+        try:
+            cadence_ok = float(cadence) > 0
+        except ValueError:
+            cadence_ok = False
+        if not cadence_ok:
+            raise StartError(
+                f"AUTORESEARCH_CADENCE_MIN must be a positive number of minutes, got {cadence!r}"
+            )
     pat = _setting("AUTORESEARCH_PAT_FILE", "", environ, from_file)
     # both modes run from a checkout: the tick's launch lanes and GitHub
     # servicing switch off without AUTORESEARCH_HOME

--- a/src/autoresearch/cli.py
+++ b/src/autoresearch/cli.py
@@ -1,0 +1,353 @@
+"""The one launch command: `autoresearch start`.
+
+With `sbatch` on PATH it submits the resident tick
+(docs/design/resident-tick.md) and returns; without it, or with
+AUTORESEARCH_COMPUTE=local, it runs the local loop in the foreground.
+Settings come from flags, then the process environment, then
+~/.config/autoresearch/.env, read once here at launch. The running chain
+never takes identity or placement from that file (tick_deploy.sh reads an
+allowlist of author knobs per tick), so editing it later cannot move a chain.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import shutil
+import stat
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+RESIDENT_JOB_NAME = "autoresearch-resident"
+DEFAULT_RESIDENT_MINUTES = 360  # cpu_short's ceiling on Torch; the loop hands over to itself
+DEFAULT_LOCAL_ROOT = Path.home() / ".autoresearch"
+ENV_FILE = Path.home() / ".config" / "autoresearch" / ".env"
+
+# What start itself decides from: mode, placement, root, cadence, walltime.
+START_KEYS = (
+    "AUTORESEARCH_COMPUTE",
+    "AUTORESEARCH_ROOT",
+    "AUTORESEARCH_ACCOUNT",
+    "AUTORESEARCH_PARTITION",
+    "AUTORESEARCH_CADENCE_MIN",
+    "AUTORESEARCH_RESIDENT_MINUTES",
+    "AUTORESEARCH_PAT_FILE",
+)
+# The author knobs the chain's deploy step exports from .env every tick. The
+# local loop has no deploy step, so start exports them once at launch; a test
+# keeps this list identical to tick_deploy.sh's.
+TICK_ENV_KEYS = (
+    "AUTORESEARCH_AUTHOR_BACKEND",
+    "AUTORESEARCH_AUTHOR_MODEL",
+    "AUTORESEARCH_CODEX_BIN",
+    "AUTORESEARCH_CODEX_KEY_FILE",
+    "AUTORESEARCH_HARNESS_KEY_FILE",
+    "AUTORESEARCH_VERTEX_PROJECT",
+    "AUTORESEARCH_VERTEX_REGION",
+    "AUTORESEARCH_VERTEX_ADC",
+    "AUTORESEARCH_TARGET",
+    "AUTORESEARCH_GITHUB_APP_FILE",
+    "AUTORESEARCH_BOT_LOGIN",
+    "AUTORESEARCH_BOT_ALIASES",
+    "AUTORESEARCH_GPU_PARTITION",
+    "AUTORESEARCH_GPU_ACCOUNT",
+    "AUTORESEARCH_PANEL",
+    "AUTORESEARCH_PANEL_KEY_FILE",
+    "AUTORESEARCH_PANEL_CODEX_KEY_FILE",
+    "AUTORESEARCH_PANEL_HERMES_KEY_FILE",
+    "REVIEW_HERMES_REPO",
+    "REVIEW_HERMES_PROVIDER",
+)
+
+
+class StartError(Exception):
+    """A start that cannot proceed; the message is the whole diagnosis."""
+
+
+def env_file_values(path: Path = ENV_FILE, keys: tuple[str, ...] = START_KEYS) -> dict[str, str]:
+    """`keys` from the operator's .env under the deploy step's trust rule: the
+    file must be ours and not group/world-writable, or it is refused. Last
+    assignment wins; surrounding quotes and a CR are stripped; a key set to
+    an empty value is present (an off-switch), an absent key is absent.
+    No file: nothing."""
+    try:
+        st = path.stat()
+    except OSError:
+        return {}
+    if st.st_uid != os.getuid() or st.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        raise StartError(
+            f"refusing to read {path}: it must be owned by you and not group/world-writable"
+        )
+    out: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.rstrip("\r").strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key not in keys:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+            value = value[1:-1]
+        out[key] = value
+    return out
+
+
+@dataclass(frozen=True)
+class StartPlan:
+    mode: str  # "slurm" | "local"
+    root: Path
+    home: Path | None = None
+    account: str = ""
+    partition: str = ""
+    cadence_min: str = ""
+    resident_minutes: int = DEFAULT_RESIDENT_MINUTES
+    pat_file: str = ""
+
+    def command(self) -> list[str]:
+        if self.mode == "local":
+            return [sys.executable, "-m", "autoresearch.tick", "--root", str(self.root), "--loop"]
+        assert self.home is not None
+        exports = [
+            "ALL",
+            "AUTORESEARCH_RESIDENT=1",
+            f"AUTORESEARCH_HOME={self.home}",
+            f"AUTORESEARCH_ROOT={self.root}",
+            f"AUTORESEARCH_ACCOUNT={self.account}",
+            f"AUTORESEARCH_PARTITION={self.partition}",
+        ]
+        if self.cadence_min:
+            exports.append(f"AUTORESEARCH_CADENCE_MIN={self.cadence_min}")
+        if self.pat_file:
+            exports.append(f"AUTORESEARCH_PAT_FILE={self.pat_file}")
+        return [
+            "sbatch",
+            "--parsable",
+            f"--time={self.resident_minutes}",
+            f"--job-name={RESIDENT_JOB_NAME}",
+            f"--account={self.account}",
+            f"--partition={self.partition}",
+            "--export=" + ",".join(exports),
+            str(self.home / "scripts" / "tick_chain.sbatch"),
+        ]
+
+
+def _setting(key: str, flag: str, environ: dict[str, str], from_file: dict[str, str]) -> str:
+    """Flag, then the process environment, then .env."""
+    if flag:
+        return flag
+    if key in environ:
+        return environ[key]
+    return from_file.get(key, "")
+
+
+def _home(environ: dict[str, str], cwd: Path) -> Path:
+    """The checkout the chain deploys from: AUTORESEARCH_HOME, else the
+    current directory when it is one."""
+    home = (
+        Path(environ["AUTORESEARCH_HOME"]).expanduser() if environ.get("AUTORESEARCH_HOME") else cwd
+    )
+    if not (home / "scripts" / "tick_chain.sbatch").is_file():
+        raise StartError(
+            f"{home} is not an autoresearch checkout (no scripts/tick_chain.sbatch); "
+            "run start from the checkout the chain should deploy from, or set AUTORESEARCH_HOME"
+        )
+    return home
+
+
+def plan_start(
+    *,
+    root: str,
+    account: str,
+    partition: str,
+    local: bool,
+    environ: dict[str, str],
+    from_file: dict[str, str],
+    sbatch_on_path: bool,
+    cwd: Path,
+) -> StartPlan:
+    compute = _setting("AUTORESEARCH_COMPUTE", "local" if local else "", environ, from_file)
+    mode = "local" if compute.strip().lower() == "local" or not sbatch_on_path else "slurm"
+    root_s = _setting("AUTORESEARCH_ROOT", root, environ, from_file)
+    if mode == "local":
+        return StartPlan(
+            mode="local", root=Path(root_s).expanduser() if root_s else DEFAULT_LOCAL_ROOT
+        )
+    home = _home(environ, cwd)
+    if not root_s:
+        raise StartError(
+            "Slurm mode needs the state root on the shared filesystem: "
+            "--root, AUTORESEARCH_ROOT, or AUTORESEARCH_ROOT= in ~/.config/autoresearch/.env"
+        )
+    acc = _setting("AUTORESEARCH_ACCOUNT", account, environ, from_file)
+    part = _setting("AUTORESEARCH_PARTITION", partition, environ, from_file)
+    missing = [
+        name
+        for name, value in (
+            ("--account / AUTORESEARCH_ACCOUNT", acc),
+            ("--partition / AUTORESEARCH_PARTITION", part),
+        )
+        if not value
+    ]
+    if missing:
+        raise StartError("Slurm mode needs " + " and ".join(missing))
+    cadence = _setting("AUTORESEARCH_CADENCE_MIN", "", environ, from_file)
+    minutes_s = _setting("AUTORESEARCH_RESIDENT_MINUTES", "", environ, from_file)
+    try:
+        minutes = int(minutes_s) if minutes_s else DEFAULT_RESIDENT_MINUTES
+    except ValueError:
+        raise StartError(
+            f"AUTORESEARCH_RESIDENT_MINUTES must be a whole number of minutes, got {minutes_s!r}"
+        ) from None
+    if minutes <= 0:
+        raise StartError("AUTORESEARCH_RESIDENT_MINUTES must be positive")
+    pat = _setting("AUTORESEARCH_PAT_FILE", "", environ, from_file)
+    for name, value in (
+        ("root", root_s),
+        ("account", acc),
+        ("partition", part),
+        ("cadence", cadence),
+        ("PAT file", pat),
+        ("checkout path", str(home)),
+    ):
+        if "," in value or any(c.isspace() for c in value):
+            raise StartError(
+                f"{name} {value!r} cannot contain commas or whitespace: it rides in sbatch --export"
+            )
+    return StartPlan(
+        mode="slurm",
+        root=Path(root_s).expanduser(),
+        home=home,
+        account=acc,
+        partition=part,
+        cadence_min=cadence,
+        resident_minutes=minutes,
+        pat_file=pat,
+    )
+
+
+def _resident_job() -> str:
+    """The id of a queued or running resident tick, or ''. Unknown on error."""
+    try:
+        out = subprocess.run(
+            [
+                "squeue",
+                "-u",
+                os.environ.get("USER", ""),
+                f"--name={RESIDENT_JOB_NAME}",
+                "-h",
+                "-o",
+                "%i",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return out.split()[0] if out.split() else ""
+
+
+def _exec(cmd: list[str], env: dict[str, str]) -> int:
+    os.execvpe(cmd[0], cmd, env)
+    return 1  # unreachable; keeps the signature honest for tests that stub this
+
+
+def start(args: argparse.Namespace) -> int:
+    try:
+        from_file = env_file_values(ENV_FILE)
+        plan = plan_start(
+            root=args.root or "",
+            account=args.account or "",
+            partition=args.partition or "",
+            local=args.local,
+            environ=dict(os.environ),
+            from_file=from_file,
+            sbatch_on_path=shutil.which("sbatch") is not None,
+            cwd=Path.cwd(),
+        )
+    except StartError as e:
+        print(f"autoresearch start: {e}", file=sys.stderr)
+        return 2
+    cmd = plan.command()
+    if args.dry_run:
+        print(shlex.join(cmd))
+        return 0
+    if plan.mode == "local":
+        # the loop has no deploy step, so the author knobs the chain would
+        # export from .env each tick are exported here once; the shell wins
+        env = dict(os.environ)
+        try:
+            knobs = env_file_values(ENV_FILE, TICK_ENV_KEYS)
+        except StartError as e:
+            print(f"autoresearch start: {e}", file=sys.stderr)
+            return 2
+        for key, value in knobs.items():
+            env.setdefault(key, value)
+        env["AUTORESEARCH_COMPUTE"] = "local"
+        env["AUTORESEARCH_ROOT"] = str(plan.root)
+        print(
+            f"local loop: state in {plan.root}; Ctrl-C stops it, the records resume it",
+            file=sys.stderr,
+        )
+        return _exec(cmd, env)
+    existing = _resident_job()
+    if existing:
+        print(
+            f"a resident tick is already queued or running (job {existing}); nothing "
+            f"submitted. Stop it with `scancel --name {RESIDENT_JOB_NAME}`, or pause it "
+            f"with `touch {plan.root}/PAUSE`.",
+            file=sys.stderr,
+        )
+        return 0
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        print(
+            f"autoresearch start: sbatch failed: {(proc.stderr or proc.stdout).strip()}",
+            file=sys.stderr,
+        )
+        return 1
+    job = proc.stdout.strip().split(";")[0]
+    print(
+        f"resident tick submitted: job {job} on {plan.partition}, "
+        f"{plan.resident_minutes} min walltime, hands over to itself. "
+        f"Logs: {plan.root}/logs. Pause: touch {plan.root}/PAUSE. "
+        f"Stop: scancel --name {RESIDENT_JOB_NAME}."
+    )
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="autoresearch", description="autonomous research agents in an outer loop"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    p = sub.add_parser(
+        "start", help="start the loop: the resident tick on Slurm, the local loop elsewhere"
+    )
+    p.add_argument(
+        "--root", help="state root (shared filesystem on Slurm; default ~/.autoresearch locally)"
+    )
+    p.add_argument("--account", help="Slurm account")
+    p.add_argument("--partition", help="Slurm partition for the tick")
+    p.add_argument(
+        "--local", action="store_true", help="run the local loop even where sbatch exists"
+    )
+    p.add_argument("--dry-run", action="store_true", help="print the command and exit")
+    sub.add_parser("tick", help="one tick, or --loop; the chain's own entry", add_help=False)
+    argv = sys.argv[1:] if argv is None else list(argv)
+    if argv[:1] == ["tick"]:
+        # the tick entry owns its own parser; hand it the rest untouched
+        from autoresearch import tick
+
+        sys.argv = ["autoresearch tick", *argv[1:]]
+        return tick.main()
+    return start(parser.parse_args(argv))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -390,6 +390,48 @@ def test_slurm_start_withdraws_when_another_start_won_the_race(
     assert "job 4100" in capsys.readouterr().err
 
 
+def test_slurm_start_reports_a_race_loser_it_could_not_cancel(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home = checkout(clean_env)
+    bin_dir = clean_env / "bin"
+    bin_dir.mkdir()
+    calls = clean_env / "squeue.calls"
+    shim(bin_dir, "sbatch", "echo 4242\n")
+    shim(
+        bin_dir,
+        "squeue",
+        f"echo x >> {calls}\n[ $(wc -l < {calls}) -gt 1 ] && printf '4242\\n4100\\n'\nexit 0\n",
+    )
+    shim(bin_dir, "scancel", "echo 'scancel: error: Kill job error' >&2\nexit 1\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.chdir(home)
+    assert main(["start", "--root", "/r", "--account", "a", "--partition", "p"]) == 1
+    err = capsys.readouterr().err
+    assert "could not be cancelled" in err and "scancel 4242" in err
+
+
+def test_local_start_reads_the_env_file_once(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli, "ENV_FILE", env_file(clean_env, "AUTORESEARCH_TARGET=o/r\n"))
+    reads: list[tuple[str, ...]] = []
+    real = cli.env_file_values
+
+    def counting(path: Path, keys: tuple[str, ...] = cli.START_KEYS) -> dict[str, str]:
+        reads.append(keys)
+        return real(path, keys)
+
+    monkeypatch.setattr(cli, "env_file_values", counting)
+    seen: dict[str, dict[str, str]] = {}
+    monkeypatch.setattr(cli, "_exec", lambda cmd, env: seen.setdefault("env", env) and 0)
+    monkeypatch.chdir(checkout(clean_env))
+    assert main(["start", "--root", str(clean_env / "s")]) == 0
+    assert len(reads) == 1
+    assert seen["env"]["AUTORESEARCH_TARGET"] == "o/r"
+
+
 def test_start_errors_are_exit_2_with_the_diagnosis(
     clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -115,6 +115,7 @@ def test_local_without_sbatch_defaults_the_root(tmp_path: Path) -> None:
     p = plan(tmp_path, sbatch_on_path=False)
     assert p.mode == "local"
     assert p.root == DEFAULT_LOCAL_ROOT
+    assert p.home == tmp_path / "checkout"  # the loop needs the checkout too
     assert p.command() == [
         sys.executable,
         "-m",
@@ -182,14 +183,16 @@ def test_precedence_is_flag_then_environment_then_file(tmp_path: Path) -> None:
     assert (str(p.root), p.account, p.partition) == ("/env/root", "envacct", "flagged")
 
 
-def test_slurm_home_from_env_or_cwd_and_must_be_a_checkout(tmp_path: Path) -> None:
+def test_home_from_env_or_cwd_and_must_be_a_checkout_in_both_modes(tmp_path: Path) -> None:
     home = checkout(tmp_path)
     base = {"AUTORESEARCH_ROOT": "/r", "AUTORESEARCH_ACCOUNT": "a", "AUTORESEARCH_PARTITION": "p"}
-    assert (
-        plan(tmp_path, cwd=tmp_path, environ={**base, "AUTORESEARCH_HOME": str(home)}).home == home
-    )
+    with_home = {**base, "AUTORESEARCH_HOME": str(home)}
+    assert plan(tmp_path, cwd=tmp_path, environ=with_home).home == home
+    assert plan(tmp_path, cwd=tmp_path, local=True, environ=with_home).home == home
     with pytest.raises(StartError, match="not an autoresearch checkout"):
         plan(tmp_path, cwd=tmp_path, environ=base)
+    with pytest.raises(StartError, match="not an autoresearch checkout"):
+        plan(tmp_path, cwd=tmp_path, local=True)
 
 
 def test_slurm_requires_root_account_and_partition(tmp_path: Path) -> None:
@@ -244,6 +247,7 @@ def test_dry_run_prints_the_command(
     clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.chdir(checkout(clean_env))
     assert main(["start", "--dry-run", "--root", str(clean_env / "s")]) == 0
     out = capsys.readouterr().out
     assert "autoresearch.tick" in out and "--loop" in out and str(clean_env / "s") in out
@@ -270,6 +274,8 @@ def test_local_start_execs_the_loop_with_env_knobs(
         return 0
 
     monkeypatch.setattr(cli, "_exec", fake_exec)
+    home = checkout(clean_env)
+    monkeypatch.chdir(home)
     assert main(["start", "--root", str(clean_env / "state")]) == 0
     assert seen["cmd"] == [
         sys.executable,
@@ -283,6 +289,7 @@ def test_local_start_execs_the_loop_with_env_knobs(
     assert isinstance(env, dict)
     assert env["AUTORESEARCH_COMPUTE"] == "local"
     assert env["AUTORESEARCH_ROOT"] == str(clean_env / "state")
+    assert env["AUTORESEARCH_HOME"] == str(home)  # the tick's lanes need the checkout
     assert env["AUTORESEARCH_TARGET"] == "shell/wins"  # the shell beats the file at launch
     assert env["AUTORESEARCH_PANEL"] == ""  # an off-switch in the file still lands
     assert env["AUTORESEARCH_CADENCE_MIN"] == "15"  # the loop's cadence comes from .env too

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -1,0 +1,351 @@
+"""`autoresearch start`: one command, Slurm or local, settings from flags,
+environment, then .env."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from autoresearch import cli
+from autoresearch.cli import (
+    DEFAULT_LOCAL_ROOT,
+    DEFAULT_RESIDENT_MINUTES,
+    RESIDENT_JOB_NAME,
+    START_KEYS,
+    TICK_ENV_KEYS,
+    StartError,
+    StartPlan,
+    env_file_values,
+    main,
+    plan_start,
+)
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def checkout(tmp_path: Path) -> Path:
+    home = tmp_path / "checkout"
+    (home / "scripts").mkdir(parents=True, exist_ok=True)
+    (home / "scripts" / "tick_chain.sbatch").write_text("#!/bin/bash\n")
+    return home
+
+
+def env_file(tmp_path: Path, text: str, mode: int = 0o600) -> Path:
+    path = tmp_path / ".env"
+    path.write_text(text)
+    path.chmod(mode)
+    return path
+
+
+# ---------------------------------------------------------------- .env
+
+
+def test_env_file_values_reads_only_start_keys_last_wins_and_unquotes(tmp_path: Path) -> None:
+    path = env_file(
+        tmp_path,
+        "# comment\nAUTORESEARCH_ROOT=/old\nAUTORESEARCH_ROOT='/scratch/me/ar'\r\n"
+        'AUTORESEARCH_ACCOUNT="acct"\nAUTORESEARCH_PANEL=\nOTHER=x\n'
+        "AUTORESEARCH_CADENCE_MIN = 20\n",
+    )
+    got = env_file_values(path)
+    assert got == {
+        "AUTORESEARCH_ROOT": "/scratch/me/ar",
+        "AUTORESEARCH_ACCOUNT": "acct",
+        "AUTORESEARCH_CADENCE_MIN": "20",
+    }
+    # the author-knob view of the same file: an empty value is PRESENT
+    assert env_file_values(path, TICK_ENV_KEYS) == {"AUTORESEARCH_PANEL": ""}
+
+
+def test_env_file_values_missing_file_is_empty(tmp_path: Path) -> None:
+    assert env_file_values(tmp_path / "absent") == {}
+
+
+@pytest.mark.parametrize("mode", [0o620, 0o602, 0o666])
+def test_env_file_values_refuses_a_writable_file(tmp_path: Path, mode: int) -> None:
+    path = env_file(tmp_path, "AUTORESEARCH_ROOT=/x\n", mode)
+    if not path.stat().st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        pytest.skip("filesystem drops group/other write bits")
+    with pytest.raises(StartError, match="refusing to read"):
+        env_file_values(path)
+
+
+def test_tick_env_keys_match_the_deploy_allowlist() -> None:
+    """The local loop exports the same author knobs the chain's deploy step
+    does; the two lists must not drift."""
+    sh = (REPO / "scripts" / "tick_deploy.sh").read_text()
+    m = re.search(r"for _k in (.*?); do", sh, re.S)
+    assert m is not None
+    keys = tuple(m.group(1).replace("\\\n", " ").split())
+    assert keys == TICK_ENV_KEYS
+    assert not set(START_KEYS) & set(TICK_ENV_KEYS)  # start's own keys are not per-tick knobs
+
+
+# ---------------------------------------------------------------- planning
+
+
+def plan(tmp_path: Path, **kw: Any) -> StartPlan:
+    args: dict[str, Any] = dict(
+        root="",
+        account="",
+        partition="",
+        local=False,
+        environ={},
+        from_file={},
+        sbatch_on_path=True,
+        cwd=checkout(tmp_path),
+    )
+    args.update(kw)
+    return plan_start(**args)
+
+
+def test_local_without_sbatch_defaults_the_root(tmp_path: Path) -> None:
+    p = plan(tmp_path, sbatch_on_path=False)
+    assert p.mode == "local"
+    assert p.root == DEFAULT_LOCAL_ROOT
+    assert p.command() == [
+        sys.executable,
+        "-m",
+        "autoresearch.tick",
+        "--root",
+        str(DEFAULT_LOCAL_ROOT),
+        "--loop",
+    ]
+
+
+def test_local_by_flag_or_env_or_file_even_with_sbatch(tmp_path: Path) -> None:
+    assert plan(tmp_path, local=True).mode == "local"
+    assert plan(tmp_path, environ={"AUTORESEARCH_COMPUTE": "Local"}).mode == "local"
+    assert plan(tmp_path, from_file={"AUTORESEARCH_COMPUTE": "local"}).mode == "local"
+    p = plan(tmp_path, local=True, root="~/state")
+    assert p.root == Path("~/state").expanduser()
+
+
+def test_slurm_composes_the_resident_submit(tmp_path: Path) -> None:
+    home = checkout(tmp_path)
+    p = plan(
+        tmp_path,
+        cwd=home,
+        from_file={
+            "AUTORESEARCH_ROOT": "/scratch/me/ar",
+            "AUTORESEARCH_ACCOUNT": "pr_1_general",
+            "AUTORESEARCH_PARTITION": "cpu_short",
+            "AUTORESEARCH_CADENCE_MIN": "20",
+            "AUTORESEARCH_PAT_FILE": "/home/me/.config/autoresearch/bot_pat",
+        },
+    )
+    assert p.mode == "slurm"
+    assert p.command() == [
+        "sbatch",
+        "--parsable",
+        f"--time={DEFAULT_RESIDENT_MINUTES}",
+        f"--job-name={RESIDENT_JOB_NAME}",
+        "--account=pr_1_general",
+        "--partition=cpu_short",
+        "--export=ALL,AUTORESEARCH_RESIDENT=1,"
+        f"AUTORESEARCH_HOME={home},AUTORESEARCH_ROOT=/scratch/me/ar,"
+        "AUTORESEARCH_ACCOUNT=pr_1_general,AUTORESEARCH_PARTITION=cpu_short,"
+        "AUTORESEARCH_CADENCE_MIN=20,AUTORESEARCH_PAT_FILE=/home/me/.config/autoresearch/bot_pat",
+        str(home / "scripts" / "tick_chain.sbatch"),
+    ]
+
+
+def test_precedence_is_flag_then_environment_then_file(tmp_path: Path) -> None:
+    p = plan(
+        tmp_path,
+        partition="flagged",
+        environ={
+            "AUTORESEARCH_ROOT": "/env/root",
+            "AUTORESEARCH_ACCOUNT": "envacct",
+            "AUTORESEARCH_PARTITION": "envpart",
+        },
+        from_file={
+            "AUTORESEARCH_ROOT": "/file/root",
+            "AUTORESEARCH_ACCOUNT": "fileacct",
+            "AUTORESEARCH_PARTITION": "filepart",
+        },
+    )
+    assert (str(p.root), p.account, p.partition) == ("/env/root", "envacct", "flagged")
+
+
+def test_slurm_home_from_env_or_cwd_and_must_be_a_checkout(tmp_path: Path) -> None:
+    home = checkout(tmp_path)
+    base = {"AUTORESEARCH_ROOT": "/r", "AUTORESEARCH_ACCOUNT": "a", "AUTORESEARCH_PARTITION": "p"}
+    assert (
+        plan(tmp_path, cwd=tmp_path, environ={**base, "AUTORESEARCH_HOME": str(home)}).home == home
+    )
+    with pytest.raises(StartError, match="not an autoresearch checkout"):
+        plan(tmp_path, cwd=tmp_path, environ=base)
+
+
+def test_slurm_requires_root_account_and_partition(tmp_path: Path) -> None:
+    with pytest.raises(StartError, match="state root"):
+        plan(tmp_path)
+    with pytest.raises(
+        StartError,
+        match="--account / AUTORESEARCH_ACCOUNT and --partition / AUTORESEARCH_PARTITION",
+    ):
+        plan(tmp_path, root="/r")
+    with pytest.raises(StartError, match="--partition / AUTORESEARCH_PARTITION"):
+        plan(tmp_path, root="/r", account="a")
+
+
+def test_slurm_rejects_values_that_would_break_export(tmp_path: Path) -> None:
+    with pytest.raises(StartError, match="commas or whitespace"):
+        plan(tmp_path, root="/r", account="a,b", partition="p")
+    with pytest.raises(StartError, match="commas or whitespace"):
+        plan(tmp_path, root="/my root", account="a", partition="p")
+
+
+def test_slurm_resident_minutes_must_be_a_positive_integer(tmp_path: Path) -> None:
+    base = dict(root="/r", account="a", partition="p")
+    assert (
+        plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "240"}).resident_minutes
+        == 240
+    )
+    with pytest.raises(StartError, match="whole number"):
+        plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "4h"})
+    with pytest.raises(StartError, match="positive"):
+        plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "0"})
+
+
+# ---------------------------------------------------------------- main
+
+
+@pytest.fixture
+def clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    for key in (*START_KEYS, *TICK_ENV_KEYS, "AUTORESEARCH_HOME"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(cli, "ENV_FILE", tmp_path / "absent.env")
+    return tmp_path
+
+
+def shim(bin_dir: Path, name: str, body: str) -> None:
+    path = bin_dir / name
+    path.write_text("#!/bin/bash\n" + body)
+    path.chmod(0o755)
+
+
+def test_dry_run_prints_the_command(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    assert main(["start", "--dry-run", "--root", str(clean_env / "s")]) == 0
+    out = capsys.readouterr().out
+    assert "autoresearch.tick" in out and "--loop" in out and str(clean_env / "s") in out
+
+
+def test_local_start_execs_the_loop_with_env_knobs(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(
+        cli, "ENV_FILE", env_file(clean_env, "AUTORESEARCH_TARGET=o/r\nAUTORESEARCH_PANEL=\n")
+    )
+    monkeypatch.setenv("AUTORESEARCH_TARGET", "shell/wins")
+    seen: dict[str, object] = {}
+
+    def fake_exec(cmd: list[str], env: dict[str, str]) -> int:
+        seen["cmd"], seen["env"] = cmd, env
+        return 0
+
+    monkeypatch.setattr(cli, "_exec", fake_exec)
+    assert main(["start", "--root", str(clean_env / "state")]) == 0
+    assert seen["cmd"] == [
+        sys.executable,
+        "-m",
+        "autoresearch.tick",
+        "--root",
+        str(clean_env / "state"),
+        "--loop",
+    ]
+    env = seen["env"]
+    assert isinstance(env, dict)
+    assert env["AUTORESEARCH_COMPUTE"] == "local"
+    assert env["AUTORESEARCH_ROOT"] == str(clean_env / "state")
+    assert env["AUTORESEARCH_TARGET"] == "shell/wins"  # the shell beats the file at launch
+    assert env["AUTORESEARCH_PANEL"] == ""  # an off-switch in the file still lands
+
+
+def test_slurm_start_submits_once_and_reports(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home = checkout(clean_env)
+    bin_dir = clean_env / "bin"
+    bin_dir.mkdir()
+    log = clean_env / "sbatch.log"
+    shim(bin_dir, "sbatch", f'printf "%s\\n" "$@" > {log}\necho "4242;torch"\n')
+    shim(bin_dir, "squeue", "exit 0\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.chdir(home)
+    rc = main(
+        ["start", "--root", "/scratch/me/ar", "--account", "acct", "--partition", "cpu_short"]
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "job 4242" in out and "cpu_short" in out and "PAUSE" in out
+    argv = log.read_text().split("\n")
+    assert argv[0] == "--parsable" and f"--job-name={RESIDENT_JOB_NAME}" in argv
+    assert any(
+        a.startswith("--export=ALL,AUTORESEARCH_RESIDENT=1,") and f"AUTORESEARCH_HOME={home}" in a
+        for a in argv
+    )
+    assert argv[-2] == str(home / "scripts" / "tick_chain.sbatch")
+
+
+def test_slurm_start_does_not_submit_beside_a_live_resident(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home = checkout(clean_env)
+    bin_dir = clean_env / "bin"
+    bin_dir.mkdir()
+    shim(bin_dir, "sbatch", "echo SUBMITTED > " + str(clean_env / "submitted") + "\necho 1\n")
+    shim(bin_dir, "squeue", "echo 777\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.chdir(home)
+    assert main(["start", "--root", "/r", "--account", "a", "--partition", "p"]) == 0
+    assert "already queued or running (job 777)" in capsys.readouterr().err
+    assert not (clean_env / "submitted").exists()
+
+
+def test_slurm_start_reports_a_failed_submit(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home = checkout(clean_env)
+    bin_dir = clean_env / "bin"
+    bin_dir.mkdir()
+    shim(bin_dir, "sbatch", "echo 'sbatch: error: invalid partition' >&2\nexit 1\n")
+    shim(bin_dir, "squeue", "exit 0\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.chdir(home)
+    assert main(["start", "--root", "/r", "--account", "a", "--partition", "nope"]) == 1
+    assert "invalid partition" in capsys.readouterr().err
+
+
+def test_start_errors_are_exit_2_with_the_diagnosis(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/sbatch")
+    monkeypatch.chdir(checkout(clean_env))
+    assert main(["start"]) == 2
+    assert "state root" in capsys.readouterr().err
+
+
+def test_tick_subcommand_forwards_to_the_tick_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    from autoresearch import tick
+
+    seen: list[str] = []
+
+    def fake_main() -> int:
+        seen.extend(sys.argv)
+        return 7
+
+    monkeypatch.setattr(tick, "main", fake_main)
+    assert main(["tick", "--root", "/r", "--loop"]) == 7
+    assert seen[1:] == ["--root", "/r", "--loop"]

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -214,6 +214,25 @@ def test_slurm_rejects_values_that_would_break_export(tmp_path: Path) -> None:
         plan(tmp_path, root="/my root", account="a", partition="p")
 
 
+@pytest.mark.parametrize("bad", ["0", "-5", "30m", ""])
+def test_cadence_must_be_a_positive_number_in_both_modes(tmp_path: Path, bad: str) -> None:
+    if bad == "":
+        assert (
+            plan(tmp_path, local=True, environ={"AUTORESEARCH_CADENCE_MIN": ""}).cadence_min == ""
+        )
+        return
+    with pytest.raises(StartError, match="positive number of minutes"):
+        plan(tmp_path, local=True, environ={"AUTORESEARCH_CADENCE_MIN": bad})
+    with pytest.raises(StartError, match="positive number of minutes"):
+        plan(
+            tmp_path,
+            root="/r",
+            account="a",
+            partition="p",
+            from_file={"AUTORESEARCH_CADENCE_MIN": bad},
+        )
+
+
 def test_slurm_resident_minutes_must_be_a_positive_integer(tmp_path: Path) -> None:
     base = dict(root="/r", account="a", partition="p")
     p = plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "240"})

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -67,6 +67,12 @@ def test_env_file_values_missing_file_is_empty(tmp_path: Path) -> None:
     assert env_file_values(tmp_path / "absent") == {}
 
 
+def test_env_file_values_unreadable_is_a_start_error(tmp_path: Path) -> None:
+    (tmp_path / ".env").mkdir()  # a directory where the file should be
+    with pytest.raises(StartError, match="cannot read"):
+        env_file_values(tmp_path / ".env")
+
+
 @pytest.mark.parametrize("mode", [0o620, 0o602, 0o666])
 def test_env_file_values_refuses_a_writable_file(tmp_path: Path, mode: int) -> None:
     path = env_file(tmp_path, "AUTORESEARCH_ROOT=/x\n", mode)
@@ -144,6 +150,7 @@ def test_slurm_composes_the_resident_submit(tmp_path: Path) -> None:
     assert p.command() == [
         "sbatch",
         "--parsable",
+        "--dependency=singleton",
         f"--time={DEFAULT_RESIDENT_MINUTES}",
         f"--job-name={RESIDENT_JOB_NAME}",
         "--account=pr_1_general",
@@ -151,6 +158,7 @@ def test_slurm_composes_the_resident_submit(tmp_path: Path) -> None:
         "--export=ALL,AUTORESEARCH_RESIDENT=1,"
         f"AUTORESEARCH_HOME={home},AUTORESEARCH_ROOT=/scratch/me/ar,"
         "AUTORESEARCH_ACCOUNT=pr_1_general,AUTORESEARCH_PARTITION=cpu_short,"
+        f"AUTORESEARCH_RESIDENT_MINUTES={DEFAULT_RESIDENT_MINUTES},"
         "AUTORESEARCH_CADENCE_MIN=20,AUTORESEARCH_PAT_FILE=/home/me/.config/autoresearch/bot_pat",
         str(home / "scripts" / "tick_chain.sbatch"),
     ]
@@ -205,10 +213,10 @@ def test_slurm_rejects_values_that_would_break_export(tmp_path: Path) -> None:
 
 def test_slurm_resident_minutes_must_be_a_positive_integer(tmp_path: Path) -> None:
     base = dict(root="/r", account="a", partition="p")
-    assert (
-        plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "240"}).resident_minutes
-        == 240
-    )
+    p = plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "240"})
+    assert p.resident_minutes == 240
+    assert "--time=240" in p.command()
+    assert any("AUTORESEARCH_RESIDENT_MINUTES=240" in a for a in p.command())  # successors keep it
     with pytest.raises(StartError, match="whole number"):
         plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "4h"})
     with pytest.raises(StartError, match="positive"):
@@ -246,7 +254,13 @@ def test_local_start_execs_the_loop_with_env_knobs(
 ) -> None:
     monkeypatch.setattr(cli.shutil, "which", lambda name: None)
     monkeypatch.setattr(
-        cli, "ENV_FILE", env_file(clean_env, "AUTORESEARCH_TARGET=o/r\nAUTORESEARCH_PANEL=\n")
+        cli,
+        "ENV_FILE",
+        env_file(
+            clean_env,
+            "AUTORESEARCH_TARGET=o/r\nAUTORESEARCH_PANEL=\nAUTORESEARCH_CADENCE_MIN=15\n"
+            "AUTORESEARCH_PAT_FILE=/home/me/pat\n",
+        ),
     )
     monkeypatch.setenv("AUTORESEARCH_TARGET", "shell/wins")
     seen: dict[str, object] = {}
@@ -271,6 +285,8 @@ def test_local_start_execs_the_loop_with_env_knobs(
     assert env["AUTORESEARCH_ROOT"] == str(clean_env / "state")
     assert env["AUTORESEARCH_TARGET"] == "shell/wins"  # the shell beats the file at launch
     assert env["AUTORESEARCH_PANEL"] == ""  # an off-switch in the file still lands
+    assert env["AUTORESEARCH_CADENCE_MIN"] == "15"  # the loop's cadence comes from .env too
+    assert env["AUTORESEARCH_PAT_FILE"] == "/home/me/pat"
 
 
 def test_slurm_start_submits_once_and_reports(
@@ -292,6 +308,7 @@ def test_slurm_start_submits_once_and_reports(
     assert "job 4242" in out and "cpu_short" in out and "PAUSE" in out
     argv = log.read_text().split("\n")
     assert argv[0] == "--parsable" and f"--job-name={RESIDENT_JOB_NAME}" in argv
+    assert "--dependency=singleton" in argv
     assert any(
         a.startswith("--export=ALL,AUTORESEARCH_RESIDENT=1,") and f"AUTORESEARCH_HOME={home}" in a
         for a in argv
@@ -326,6 +343,44 @@ def test_slurm_start_reports_a_failed_submit(
     monkeypatch.chdir(home)
     assert main(["start", "--root", "/r", "--account", "a", "--partition", "nope"]) == 1
     assert "invalid partition" in capsys.readouterr().err
+
+
+def test_slurm_start_fails_closed_when_the_scheduler_cannot_be_asked(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home = checkout(clean_env)
+    bin_dir = clean_env / "bin"
+    bin_dir.mkdir()
+    shim(bin_dir, "sbatch", "echo SUBMITTED > " + str(clean_env / "submitted") + "\necho 1\n")
+    shim(bin_dir, "squeue", "echo 'squeue: error: slurm_load_jobs' >&2\nexit 1\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.chdir(home)
+    assert main(["start", "--root", "/r", "--account", "a", "--partition", "p"]) == 1
+    assert "could not ask the scheduler" in capsys.readouterr().err
+    assert not (clean_env / "submitted").exists()
+
+
+def test_slurm_start_withdraws_when_another_start_won_the_race(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Both starts see no resident, both submit; the later job id withdraws."""
+    home = checkout(clean_env)
+    bin_dir = clean_env / "bin"
+    bin_dir.mkdir()
+    calls = clean_env / "squeue.calls"
+    shim(bin_dir, "sbatch", "echo 4242\n")
+    # first lookup: nothing; after the submit: the other start's job and ours
+    shim(
+        bin_dir,
+        "squeue",
+        f"echo x >> {calls}\n[ $(wc -l < {calls}) -gt 1 ] && printf '4242\\n4100\\n'\nexit 0\n",
+    )
+    shim(bin_dir, "scancel", 'echo "$1" > ' + str(clean_env / "cancelled") + "\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.chdir(home)
+    assert main(["start", "--root", "/r", "--account", "a", "--partition", "p"]) == 0
+    assert (clean_env / "cancelled").read_text().strip() == "4242"
+    assert "job 4100" in capsys.readouterr().err
 
 
 def test_start_errors_are_exit_2_with_the_diagnosis(


### PR DESCRIPTION
One launch command, `autoresearch start`, so setup ends in one line on both paths:

- `sbatch` on PATH (unless `AUTORESEARCH_COMPUTE=local` / `--local`): submits the resident tick with `--time`, `--job-name=autoresearch-resident`, `--account`, `--partition`, and `--export=ALL,AUTORESEARCH_RESIDENT=1,HOME,ROOT,ACCOUNT,PARTITION[,CADENCE_MIN][,PAT_FILE]` filled in. Refuses to submit beside a queued/running resident; prints the job id and the pause/stop commands.
- otherwise: `python -m autoresearch.tick --root ROOT --loop` in the foreground with `AUTORESEARCH_COMPUTE=local`, exporting the same author knobs the chain's deploy step reads from `.env` (a test pins the two lists identical).

Settings resolve flag → process environment → `~/.config/autoresearch/.env` (read once, at launch, under the deploy step's trust rule: owned by us, not group/world-writable). The chain itself still never takes identity or placement from that file per tick.

Also `autoresearch tick …` forwards to the tick entry, a console script `autoresearch`, and `python -m autoresearch`.

Tests: `tests/test_start.py` (planning, precedence, checkout detection, export-safe values, walltime parsing, dry run, local exec with knobs, Slurm submit via PATH shims, live-resident refusal, failed submit, tick forwarding, allowlist parity with `tick_deploy.sh`).
