### PR TITLE
Changed paths measured against the base, not a stale line HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,12 @@ Versions follow [SemVer](https://semver.org).
 ### Fixed
 
 - A research line's first run after main moved no longer ends in a scope
-  violation on the kernel's own ledger files. The run merges main into the
+  violation on the project's ledger files (BENCHMARKS.md, results/leader.json). The run merges main into the
   line at start; when that merge conflicts it stays uncommitted, and the
   files git auto-merged were counted as agent edits. Changed paths are now
-  measured against the base commit, so a path identical to base never
-  counts (gpt-speedrun, 2026-09-03, agent-01 right after its own win).
+  measured against the base branch head in both the first pass and the
+  wake, so a path identical to base never counts (gpt-speedrun, 2026-09-03,
+  agent-01 right after its own win).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ Versions follow [SemVer](https://semver.org).
   with `AUTORESEARCH_COMPUTE=local`, it runs the local loop in the
   foreground. `autoresearch tick` forwards to the tick entry.
 
+### Fixed
+
+- A research line's first run after main moved no longer ends in a scope
+  violation on the kernel's own ledger files. The run merges main into the
+  line at start; when that merge conflicts it stays uncommitted, and the
+  files git auto-merged were counted as agent edits. Changed paths are now
+  measured against the base commit, so a path identical to base never
+  counts (gpt-speedrun, 2026-09-03, agent-01 right after its own win).
+
 ### Changed
 
 - A candidate is now credited when its improvement equals the contract's

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -793,10 +793,7 @@ def _wake_author_sleep(
         return snap.commit
 
     def changed_paths() -> list[str]:
-        ws.git("add", "-A")
-        paths = ws.staged_paths()
-        ws.git("reset")
-        return _without_line_memory(paths, wake_line)
+        return _paths_changed_from_base(ws, base_sha, wake_line)
 
     panel_runner = (
         build_panel_runner(
@@ -1185,6 +1182,35 @@ def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: s
         # pushed: the conflict is session work, not line state.
         ws.push(line)
     return line
+
+
+def _paths_changed_from_base(ws: Workspace, base_sha: str, line_ref: str) -> list[str]:
+    """The paths the tree changed, measured against the BASE, not HEAD. On a
+    research line HEAD can be behind main: a run starts by merging main in,
+    and when that merge conflicts it stays uncommitted, so the files git
+    auto-merged (the kernel's own BENCHMARKS.md, results/leader.json) sit
+    staged against the stale HEAD while being identical to main. Those are
+    main's edits, not the agent's, and must not read as scope violations
+    (gpt-speedrun, 2026-09-03: agent-01's first run after its own win ended
+    scope-violation on exactly those two files). Line memory is excluded
+    as before."""
+    ws.git("add", "-A")
+    try:
+        staged = ws.staged_paths()
+        if not staged:
+            return []
+        # index vs base, restricted to what moved against HEAD: a path identical
+        # to base drops out, a new or deleted file still counts
+        differs = {
+            entry
+            for entry in ws.git(
+                "diff", "--cached", "--name-only", "-z", base_sha, "--", *staged
+            ).split("\0")
+            if entry
+        }
+    finally:
+        ws.git("reset")
+    return _without_line_memory([p for p in staged if p in differs], line_ref)
 
 
 def _sibling_entries(ws: Workspace, self_agent: str) -> list[dict]:

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -793,7 +793,9 @@ def _wake_author_sleep(
         return snap.commit
 
     def changed_paths() -> list[str]:
-        return _paths_changed_from_base(ws, base_sha, wake_line)
+        return _paths_changed_from_base(
+            ws, f"refs/remotes/origin/{base_branch}", bool(wake_line), fallback=base_sha
+        )
 
     panel_runner = (
         build_panel_runner(
@@ -1184,16 +1186,26 @@ def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: s
     return line
 
 
-def _paths_changed_from_base(ws: Workspace, base_sha: str, line_ref: str) -> list[str]:
-    """The paths the tree changed, measured against the BASE, not HEAD. On a
+def _paths_changed_from_base(
+    ws: Workspace, base: str, exclude_memory: bool, fallback: str = "HEAD"
+) -> list[str]:
+    """The paths the session changed, measured against the BASE BRANCH head
+    (`base`, a commit-ish such as refs/remotes/origin/main), not HEAD. On a
     research line HEAD can be behind main: a run starts by merging main in,
     and when that merge conflicts it stays uncommitted, so the files git
-    auto-merged (the kernel's own BENCHMARKS.md, results/leader.json) sit
+    auto-merged (the project's BENCHMARKS.md and results/leader.json) sit
     staged against the stale HEAD while being identical to main. Those are
     main's edits, not the agent's, and must not read as scope violations
     (gpt-speedrun, 2026-09-03: agent-01's first run after its own win ended
-    scope-violation on exactly those two files). Line memory is excluded
-    as before."""
+    scope-violation on exactly those two files). A path counts only when it
+    moved against HEAD AND differs from the base; new and deleted files
+    count. `fallback` is used when `base` does not resolve (no remote).
+    `exclude_memory` drops the line's memory files whenever lines are active
+    for the benchmark (a failed line checkout still keeps them out)."""
+    try:
+        base_commit = ws.git("rev-parse", "--verify", f"{base}^{{commit}}").strip()
+    except Exception:
+        base_commit = fallback
     ws.git("add", "-A")
     try:
         staged = ws.staged_paths()
@@ -1204,13 +1216,14 @@ def _paths_changed_from_base(ws: Workspace, base_sha: str, line_ref: str) -> lis
         differs = {
             entry
             for entry in ws.git(
-                "diff", "--cached", "--name-only", "-z", base_sha, "--", *staged
+                "diff", "--cached", "--name-only", "-z", base_commit, "--", *staged
             ).split("\0")
             if entry
         }
     finally:
         ws.git("reset")
-    return _without_line_memory([p for p in staged if p in differs], line_ref)
+    kept = [p for p in staged if p in differs]
+    return [p for p in kept if not (exclude_memory and _is_line_memory(p))]
 
 
 def _sibling_entries(ws: Workspace, self_agent: str) -> list[dict]:
@@ -2386,12 +2399,9 @@ def live_attempt(
             syscall_write_siblings(workspace, _sibling_entries(ws, config.agent_id))
 
         def changed_paths() -> list[str]:
-            ws.git("add", "-A")
-            paths = ws.staged_paths()
-            ws.git("reset")
-            if lines_active:
-                paths = [p for p in paths if not _is_line_memory(p)]
-            return paths
+            # against the base branch head, never the line tip a conflicted
+            # merge can leave HEAD on (see _paths_changed_from_base)
+            return _paths_changed_from_base(ws, f"refs/remotes/origin/{base_branch}", lines_active)
 
         if issue_number:
             from autoresearch.intake import CLAIM_MARKER

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4289,6 +4289,60 @@ def test_wake_on_a_line_never_reads_the_lines_memory_as_out_of_scope(tmp_path, m
     assert record.ending == "negative-result" and "out-of-scope" not in record.ending_note
 
 
+def test_changed_paths_ignore_files_a_stale_line_merge_brought_to_base(tmp_path: Path) -> None:
+    """A line behind main merges main at run start; when that merge conflicts
+    it stays uncommitted, and git's auto-merged files (the kernel's ledger)
+    are staged against the stale HEAD yet identical to base. They are not the
+    agent's edits and must not count; a real edit still does."""
+    import subprocess
+
+    from autoresearch.attempt import _paths_changed_from_base
+    from autoresearch.github import Workspace
+
+    root = tmp_path / "ws"
+    root.mkdir()
+
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+            cwd=root,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    git("init", "-q", "-b", "main")
+    (root / "BENCHMARKS.md").write_text("best 8640\n")
+    (root / "train.py").write_text("warmdown = 2048\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "line state")
+    stale_head = git("rev-parse", "HEAD")
+    # main moved on: the ledger and train.py both changed
+    (root / "BENCHMARKS.md").write_text("best 8192\n")
+    (root / "train.py").write_text("warmdown = 3072\n")
+    git("add", "-A")
+    git("commit", "-q", "-m", "main: improve speedrun")
+    base_sha = git("rev-parse", "HEAD")
+    # back on the stale line HEAD with main's ledger auto-merged in (identical
+    # to base) and train.py carrying the agent's own, different edit
+    git("checkout", "-q", stale_head)
+    (root / "BENCHMARKS.md").write_text("best 8192\n")
+    (root / "train.py").write_text("warmdown = 2560\n")
+    (root / "agent_memory").mkdir()
+    (root / "agent_memory" / "note.md").write_text("x\n")
+
+    ws = Workspace(root=root)
+    assert _paths_changed_from_base(ws, base_sha, "agents/agent-01") == ["train.py"]
+    # without a line the memory dir is an ordinary path; the ledger still drops
+    assert _paths_changed_from_base(ws, base_sha, "") == ["agent_memory/note.md", "train.py"]
+    # nothing staged against HEAD -> nothing, even though HEAD differs from base
+    (root / "BENCHMARKS.md").write_text("best 8640\n")
+    (root / "train.py").write_text("warmdown = 2048\n")
+    (root / "agent_memory" / "note.md").unlink()
+    (root / "agent_memory").rmdir()
+    assert _paths_changed_from_base(ws, base_sha, "agents/agent-01") == []
+
+
 def test_without_line_memory_drops_memory_only_when_a_line_is_active() -> None:
     from autoresearch.attempt import _without_line_memory
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4332,15 +4332,27 @@ def test_changed_paths_ignore_files_a_stale_line_merge_brought_to_base(tmp_path:
     (root / "agent_memory" / "note.md").write_text("x\n")
 
     ws = Workspace(root=root)
-    assert _paths_changed_from_base(ws, base_sha, "agents/agent-01") == ["train.py"]
-    # without a line the memory dir is an ordinary path; the ledger still drops
-    assert _paths_changed_from_base(ws, base_sha, "") == ["agent_memory/note.md", "train.py"]
+    assert _paths_changed_from_base(ws, base_sha, True) == ["train.py"]
+    # the real call sites pass the base BRANCH ref; an unresolvable ref falls
+    # back (here to the same base) rather than crashing
+    git("update-ref", "refs/remotes/origin/main", base_sha)
+    assert _paths_changed_from_base(ws, "refs/remotes/origin/main", True) == ["train.py"]
+    assert _paths_changed_from_base(ws, "refs/remotes/origin/nope", True, fallback=base_sha) == [
+        "train.py"
+    ]
+    # falling back to HEAD restores the old staged-vs-HEAD reading
+    assert _paths_changed_from_base(ws, "refs/remotes/origin/nope", True) == [
+        "BENCHMARKS.md",
+        "train.py",
+    ]
+    # memory not excluded (lines off): an ordinary path; the ledger still drops
+    assert _paths_changed_from_base(ws, base_sha, False) == ["agent_memory/note.md", "train.py"]
     # nothing staged against HEAD -> nothing, even though HEAD differs from base
     (root / "BENCHMARKS.md").write_text("best 8640\n")
     (root / "train.py").write_text("warmdown = 2048\n")
     (root / "agent_memory" / "note.md").unlink()
     (root / "agent_memory").rmdir()
-    assert _paths_changed_from_base(ws, base_sha, "agents/agent-01") == []
+    assert _paths_changed_from_base(ws, base_sha, True) == []
 
 
 def test_without_line_memory_drops_memory_only_when_a_line_is_active() -> None:


### PR DESCRIPTION
gpt-speedrun, 2026-09-03 12:03Z: `speedrun-20260903-120052-agent-01` ended **scope-violation** ("out-of-scope paths at launch: BENCHMARKS.md, results/leader.json") three minutes after starting, right after agent-01's own PR #6 merged.

Mechanism: the line `agents/agent-01` was behind main (the winning dispatched run's tree was never recorded on the line, so main had PR #6's commits and the line did not). The run merged main into the line at start; the merge conflicted on `train.py`, so it stayed uncommitted, and git's auto-merged `BENCHMARKS.md` / `results/leader.json` sat staged against the stale HEAD while being identical to main. `changed_paths()` (`git add -A` + staged vs HEAD) reported them, and the launch scope check ended the run.

Fix: `_paths_changed_from_base(ws, base_sha, line_ref)` keeps only staged paths whose index content differs from the base commit (`git diff --cached --name-only base -- <staged>`), so a path merely brought to main's version never counts; new and deleted files still do; line memory is excluded as before. Both `changed_paths` users (launch and candidate scope checks, the measured-path set) go through it.

Test: a real git repo with a stale line HEAD, a moved base, the ledger auto-merged to base's content and `train.py` edited differently; only `train.py` counts (with a line, memory is excluded too), and a tree back at HEAD reports nothing.

Not in this PR: the line falling behind after a dispatched win (the improved terminal ends in the tick/follow-up path and writes no line snapshot). Noted for a follow-up.
