### PR TITLE
Line snapshots parent on a remote line that moved while the run was parked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ Versions follow [SemVer](https://semver.org).
 
 - A line snapshot now builds on a newer remote version of the line instead
   of being skipped when another run on the same line pushed while this run
-  was parked. Files that newer version added are kept, and a push refused
+  was parked. Files the other run added, changed, or deleted that this run
+  never touched follow the other run, and a push refused
   because the line moved again is retried on the new head. (This is how
   agent-01's line fell behind its own merged win on gpt-speedrun,
   2026-09-03.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,14 @@ Versions follow [SemVer](https://semver.org).
   with `AUTORESEARCH_COMPUTE=local`, it runs the local loop in the
   foreground. `autoresearch tick` forwards to the tick entry.
 
+### Fixed
+
+- A research line no longer loses the snapshot of a run that ended while a
+  newer run on the same line had already pushed: the seal now parents on
+  the remote line head when the local ref is behind it, so the push
+  fast-forwards instead of being refused and skipped (this is how agent-01's
+  line fell behind its own merged win on gpt-speedrun, 2026-09-03).
+
 ### Changed
 
 - A candidate is now credited when its improvement equals the contract's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- A research line no longer loses the snapshot of a run that ended while a
-  newer run on the same line had already pushed: the seal now parents on
-  the remote line head when the local ref is behind it, so the push
-  fast-forwards instead of being refused and skipped (this is how agent-01's
-  line fell behind its own merged win on gpt-speedrun, 2026-09-03).
+- A line snapshot now builds on a newer remote version of the line instead
+  of being skipped when another run on the same line pushed while this run
+  was parked. Files that newer version added are kept, and a push refused
+  because the line moved again is retried on the new head. (This is how
+  agent-01's line fell behind its own merged win on gpt-speedrun,
+  2026-09-03.)
 
 ### Changed
 

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1117,7 +1117,7 @@ def _push_line_snapshot(
                 remote = ws.git("rev-parse", f"refs/remotes/origin/{line_ref}").strip()
                 if remote != local:
                     ws.git("merge-base", "--is-ancestor", local, remote)  # raises when not
-                    _keep_remote_additions(ws, local, remote)
+                    _reconcile_with_remote(ws, local, remote)
                     parent = remote
             except Exception as exc:
                 log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
@@ -1162,17 +1162,35 @@ def _push_line_snapshot(
     _best_effort(f"line push ({outcome})", _seal_and_push, secrets)
 
 
-def _keep_remote_additions(ws: Workspace, old: str, new: str) -> None:
-    """The seal is built from THIS workspace, so a file another run added to
-    the line since `old` (a sibling's memory note, say) would read as deleted.
-    Materialize the ones this workspace lacks; files both sides have keep
-    this run's version, as the line always did."""
-    added = [
-        p for p in ws.git("diff", "--name-only", "-z", "--diff-filter=A", old, new).split("\0") if p
+def _reconcile_with_remote(ws: Workspace, old: str, new: str) -> None:
+    """The seal is built from THIS workspace, which forked the line at `old`;
+    another run has since moved the line to `new`. For every path that run
+    changed, take its state when this workspace left the path untouched
+    since `old` (added: materialize, modified: update, deleted: remove); a
+    path this run touched keeps this run's version, as the line always did.
+    Without this, a seal would silently undo the other run's work on files
+    this run never looked at."""
+    entries = [
+        e for e in ws.git("diff", "--name-status", "--no-renames", "-z", old, new).split("\0") if e
     ]
-    missing = [p for p in added if not (Path(ws.root) / p).exists()]
-    if missing:
-        ws.git("checkout", new, "--", *missing)
+    remote_changes = list(zip(entries[0::2], entries[1::2], strict=True))
+    if not remote_changes:
+        return
+    touched = {
+        p for p in ws.git("diff", "--name-only", "-z", old).split("\0") if p
+    }  # tracked paths this run changed or deleted
+    touched |= {
+        p for p in ws.git("ls-files", "--others", "--exclude-standard", "-z").split("\0") if p
+    }  # and the files it created
+    for status, path in remote_changes:
+        if path in touched:
+            continue
+        if status.startswith("D"):
+            target = Path(ws.root) / path
+            if target.is_file() or target.is_symlink():
+                target.unlink()
+        else:
+            ws.git("checkout", new, "--", path)
 
 
 def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: str) -> str:

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1101,6 +1101,22 @@ def _push_line_snapshot(
         # raises if the ref is absent (e.g. a park that predates the line
         # feature) — _best_effort turns that into a logged skip
         parent = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
+        # A park frees the slot, so a newer run on the same line can end
+        # (and push) while this one is parked: the remote line then sits
+        # past our local ref and a seal parented on the stale ref would be
+        # refused as a non-fast-forward (gpt-speedrun, 2026-09-03: agent-01's
+        # winning run left no snapshot for exactly this reason, and its line
+        # fell behind main). Parent on the remote head whenever our ref is
+        # an ancestor of it; offline, seal on the local ref as before.
+        try:
+            ws.fetch_origin()
+            remote = ws.git("rev-parse", f"refs/remotes/origin/{line_ref}").strip()
+            if remote != parent:
+                ws.git("merge-base", "--is-ancestor", parent, remote)  # raises when not
+                ws.git("update-ref", f"refs/heads/{line_ref}", remote)
+                parent = remote
+        except Exception as exc:
+            log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
         memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
         snap = snapshot_tree(ws, parent, force=memory)
         try:

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1102,8 +1102,12 @@ def _push_line_snapshot(
         local = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
         memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
         last_exc: Exception | None = None
+        # the line commit this workspace's untouched files currently match:
+        # the local ref at first, then each remote head reconciled into it
+        # (so a retry does not mistake copied-in files for this run's edits)
+        fork = local
         for _ in range(3):
-            parent = local
+            parent = fork
             # A park frees the slot, so a newer run on the same line can end
             # (and push) while this one is parked: the remote line then sits
             # past our local ref, and a seal parented on the stale ref would be
@@ -1115,10 +1119,10 @@ def _push_line_snapshot(
             try:
                 ws.fetch_origin()
                 remote = ws.git("rev-parse", f"refs/remotes/origin/{line_ref}").strip()
-                if remote != local:
-                    ws.git("merge-base", "--is-ancestor", local, remote)  # raises when not
-                    _reconcile_with_remote(ws, local, remote)
-                    parent = remote
+                if remote != fork:
+                    ws.git("merge-base", "--is-ancestor", fork, remote)  # raises when not
+                    _reconcile_with_remote(ws, fork, remote)
+                    fork = parent = remote
             except Exception as exc:
                 log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
             snap = snapshot_tree(ws, parent, force=memory)

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1100,49 +1100,80 @@ def _push_line_snapshot(
     def _seal_and_push() -> None:
         # raises if the ref is absent (e.g. a park that predates the line
         # feature) — _best_effort turns that into a logged skip
-        parent = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
-        # A park frees the slot, so a newer run on the same line can end
-        # (and push) while this one is parked: the remote line then sits
-        # past our local ref and a seal parented on the stale ref would be
-        # refused as a non-fast-forward (gpt-speedrun, 2026-09-03: agent-01's
-        # winning run left no snapshot for exactly this reason, and its line
-        # fell behind main). Parent on the remote head whenever our ref is
-        # an ancestor of it; offline, seal on the local ref as before.
-        try:
-            ws.fetch_origin()
-            remote = ws.git("rev-parse", f"refs/remotes/origin/{line_ref}").strip()
-            if remote != parent:
-                ws.git("merge-base", "--is-ancestor", parent, remote)  # raises when not
-                ws.git("update-ref", f"refs/heads/{line_ref}", remote)
-                parent = remote
-        except Exception as exc:
-            log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
+        local = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
         memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
-        snap = snapshot_tree(ws, parent, force=memory)
-        try:
-            # seal only when the tree moved past the local ref; the PUSH runs
-            # either way — a session that COMMITTED its work advanced the
-            # local ref without dirtying the tree, and that commit must still
-            # reach the remote (an already-current ref push is a no-op).
-            if snap.tree != ws.git("rev-parse", f"{parent}^{{tree}}").strip():
-                sealed = ws.git(
-                    "-c",
-                    "user.name=autoresearch",
-                    "-c",
-                    "user.email=autoresearch@localhost",
-                    "commit-tree",
-                    snap.tree,
-                    "-p",
-                    parent,
-                    "-m",
-                    f"line snapshot: {run_id} ({outcome})",
-                ).strip()
+        last_exc: Exception | None = None
+        for _ in range(3):
+            parent = local
+            # A park frees the slot, so a newer run on the same line can end
+            # (and push) while this one is parked: the remote line then sits
+            # past our local ref, and a seal parented on the stale ref would be
+            # refused as a non-fast-forward (gpt-speedrun, 2026-09-03: agent-01's
+            # winning run left no snapshot this way, and its line fell behind
+            # main). Parent on the remote head whenever our ref is an ancestor
+            # of it, keeping the files that head added since; offline, seal on
+            # the local ref as before.
+            try:
+                ws.fetch_origin()
+                remote = ws.git("rev-parse", f"refs/remotes/origin/{line_ref}").strip()
+                if remote != local:
+                    ws.git("merge-base", "--is-ancestor", local, remote)  # raises when not
+                    _keep_remote_additions(ws, local, remote)
+                    parent = remote
+            except Exception as exc:
+                log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
+            snap = snapshot_tree(ws, parent, force=memory)
+            try:
+                # seal only when the tree moved past the parent; the PUSH runs
+                # either way — a session that COMMITTED its work advanced the
+                # local ref without dirtying the tree, and that commit must
+                # still reach the remote (an already-current ref push is a no-op)
+                sealed = parent
+                if snap.tree != ws.git("rev-parse", f"{parent}^{{tree}}").strip():
+                    sealed = ws.git(
+                        "-c",
+                        "user.name=autoresearch",
+                        "-c",
+                        "user.email=autoresearch@localhost",
+                        "commit-tree",
+                        snap.tree,
+                        "-p",
+                        parent,
+                        "-m",
+                        f"line snapshot: {run_id} ({outcome})",
+                    ).strip()
                 ws.git("update-ref", f"refs/heads/{line_ref}", sealed)
-            ws.push(line_ref)
-        finally:
-            drop_snapshot(ws, snap)
+                try:
+                    ws.push(line_ref)
+                    return
+                except Exception as exc:
+                    # another run pushed between our fetch and this push:
+                    # re-read the line and seal again on its new head
+                    last_exc = exc
+                    log.info(
+                        "line %s: push refused, re-sealing on the moved line (%s)",
+                        line_ref,
+                        type(exc).__name__,
+                    )
+            finally:
+                drop_snapshot(ws, snap)
+        assert last_exc is not None
+        raise last_exc
 
     _best_effort(f"line push ({outcome})", _seal_and_push, secrets)
+
+
+def _keep_remote_additions(ws: Workspace, old: str, new: str) -> None:
+    """The seal is built from THIS workspace, so a file another run added to
+    the line since `old` (a sibling's memory note, say) would read as deleted.
+    Materialize the ones this workspace lacks; files both sides have keep
+    this run's version, as the line always did."""
+    added = [
+        p for p in ws.git("diff", "--name-only", "-z", "--diff-filter=A", old, new).split("\0") if p
+    ]
+    missing = [p for p in added if not (Path(ws.root) / p).exists()]
+    if missing:
+        ws.git("checkout", new, "--", *missing)
 
 
 def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: str) -> str:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4299,6 +4299,8 @@ def test_line_snapshot_parents_on_a_remote_line_that_moved_while_parked(tmp_path
     wsroot = tmp_path / "ws"
     wsroot.mkdir()
     (wsroot / "train.py").write_text("v1\n")
+    (wsroot / "notes.txt").write_text("stale\n")  # the sibling will delete this
+    (wsroot / "config.txt").write_text("v1\n")  # the sibling will change this
     _git(wsroot, "init", "-q", "-b", "main")
     _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
     _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
@@ -4312,6 +4314,8 @@ def test_line_snapshot_parents_on_a_remote_line_that_moved_while_parked(tmp_path
     other = tmp_path / "other"
     _git(tmp_path, "clone", "-q", "-b", "agents/agent-01", str(bare), str(other))
     (other / "train.py").write_text("sibling\n")
+    (other / "notes.txt").unlink()
+    (other / "config.txt").write_text("sibling config\n")
     (other / "agent_memory").mkdir()
     (other / "agent_memory" / "sibling.md").write_text("a note only the sibling wrote\n")
     _git(other, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
@@ -4334,8 +4338,12 @@ def test_line_snapshot_parents_on_a_remote_line_that_moved_while_parked(tmp_path
     assert head != sibling
     assert _git(bare, "rev-parse", f"{head}^").strip() == sibling  # parented on the moved remote
     assert _git(bare, "show", f"{head}:train.py").strip() == "winner"
-    # the sibling's addition survives; a file both had keeps our version
+    # the sibling's addition survives; a file both touched keeps our version
     assert "only the sibling" in _git(bare, "show", f"{head}:agent_memory/sibling.md")
+    # files this run never touched follow the sibling: deleted stays deleted,
+    # modified takes the sibling's content
+    assert "notes.txt" not in _git(bare, "ls-tree", "-r", "--name-only", head)
+    assert _git(bare, "show", f"{head}:config.txt").strip() == "sibling config"
     assert _git(wsroot, "rev-parse", "agents/agent-01").strip() == head  # local ref advanced too
 
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4312,6 +4312,9 @@ def test_line_snapshot_parents_on_a_remote_line_that_moved_while_parked(tmp_path
     other = tmp_path / "other"
     _git(tmp_path, "clone", "-q", "-b", "agents/agent-01", str(bare), str(other))
     (other / "train.py").write_text("sibling\n")
+    (other / "agent_memory").mkdir()
+    (other / "agent_memory" / "sibling.md").write_text("a note only the sibling wrote\n")
+    _git(other, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
     _git(
         other,
         "-c",
@@ -4319,7 +4322,7 @@ def test_line_snapshot_parents_on_a_remote_line_that_moved_while_parked(tmp_path
         "-c",
         "user.email=t@t",
         "commit",
-        "-qam",
+        "-qm",
         "line snapshot: sibling",
     )
     _git(other, "push", "-q", "origin", "agents/agent-01")
@@ -4331,7 +4334,52 @@ def test_line_snapshot_parents_on_a_remote_line_that_moved_while_parked(tmp_path
     assert head != sibling
     assert _git(bare, "rev-parse", f"{head}^").strip() == sibling  # parented on the moved remote
     assert _git(bare, "show", f"{head}:train.py").strip() == "winner"
+    # the sibling's addition survives; a file both had keeps our version
+    assert "only the sibling" in _git(bare, "show", f"{head}:agent_memory/sibling.md")
     assert _git(wsroot, "rev-parse", "agents/agent-01").strip() == head  # local ref advanced too
+
+
+def test_line_snapshot_reseals_when_the_line_moves_between_fetch_and_push(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from autoresearch import attempt as attempt_mod
+    from autoresearch.attempt import _push_line_snapshot
+    from autoresearch.github import Workspace
+
+    wsroot = tmp_path / "ws"
+    wsroot.mkdir()
+    (wsroot / "train.py").write_text("v1\n")
+    _git(wsroot, "init", "-q", "-b", "main")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
+    base = _git(wsroot, "rev-parse", "HEAD").strip()
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(wsroot), str(bare))
+    _git(wsroot, "remote", "add", "origin", str(bare))
+    _git(wsroot, "branch", "agents/agent-01", base)
+    _git(wsroot, "push", "-q", "origin", "agents/agent-01")
+    other = tmp_path / "other"
+    _git(tmp_path, "clone", "-q", "-b", "agents/agent-01", str(bare), str(other))
+    pushes: list[str] = []
+    real_push = Workspace.push
+
+    def racing_push(self: Workspace, branch: str) -> None:
+        pushes.append(branch)
+        if len(pushes) == 1:
+            # a sibling lands between our fetch and our push
+            (other / "train.py").write_text("sibling\n")
+            _git(other, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qam", "sibling")
+            _git(other, "push", "-q", "origin", "agents/agent-01")
+        real_push(self, branch)  # the first attempt is now a non-fast-forward and raises
+
+    monkeypatch.setattr(attempt_mod.Workspace, "push", racing_push)
+    (wsroot / "train.py").write_text("winner\n")
+    _push_line_snapshot(Workspace(root=wsroot), "agents/agent-01", "run-1", "improved")
+    sibling = _git(other, "rev-parse", "HEAD").strip()
+    head = _git(bare, "rev-parse", "agents/agent-01").strip()
+    assert len(pushes) == 2
+    assert _git(bare, "rev-parse", f"{head}^").strip() == sibling
+    assert _git(bare, "show", f"{head}:train.py").strip() == "winner"
 
 
 def test_without_line_memory_drops_memory_only_when_a_line_is_active() -> None:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4289,6 +4289,51 @@ def test_wake_on_a_line_never_reads_the_lines_memory_as_out_of_scope(tmp_path, m
     assert record.ending == "negative-result" and "out-of-scope" not in record.ending_note
 
 
+def test_line_snapshot_parents_on_a_remote_line_that_moved_while_parked(tmp_path: Path) -> None:
+    """A park frees the slot; a newer run on the same line can push while this
+    one is parked. The seal must then parent on the remote head so its push
+    fast-forwards, instead of being refused and silently skipped."""
+    from autoresearch.attempt import _push_line_snapshot
+    from autoresearch.github import Workspace
+
+    wsroot = tmp_path / "ws"
+    wsroot.mkdir()
+    (wsroot / "train.py").write_text("v1\n")
+    _git(wsroot, "init", "-q", "-b", "main")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(wsroot, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
+    base = _git(wsroot, "rev-parse", "HEAD").strip()
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(wsroot), str(bare))
+    _git(wsroot, "remote", "add", "origin", str(bare))
+    _git(wsroot, "branch", "agents/agent-01", base)
+    _git(wsroot, "push", "-q", "origin", "agents/agent-01")
+    # the sibling run advances the remote line while we are parked
+    other = tmp_path / "other"
+    _git(tmp_path, "clone", "-q", "-b", "agents/agent-01", str(bare), str(other))
+    (other / "train.py").write_text("sibling\n")
+    _git(
+        other,
+        "-c",
+        "user.name=t",
+        "-c",
+        "user.email=t@t",
+        "commit",
+        "-qam",
+        "line snapshot: sibling",
+    )
+    _git(other, "push", "-q", "origin", "agents/agent-01")
+    sibling = _git(other, "rev-parse", "HEAD").strip()
+    # our run ends with its own tree
+    (wsroot / "train.py").write_text("winner\n")
+    _push_line_snapshot(Workspace(root=wsroot), "agents/agent-01", "run-1", "improved")
+    head = _git(bare, "rev-parse", "agents/agent-01").strip()
+    assert head != sibling
+    assert _git(bare, "rev-parse", f"{head}^").strip() == sibling  # parented on the moved remote
+    assert _git(bare, "show", f"{head}:train.py").strip() == "winner"
+    assert _git(wsroot, "rev-parse", "agents/agent-01").strip() == head  # local ref advanced too
+
+
 def test_without_line_memory_drops_memory_only_when_a_line_is_active() -> None:
     from autoresearch.attempt import _without_line_memory
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4368,15 +4368,23 @@ def test_line_snapshot_reseals_when_the_line_moves_between_fetch_and_push(
     _git(wsroot, "push", "-q", "origin", "agents/agent-01")
     other = tmp_path / "other"
     _git(tmp_path, "clone", "-q", "-b", "agents/agent-01", str(bare), str(other))
+    # a first sibling commit is already on the remote when we seal: it adds
+    # config.txt, which the first reconciliation copies into our workspace
+    (other / "config.txt").write_text("s1\n")
+    _git(other, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(other, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "sibling 1")
+    _git(other, "push", "-q", "origin", "agents/agent-01")
     pushes: list[str] = []
     real_push = Workspace.push
 
     def racing_push(self: Workspace, branch: str) -> None:
         pushes.append(branch)
         if len(pushes) == 1:
-            # a sibling lands between our fetch and our push
+            # a second sibling commit lands between our fetch and our push,
+            # changing the very file the first reconciliation copied in
             (other / "train.py").write_text("sibling\n")
-            _git(other, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qam", "sibling")
+            (other / "config.txt").write_text("s2\n")
+            _git(other, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qam", "sibling 2")
             _git(other, "push", "-q", "origin", "agents/agent-01")
         real_push(self, branch)  # the first attempt is now a non-fast-forward and raises
 
@@ -4388,6 +4396,8 @@ def test_line_snapshot_reseals_when_the_line_moves_between_fetch_and_push(
     assert len(pushes) == 2
     assert _git(bare, "rev-parse", f"{head}^").strip() == sibling
     assert _git(bare, "show", f"{head}:train.py").strip() == "winner"
+    # the copied-in file is not "ours": the retry takes the sibling's newer version
+    assert _git(bare, "show", f"{head}:config.txt").strip() == "s2"
 
 
 def test_changed_paths_ignore_files_a_stale_line_merge_brought_to_base(tmp_path: Path) -> None:


### PR DESCRIPTION
The other half of today's research-line finding (#244 is the scope check).

gpt-speedrun timeline: agent-01's run `…-131552` parked as a candidate; run `…-221454` started on the same line at 22:14Z (a park frees the slot); `…-131552` woke and pushed its line snapshot at 22:52Z; `…-221454` woke at 11:02Z the next day, published PR #6 (8640 → 8192), and its `_push_line_snapshot` sealed on the LOCAL line ref from 22:14Z, so the push was a non-fast-forward, refused, and dropped by `_best_effort`. The line never received the winning tree, so the next run merged main into a stale line and conflicted on `train.py`.

Fix: `_seal_and_push` fetches origin and, when the local line ref is an ancestor of `origin/<line>`, parents the seal on the remote head and advances the local ref first, so the push fast-forwards. Offline (fetch fails) or when the refs agree, it behaves exactly as before. A diverged remote (neither an ancestor) still logs and skips: that is a different fault, not something to force over.

Test: bare remote, a sibling clone advances the line while "we" are parked, then the seal lands as a child of the sibling's commit with our tree, and the local ref follows.
