### PR TITLE
Disk housekeeping: ended runs shed their workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Disk housekeeping: an ended run sheds its `ws/` and `ws-home/` directories
+  once its tree is on GitHub, keeping the record, report, transcripts, and
+  ledger. The tick sheds after a 24 h grace, oldest first; when the state
+  filesystem's write probe fails the grace is waived and it frees oldest-first
+  until the probe passes, so a full quota heals itself. A symlinked workspace
+  is left for a human. (2026-09-03: 139 ended runs held ~1.6M files under the
+  state root and the scratch inode quota hit its ceiling.)
 - `autoresearch start`, the one launch command: with `sbatch` on PATH it
   submits the resident tick (walltime, job name, and exports filled in from
   flags, the environment, or `~/.config/autoresearch/.env`); otherwise, or

--- a/src/autoresearch/housekeeping.py
+++ b/src/autoresearch/housekeeping.py
@@ -1,0 +1,100 @@
+"""Disk housekeeping: ended runs shed their workspaces.
+
+A run's workspace (`ws/`, the clone the session worked in, and `ws-home/`,
+the session's home with its tool caches) is the bulk of what a run leaves
+on the state filesystem, in files far more than in bytes: 2026-09-03 the
+scratch quota on Torch hit its 5M-file ceiling with 1.67M of them under
+state/runs, and no tick could start for two hours. Everything the record
+keeps for the research record lives outside those two directories: the
+run's state.json, its report, its transcripts, and the ledger entries; the
+tree itself is on GitHub (the PR branch, or the research line's snapshot).
+
+Rules (docs/design/disk-maintenance.md):
+
+- only ENDED runs shed, and only the two directories `ws` and `ws-home`;
+- after a grace period (default 24 h, for post-mortems), oldest first;
+- when the state filesystem's write probe FAILS, the grace is waived: the
+  tick sheds until the probe passes again, so a full quota heals itself;
+- a workspace whose top-level entry is a symlink is not removed (a session
+  could aim it anywhere); it is logged and left for a human;
+- the record notes when it shed (`workspace_shed`), so nothing runs twice.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+from dataclasses import replace
+from pathlib import Path
+
+from autoresearch.runstate import ENDED, RunRecord, list_runs, run_dir, save_record
+
+log = logging.getLogger(__name__)
+
+WORKSPACE_DIRS = ("ws", "ws-home")
+DEFAULT_SHED_GRACE_S = 24 * 3600.0
+
+
+def shed_candidates(root: Path, now: float, grace_s: float, force: bool) -> list[RunRecord]:
+    """Ended runs whose workspaces may go now, oldest ending first. With
+    `force` (the disk is failing) the grace period does not apply."""
+    due: list[RunRecord] = []
+    for record in list_runs(root):
+        if record.state != ENDED or record.workspace_shed:
+            continue
+        if not force and now - record.updated < grace_s:
+            continue
+        if not any((run_dir(root, record.run_id) / d).exists() for d in WORKSPACE_DIRS):
+            continue
+        due.append(record)
+    due.sort(key=lambda r: r.updated)
+    return due
+
+
+def shed_workspace(root: Path, record: RunRecord, now: float) -> bool:
+    """Remove the run's `ws` and `ws-home` directories and stamp the record.
+    Returns False (and removes nothing) when either is a symlink."""
+    base = run_dir(root, record.run_id)
+    targets = [base / d for d in WORKSPACE_DIRS if (base / d).exists() or (base / d).is_symlink()]
+    for path in targets:
+        if path.is_symlink():
+            log.warning("not shedding %s: %s is a symlink", record.run_id, path.name)
+            return False
+    for path in targets:
+        shutil.rmtree(path, ignore_errors=True)
+    remaining = [p.name for p in targets if p.exists()]
+    if remaining:
+        log.warning("shed %s incompletely: %s remain", record.run_id, ", ".join(remaining))
+        return False
+    save_record(root, replace(record, workspace_shed=now), now)
+    return True
+
+
+def shed_ended_workspaces(
+    root: Path,
+    now: float,
+    *,
+    grace_s: float = DEFAULT_SHED_GRACE_S,
+    force: bool = False,
+    limit: int = 50,
+    until_ok: object = None,
+) -> list[str]:
+    """Shed due workspaces, at most `limit` per call. With `until_ok` (a
+    callable returning True once the disk is healthy again) the sweep stops
+    as soon as it reports True, so a forced sweep frees only what it must."""
+    shed: list[str] = []
+    for record in shed_candidates(root, now, grace_s, force):
+        if len(shed) >= limit:
+            break
+        if until_ok is not None and callable(until_ok) and until_ok():
+            break
+        if shed_workspace(root, record, now):
+            shed.append(record.run_id)
+    if shed:
+        log.info(
+            "shed %d ended workspace(s)%s: %s",
+            len(shed),
+            " (forced)" if force else "",
+            ", ".join(shed),
+        )
+    return shed

--- a/src/autoresearch/runstate.py
+++ b/src/autoresearch/runstate.py
@@ -187,6 +187,9 @@ class RunRecord:
     ending_note: str = ""
     created: float = 0.0
     updated: float = 0.0
+    # when housekeeping removed this ended run's ws/ and ws-home/ (0 = never);
+    # the record, report, transcripts, and ledger stay (housekeeping.py)
+    workspace_shed: float = 0.0
 
     def ended(self) -> bool:
         return self.state == ENDED

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -42,6 +42,7 @@ from autoresearch.compute import (
 )
 from autoresearch.disk import DEFAULT_MIN_FREE_BYTES, check_disk
 from autoresearch.harness import DEFAULT_MAX_TURNS, redact
+from autoresearch.housekeeping import shed_ended_workspaces
 from autoresearch.limits import EffectiveLimits, effective_limits
 from autoresearch.runstate import (
     ABORTED,
@@ -145,6 +146,7 @@ class TickReport:
     steward: tuple[str, str] = ("", "")  # (issue tag, job_id) when a stewardship launched
     disk: tuple[str, ...] = ()  # preflight warnings (home entries are warn-only)
     launch_blocked: bool = False  # True when the preflight turned launch lanes off
+    shed: tuple[str, ...] = ()  # ended runs whose workspaces housekeeping removed
 
 
 # The submitted walltime must never exceed the job partition's MaxTime —
@@ -1632,6 +1634,26 @@ def tick(
             )
             return TickReport(coalesced=True)
     report = sweep(root, compute, dispatcher, now, grace_s, lease_ttl_s, dry_run=dry_run)
+    # Housekeeping: ended runs shed ws/ and ws-home/ after a grace period;
+    # when the state filesystem's write probe failed, the grace is waived and
+    # the sweep frees oldest-first until the probe passes, then the preflight
+    # is taken again so launch lanes can come back this very tick.
+    disk_failing = not disk_health.launch_ok()
+    shed = shed_ended_workspaces(
+        root,
+        now,
+        force=disk_failing,
+        until_ok=(lambda: check_disk(root, min_free_bytes=min_free_bytes).launch_ok())
+        if disk_failing
+        else None,
+    )
+    if shed and disk_failing:
+        disk_health = check_disk(root, min_free_bytes=min_free_bytes)
+        write_heartbeat(root, now, disk=disk_health.as_dict())
+    if shed:
+        from dataclasses import replace as _dc_replace
+
+        report = _dc_replace(report, shed=tuple(shed))
     launch_ok = disk_health.launch_ok()
     if not launch_ok:
         log.warning("disk preflight failed; launch lanes are OFF this tick")
@@ -3082,7 +3104,7 @@ def main() -> int:
         log.info(
             "tick done: paused=%s coalesced=%s swept=%d woken=%d deferred=%d reaped=%d stuck=%d "
             "impl_ended=%s review_ended=%s followups=%s intake=%s self_initiated=%s steward=%s "
-            "disk=%s launch_blocked=%s",
+            "disk=%s launch_blocked=%s shed=%d",
             report.paused,
             report.coalesced,
             report.swept,
@@ -3098,6 +3120,7 @@ def main() -> int:
             report.steward,
             report.disk or "ok",
             report.launch_blocked,
+            len(report.shed),
         )
 
     if not args.loop:

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1638,18 +1638,25 @@ def tick(
     # when the state filesystem's write probe failed, the grace is waived and
     # the sweep frees oldest-first until the probe passes, then the preflight
     # is taken again so launch lanes can come back this very tick.
-    disk_failing = not disk_health.launch_ok()
-    shed = shed_ended_workspaces(
-        root,
-        now,
-        force=disk_failing,
-        until_ok=(lambda: check_disk(root, min_free_bytes=min_free_bytes).launch_ok())
-        if disk_failing
-        else None,
-    )
-    if shed and disk_failing:
-        disk_health = check_disk(root, min_free_bytes=min_free_bytes)
-        write_heartbeat(root, now, disk=disk_health.as_dict())
+    # Force-shed (waive the grace) only when the state root cannot be WRITTEN,
+    # not merely when it is below the free-space threshold: a writable disk
+    # that is just low keeps the 24 h grace so a post-mortem is not deleted
+    # under someone. A dry-run tick sheds nothing (the destructive lane obeys
+    # the zero-writes contract, like sweep()).
+    shed: list[str] = []
+    if not dry_run:
+        cannot_write = not disk_health.state_root.writable
+        shed = shed_ended_workspaces(
+            root,
+            now,
+            force=cannot_write,
+            until_ok=(lambda: check_disk(root, min_free_bytes=min_free_bytes).state_root.writable)
+            if cannot_write
+            else None,
+        )
+        if shed and cannot_write:
+            disk_health = check_disk(root, min_free_bytes=min_free_bytes)
+            write_heartbeat(root, now, disk=disk_health.as_dict())
     if shed:
         from dataclasses import replace as _dc_replace
 

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -102,3 +102,34 @@ def test_the_per_call_limit_bounds_a_tick(tmp_path: Path) -> None:
     assert len(shed_ended_workspaces(root, NOW, limit=2)) == 2
     assert len(shed_ended_workspaces(root, NOW, limit=2)) == 2
     assert len(shed_ended_workspaces(root, NOW, limit=2)) == 1
+
+
+def test_a_dry_run_tick_sheds_nothing(tmp_path: Path, monkeypatch) -> None:
+    """The destructive housekeeping lane obeys the zero-writes dry-run
+    contract: tick(..., dry_run=True) removes no workspace and writes no
+    workspace_shed."""
+    import autoresearch.tick as tickmod
+    from autoresearch.compute import LocalCompute
+
+    root = tmp_path / "state"
+    _run(root, "old-ended", ENDED, NOW - DEFAULT_SHED_GRACE_S - 1)
+    calls = {"n": 0}
+    real = tickmod.shed_ended_workspaces
+
+    def spy(*a, **k):
+        calls["n"] += 1
+        return real(*a, **k)
+
+    monkeypatch.setattr(tickmod, "shed_ended_workspaces", spy)
+    report = tickmod.tick(
+        root,
+        LocalCompute(),
+        tickmod.LoggingDispatcher(),
+        now=NOW,
+        dry_run=True,
+        min_free_bytes=1,  # writable; never below threshold
+    )
+    assert calls["n"] == 0
+    assert report.shed == ()
+    assert (run_dir(root, "old-ended") / "ws").exists()
+    assert load_record(root, "old-ended").workspace_shed == 0.0

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -1,0 +1,104 @@
+"""Ended runs shed ws/ and ws-home/ after a grace period, at once when the
+disk is failing; nothing else is touched."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from autoresearch.housekeeping import (
+    DEFAULT_SHED_GRACE_S,
+    shed_candidates,
+    shed_ended_workspaces,
+    shed_workspace,
+)
+from autoresearch.runstate import ENDED, WAITING, RunRecord, load_record, run_dir, save_record
+
+NOW = 2_000_000.0
+
+
+def _run(root: Path, run_id: str, state: str, updated: float, with_ws: bool = True) -> RunRecord:
+    rec = RunRecord(
+        run_id=run_id,
+        target="o/r",
+        task_title="t",
+        state=state,
+        ending="aborted" if state == ENDED else "",
+    )
+    save_record(root, rec, updated)
+    d = run_dir(root, run_id)
+    if with_ws:
+        (d / "ws" / ".git").mkdir(parents=True)
+        (d / "ws" / "train.py").write_text("x\n")
+        (d / "ws-home" / ".cache").mkdir(parents=True)
+        (d / "ws-home" / ".cache" / "blob").write_text("y\n")
+    (d / "report.md").write_text("Outcome: aborted\n")
+    (d / "ws-codex.jsonl").write_text("{}\n")
+    return load_record(root, run_id)
+
+
+def test_only_ended_runs_past_the_grace_shed_and_only_the_two_directories(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    _run(root, "old-ended", ENDED, NOW - DEFAULT_SHED_GRACE_S - 1)
+    _run(root, "fresh-ended", ENDED, NOW - 60)
+    _run(root, "live", WAITING, NOW - DEFAULT_SHED_GRACE_S - 1)
+    assert [r.run_id for r in shed_candidates(root, NOW, DEFAULT_SHED_GRACE_S, force=False)] == [
+        "old-ended"
+    ]
+    shed = shed_ended_workspaces(root, NOW)
+    assert shed == ["old-ended"]
+    d = run_dir(root, "old-ended")
+    assert not (d / "ws").exists() and not (d / "ws-home").exists()
+    assert (
+        (d / "report.md").exists()
+        and (d / "ws-codex.jsonl").exists()
+        and (d / "state.json").exists()
+    )
+    assert load_record(root, "old-ended").workspace_shed == NOW
+    for kept in ("fresh-ended", "live"):
+        assert (run_dir(root, kept) / "ws" / "train.py").exists()
+    # idempotent: nothing left to shed
+    assert shed_ended_workspaces(root, NOW) == []
+
+
+def test_a_failing_disk_waives_the_grace_oldest_first_until_the_probe_passes(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "state"
+    _run(root, "b", ENDED, NOW - 120)
+    _run(root, "a", ENDED, NOW - 300)
+    _run(root, "c", ENDED, NOW - 30)
+    _run(root, "live", WAITING, NOW - 9000)
+    calls = {"n": 0}
+
+    def until_ok() -> bool:
+        calls["n"] += 1
+        return calls["n"] > 2  # healthy again after two sheds
+
+    shed = shed_ended_workspaces(root, NOW, force=True, until_ok=until_ok)
+    assert shed == ["a", "b"]  # oldest first, stopped once the probe passed
+    assert (run_dir(root, "c") / "ws").exists()
+    assert (run_dir(root, "live") / "ws").exists()
+
+
+def test_a_symlinked_workspace_is_left_alone_and_logged(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    rec = _run(root, "linked", ENDED, NOW - DEFAULT_SHED_GRACE_S - 1, with_ws=False)
+    elsewhere = tmp_path / "elsewhere"
+    (elsewhere / "precious").mkdir(parents=True)
+    d = run_dir(root, "linked")
+    os.symlink(elsewhere, d / "ws")
+    (d / "ws-home").mkdir()
+    assert shed_workspace(root, rec, NOW) is False
+    assert (elsewhere / "precious").exists()
+    assert (d / "ws-home").exists()  # nothing removed when any target is a link
+    assert load_record(root, "linked").workspace_shed == 0.0
+
+
+def test_the_per_call_limit_bounds_a_tick(tmp_path: Path) -> None:
+    root = tmp_path / "state"
+    for i in range(5):
+        _run(root, f"r{i}", ENDED, NOW - DEFAULT_SHED_GRACE_S - 100 + i)
+    assert len(shed_ended_workspaces(root, NOW, limit=2)) == 2
+    assert len(shed_ended_workspaces(root, NOW, limit=2)) == 2
+    assert len(shed_ended_workspaces(root, NOW, limit=2)) == 1


### PR DESCRIPTION
Automatic disk housekeeping, the permanent fix for the 2026-09-03 outage (PR #247 stopped a full quota from freezing the tick; this stops the quota filling).

An ended run's `ws/` (the clone) and `ws-home/` (the session's home with its tool caches) are the bulk of what a run leaves on the state filesystem — in files far more than bytes: 139 ended runs held ~1.6M of the account's 5M-file scratch inode quota, which hit its ceiling and stalled the tick for two hours. Everything kept for the research record lives outside those two directories (state.json, the report, the transcripts, the ledger), and the tree itself is on GitHub (the PR branch or the research line's snapshot).

`autoresearch/housekeeping.py`:
- only ENDED runs shed, only `ws` and `ws-home`, after a 24h grace (post-mortems), oldest first;
- when the state filesystem's write probe FAILS, the grace is waived and the tick frees oldest-first until the probe passes, then re-takes the preflight so launch lanes can come back the same tick — a full quota heals itself;
- a workspace whose top-level dir is a symlink is left for a human;
- the record notes `workspace_shed` so nothing runs twice; a per-tick limit bounds the work.

Wired into `tick()` right after the sweep. `RunRecord.workspace_shed` added. Tests: `tests/test_housekeeping.py` (grace, forced-until-probe-passes, symlink refusal, per-call limit).

Operational note: I already freed the current backlog by hand on Torch (removed 139 ended runs' `ws`/`ws-home`), which unblocked writes; this makes it automatic.
