### PR TITLE
Refuse a workspace whose .git the session altered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- A session that alters the workspace's `.git` (a symlinked object store,
-  pack directory, refs, HEAD, index, or config) now ends the run with a note
-  naming the tampering, at the first kernel git operation after the session,
-  instead of a later git error. (2026-09-03: an author moved the pack files
+- A session that reshapes the workspace's `.git` (a symlink or gitdir file
+  in place of `.git`, a symlinked or missing object store, pack directory, or
+  refs, a FIFO or missing control file, object alternates) now ends the run
+  with a note naming the tampering. Every kernel git call checks, so no
+  path, wake, or follow-up can reach a later bare git error instead. (2026-09-03: an author moved the pack files
   into the container's private /tmp and symlinked them; the kernel's git saw
   refs with no objects.)
 - A line snapshot now builds on a newer remote version of the line instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- A session that alters the workspace's `.git` (a symlinked object store,
+  pack directory, refs, HEAD, index, or config) now ends the run with a note
+  naming the tampering, at the first kernel git operation after the session,
+  instead of a later git error. (2026-09-03: an author moved the pack files
+  into the container's private /tmp and symlinked them; the kernel's git saw
+  refs with no objects.)
 - A line snapshot now builds on a newer remote version of the line instead
   of being skipped when another run on the same line pushed while this run
   was parked. Files the other run added, changed, or deleted that this run

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1099,9 +1099,8 @@ def _push_line_snapshot(
 
     def _seal_and_push() -> None:
         # raises if the ref is absent (e.g. a park that predates the line
-        # feature) or the session altered .git — _best_effort turns either
-        # into a logged skip
-        ensure_regular_git_dir(Path(ws.root))
+        # feature) or the session altered .git (every ws.git call checks) —
+        # _best_effort turns either into a logged skip
         local = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
         memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
         last_exc: Exception | None = None
@@ -1274,7 +1273,6 @@ def _paths_changed_from_base(
     count. `fallback` is used when `base` does not resolve (no remote).
     `exclude_memory` drops the line's memory files whenever lines are active
     for the benchmark (a failed line checkout still keeps them out)."""
-    ensure_regular_git_dir(Path(ws.root))  # the first kernel git op after a session
     try:
         base_commit = ws.git("rev-parse", "--verify", f"{base}^{{commit}}").strip()
     except Exception:
@@ -1394,6 +1392,10 @@ def resume_run(
     # to another remote. Passing `url` here means `Workspace.push` uses it
     # instead of reading `remote.origin.url`.
     ws = Workspace(root=workspace, auth=bot_auth, url=_target_clone_url(record.target))
+    # A session reshaped .git (symlinked object store, gitdir file, FIFO) is
+    # refused BEFORE anything writes through it: the exclude below opens
+    # .git/info/exclude, and every ws.git call re-checks.
+    ensure_regular_git_dir(workspace)
     # Re-establish the merge-artifact exclude on the wake too: the workspace
     # persisted across the park, but a session could have removed the exclude,
     # and this wake's changed_paths / seal run `git add -A`. Idempotent.

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1356,8 +1356,12 @@ def _end_refused_wake(
     run_root: Path, record: RunRecord, exc: Exception, now: float, secrets: tuple[str, ...]
 ) -> AttemptOutcome:
     """End a parked run whose workspace the wake refused (a session altered
-    .git): ABORTED with the tampering as the note. The candidate snapshot
-    lives in that same workspace and is not touched."""
+    .git): ABORTED with the tampering as the note. The candidate snapshot's
+    retaining ref lives inside that same, now untrusted, repository and is
+    deliberately not touched: deleting it would mean writing through the
+    very structure the guard refused (a symlinked refs dir carries the write
+    elsewhere), and an ENDED workspace is inert — the ref keeps a commit
+    alive only within a repository nothing will read again."""
     note = redact(str(exc), secrets)[:480]
     log.warning("wake refused for %s: %s", record.run_id, note)
     failed = _clear_stage(

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -37,6 +37,7 @@ from autoresearch.dispatch import (
     snapshot_tree,
 )
 from autoresearch.github import (
+    GitError,
     GitHubClient,
     TokenProvider,
     Workspace,
@@ -1351,6 +1352,21 @@ def _utc_date(now: float) -> str:
     return datetime.fromtimestamp(now, UTC).strftime("%Y-%m-%d")
 
 
+def _end_refused_wake(
+    run_root: Path, record: RunRecord, exc: Exception, now: float, secrets: tuple[str, ...]
+) -> AttemptOutcome:
+    """End a parked run whose workspace the wake refused (a session altered
+    .git): ABORTED with the tampering as the note. The candidate snapshot
+    lives in that same workspace and is not touched."""
+    note = redact(str(exc), secrets)[:480]
+    log.warning("wake refused for %s: %s", record.run_id, note)
+    failed = _clear_stage(
+        RunRecord(**{**record.__dict__, "state": ENDED, "ending": ABORTED, "ending_note": note})
+    )
+    _best_effort("ending record", lambda: save_record(run_root, failed, now), secrets)
+    return AttemptOutcome(run_id=record.run_id, outcome="attempt-error")
+
+
 def resume_run(
     run_root: Path,
     run_id: str,
@@ -1394,8 +1410,14 @@ def resume_run(
     ws = Workspace(root=workspace, auth=bot_auth, url=_target_clone_url(record.target))
     # A session reshaped .git (symlinked object store, gitdir file, FIFO) is
     # refused BEFORE anything writes through it: the exclude below opens
-    # .git/info/exclude, and every ws.git call re-checks.
-    ensure_regular_git_dir(workspace)
+    # .git/info/exclude, and every ws.git call re-checks. The refusal ENDS
+    # the parked run with the tampering as its note — the tree cannot be
+    # trusted, and a record left waiting would only be re-woken into the
+    # same refusal.
+    try:
+        ensure_regular_git_dir(workspace)
+    except GitError as exc:
+        return _end_refused_wake(run_root, record, exc, now, secrets)
     # Re-establish the merge-artifact exclude on the wake too: the workspace
     # persisted across the park, but a session could have removed the exclude,
     # and this wake's changed_paths / seal run `git add -A`. Idempotent.

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -40,6 +40,7 @@ from autoresearch.github import (
     GitHubClient,
     TokenProvider,
     Workspace,
+    ensure_regular_git_dir,
 )
 from autoresearch.harness import Harness, SessionResult, redact
 from autoresearch.measure import DispatchedMeasurer, DispatchSettings
@@ -1098,7 +1099,9 @@ def _push_line_snapshot(
 
     def _seal_and_push() -> None:
         # raises if the ref is absent (e.g. a park that predates the line
-        # feature) — _best_effort turns that into a logged skip
+        # feature) or the session altered .git — _best_effort turns either
+        # into a logged skip
+        ensure_regular_git_dir(Path(ws.root))
         local = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
         memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
         last_exc: Exception | None = None
@@ -1271,6 +1274,7 @@ def _paths_changed_from_base(
     count. `fallback` is used when `base` does not resolve (no remote).
     `exclude_memory` drops the line's memory files whenever lines are active
     for the benchmark (a failed line checkout still keeps them out)."""
+    ensure_regular_git_dir(Path(ws.root))  # the first kernel git op after a session
     try:
         base_commit = ws.git("rev-parse", "--verify", f"{base}^{{commit}}").strip()
     except Exception:

--- a/src/autoresearch/dispatch.py
+++ b/src/autoresearch/dispatch.py
@@ -36,7 +36,7 @@ from pathlib import Path
 from uuid import uuid4
 
 from autoresearch.compute import JobSpec
-from autoresearch.github import SAFE_GIT_FLAGS, Workspace
+from autoresearch.github import SAFE_GIT_FLAGS, GitError, Workspace, ensure_regular_git_dir
 from autoresearch.orchestrator import EvalError, _metric_from_output, managed_eval_env
 
 log = logging.getLogger(__name__)
@@ -107,6 +107,10 @@ def snapshot_tree(
     a .gitignore entry cannot silently discard session memory; callers pass
     only paths that exist.
     """
+    # the snapshot writes an index, a tree, a commit, and a ref into this
+    # repository: a session-reshaped .git is refused first, like every other
+    # kernel git call on a workspace
+    ensure_regular_git_dir(Path(ws.root))
     # Unique per snapshot: two snapshots against the SAME base run
     # concurrently (the design's paired baseline/candidate fan-out) and must
     # not collide on one index file.
@@ -225,7 +229,14 @@ def drop_snapshot(ws: Workspace, snapshot: Snapshot) -> None:
     """Release the retaining ref (the commit becomes gc-eligible again). Called
     once the eval result has been read. Best-effort — it never RAISES, so a
     caller's ending sequence cannot hinge on it — but not SILENT: a ref that
-    fails to drop keeps its commit alive forever, so the failure is logged."""
+    fails to drop keeps its commit alive forever, so the failure is logged.
+    A session-reshaped .git is not written to at all (a symlinked refs dir
+    would carry the ref deletion outside the workspace): logged and left."""
+    try:
+        ensure_regular_git_dir(Path(ws.root))
+    except GitError as exc:
+        log.warning("snapshot ref %s not dropped: %s", snapshot.ref, exc)
+        return
     try:
         result = subprocess.run(
             ["git", "-C", str(ws.root), *SAFE_GIT_FLAGS, "update-ref", "-d", snapshot.ref],

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -915,36 +915,63 @@ _SECTION_RE = re.compile(r"^\s*\[\s*([A-Za-z0-9.-]+)")
 
 
 # The parts of a workspace's .git the kernel relies on after a session ran.
-# Any of them replaced by a symlink (or gone) means the session reached into
-# the repository's plumbing: 2026-09-03 an author copied the pack files into
-# the container's private /tmp and symlinked objects/pack there, so the
-# kernel's git on the host found refs with no objects behind them.
-GIT_DIR_INTEGRITY_PATHS = ("objects", "objects/pack", "refs", "HEAD", "index", "config")
+# 2026-09-03 an author copied the pack files into the container's private
+# /tmp and symlinked objects/pack there, so the kernel's git on the host
+# found refs with no objects behind them. The guard runs inside every kernel
+# git call (Workspace.git / git_network), so no path can skip it.
+_GIT_REGULAR_FILES = ("HEAD", "config")  # must exist and be regular files
+_GIT_REGULAR_IF_PRESENT = ("index", "config.worktree", "packed-refs", "MERGE_HEAD", "FETCH_HEAD")
+_GIT_DIRS = ("objects", "refs")  # must exist and be directories
+_GIT_DIRS_IF_PRESENT = ("objects/pack", "objects/info", "hooks", "info")
+
+
+def _altered(what: str) -> GitError:
+    return GitError(f"workspace .git altered by the session: {what}")
 
 
 def ensure_regular_git_dir(root: Path | None) -> None:
-    """Refuse a workspace whose .git was altered by the session: `.git` and
-    the entries the kernel reads must be regular (no symlinks), and the
-    object store and refs must be directories. Raises GitError with the
-    offending path; a workspace without .git is left to git's own error."""
+    """Refuse a workspace whose .git a session reshaped. `.git` must be a
+    real directory (no symlink, no gitdir file); HEAD and config must be
+    regular files and the other control files regular when present (a FIFO
+    would hang the next git call); objects and refs must be directories, as
+    must objects/pack when present; object alternates are never ours. A
+    root with no .git at all is left to git's own error."""
     if root is None:
         return
     git_dir = Path(root) / ".git"
-    if git_dir.is_symlink():
-        raise GitError(f"workspace .git altered by the session: {git_dir} is a symlink")
-    if not git_dir.is_dir():
+    try:
+        st = os.lstat(git_dir)
+    except OSError:
         return
-    for rel in GIT_DIR_INTEGRITY_PATHS:
-        path = git_dir / rel
-        if path.is_symlink():
-            raise GitError(f"workspace .git altered by the session: .git/{rel} is a symlink")
-        if rel in ("objects", "objects/pack", "refs"):
-            if rel == "objects/pack" and not path.exists():
-                continue  # a fresh repo with only loose objects has no pack dir
-            if not path.is_dir():
-                raise GitError(
-                    f"workspace .git altered by the session: .git/{rel} is not a directory"
-                )
+    if stat.S_ISLNK(st.st_mode):
+        raise _altered(".git is a symlink")
+    if not stat.S_ISDIR(st.st_mode):
+        raise _altered(".git is not a directory (a gitdir file)")
+
+    def check(rel: str, want_dir: bool, required: bool) -> None:
+        try:
+            st = os.lstat(git_dir / rel)
+        except OSError:
+            if required:
+                raise _altered(f".git/{rel} is missing") from None
+            return
+        if stat.S_ISLNK(st.st_mode):
+            raise _altered(f".git/{rel} is a symlink")
+        if want_dir and not stat.S_ISDIR(st.st_mode):
+            raise _altered(f".git/{rel} is not a directory")
+        if not want_dir and not stat.S_ISREG(st.st_mode):
+            raise _altered(f".git/{rel} is not a regular file")
+
+    for rel in _GIT_REGULAR_FILES:
+        check(rel, want_dir=False, required=True)
+    for rel in _GIT_REGULAR_IF_PRESENT:
+        check(rel, want_dir=False, required=False)
+    for rel in _GIT_DIRS:
+        check(rel, want_dir=True, required=True)
+    for rel in _GIT_DIRS_IF_PRESENT:
+        check(rel, want_dir=True, required=False)
+    if os.path.lexists(git_dir / "objects" / "info" / "alternates"):
+        raise _altered("object alternates are present")
 
 
 def _ensure_regular_config(root: Path | None) -> None:
@@ -1111,7 +1138,9 @@ class Workspace:
 
     def git(self, *args: str) -> str:
         """Run a local git subcommand: no credential, no child-spawning config,
-        repo-defined filter drivers neutralized."""
+        repo-defined filter drivers neutralized. A session-reshaped .git is
+        refused before git runs (ensure_regular_git_dir)."""
+        ensure_regular_git_dir(self.root)
         _ensure_regular_config(self.root)
         return _run_git(
             ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(None, self.root)

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -932,23 +932,14 @@ _GIT_REGULAR_IF_PRESENT = (
 )
 _GIT_DIRS = ("objects", "refs")  # must exist and be directories
 _GIT_DIRS_IF_PRESENT = ("objects/pack", "objects/info", "hooks", "info", "logs", "logs/refs")
-# Directories whose direct entries may not be symlinks at all: git appends
-# to reflogs, writes refs, and reads hooks/info from here, and a link would
-# carry that write or read outside the workspace. One-level listings, cheap.
-_GIT_NO_SYMLINK_ENTRIES = (
-    "",
-    "refs",
-    "refs/heads",
-    "refs/remotes",
-    "logs",
-    "logs/refs",
-    "logs/refs/heads",
-    "objects",
-    "objects/info",
-    "objects/pack",
-    "info",
-    "hooks",
-)
+# No symlink may appear among .git's own entries, nor ANYWHERE under the
+# small control trees git writes to or reads from (refs, reflogs, hooks,
+# info): a link there carries a ref update, a reflog append, or a hook read
+# outside the workspace. The object store is checked one level deep plus
+# its pack/info dirs (loose-object trees are large; a missing object is
+# caught by the HEAD readability check below).
+_GIT_NO_SYMLINK_TREES = ("refs", "logs", "hooks", "info")
+_GIT_NO_SYMLINK_ENTRIES = ("", "objects", "objects/info", "objects/pack")
 
 
 def _altered(what: str) -> GitError:
@@ -1006,12 +997,25 @@ def ensure_regular_git_dir(root: Path | None) -> None:
                         raise _altered(f".git/{shown} is a symlink")
         except OSError:
             continue
+    for rel in _GIT_NO_SYMLINK_TREES:
+        top = git_dir / rel
+        if not top.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(top, followlinks=False):
+            for name in (*dirnames, *filenames):
+                if os.path.islink(os.path.join(dirpath, name)):
+                    shown = os.path.relpath(os.path.join(dirpath, name), git_dir)
+                    raise _altered(f".git/{shown} is a symlink")
     if os.path.lexists(git_dir / "objects" / "info" / "alternates"):
         raise _altered("object alternates are present")
     # The structure can be intact with the objects gone (pack files deleted,
     # or moved and the link removed): HEAD's commit must still be readable.
-    # An unborn HEAD (a branch with no commit yet) has nothing to check.
+    # An unborn HEAD (a fresh repository whose branch has no commit yet) has
+    # nothing to check; a HEAD whose branch ref vanished from a repository
+    # that has other refs is an erased ref, not an unborn one.
     sha = _head_commit_sha(git_dir)
+    if sha is None and _has_any_ref(git_dir):
+        raise _altered("HEAD names a branch whose ref is missing")
     if sha is not None:
         try:
             _run_git(
@@ -1022,6 +1026,18 @@ def ensure_regular_git_dir(root: Path | None) -> None:
             raise _altered(
                 "HEAD's commit is unreadable: the object store was emptied or moved"
             ) from None
+
+
+def _has_any_ref(git_dir: Path) -> bool:
+    """Does the repository hold any ref at all (loose or packed)? A clone
+    always does; only a fresh `git init` with no commit has none."""
+    if (git_dir / "packed-refs").is_file():
+        return True
+    for sub in ("heads", "remotes", "tags"):
+        top = git_dir / "refs" / sub
+        if top.is_dir() and any(p.is_file() for p in top.rglob("*")):
+            return True
+    return False
 
 
 def _head_commit_sha(git_dir: Path) -> str | None:

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -914,6 +914,39 @@ _REDIRECT_SECTIONS = ("url", "include", "includeif")
 _SECTION_RE = re.compile(r"^\s*\[\s*([A-Za-z0-9.-]+)")
 
 
+# The parts of a workspace's .git the kernel relies on after a session ran.
+# Any of them replaced by a symlink (or gone) means the session reached into
+# the repository's plumbing: 2026-09-03 an author copied the pack files into
+# the container's private /tmp and symlinked objects/pack there, so the
+# kernel's git on the host found refs with no objects behind them.
+GIT_DIR_INTEGRITY_PATHS = ("objects", "objects/pack", "refs", "HEAD", "index", "config")
+
+
+def ensure_regular_git_dir(root: Path | None) -> None:
+    """Refuse a workspace whose .git was altered by the session: `.git` and
+    the entries the kernel reads must be regular (no symlinks), and the
+    object store and refs must be directories. Raises GitError with the
+    offending path; a workspace without .git is left to git's own error."""
+    if root is None:
+        return
+    git_dir = Path(root) / ".git"
+    if git_dir.is_symlink():
+        raise GitError(f"workspace .git altered by the session: {git_dir} is a symlink")
+    if not git_dir.is_dir():
+        return
+    for rel in GIT_DIR_INTEGRITY_PATHS:
+        path = git_dir / rel
+        if path.is_symlink():
+            raise GitError(f"workspace .git altered by the session: .git/{rel} is a symlink")
+        if rel in ("objects", "objects/pack", "refs"):
+            if rel == "objects/pack" and not path.exists():
+                continue  # a fresh repo with only loose objects has no pack dir
+            if not path.is_dir():
+                raise GitError(
+                    f"workspace .git altered by the session: .git/{rel} is not a directory"
+                )
+
+
 def _ensure_regular_config(root: Path | None) -> None:
     """Sanitize .git/config before any git command reads it. A session can
     (a) replace the file with a FIFO/symlink/device — git's own parse, or a
@@ -1091,6 +1124,7 @@ class Workspace:
         remote or rewrite can steer a credentialed op."""
         if args and args[0] not in NETWORK_GIT_COMMANDS:
             raise ValueError(f"{args[0]!r} is not a network git command")
+        ensure_regular_git_dir(self.root)
         _ensure_regular_config(self.root)
         token = self.auth.token() if self.auth is not None else None
         return _run_git(

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -992,6 +992,13 @@ def ensure_regular_git_dir(root: Path | None) -> None:
     if not stat.S_ISDIR(st.st_mode):
         raise _altered(".git is not a directory (a gitdir file)")
     _ensure_regular_config(root)  # before any git subprocess below reads it
+    # The kernel clones with the files ref backend; a reftable repository
+    # (`git init --ref-format=reftable`, or a `git refs migrate`) keeps its
+    # refs in `.git/reftable/`, where none of the ref reads below would see
+    # them, so an emptied object store could slip past. It is not one the
+    # kernel made: refuse it.
+    if os.path.lexists(git_dir / "reftable"):
+        raise _altered("ref storage is not the files backend (reftable present)")
 
     def check(rel: str, want_dir: bool, required: bool) -> None:
         try:

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -950,6 +950,25 @@ _GIT_NO_SYMLINK_ENTRIES = ("", "objects", "objects/info", "objects/pack")
 GUARD_GIT_TIMEOUT_S = 20  # the guard's own git read; a stall here is a stall everywhere
 
 
+def _regular_files_only(git_dir: Path, rel: str, allow_dirs: tuple[str, ...] = ()) -> None:
+    """Every entry of .git/<rel> must be a regular file (directory-entry type,
+    no per-file stat); `allow_dirs` names the subdirectories git itself
+    creates there (objects/info/commit-graphs for a split commit graph),
+    which are checked the same way one level down."""
+    try:
+        with os.scandir(git_dir / rel) as entries:
+            for entry in entries:
+                if entry.is_dir(follow_symlinks=False) and entry.name in allow_dirs:
+                    _regular_files_only(git_dir, f"{rel}/{entry.name}")
+                    continue
+                if not entry.is_file(follow_symlinks=False):
+                    raise _altered(f".git/{rel}/{entry.name} is not a regular file")
+    except PermissionError:
+        raise _altered(f".git/{rel} is unreadable") from None
+    except FileNotFoundError:
+        return
+
+
 def _altered(what: str) -> GitError:
     return GitError(f"workspace .git altered by the session: {what}")
 
@@ -1036,15 +1055,7 @@ def ensure_regular_git_dir(root: Path | None) -> None:
             len(fan.name) == 2 and _HEX2.fullmatch(fan.name)
         ):
             raise _altered(f".git/objects/{fan.name} is not a git object directory")
-        try:
-            with os.scandir(fan.path) as entries:
-                for entry in entries:
-                    if not entry.is_file(follow_symlinks=False):
-                        raise _altered(
-                            f".git/objects/{fan.name}/{entry.name} is not a regular file"
-                        )
-        except PermissionError:
-            raise _altered(f".git/objects/{fan.name} is unreadable") from None
+        _regular_files_only(git_dir, f"objects/{fan.name}", allow_dirs=("commit-graphs",))
     # The structure can be intact with the objects gone (pack files deleted,
     # or moved and the link removed): a commit the refs name must still be
     # readable. HEAD's commit when HEAD is born; otherwise any other ref (a

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -1009,13 +1009,12 @@ def ensure_regular_git_dir(root: Path | None) -> None:
     if os.path.lexists(git_dir / "objects" / "info" / "alternates"):
         raise _altered("object alternates are present")
     # The structure can be intact with the objects gone (pack files deleted,
-    # or moved and the link removed): HEAD's commit must still be readable.
-    # An unborn HEAD (a fresh repository whose branch has no commit yet) has
-    # nothing to check; a HEAD whose branch ref vanished from a repository
-    # that has other refs is an erased ref, not an unborn one.
-    sha = _head_commit_sha(git_dir)
-    if sha is None and _has_any_ref(git_dir):
-        raise _altered("HEAD names a branch whose ref is missing")
+    # or moved and the link removed): a commit the refs name must still be
+    # readable. HEAD's commit when HEAD is born; otherwise any other ref (a
+    # clone whose remote HEAD names an unpushed branch has an unborn local
+    # HEAD beside real remote refs); a fresh repository with no refs at all
+    # has nothing to check.
+    sha = _head_commit_sha(git_dir) or _any_ref_sha(git_dir)
     if sha is not None:
         try:
             _run_git(
@@ -1028,38 +1027,70 @@ def ensure_regular_git_dir(root: Path | None) -> None:
             ) from None
 
 
-def _has_any_ref(git_dir: Path) -> bool:
-    """Does the repository hold any ref at all (loose or packed)? A clone
-    always does; only a fresh `git init` with no commit has none."""
-    if (git_dir / "packed-refs").is_file():
-        return True
-    for sub in ("heads", "remotes", "tags"):
-        top = git_dir / "refs" / sub
-        if top.is_dir() and any(p.is_file() for p in top.rglob("*")):
-            return True
-    return False
+_SHA_RE = re.compile(r"[0-9a-f]{40,64}")
+_REF_RE = re.compile(r"refs/[A-Za-z0-9][A-Za-z0-9._/-]{0,200}")
+
+
+def _read_small_regular(path: Path, limit: int = 512) -> str | None:
+    """Read a small control file only if it is a regular file (never follow a
+    symlink or block on a FIFO); None when absent or not regular."""
+    try:
+        st = os.lstat(path)
+    except OSError:
+        return None
+    if not stat.S_ISREG(st.st_mode):
+        raise _altered(f"{path.name} is not a regular file")
+    with open(path, "rb") as fh:
+        return fh.read(limit).decode("utf-8", errors="replace")
+
+
+def _ref_sha(git_dir: Path, ref: str) -> str | None:
+    """A ref's sha from its loose file (inside .git only) or packed-refs."""
+    loose = _read_small_regular(git_dir / ref)
+    if loose is not None:
+        value = loose.strip()
+        return value if _SHA_RE.fullmatch(value) else None
+    packed = _read_small_regular(git_dir / "packed-refs", limit=1_000_000) or ""
+    for line in packed.splitlines():
+        if line.endswith(" " + ref) and _SHA_RE.fullmatch(line.split(" ", 1)[0]):
+            return line.split(" ", 1)[0]
+    return None
 
 
 def _head_commit_sha(git_dir: Path) -> str | None:
-    """The sha HEAD names, from the loose ref file or packed-refs, or None when
-    HEAD is detached-invalid or its branch is unborn (nothing to verify)."""
-    try:
-        head = (git_dir / "HEAD").read_text().strip()
-    except OSError:
-        return None
+    """The sha HEAD names, or None when HEAD's branch is unborn. A HEAD that
+    is not a plain sha or a well-formed `ref: refs/...` (a path with `..`, an
+    absolute path, junk) is tampering, not a state git ever writes."""
+    head = (_read_small_regular(git_dir / "HEAD") or "").strip()
+    if not head:
+        raise _altered("HEAD is empty")
+    if _SHA_RE.fullmatch(head):
+        return head
     if not head.startswith("ref: "):
-        return head if re.fullmatch(r"[0-9a-f]{40,64}", head) else None
+        raise _altered("HEAD is malformed")
     ref = head[5:].strip()
-    try:
-        return (git_dir / ref).read_text().strip() or None
-    except OSError:
-        pass
-    try:
-        for line in (git_dir / "packed-refs").read_text().splitlines():
-            if line.endswith(" " + ref):
-                return line.split(" ", 1)[0]
-    except OSError:
-        pass
+    if not _REF_RE.fullmatch(ref) or ".." in ref.split("/"):
+        raise _altered("HEAD names a ref outside refs/")
+    return _ref_sha(git_dir, ref)
+
+
+def _any_ref_sha(git_dir: Path) -> str | None:
+    """Some commit-bearing ref's sha (packed first, then loose under refs/),
+    used to verify the object store when HEAD is unborn; None when the
+    repository has no refs at all."""
+    packed = _read_small_regular(git_dir / "packed-refs", limit=1_000_000) or ""
+    for line in packed.splitlines():
+        if line and not line.startswith(("#", "^")):
+            sha = line.split(" ", 1)[0]
+            if _SHA_RE.fullmatch(sha):
+                return sha
+    top = git_dir / "refs"
+    if top.is_dir():
+        for path in sorted(top.rglob("*")):
+            if path.is_file() and not path.is_symlink():
+                value = (_read_small_regular(path) or "").strip()
+                if _SHA_RE.fullmatch(value):
+                    return value
     return None
 
 

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -995,13 +995,20 @@ def ensure_regular_git_dir(root: Path | None) -> None:
                     if entry.is_symlink():
                         shown = f"{rel}/{entry.name}" if rel else entry.name
                         raise _altered(f".git/{shown} is a symlink")
+        except PermissionError:
+            raise _altered(f".git/{rel or '.'} is unreadable") from None
         except OSError:
             continue
+
+    def _unreadable(err: OSError) -> None:
+        shown = os.path.relpath(err.filename or "?", git_dir)
+        raise _altered(f".git/{shown} is unreadable") from None
+
     for rel in _GIT_NO_SYMLINK_TREES:
         top = git_dir / rel
         if not top.is_dir():
             continue
-        for dirpath, dirnames, filenames in os.walk(top, followlinks=False):
+        for dirpath, dirnames, filenames in os.walk(top, followlinks=False, onerror=_unreadable):
             for name in (*dirnames, *filenames):
                 if os.path.islink(os.path.join(dirpath, name)):
                     shown = os.path.relpath(os.path.join(dirpath, name), git_dir)
@@ -1040,8 +1047,11 @@ def _read_small_regular(path: Path, limit: int = 512) -> str | None:
         return None
     if not stat.S_ISREG(st.st_mode):
         raise _altered(f"{path.name} is not a regular file")
-    with open(path, "rb") as fh:
-        return fh.read(limit).decode("utf-8", errors="replace")
+    try:
+        with open(path, "rb") as fh:
+            return fh.read(limit).decode("utf-8", errors="replace")
+    except OSError as exc:  # chmod 000 and friends: unreadable is altered, not "absent"
+        raise _altered(f"{path.name} is unreadable ({exc.strerror})") from None
 
 
 def _ref_sha(git_dir: Path, ref: str) -> str | None:

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -931,7 +931,24 @@ _GIT_REGULAR_IF_PRESENT = (
     "info/exclude",  # the wake writes it; a symlink would carry the write elsewhere
 )
 _GIT_DIRS = ("objects", "refs")  # must exist and be directories
-_GIT_DIRS_IF_PRESENT = ("objects/pack", "objects/info", "hooks", "info")
+_GIT_DIRS_IF_PRESENT = ("objects/pack", "objects/info", "hooks", "info", "logs", "logs/refs")
+# Directories whose direct entries may not be symlinks at all: git appends
+# to reflogs, writes refs, and reads hooks/info from here, and a link would
+# carry that write or read outside the workspace. One-level listings, cheap.
+_GIT_NO_SYMLINK_ENTRIES = (
+    "",
+    "refs",
+    "refs/heads",
+    "refs/remotes",
+    "logs",
+    "logs/refs",
+    "logs/refs/heads",
+    "objects",
+    "objects/info",
+    "objects/pack",
+    "info",
+    "hooks",
+)
 
 
 def _altered(what: str) -> GitError:
@@ -980,6 +997,15 @@ def ensure_regular_git_dir(root: Path | None) -> None:
         check(rel, want_dir=True, required=True)
     for rel in _GIT_DIRS_IF_PRESENT:
         check(rel, want_dir=True, required=False)
+    for rel in _GIT_NO_SYMLINK_ENTRIES:
+        try:
+            with os.scandir(git_dir / rel if rel else git_dir) as entries:
+                for entry in entries:
+                    if entry.is_symlink():
+                        shown = f"{rel}/{entry.name}" if rel else entry.name
+                        raise _altered(f".git/{shown} is a symlink")
+        except OSError:
+            continue
     if os.path.lexists(git_dir / "objects" / "info" / "alternates"):
         raise _altered("object alternates are present")
     # The structure can be intact with the objects gone (pack files deleted,

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -1094,15 +1094,22 @@ _HEX2 = re.compile(r"[0-9a-f]{2}")
 _REF_RE = re.compile(r"refs/[A-Za-z0-9][A-Za-z0-9._/-]{0,200}")
 
 
+PACKED_REFS_MAX_BYTES = 64 * 1024 * 1024  # far beyond any real repository's packed-refs
+
+
 def _read_small_regular(path: Path, limit: int = 512) -> str | None:
-    """Read a small control file only if it is a regular file (never follow a
-    symlink or block on a FIFO); None when absent or not regular."""
+    """Read a control file only if it is a regular file (never follow a
+    symlink or block on a FIFO); None when absent. A file larger than
+    `limit` is refused rather than truncated: a truncated read would silently
+    drop entries (a HEAD ref past the cut would read as unborn)."""
     try:
         st = os.lstat(path)
     except OSError:
         return None
     if not stat.S_ISREG(st.st_mode):
         raise _altered(f"{path.name} is not a regular file")
+    if st.st_size > limit:
+        raise _altered(f"{path.name} is oversized ({st.st_size} bytes)")
     try:
         with open(path, "rb") as fh:
             return fh.read(limit).decode("utf-8", errors="replace")
@@ -1116,7 +1123,7 @@ def _ref_sha(git_dir: Path, ref: str) -> str | None:
     if loose is not None:
         value = loose.strip()
         return value if _SHA_RE.fullmatch(value) else None
-    packed = _read_small_regular(git_dir / "packed-refs", limit=1_000_000) or ""
+    packed = _read_small_regular(git_dir / "packed-refs", limit=PACKED_REFS_MAX_BYTES) or ""
     for line in packed.splitlines():
         if line.endswith(" " + ref) and _SHA_RE.fullmatch(line.split(" ", 1)[0]):
             return line.split(" ", 1)[0]
@@ -1144,7 +1151,7 @@ def _any_ref_sha(git_dir: Path) -> str | None:
     """Some commit-bearing ref's sha (packed first, then loose under refs/),
     used to verify the object store when HEAD is unborn; None when the
     repository has no refs at all."""
-    packed = _read_small_regular(git_dir / "packed-refs", limit=1_000_000) or ""
+    packed = _read_small_regular(git_dir / "packed-refs", limit=PACKED_REFS_MAX_BYTES) or ""
     for line in packed.splitlines():
         if line and not line.startswith(("#", "^")):
             sha = line.split(" ", 1)[0]

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -919,8 +919,17 @@ _SECTION_RE = re.compile(r"^\s*\[\s*([A-Za-z0-9.-]+)")
 # /tmp and symlinked objects/pack there, so the kernel's git on the host
 # found refs with no objects behind them. The guard runs inside every kernel
 # git call (Workspace.git / git_network), so no path can skip it.
-_GIT_REGULAR_FILES = ("HEAD", "config")  # must exist and be regular files
-_GIT_REGULAR_IF_PRESENT = ("index", "config.worktree", "packed-refs", "MERGE_HEAD", "FETCH_HEAD")
+# config and config.worktree are NOT here: _ensure_regular_config sanitizes
+# them in place (a FIFO or symlink config is replaced, not fatal) and runs
+# first, so the guard's own git subprocess never reads a tampered config.
+_GIT_REGULAR_FILES = ("HEAD",)  # must exist and be regular files
+_GIT_REGULAR_IF_PRESENT = (
+    "index",
+    "packed-refs",
+    "MERGE_HEAD",
+    "FETCH_HEAD",
+    "info/exclude",  # the wake writes it; a symlink would carry the write elsewhere
+)
 _GIT_DIRS = ("objects", "refs")  # must exist and be directories
 _GIT_DIRS_IF_PRESENT = ("objects/pack", "objects/info", "hooks", "info")
 
@@ -947,6 +956,7 @@ def ensure_regular_git_dir(root: Path | None) -> None:
         raise _altered(".git is a symlink")
     if not stat.S_ISDIR(st.st_mode):
         raise _altered(".git is not a directory (a gitdir file)")
+    _ensure_regular_config(root)  # before any git subprocess below reads it
 
     def check(rel: str, want_dir: bool, required: bool) -> None:
         try:
@@ -972,6 +982,43 @@ def ensure_regular_git_dir(root: Path | None) -> None:
         check(rel, want_dir=True, required=False)
     if os.path.lexists(git_dir / "objects" / "info" / "alternates"):
         raise _altered("object alternates are present")
+    # The structure can be intact with the objects gone (pack files deleted,
+    # or moved and the link removed): HEAD's commit must still be readable.
+    # An unborn HEAD (a branch with no commit yet) has nothing to check.
+    sha = _head_commit_sha(git_dir)
+    if sha is not None:
+        try:
+            _run_git(
+                ["git", "-C", str(root), *SAFE_GIT_FLAGS, "cat-file", "-e", f"{sha}^{{commit}}"],
+                _git_env(None, Path(root)),
+            )
+        except GitError:
+            raise _altered(
+                "HEAD's commit is unreadable: the object store was emptied or moved"
+            ) from None
+
+
+def _head_commit_sha(git_dir: Path) -> str | None:
+    """The sha HEAD names, from the loose ref file or packed-refs, or None when
+    HEAD is detached-invalid or its branch is unborn (nothing to verify)."""
+    try:
+        head = (git_dir / "HEAD").read_text().strip()
+    except OSError:
+        return None
+    if not head.startswith("ref: "):
+        return head if re.fullmatch(r"[0-9a-f]{40,64}", head) else None
+    ref = head[5:].strip()
+    try:
+        return (git_dir / ref).read_text().strip() or None
+    except OSError:
+        pass
+    try:
+        for line in (git_dir / "packed-refs").read_text().splitlines():
+            if line.endswith(" " + ref):
+                return line.split(" ", 1)[0]
+    except OSError:
+        pass
+    return None
 
 
 def _ensure_regular_config(root: Path | None) -> None:
@@ -1139,9 +1186,9 @@ class Workspace:
     def git(self, *args: str) -> str:
         """Run a local git subcommand: no credential, no child-spawning config,
         repo-defined filter drivers neutralized. A session-reshaped .git is
-        refused before git runs (ensure_regular_git_dir)."""
+        refused before git runs (ensure_regular_git_dir, which also
+        sanitizes the config first)."""
         ensure_regular_git_dir(self.root)
-        _ensure_regular_config(self.root)
         return _run_git(
             ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args], _git_env(None, self.root)
         )
@@ -1153,8 +1200,7 @@ class Workspace:
         remote or rewrite can steer a credentialed op."""
         if args and args[0] not in NETWORK_GIT_COMMANDS:
             raise ValueError(f"{args[0]!r} is not a network git command")
-        ensure_regular_git_dir(self.root)
-        _ensure_regular_config(self.root)
+        ensure_regular_git_dir(self.root)  # sanitizes the config first, too
         token = self.auth.token() if self.auth is not None else None
         return _run_git(
             ["git", "-C", str(self.root), *SAFE_GIT_FLAGS, *args],

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -926,8 +926,13 @@ _GIT_REGULAR_FILES = ("HEAD",)  # must exist and be regular files
 _GIT_REGULAR_IF_PRESENT = (
     "index",
     "packed-refs",
+    "shallow",
     "MERGE_HEAD",
     "FETCH_HEAD",
+    "ORIG_HEAD",
+    "COMMIT_EDITMSG",
+    "description",
+    "objects/info/packs",
     "info/exclude",  # the wake writes it; a symlink would carry the write elsewhere
 )
 _GIT_DIRS = ("objects", "refs")  # must exist and be directories
@@ -940,6 +945,9 @@ _GIT_DIRS_IF_PRESENT = ("objects/pack", "objects/info", "hooks", "info", "logs",
 # caught by the HEAD readability check below).
 _GIT_NO_SYMLINK_TREES = ("refs", "logs", "hooks", "info")
 _GIT_NO_SYMLINK_ENTRIES = ("", "objects", "objects/info", "objects/pack")
+
+
+GUARD_GIT_TIMEOUT_S = 20  # the guard's own git read; a stall here is a stall everywhere
 
 
 def _altered(what: str) -> GitError:
@@ -1015,6 +1023,28 @@ def ensure_regular_git_dir(root: Path | None) -> None:
                     raise _altered(f".git/{shown} is a symlink")
     if os.path.lexists(git_dir / "objects" / "info" / "alternates"):
         raise _altered("object alternates are present")
+    # Every loose object and pack file must be a regular file: a FIFO in
+    # place of one would stall the next git call that reads it. d_type from
+    # scandir, no per-file stat, so this stays cheap on large stores.
+    objects = git_dir / "objects"
+    try:
+        fanouts = [e for e in os.scandir(objects) if e.is_dir(follow_symlinks=False)]
+    except OSError:
+        fanouts = []
+    for fan in fanouts:
+        if fan.name not in ("pack", "info") and not (
+            len(fan.name) == 2 and _HEX2.fullmatch(fan.name)
+        ):
+            raise _altered(f".git/objects/{fan.name} is not a git object directory")
+        try:
+            with os.scandir(fan.path) as entries:
+                for entry in entries:
+                    if not entry.is_file(follow_symlinks=False):
+                        raise _altered(
+                            f".git/objects/{fan.name}/{entry.name} is not a regular file"
+                        )
+        except PermissionError:
+            raise _altered(f".git/objects/{fan.name} is unreadable") from None
     # The structure can be intact with the objects gone (pack files deleted,
     # or moved and the link removed): a commit the refs name must still be
     # readable. HEAD's commit when HEAD is born; otherwise any other ref (a
@@ -1027,14 +1057,18 @@ def ensure_regular_git_dir(root: Path | None) -> None:
             _run_git(
                 ["git", "-C", str(root), *SAFE_GIT_FLAGS, "cat-file", "-e", f"{sha}^{{commit}}"],
                 _git_env(None, Path(root)),
+                timeout=GUARD_GIT_TIMEOUT_S,  # a stalled read is refused, not waited on
             )
-        except GitError:
+        except GitError as exc:
+            if "timed out" in str(exc):
+                raise _altered("the object store did not answer: a git read stalled") from None
             raise _altered(
                 "HEAD's commit is unreadable: the object store was emptied or moved"
             ) from None
 
 
 _SHA_RE = re.compile(r"[0-9a-f]{40,64}")
+_HEX2 = re.compile(r"[0-9a-f]{2}")
 _REF_RE = re.compile(r"refs/[A-Za-z0-9][A-Za-z0-9._/-]{0,200}")
 
 

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -1037,9 +1037,20 @@ def ensure_regular_git_dir(root: Path | None) -> None:
             continue
         for dirpath, dirnames, filenames in os.walk(top, followlinks=False, onerror=_unreadable):
             for name in (*dirnames, *filenames):
-                if os.path.islink(os.path.join(dirpath, name)):
-                    shown = os.path.relpath(os.path.join(dirpath, name), git_dir)
+                full = os.path.join(dirpath, name)
+                if os.path.islink(full):
+                    shown = os.path.relpath(full, git_dir)
                     raise _altered(f".git/{shown} is a symlink")
+            for name in filenames:
+                # a FIFO or device where a loose ref, reflog, or hook was would
+                # stall the next git command that scans this tree
+                full = os.path.join(dirpath, name)
+                try:
+                    if not stat.S_ISREG(os.lstat(full).st_mode):
+                        shown = os.path.relpath(full, git_dir)
+                        raise _altered(f".git/{shown} is not a regular file")
+                except FileNotFoundError:
+                    continue
     if os.path.lexists(git_dir / "objects" / "info" / "alternates"):
         raise _altered("object alternates are present")
     # Every loose object and pack file must be a regular file: a FIFO in

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4466,12 +4466,12 @@ def test_changed_paths_ignore_files_a_stale_line_merge_brought_to_base(tmp_path:
     assert _paths_changed_from_base(ws, base_sha, True) == []
 
 
-def test_a_session_that_symlinks_the_object_store_is_refused_with_a_plain_note(
-    tmp_path: Path,
-) -> None:
+def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path) -> None:
     """2026-09-03: an author copied .git/objects/pack into the container's /tmp
-    and symlinked it, leaving the kernel's git with refs and no objects. The
-    kernel must name the tampering instead of failing on a later git call."""
+    and symlinked it, leaving the kernel's git with refs and no objects. Every
+    kernel git call must name the tampering instead of failing on plumbing;
+    the same goes for a gitdir file, a FIFO where a control file was, a
+    missing control file, and object alternates."""
     import os
 
     from autoresearch.attempt import _paths_changed_from_base
@@ -4484,31 +4484,65 @@ def test_a_session_that_symlinks_the_object_store_is_refused_with_a_plain_note(
     _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
     _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
     base = _git(root, "rev-parse", "HEAD").strip()
+    ws = Workspace(root=root)
     ensure_regular_git_dir(root)  # a clean clone passes
-    # the session's move: pack files into a private tmp, a symlink left behind
-    pack = root / ".git" / "objects" / "pack"
-    _git(root, "gc", "-q")  # make sure a pack dir with content exists
+    assert ws.git("rev-parse", "HEAD").strip() == base
+    git_dir = root / ".git"
     elsewhere = tmp_path / "private-tmp"
     elsewhere.mkdir()
+
+    # the session's move: pack files into a private tmp, a symlink left behind
+    _git(root, "gc", "-q")
+    pack = git_dir / "objects" / "pack"
     for f in pack.iterdir():
         f.rename(elsewhere / f.name)
     pack.rmdir()
     os.symlink(elsewhere, pack)
     with pytest.raises(GitError, match=r"altered by the session: \.git/objects/pack is a symlink"):
-        ensure_regular_git_dir(root)
+        ws.git("status")  # EVERY kernel git call refuses
     with pytest.raises(GitError, match="altered by the session"):
-        _paths_changed_from_base(Workspace(root=root), base, False)
-    # other plumbing is covered too
+        _paths_changed_from_base(ws, base, False)
     os.unlink(pack)
     pack.mkdir()
-    head = root / ".git" / "HEAD"
+    for f in elsewhere.iterdir():
+        f.rename(pack / f.name)
+    ensure_regular_git_dir(root)
+
+    # object alternates pointing anywhere
+    alt = git_dir / "objects" / "info" / "alternates"
+    alt.parent.mkdir(exist_ok=True)
+    alt.write_text(str(elsewhere) + "\n")
+    with pytest.raises(GitError, match="alternates"):
+        ws.git("status")
+    alt.unlink()
+
+    # a FIFO where the index was would hang the next git call
+    index = git_dir / "index"
+    index_bytes = index.read_bytes()
+    index.unlink()
+    os.mkfifo(index)
+    with pytest.raises(GitError, match=r"\.git/index is not a regular file"):
+        ws.git("status")
+    index.unlink()
+    index.write_bytes(index_bytes)
+
+    # a missing HEAD
+    head = git_dir / "HEAD"
     head_text = head.read_text()
     head.unlink()
-    os.symlink(elsewhere / "nope", head)
-    with pytest.raises(GitError, match=r"\.git/HEAD is a symlink"):
-        ensure_regular_git_dir(root)
-    head.unlink()
+    with pytest.raises(GitError, match=r"\.git/HEAD is missing"):
+        ws.git("status")
     head.write_text(head_text)
+    ensure_regular_git_dir(root)
+
+    # .git replaced by a gitdir file pointing at a session-owned repository
+    real = tmp_path / "moved.git"
+    git_dir.rename(real)
+    (root / ".git").write_text(f"gitdir: {real}\n")
+    with pytest.raises(GitError, match=r"\.git is not a directory"):
+        ws.git("status")
+    (root / ".git").unlink()
+    real.rename(git_dir)
     ensure_regular_git_dir(root)
 
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4526,6 +4526,29 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     index.unlink()
     index.write_bytes(index_bytes)
 
+    # the pack directory intact but emptied: structure passes, objects gone
+    for f in list(pack.iterdir()):
+        f.rename(elsewhere / f.name)
+    with pytest.raises(GitError, match="object store was emptied or moved"):
+        ws.git("status")
+    for f in list(elsewhere.iterdir()):
+        f.rename(pack / f.name)
+    ensure_regular_git_dir(root)
+
+    # a symlinked info/exclude would carry the wake's write elsewhere
+    info = git_dir / "info"
+    info.mkdir(exist_ok=True)
+    excl = info / "exclude"
+    excl_text = excl.read_text() if excl.exists() else ""
+    if excl.exists():
+        excl.unlink()
+    os.symlink(elsewhere / "exclude", excl)
+    with pytest.raises(GitError, match=r"\.git/info/exclude is a symlink"):
+        ws.git("status")
+    excl.unlink()
+    excl.write_text(excl_text)
+    ensure_regular_git_dir(root)
+
     # a missing HEAD
     head = git_dir / "HEAD"
     head_text = head.read_text()

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4575,19 +4575,42 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     nested.rmdir()
     ensure_regular_git_dir(root)
 
-    # HEAD's branch ref erased in a repository that has refs is not "unborn"
-    main_sha = _git(root, "rev-parse", "HEAD").strip()
-    _git(root, "branch", "keep", "HEAD")  # another ref exists, as in any clone
-    _git(root, "update-ref", "-d", "refs/heads/main")  # loose or packed, gone
-    with pytest.raises(GitError, match="HEAD names a branch whose ref is missing"):
-        ws.git("status")
-    _git(root, "update-ref", "refs/heads/main", main_sha)
+    # a crafted symbolic HEAD must not be followed outside .git (a FIFO there
+    # would hang the guard); it is refused at once
+    head_file = git_dir / "HEAD"
+    head_saved = head_file.read_text()
+    head_file.write_text("ref: ../../outside/fifo\n")
+    with pytest.raises(GitError, match="HEAD names a ref outside refs/"):
+        ensure_regular_git_dir(root)
+    head_file.write_text("garbage\n")
+    with pytest.raises(GitError, match="HEAD is malformed"):
+        ensure_regular_git_dir(root)
+    head_file.write_text(head_saved)
     ensure_regular_git_dir(root)
-    # while a genuinely fresh repository with an unborn branch still passes
+    # a genuinely fresh repository with an unborn branch passes
     fresh = tmp_path / "fresh"
     fresh.mkdir()
     _git(fresh, "init", "-q", "-b", "main")
     ensure_regular_git_dir(fresh)
+    # so does a clone whose remote HEAD names an unpushed branch (unborn local
+    # HEAD beside real remote refs) — and its object store is still verified
+    bare = tmp_path / "bare.git"
+    _git(tmp_path, "init", "-q", "--bare", "-b", "master", str(bare))
+    _git(root, "push", "-q", str(bare), "main")
+    clone = tmp_path / "clone"
+    _git(tmp_path, "clone", "-q", str(bare), str(clone))
+    ensure_regular_git_dir(clone)
+    Workspace(root=clone).git("status")
+    cpack = clone / ".git" / "objects" / "pack"
+    if cpack.is_dir():
+        for f in list(cpack.iterdir()):
+            f.rename(elsewhere / f.name)
+        for d in (clone / ".git" / "objects").iterdir():
+            if d.is_dir() and len(d.name) == 2:
+                for f in list(d.iterdir()):
+                    f.unlink()
+        with pytest.raises(GitError, match="object store was emptied or moved"):
+            ensure_regular_git_dir(clone)
 
     # a missing HEAD
     head = git_dir / "HEAD"
@@ -4607,6 +4630,37 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     (root / ".git").unlink()
     real.rename(git_dir)
     ensure_regular_git_dir(root)
+
+
+def test_a_refused_wake_ends_the_parked_run_with_the_tampering_note(tmp_path: Path) -> None:
+    from autoresearch.attempt import _end_refused_wake
+    from autoresearch.github import GitError
+    from autoresearch.runstate import load_record, save_record
+
+    run_root = tmp_path / "state"
+    record = RunRecord(
+        run_id="tsp-9",
+        target="org/pilot",
+        task_title="t",
+        benchmark="tsp",
+        state="waiting",
+        resume_session_id="s1",
+        agent_id="agent-02",
+        stage={"phase": "candidate", "base_sha": "a" * 40, "candidate_sha": "b" * 40},
+    )
+    save_record(run_root, record, 1.0)
+    out = _end_refused_wake(
+        run_root,
+        record,
+        GitError("workspace .git altered by the session: .git/objects/pack is a symlink"),
+        2.0,
+        (),
+    )
+    assert out.outcome == "attempt-error"
+    ended = load_record(run_root, "tsp-9")
+    assert ended.state == "ended" and ended.ending == "aborted"
+    assert "objects/pack is a symlink" in (ended.ending_note or "")
+    assert ended.stage == {}
 
 
 def test_without_line_memory_drops_memory_only_when_a_line_is_active() -> None:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4587,6 +4587,19 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
         ensure_regular_git_dir(root)
     head_file.write_text(head_saved)
     ensure_regular_git_dir(root)
+    # a FIFO in place of a loose object or of .git/shallow would stall git
+    fan = git_dir / "objects" / "ab"
+    fan.mkdir(exist_ok=True)
+    os.mkfifo(fan / "cdef")
+    with pytest.raises(GitError, match=r"\.git/objects/ab/cdef is not a regular file"):
+        ensure_regular_git_dir(root)
+    (fan / "cdef").unlink()
+    fan.rmdir()
+    os.mkfifo(git_dir / "shallow")
+    with pytest.raises(GitError, match=r"\.git/shallow is not a regular file"):
+        ensure_regular_git_dir(root)
+    (git_dir / "shallow").unlink()
+    ensure_regular_git_dir(root)
     # an unreadable control file (chmod 000) is tampering, never "absent"
     if os.geteuid() != 0:
         head_file.chmod(0)

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4580,6 +4580,44 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     nested.rmdir()
     ensure_regular_git_dir(root)
 
+    # packed-refs is read in full: HEAD's entry past the old 1 MB cut must
+    # still resolve (and its missing object still be caught), and an absurd
+    # file is refused rather than truncated
+    packed = git_dir / "packed-refs"
+    packed_saved = packed.read_text() if packed.exists() else None
+    head_sha = _git(root, "rev-parse", "HEAD").strip()
+    _git(root, "pack-refs", "--all")
+    lines = packed.read_text().splitlines()
+    head_line = next(ln for ln in lines if ln.endswith(" refs/heads/main"))
+    # no "sorted" header (git would binary-search and miss the tail entry);
+    # real shas for the filler so git accepts every line
+    others = [ln for ln in lines if ln != head_line and not ln.startswith("#")]
+    filler = [f"{head_sha} refs/tags/filler-{i:07d}" for i in range(30_000)]  # > 1 MB
+    packed.write_text("\n".join([*others, *filler, head_line]) + "\n")
+    assert _git(root, "rev-parse", "HEAD").strip() == head_sha
+    ensure_regular_git_dir(root)  # HEAD resolves through the tail of the file
+    for f in list(pack.iterdir()):
+        f.rename(elsewhere / f.name)
+    for d in (git_dir / "objects").iterdir():
+        if d.is_dir() and len(d.name) == 2:
+            for f in list(d.iterdir()):
+                f.rename(elsewhere / f"{d.name}{f.name}")
+    with pytest.raises(GitError, match="object store was emptied or moved"):
+        ensure_regular_git_dir(root)
+    for f in list(elsewhere.iterdir()):
+        if len(f.name) == 40 and not f.name.startswith("pack-"):
+            (git_dir / "objects" / f.name[:2]).mkdir(exist_ok=True)
+            f.rename(git_dir / "objects" / f.name[:2] / f.name[2:])
+        elif f.name.startswith("pack-"):
+            f.rename(pack / f.name)
+    packed.write_bytes(b"x" * (64 * 1024 * 1024 + 1))
+    with pytest.raises(GitError, match="packed-refs is oversized"):
+        ensure_regular_git_dir(root)
+    if packed_saved is None:
+        packed.write_text("\n".join([*others, head_line]) + "\n")
+    else:
+        packed.write_text(packed_saved)
+    ensure_regular_git_dir(root)
     # a crafted symbolic HEAD must not be followed outside .git (a FIFO there
     # would hang the guard); it is refused at once
     head_file = git_dir / "HEAD"

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4661,6 +4661,40 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     ensure_regular_git_dir(root)
 
 
+def test_snapshot_ops_refuse_a_reshaped_git_without_writing(tmp_path: Path) -> None:
+    """snapshot_tree and drop_snapshot drive git directly (their own index and
+    refs), so they check the workspace themselves: a symlinked refs dir would
+    carry a ref write or deletion outside the workspace."""
+    import os
+
+    from autoresearch.dispatch import drop_snapshot, snapshot_tree
+    from autoresearch.github import GitError, Workspace
+
+    root = tmp_path / "ws"
+    root.mkdir()
+    (root / "f.txt").write_text("x\n")
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
+    base = _git(root, "rev-parse", "HEAD").strip()
+    ws = Workspace(root=root)
+    snap = snapshot_tree(ws, base)  # a clean repo snapshots as before
+    assert _git(root, "rev-parse", snap.ref).strip() == snap.commit
+    # the session replaces refs/ with a link to a directory it controls
+    refs = root / ".git" / "refs"
+    outside = tmp_path / "outside-refs"
+    refs.rename(outside)
+    os.symlink(outside, refs)
+    with pytest.raises(GitError, match=r"\.git/refs is a symlink"):
+        snapshot_tree(ws, base)
+    drop_snapshot(ws, snap)  # logged, never raises, and never writes through the link
+    assert (outside / "dispatch" / snap.ref.rsplit("/", 1)[1]).exists()
+    os.unlink(refs)
+    outside.rename(refs)
+    drop_snapshot(ws, snap)
+    assert not (refs / "dispatch" / snap.ref.rsplit("/", 1)[1]).exists()
+
+
 def test_a_refused_wake_ends_the_parked_run_with_the_tampering_note(tmp_path: Path) -> None:
     from autoresearch.attempt import _end_refused_wake
     from autoresearch.github import GitError

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4587,6 +4587,22 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
         ensure_regular_git_dir(root)
     head_file.write_text(head_saved)
     ensure_regular_git_dir(root)
+    # an unreadable control file (chmod 000) is tampering, never "absent"
+    if os.geteuid() != 0:
+        head_file.chmod(0)
+        try:
+            with pytest.raises(GitError, match="HEAD is unreadable"):
+                ensure_regular_git_dir(root)
+        finally:
+            head_file.chmod(0o644)
+        refs_dir = git_dir / "refs"
+        refs_dir.chmod(0)
+        try:
+            with pytest.raises(GitError, match="is unreadable"):
+                ensure_regular_git_dir(root)
+        finally:
+            refs_dir.chmod(0o755)
+        ensure_regular_git_dir(root)
     # a genuinely fresh repository with an unborn branch passes
     fresh = tmp_path / "fresh"
     fresh.mkdir()

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4587,6 +4587,17 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
         ensure_regular_git_dir(root)
     head_file.write_text(head_saved)
     ensure_regular_git_dir(root)
+    # git's own split commit-graph layout is a directory under objects/info
+    graphs = git_dir / "objects" / "info" / "commit-graphs"
+    graphs.mkdir(parents=True, exist_ok=True)
+    (graphs / "graph-abc.graph").write_bytes(b"CGPH")
+    (git_dir / "objects" / "info" / "commit-graphs-chain").write_text("abc\n")
+    ensure_regular_git_dir(root)
+    os.mkfifo(graphs / "graph-fifo.graph")
+    with pytest.raises(GitError, match=r"commit-graphs/graph-fifo\.graph is not a regular file"):
+        ensure_regular_git_dir(root)
+    (graphs / "graph-fifo.graph").unlink()
+    ensure_regular_git_dir(root)
     # a FIFO in place of a loose object or of .git/shallow would stall git
     fan = git_dir / "objects" / "ab"
     fan.mkdir(exist_ok=True)

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4565,7 +4565,29 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     with pytest.raises(GitError, match=r"\.git/sneaky is a symlink"):
         ws.git("status")
     (git_dir / "sneaky").unlink()
+    # nested refs are walked: a research-line ref replaced by a link
+    nested = git_dir / "refs" / "heads" / "agents"
+    nested.mkdir(parents=True, exist_ok=True)
+    os.symlink(elsewhere / "ref", nested / "agent-01")
+    with pytest.raises(GitError, match=r"\.git/refs/heads/agents/agent-01 is a symlink"):
+        ws.git("status")
+    (nested / "agent-01").unlink()
+    nested.rmdir()
     ensure_regular_git_dir(root)
+
+    # HEAD's branch ref erased in a repository that has refs is not "unborn"
+    main_sha = _git(root, "rev-parse", "HEAD").strip()
+    _git(root, "branch", "keep", "HEAD")  # another ref exists, as in any clone
+    _git(root, "update-ref", "-d", "refs/heads/main")  # loose or packed, gone
+    with pytest.raises(GitError, match="HEAD names a branch whose ref is missing"):
+        ws.git("status")
+    _git(root, "update-ref", "refs/heads/main", main_sha)
+    ensure_regular_git_dir(root)
+    # while a genuinely fresh repository with an unborn branch still passes
+    fresh = tmp_path / "fresh"
+    fresh.mkdir()
+    _git(fresh, "init", "-q", "-b", "main")
+    ensure_regular_git_dir(fresh)
 
     # a missing HEAD
     head = git_dir / "HEAD"

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4466,6 +4466,52 @@ def test_changed_paths_ignore_files_a_stale_line_merge_brought_to_base(tmp_path:
     assert _paths_changed_from_base(ws, base_sha, True) == []
 
 
+def test_a_session_that_symlinks_the_object_store_is_refused_with_a_plain_note(
+    tmp_path: Path,
+) -> None:
+    """2026-09-03: an author copied .git/objects/pack into the container's /tmp
+    and symlinked it, leaving the kernel's git with refs and no objects. The
+    kernel must name the tampering instead of failing on a later git call."""
+    import os
+
+    from autoresearch.attempt import _paths_changed_from_base
+    from autoresearch.github import GitError, Workspace, ensure_regular_git_dir
+
+    root = tmp_path / "ws"
+    root.mkdir()
+    (root / "train.py").write_text("v1\n")
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
+    base = _git(root, "rev-parse", "HEAD").strip()
+    ensure_regular_git_dir(root)  # a clean clone passes
+    # the session's move: pack files into a private tmp, a symlink left behind
+    pack = root / ".git" / "objects" / "pack"
+    _git(root, "gc", "-q")  # make sure a pack dir with content exists
+    elsewhere = tmp_path / "private-tmp"
+    elsewhere.mkdir()
+    for f in pack.iterdir():
+        f.rename(elsewhere / f.name)
+    pack.rmdir()
+    os.symlink(elsewhere, pack)
+    with pytest.raises(GitError, match=r"altered by the session: \.git/objects/pack is a symlink"):
+        ensure_regular_git_dir(root)
+    with pytest.raises(GitError, match="altered by the session"):
+        _paths_changed_from_base(Workspace(root=root), base, False)
+    # other plumbing is covered too
+    os.unlink(pack)
+    pack.mkdir()
+    head = root / ".git" / "HEAD"
+    head_text = head.read_text()
+    head.unlink()
+    os.symlink(elsewhere / "nope", head)
+    with pytest.raises(GitError, match=r"\.git/HEAD is a symlink"):
+        ensure_regular_git_dir(root)
+    head.unlink()
+    head.write_text(head_text)
+    ensure_regular_git_dir(root)
+
+
 def test_without_line_memory_drops_memory_only_when_a_line_is_active() -> None:
     from autoresearch.attempt import _without_line_memory
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4572,6 +4572,11 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     with pytest.raises(GitError, match=r"\.git/refs/heads/agents/agent-01 is a symlink"):
         ws.git("status")
     (nested / "agent-01").unlink()
+    # and a FIFO where a loose ref was
+    os.mkfifo(nested / "agent-02")
+    with pytest.raises(GitError, match=r"\.git/refs/heads/agents/agent-02 is not a regular file"):
+        ws.git("status")
+    (nested / "agent-02").unlink()
     nested.rmdir()
     ensure_regular_git_dir(root)
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4549,6 +4549,24 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     excl.write_text(excl_text)
     ensure_regular_git_dir(root)
 
+    # a symlinked reflog would carry the kernel's next commit record elsewhere
+    logs_head = git_dir / "logs" / "HEAD"
+    logs_head.parent.mkdir(exist_ok=True)
+    logs_text = logs_head.read_text() if logs_head.exists() else ""
+    if logs_head.exists():
+        logs_head.unlink()
+    os.symlink(elsewhere / "reflog", logs_head)
+    with pytest.raises(GitError, match=r"\.git/logs/HEAD is a symlink"):
+        ws.git("status")
+    logs_head.unlink()
+    logs_head.write_text(logs_text)
+    # and no symlink anywhere among .git's direct entries either
+    os.symlink(elsewhere, git_dir / "sneaky")
+    with pytest.raises(GitError, match=r"\.git/sneaky is a symlink"):
+        ws.git("status")
+    (git_dir / "sneaky").unlink()
+    ensure_regular_git_dir(root)
+
     # a missing HEAD
     head = git_dir / "HEAD"
     head_text = head.read_text()

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4704,6 +4704,24 @@ def test_a_session_that_reshapes_git_is_refused_with_a_plain_note(tmp_path: Path
     head.write_text(head_text)
     ensure_regular_git_dir(root)
 
+    # a reftable repository is not one the kernel made; its refs live in
+    # .git/reftable/ where none of the ref reads would see them
+    (git_dir / "reftable").mkdir()
+    with pytest.raises(GitError, match="reftable"):
+        ensure_regular_git_dir(root)
+    (git_dir / "reftable").rmdir()
+    rt = tmp_path / "reftable-repo"
+    rt.mkdir()
+    init = subprocess.run(
+        ["git", "init", "-q", "-b", "main", "--ref-format=reftable", str(rt)],
+        capture_output=True,
+        text=True,
+    )
+    if init.returncode == 0 and (rt / ".git" / "reftable").exists():  # git >= 2.45
+        with pytest.raises(GitError, match="reftable"):
+            ensure_regular_git_dir(rt)
+    ensure_regular_git_dir(root)
+
     # .git replaced by a gitdir file pointing at a session-owned repository
     real = tmp_path / "moved.git"
     git_dir.rename(real)


### PR DESCRIPTION
gpt-speedrun, 2026-09-03 12:33Z: `speedrun-20260903-123051-agent-01` ended attempt-error, "git reset failed: fatal: Could not parse object 'HEAD'". The workspace had every ref and no objects. The transcript shows why: while checking disk usage, the codex author ran

```
mkdir -p /tmp/agent-01-git-pack
cp .git/objects/pack/* /tmp/agent-01-git-pack/
rm -rf .git/objects/pack
ln -s /tmp/agent-01-git-pack .git/objects/pack
```

Apptainer gives the session a private /tmp, so the kernel's git on the host saw refs pointing at nothing.

Fix: `ensure_regular_git_dir(root)` refuses a workspace whose `.git`, or its `objects`, `objects/pack`, `refs`, `HEAD`, `index`, `config`, is a symlink, or whose object store / refs are not directories, raising `GitError("workspace .git altered by the session: …")`. It runs at the first kernel git op after a session (`_paths_changed_from_base`), before a line seal, and in `git_network` alongside the existing config sanitizer. The run still ends (the tree cannot be trusted), but with a note that says what happened.

Test: a real repo with its pack dir moved out and symlinked, and a symlinked HEAD; a clean repo passes.
