### PR TITLE
Tick runs with uv run --no-sync: a failed deploy sync no longer stops the tick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- The tick runs the deployed environment as it stands (`uv run --no-sync`).
+  A failed `uv sync` at deploy time (a full quota, a network outage) used to
+  be repeated by `uv run` itself, so no tick started at all; now the tick
+  continues on the previous environment, as the deploy step always promised.
+  (2026-09-03: every tick from 13:30Z died this way for two hours after the
+  scratch quota filled.)
 - A line snapshot now builds on a newer remote version of the line instead
   of being skipped when another run on the same line pushed while this run
   was parked. Files the other run added, changed, or deleted that this run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- The tick runs the deployed environment as it stands (`uv run --no-sync`).
-  A failed `uv sync` at deploy time (a full quota, a network outage) used to
-  be repeated by `uv run` itself, so no tick started at all; now the tick
-  continues on the previous environment, as the deploy step always promised.
+- The tick runs the installed environment as it stands (`uv run --no-sync`),
+  and the deploy moves code and environment together: when `uv sync` fails
+  (a full quota, a network outage) the checkout goes back to the commit whose
+  environment is installed. Before, `uv run` repeated the failed sync and no
+  tick started at all.
   (2026-09-03: every tick from 13:30Z died this way for two hours after the
   scratch quota filled.)
 - A line snapshot now builds on a newer remote version of the line instead

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ Versions follow [SemVer](https://semver.org).
 ### Fixed
 
 - The tick runs the installed environment as it stands (`uv run --no-sync`),
-  and the deploy moves code and environment together: when `uv sync` fails
-  (a full quota, a network outage) the checkout goes back to the commit whose
-  environment is installed. Before, `uv run` repeated the failed sync and no
-  tick started at all.
+  so a failed `uv sync` at deploy time no longer stops it. When a fetched
+  commit's `uv.lock` is unchanged, the tick runs the new code on the existing
+  environment; when the lockfile changed and the sync failed, the deploy
+  rolls back to the previous commit and reinstalls its environment, skipping
+  the tick only if that cannot be made consistent. Before, `uv run` repeated
+  the failed sync and no tick started at all (2026-09-03: the scratch quota
+  filled and every tick died this way for two hours).
   (2026-09-03: every tick from 13:30Z died this way for two hours after the
   scratch quota filled.)
 - A line snapshot now builds on a newer remote version of the line instead

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -128,4 +128,9 @@ cd "$AUTORESEARCH_HOME"
 # The tick keeps AUTORESEARCH_PAT_FILE: it reads GitHub (PR states, review
 # comments) and submits follow-up jobs. Agent sessions remain scrubbed by the
 # harness env allowlist regardless.
-exec uv run python -m autoresearch.tick --root "$AUTORESEARCH_ROOT"
+# --no-sync: the deploy step above already synced (or logged its failure);
+# a bare `uv run` would sync AGAIN and, when that fails — a full quota,
+# 2026-09-03: every tick from 13:30Z died here for two hours — the tick never
+# starts. Running the venv as it stands is the "continue on the previous
+# code" the deploy promises.
+exec uv run --no-sync python -m autoresearch.tick --root "$AUTORESEARCH_ROOT"

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -133,4 +133,8 @@ cd "$AUTORESEARCH_HOME"
 # 2026-09-03: every tick from 13:30Z died here for two hours — the tick never
 # starts. Running the venv as it stands is the "continue on the previous
 # code" the deploy promises.
+if [ "${AUTORESEARCH_DEPLOY_BROKEN:-}" = "1" ]; then
+    echo "tick skipped: checkout and environment inconsistent after a failed deploy"
+    exit 0  # successors are already queued; the next deploy retries
+fi
 exec uv run --no-sync python -m autoresearch.tick --root "$AUTORESEARCH_ROOT"

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -40,15 +40,23 @@ mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
 # checkout goes BACK to the commit whose environment is installed: new code
 # never runs against an old venv (a merge that adds a dependency would fail
 # at import), and the tick keeps running on the previous, consistent pair.
+# AUTORESEARCH_DEPLOY_BROKEN=1 tells the caller NOT to run the tick this
+# iteration: the checkout and the installed environment do not match and
+# could not be made to (the rollback itself failed). Cleared on every deploy.
+AUTORESEARCH_DEPLOY_BROKEN=""
 if ! (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
     if [ -n "${DEPLOY_PREV:-}" ] && [ "$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD 2>/dev/null)" != "$DEPLOY_PREV" ]; then
-        git -C "$AUTORESEARCH_HOME" reset --hard --quiet "$DEPLOY_PREV" \
-            && echo "deploy: uv sync failed; back on $DEPLOY_PREV with its environment" \
-            || echo "deploy: uv sync failed and the rollback to $DEPLOY_PREV failed"
+        if git -C "$AUTORESEARCH_HOME" reset --hard --quiet "$DEPLOY_PREV"; then
+            echo "deploy: uv sync failed; back on $DEPLOY_PREV with its environment"
+        else
+            echo "deploy: uv sync failed and the rollback to $DEPLOY_PREV failed; tick skipped until a deploy succeeds"
+            AUTORESEARCH_DEPLOY_BROKEN=1
+        fi
     else
         echo "deploy: uv sync failed; environment unchanged"
     fi
 fi
+export AUTORESEARCH_DEPLOY_BROKEN
 
 # --- config knobs: read the config-driven AUTHOR knobs from the operator .env so
 # live config changes need no chain restart. These are where

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -47,7 +47,15 @@ AUTORESEARCH_DEPLOY_BROKEN=""
 if ! (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
     if [ -n "${DEPLOY_PREV:-}" ] && [ "$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD 2>/dev/null)" != "$DEPLOY_PREV" ]; then
         if git -C "$AUTORESEARCH_HOME" reset --hard --quiet "$DEPLOY_PREV"; then
-            echo "deploy: uv sync failed; back on $DEPLOY_PREV with its environment"
+            # the failed sync may have already removed packages the old code
+            # needs (an exact sync prunes before it installs): restore the OLD
+            # commit's environment too, or skip the tick until a deploy succeeds
+            if (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
+                echo "deploy: uv sync failed; back on $DEPLOY_PREV with its environment"
+            else
+                echo "deploy: uv sync failed; back on $DEPLOY_PREV but its environment could not be restored; tick skipped until a deploy succeeds"
+                AUTORESEARCH_DEPLOY_BROKEN=1
+            fi
         else
             echo "deploy: uv sync failed and the rollback to $DEPLOY_PREV failed; tick skipped until a deploy succeeds"
             AUTORESEARCH_DEPLOY_BROKEN=1

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -18,6 +18,7 @@ bash "$AUTORESEARCH_HOME/scripts/sweep_git_locks.sh" "$AUTORESEARCH_HOME" 10 || 
 if [ -n "${AUTORESEARCH_PAT_FILE:-}" ] && [ -r "$AUTORESEARCH_PAT_FILE" ]; then
     ASKPASS=$(mktemp 2>/dev/null || echo "") && [ -n "$ASKPASS" ] && chmod 700 "$ASKPASS"
     printf '#!/bin/sh\ncat "%s"\n' "$AUTORESEARCH_PAT_FILE" > "$ASKPASS"
+    DEPLOY_PREV=$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD 2>/dev/null || echo "")
     if GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 git -C "$AUTORESEARCH_HOME" fetch --quiet \
         "https://x-access-token@github.com/agentic-learning-ai-lab/autoresearch.git" main; then
         git -C "$AUTORESEARCH_HOME" reset --hard --quiet FETCH_HEAD || echo "deploy: reset failed"
@@ -34,9 +35,20 @@ export UV_CACHE_DIR="${UV_CACHE_DIR:-$AUTORESEARCH_ROOT/cache/uv}"
 export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-$AUTORESEARCH_ROOT/cache/apptainer}"
 mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
 
-# the tick runs with `uv run --no-sync` afterwards, so a failed sync here
-# (quota, network) leaves the previous venv in service instead of no tick
-(cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet) || echo "deploy: uv sync failed"
+# Code and environment move together or not at all. The tick runs with
+# `uv run --no-sync` afterwards, so when the sync fails (quota, network) the
+# checkout goes BACK to the commit whose environment is installed: new code
+# never runs against an old venv (a merge that adds a dependency would fail
+# at import), and the tick keeps running on the previous, consistent pair.
+if ! (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
+    if [ -n "${DEPLOY_PREV:-}" ] && [ "$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD 2>/dev/null)" != "$DEPLOY_PREV" ]; then
+        git -C "$AUTORESEARCH_HOME" reset --hard --quiet "$DEPLOY_PREV" \
+            && echo "deploy: uv sync failed; back on $DEPLOY_PREV with its environment" \
+            || echo "deploy: uv sync failed and the rollback to $DEPLOY_PREV failed"
+    else
+        echo "deploy: uv sync failed; environment unchanged"
+    fi
+fi
 
 # --- config knobs: read the config-driven AUTHOR knobs from the operator .env so
 # live config changes need no chain restart. These are where

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -34,6 +34,8 @@ export UV_CACHE_DIR="${UV_CACHE_DIR:-$AUTORESEARCH_ROOT/cache/uv}"
 export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-$AUTORESEARCH_ROOT/cache/apptainer}"
 mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
 
+# the tick runs with `uv run --no-sync` afterwards, so a failed sync here
+# (quota, network) leaves the previous venv in service instead of no tick
 (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet) || echo "deploy: uv sync failed"
 
 # --- config knobs: read the config-driven AUTHOR knobs from the operator .env so

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -45,23 +45,33 @@ mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
 # could not be made to (the rollback itself failed). Cleared on every deploy.
 AUTORESEARCH_DEPLOY_BROKEN=""
 if ! (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
-    if [ -n "${DEPLOY_PREV:-}" ] && [ "$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD 2>/dev/null)" != "$DEPLOY_PREV" ]; then
-        if git -C "$AUTORESEARCH_HOME" reset --hard --quiet "$DEPLOY_PREV"; then
-            # the failed sync may have already removed packages the old code
-            # needs (an exact sync prunes before it installs): restore the OLD
-            # commit's environment too, or skip the tick until a deploy succeeds
-            if (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
-                echo "deploy: uv sync failed; back on $DEPLOY_PREV with its environment"
-            else
-                echo "deploy: uv sync failed; back on $DEPLOY_PREV but its environment could not be restored; tick skipped until a deploy succeeds"
-                AUTORESEARCH_DEPLOY_BROKEN=1
-            fi
+    NEW_HEAD=$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD 2>/dev/null || echo "")
+    if [ -z "${DEPLOY_PREV:-}" ] || [ "$NEW_HEAD" = "$DEPLOY_PREV" ]; then
+        # nothing was fetched: the environment is whatever the last good
+        # deploy installed, and the checkout still matches it
+        echo "deploy: uv sync failed; environment unchanged"
+    elif [ -n "$NEW_HEAD" ] \
+        && [ "$(git -C "$AUTORESEARCH_HOME" rev-parse "$DEPLOY_PREV":uv.lock 2>/dev/null)" \
+           = "$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD:uv.lock 2>/dev/null)" ]; then
+        # the lockfile did not change between the old and new commit, so the
+        # installed environment already satisfies the new code: run it. This
+        # is the common case under quota exhaustion — an ordinary merge does
+        # not touch uv.lock — and it keeps the tick alive (2026-09-03: the
+        # scratch quota filled and every tick died here for two hours).
+        echo "deploy: uv sync failed but uv.lock is unchanged; running new code on the current environment"
+    else
+        # dependencies changed and could not be installed; the partial sync
+        # may have altered the environment, so go back to the previous commit
+        # and reinstall ITS environment. If that also fails (the quota is
+        # still full), the pair cannot be made consistent — skip the tick
+        # until a deploy succeeds rather than run on a half-synced venv.
+        if git -C "$AUTORESEARCH_HOME" reset --hard --quiet "$DEPLOY_PREV" \
+           && (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
+            echo "deploy: uv sync failed; back on $DEPLOY_PREV with its environment"
         else
-            echo "deploy: uv sync failed and the rollback to $DEPLOY_PREV failed; tick skipped until a deploy succeeds"
+            echo "deploy: uv sync failed and the environment could not be made consistent; tick skipped until a deploy succeeds"
             AUTORESEARCH_DEPLOY_BROKEN=1
         fi
-    else
-        echo "deploy: uv sync failed; environment unchanged"
     fi
 fi
 export AUTORESEARCH_DEPLOY_BROKEN

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -135,8 +135,12 @@ while :; do
         fi
     fi
     echo "=== tick $(date -Is) on $(hostname -s) job=${self:-none} (resident)"
+    if [ "${AUTORESEARCH_DEPLOY_BROKEN:-}" = "1" ]; then
+        echo "$(date -u +%FT%TZ) tick skipped: checkout and environment inconsistent after a failed deploy (resident)"
+    else
     (cd "$AUTORESEARCH_HOME" && timeout --kill-after=60s "$tick_timeout" \
         uv run --no-sync python -m autoresearch.tick --root "$AUTORESEARCH_ROOT")
+    fi
     rc=$?
     [ "$rc" -ne 0 ] && echo "resident: tick exited $rc; the loop continues"
     # sleep to the next slot, but never past the walltime margin: the loop

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -136,7 +136,7 @@ while :; do
     fi
     echo "=== tick $(date -Is) on $(hostname -s) job=${self:-none} (resident)"
     (cd "$AUTORESEARCH_HOME" && timeout --kill-after=60s "$tick_timeout" \
-        uv run python -m autoresearch.tick --root "$AUTORESEARCH_ROOT")
+        uv run --no-sync python -m autoresearch.tick --root "$AUTORESEARCH_ROOT")
     rc=$?
     [ "$rc" -ne 0 ] && echo "resident: tick exited $rc; the loop continues"
     # sleep to the next slot, but never past the walltime margin: the loop

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -302,10 +302,10 @@ def test_the_tick_runs_the_installed_environment_without_resyncing(tmp_path: Pat
     assert all(ln.startswith("run --no-sync python -m autoresearch.tick") for ln in runs), runs
 
 
-def test_a_failed_sync_rolls_the_checkout_back_to_the_installed_commit(tmp_path: Path) -> None:
-    """The deploy resets the checkout to the fetched commit and then syncs;
-    when the sync fails the checkout returns to the previous commit, so the
-    `--no-sync` tick never runs new source against the old environment."""
+def test_a_failed_sync_rolls_back_when_dependencies_changed(tmp_path: Path) -> None:
+    """A merge that changes uv.lock whose sync fails: the checkout returns to
+    the previous commit and that commit's environment is reinstalled, so the
+    `--no-sync` tick never runs new source against a half-synced venv."""
     home = tmp_path / "home"
     (home / "scripts").mkdir(parents=True)
     for name in ("tick_deploy.sh", "sweep_git_locks.sh"):
@@ -317,11 +317,13 @@ def test_a_failed_sync_rolls_the_checkout_back_to_the_installed_commit(tmp_path:
     log = tmp_path / "gitlog"
     pat = tmp_path / "pat"
     pat.write_text("token\n")
-    # git: HEAD is OLD before the fetch and NEW after the reset to FETCH_HEAD
+    # locks DIFFER between OLD and HEAD -> the deploy must roll back
     (bindir / "git").write_text(
         f"""#!/bin/sh
 echo "$@" >> "{log}"
 case "$*" in
+  *"rev-parse OLD:uv.lock"*) echo lockOLD ;;
+  *"rev-parse HEAD:uv.lock"*) echo lockNEW ;;
   *"rev-parse HEAD"*) if [ -f "{tmp_path}/reset" ]; then echo NEW; else echo OLD; fi ;;
   *"reset --hard --quiet FETCH_HEAD"*) touch "{tmp_path}/reset" ;;
   *"reset --hard --quiet OLD"*) rm -f "{tmp_path}/reset" ;;
@@ -329,7 +331,6 @@ esac
 exit 0
 """
     )
-    # the sync for NEW fails; the sync for OLD (after the rollback) succeeds
     syncs = tmp_path / "syncs"
     (bindir / "uv").write_text(
         f'#!/bin/sh\ncase "$1" in sync) echo x >> "{syncs}"; '
@@ -359,15 +360,11 @@ exit 0
         timeout=60,
     )
     assert proc.returncode == 0, proc.stderr
-    assert "deploy: uv sync failed; back on OLD with its environment" in proc.stdout
-    assert "BROKEN=\n" in proc.stdout  # the old pair is whole again: the tick runs
-    assert syncs.read_text().count("x") == 2  # NEW's sync, then OLD's
+    assert "back on OLD with its environment" in proc.stdout
+    assert "BROKEN=\n" in proc.stdout  # consistent again: the tick runs
     gitlog = log.read_text()
-    assert "reset --hard --quiet FETCH_HEAD" in gitlog
-    assert gitlog.index("reset --hard --quiet FETCH_HEAD") < gitlog.index(
-        "reset --hard --quiet OLD"
-    )
-    assert not (tmp_path / "reset").exists()  # the checkout is back on OLD
+    assert "reset --hard --quiet OLD" in gitlog
+    assert syncs.read_text().count("x") == 2  # NEW's sync, then OLD's
 
 
 def test_a_failed_rollback_marks_the_deploy_broken_so_no_tick_runs(tmp_path: Path) -> None:
@@ -387,6 +384,8 @@ def test_a_failed_rollback_marks_the_deploy_broken_so_no_tick_runs(tmp_path: Pat
     (bindir / "git").write_text(
         f"""#!/bin/sh
 case "$*" in
+  *"rev-parse OLD:uv.lock"*) echo lockOLD ;;
+  *"rev-parse HEAD:uv.lock"*) echo lockNEW ;;
   *"rev-parse HEAD"*) if [ -f "{tmp_path}/reset" ]; then echo NEW; else echo OLD; fi ;;
   *"reset --hard --quiet FETCH_HEAD"*) touch "{tmp_path}/reset" ;;
   *"reset --hard --quiet OLD"*) exit 1 ;;
@@ -397,8 +396,6 @@ exit 0
     (bindir / "uv").write_text('#!/bin/sh\ncase "$1" in sync) exit 2 ;; esac\nexit 0\n')
     for p in bindir.iterdir():
         os.chmod(p, 0o755)
-    # (the same shim, with a git whose rollback fails, is exercised below; a
-    # rollback that succeeds but whose re-sync fails is the case right after)
     env = {
         **os.environ,
         "PATH": f"{bindir}:{os.environ['PATH']}",
@@ -419,7 +416,7 @@ exit 0
         timeout=60,
     )
     assert proc.returncode == 0, proc.stderr
-    assert "rollback to OLD failed; tick skipped" in proc.stdout
+    assert "environment could not be made consistent; tick skipped" in proc.stdout
     assert "BROKEN=1" in proc.stdout
     # and the chain honours it: no tick, successors untouched, clean exit
     shim = (ROOT / "scripts" / "tick_chain.sbatch").read_text()
@@ -428,12 +425,11 @@ exit 0
     assert 'AUTORESEARCH_DEPLOY_BROKEN:-}" = "1"' in resident and "tick skipped" in resident
 
 
-def test_a_rollback_whose_environment_cannot_be_restored_marks_the_deploy_broken(
-    tmp_path: Path,
-) -> None:
-    """The checkout goes back, but every sync fails (the quota is still
-    full): the old code's environment may already be pruned, so the tick is
-    skipped rather than run on it."""
+def test_a_failed_sync_with_unchanged_lock_keeps_ticking_on_the_current_env(tmp_path: Path) -> None:
+    """The 2026-09-03 quota case: a new commit whose uv.lock is identical to
+    the previous one, sync fails on the full disk. The installed environment
+    already satisfies the new code, so the deploy neither rolls back nor
+    marks itself broken — the tick runs."""
     home = tmp_path / "home"
     (home / "scripts").mkdir(parents=True)
     for name in ("tick_deploy.sh", "sweep_git_locks.sh"):
@@ -442,14 +438,17 @@ def test_a_rollback_whose_environment_cannot_be_restored_marks_the_deploy_broken
     root.mkdir()
     bindir = tmp_path / "bin"
     bindir.mkdir()
+    log = tmp_path / "gitlog"
     pat = tmp_path / "pat"
     pat.write_text("token\n")
     (bindir / "git").write_text(
         f"""#!/bin/sh
+echo "$@" >> "{log}"
 case "$*" in
+  *"rev-parse OLD:uv.lock"*) echo samelock ;;
+  *"rev-parse HEAD:uv.lock"*) echo samelock ;;
   *"rev-parse HEAD"*) if [ -f "{tmp_path}/reset" ]; then echo NEW; else echo OLD; fi ;;
   *"reset --hard --quiet FETCH_HEAD"*) touch "{tmp_path}/reset" ;;
-  *"reset --hard --quiet OLD"*) rm -f "{tmp_path}/reset" ;;
 esac
 exit 0
 """
@@ -477,6 +476,6 @@ exit 0
         timeout=60,
     )
     assert proc.returncode == 0, proc.stderr
-    assert "environment could not be restored; tick skipped" in proc.stdout
-    assert "BROKEN=1" in proc.stdout
-    assert not (tmp_path / "reset").exists()  # the checkout is on OLD
+    assert "uv.lock is unchanged; running new code on the current environment" in proc.stdout
+    assert "BROKEN=\n" in proc.stdout
+    assert "reset --hard --quiet OLD" not in log.read_text()  # no rollback: HEAD kept

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -40,6 +40,7 @@ def _install(tmp_path: Path) -> tuple[Path, Path, Path, Path]:
         # uv: `sync` is a no-op; `run ... tick` is the fake tick — it counts
         # its calls, appends to the shim on the 2nd call, sets PAUSE on the 3rd
         "uv": f'''#!/bin/sh
+echo "$@" >> "{shimlog}/uv"
 case "$1" in
   sync) exit 0 ;;
   run)
@@ -287,3 +288,73 @@ def test_a_misconfigured_resident_start_fails_loudly_before_queuing_anything(
     assert proc.returncode == 1
     assert "resident tick misconfigured; missing: AUTORESEARCH_ROOT" in proc.stderr
     assert not (shimlog / "sbatch").exists() and not (shimlog / "ticks").exists()
+
+
+def test_the_tick_runs_the_installed_environment_without_resyncing(tmp_path: Path) -> None:
+    """Every tick invocation is `uv run --no-sync ...`: the deploy step owns
+    syncing, so a sync that fails (a full quota, 2026-09-03) cannot stop the
+    tick from starting on the environment that is installed."""
+    home, root, bindir, shimlog = _install(tmp_path)
+    proc = _run_chain(home, _resident_env(home, root, bindir))
+    assert proc.returncode == 0, proc.stderr
+    runs = [ln for ln in (shimlog / "uv").read_text().splitlines() if ln.startswith("run ")]
+    assert runs, "no tick was run"
+    assert all(ln.startswith("run --no-sync python -m autoresearch.tick") for ln in runs), runs
+
+
+def test_a_failed_sync_rolls_the_checkout_back_to_the_installed_commit(tmp_path: Path) -> None:
+    """The deploy resets the checkout to the fetched commit and then syncs;
+    when the sync fails the checkout returns to the previous commit, so the
+    `--no-sync` tick never runs new source against the old environment."""
+    home = tmp_path / "home"
+    (home / "scripts").mkdir(parents=True)
+    for name in ("tick_deploy.sh", "sweep_git_locks.sh"):
+        (home / "scripts" / name).write_text((ROOT / "scripts" / name).read_text())
+    root = tmp_path / "root"
+    root.mkdir()
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    log = tmp_path / "gitlog"
+    pat = tmp_path / "pat"
+    pat.write_text("token\n")
+    # git: HEAD is OLD before the fetch and NEW after the reset to FETCH_HEAD
+    (bindir / "git").write_text(
+        f"""#!/bin/sh
+echo "$@" >> "{log}"
+case "$*" in
+  *"rev-parse HEAD"*) if [ -f "{tmp_path}/reset" ]; then echo NEW; else echo OLD; fi ;;
+  *"reset --hard --quiet FETCH_HEAD"*) touch "{tmp_path}/reset" ;;
+  *"reset --hard --quiet OLD"*) rm -f "{tmp_path}/reset" ;;
+esac
+exit 0
+"""
+    )
+    (bindir / "uv").write_text(
+        '#!/bin/sh\ncase "$1" in sync) echo "error: Disk quota exceeded" >&2; exit 2 ;; esac\n'
+        "exit 0\n"
+    )
+    for p in bindir.iterdir():
+        os.chmod(p, 0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AUTORESEARCH_HOME": str(home),
+        "AUTORESEARCH_ROOT": str(root),
+        "AUTORESEARCH_PAT_FILE": str(pat),
+        "HOME": str(tmp_path),
+    }
+    proc = subprocess.run(
+        ["bash", "-c", f'. "{home}/scripts/tick_deploy.sh"'],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "deploy: uv sync failed; back on OLD" in proc.stdout
+    gitlog = log.read_text()
+    assert "reset --hard --quiet FETCH_HEAD" in gitlog
+    assert gitlog.index("reset --hard --quiet FETCH_HEAD") < gitlog.index(
+        "reset --hard --quiet OLD"
+    )
+    assert not (tmp_path / "reset").exists()  # the checkout is back on OLD

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -358,3 +358,59 @@ exit 0
         "reset --hard --quiet OLD"
     )
     assert not (tmp_path / "reset").exists()  # the checkout is back on OLD
+
+
+def test_a_failed_rollback_marks_the_deploy_broken_so_no_tick_runs(tmp_path: Path) -> None:
+    """When the sync fails AND the reset back to the previous commit fails,
+    the deploy exports AUTORESEARCH_DEPLOY_BROKEN=1 and the tick callers skip
+    the tick: new source must never run against the old environment."""
+    home = tmp_path / "home"
+    (home / "scripts").mkdir(parents=True)
+    for name in ("tick_deploy.sh", "sweep_git_locks.sh"):
+        (home / "scripts" / name).write_text((ROOT / "scripts" / name).read_text())
+    root = tmp_path / "root"
+    root.mkdir()
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    pat = tmp_path / "pat"
+    pat.write_text("token\n")
+    (bindir / "git").write_text(
+        f"""#!/bin/sh
+case "$*" in
+  *"rev-parse HEAD"*) if [ -f "{tmp_path}/reset" ]; then echo NEW; else echo OLD; fi ;;
+  *"reset --hard --quiet FETCH_HEAD"*) touch "{tmp_path}/reset" ;;
+  *"reset --hard --quiet OLD"*) exit 1 ;;
+esac
+exit 0
+"""
+    )
+    (bindir / "uv").write_text('#!/bin/sh\ncase "$1" in sync) exit 2 ;; esac\nexit 0\n')
+    for p in bindir.iterdir():
+        os.chmod(p, 0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AUTORESEARCH_HOME": str(home),
+        "AUTORESEARCH_ROOT": str(root),
+        "AUTORESEARCH_PAT_FILE": str(pat),
+        "HOME": str(tmp_path),
+    }
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$AUTORESEARCH_DEPLOY_BROKEN"',
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "rollback to OLD failed; tick skipped" in proc.stdout
+    assert "BROKEN=1" in proc.stdout
+    # and the chain honours it: no tick, successors untouched, clean exit
+    shim = (ROOT / "scripts" / "tick_chain.sbatch").read_text()
+    assert 'AUTORESEARCH_DEPLOY_BROKEN:-}" = "1"' in shim and "tick skipped" in shim
+    resident = (ROOT / "scripts" / "tick_resident.sh").read_text()
+    assert 'AUTORESEARCH_DEPLOY_BROKEN:-}" = "1"' in resident and "tick skipped" in resident

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -329,8 +329,12 @@ esac
 exit 0
 """
     )
+    # the sync for NEW fails; the sync for OLD (after the rollback) succeeds
+    syncs = tmp_path / "syncs"
     (bindir / "uv").write_text(
-        '#!/bin/sh\ncase "$1" in sync) echo "error: Disk quota exceeded" >&2; exit 2 ;; esac\n'
+        f'#!/bin/sh\ncase "$1" in sync) echo x >> "{syncs}"; '
+        f'[ "$(wc -l < "{syncs}" | tr -d " ")" -eq 1 ] && '
+        '{ echo "error: Disk quota exceeded" >&2; exit 2; } ;; esac\n'
         "exit 0\n"
     )
     for p in bindir.iterdir():
@@ -344,14 +348,20 @@ exit 0
         "HOME": str(tmp_path),
     }
     proc = subprocess.run(
-        ["bash", "-c", f'. "{home}/scripts/tick_deploy.sh"'],
+        [
+            "bash",
+            "-c",
+            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$AUTORESEARCH_DEPLOY_BROKEN"',
+        ],
         env=env,
         capture_output=True,
         text=True,
         timeout=60,
     )
     assert proc.returncode == 0, proc.stderr
-    assert "deploy: uv sync failed; back on OLD" in proc.stdout
+    assert "deploy: uv sync failed; back on OLD with its environment" in proc.stdout
+    assert "BROKEN=\n" in proc.stdout  # the old pair is whole again: the tick runs
+    assert syncs.read_text().count("x") == 2  # NEW's sync, then OLD's
     gitlog = log.read_text()
     assert "reset --hard --quiet FETCH_HEAD" in gitlog
     assert gitlog.index("reset --hard --quiet FETCH_HEAD") < gitlog.index(
@@ -387,6 +397,8 @@ exit 0
     (bindir / "uv").write_text('#!/bin/sh\ncase "$1" in sync) exit 2 ;; esac\nexit 0\n')
     for p in bindir.iterdir():
         os.chmod(p, 0o755)
+    # (the same shim, with a git whose rollback fails, is exercised below; a
+    # rollback that succeeds but whose re-sync fails is the case right after)
     env = {
         **os.environ,
         "PATH": f"{bindir}:{os.environ['PATH']}",
@@ -414,3 +426,57 @@ exit 0
     assert 'AUTORESEARCH_DEPLOY_BROKEN:-}" = "1"' in shim and "tick skipped" in shim
     resident = (ROOT / "scripts" / "tick_resident.sh").read_text()
     assert 'AUTORESEARCH_DEPLOY_BROKEN:-}" = "1"' in resident and "tick skipped" in resident
+
+
+def test_a_rollback_whose_environment_cannot_be_restored_marks_the_deploy_broken(
+    tmp_path: Path,
+) -> None:
+    """The checkout goes back, but every sync fails (the quota is still
+    full): the old code's environment may already be pruned, so the tick is
+    skipped rather than run on it."""
+    home = tmp_path / "home"
+    (home / "scripts").mkdir(parents=True)
+    for name in ("tick_deploy.sh", "sweep_git_locks.sh"):
+        (home / "scripts" / name).write_text((ROOT / "scripts" / name).read_text())
+    root = tmp_path / "root"
+    root.mkdir()
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    pat = tmp_path / "pat"
+    pat.write_text("token\n")
+    (bindir / "git").write_text(
+        f"""#!/bin/sh
+case "$*" in
+  *"rev-parse HEAD"*) if [ -f "{tmp_path}/reset" ]; then echo NEW; else echo OLD; fi ;;
+  *"reset --hard --quiet FETCH_HEAD"*) touch "{tmp_path}/reset" ;;
+  *"reset --hard --quiet OLD"*) rm -f "{tmp_path}/reset" ;;
+esac
+exit 0
+"""
+    )
+    (bindir / "uv").write_text('#!/bin/sh\ncase "$1" in sync) exit 2 ;; esac\nexit 0\n')
+    for p in bindir.iterdir():
+        os.chmod(p, 0o755)
+    env = {
+        **os.environ,
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "AUTORESEARCH_HOME": str(home),
+        "AUTORESEARCH_ROOT": str(root),
+        "AUTORESEARCH_PAT_FILE": str(pat),
+        "HOME": str(tmp_path),
+    }
+    proc = subprocess.run(
+        [
+            "bash",
+            "-c",
+            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$AUTORESEARCH_DEPLOY_BROKEN"',
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "environment could not be restored; tick skipped" in proc.stdout
+    assert "BROKEN=1" in proc.stdout
+    assert not (tmp_path / "reset").exists()  # the checkout is on OLD


### PR DESCRIPTION
2026-09-03 13:30Z–15:45Z: no tick ran for two hours while the resident job was healthy. Cause: the scratch quota filled; `uv sync --locked` in the deploy step failed (logged, as designed, "continue on the previous code"), but `uv run python -m autoresearch.tick` re-runs the sync itself and failed the same way, so the tick process never started and, with the job's stdout at /dev/null, nothing was logged.

Fix: both the resident loop and the per-cadence chain run the tick with `uv run --no-sync`, so the venv is used as it stands after the deploy step's own sync attempt. A merge that adds a new dependency still lands on the next successful sync; until then the tick runs the previous environment, which is the documented intent.

Quota exhaustion itself is a separate operational problem (being measured now); the disk write-probe reported ok at 13:00Z because the quota filled between ticks.
