### PR TITLE
Housekeeping bounded per tick so shedding never trips the tick timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,11 +25,12 @@ Versions follow [SemVer](https://semver.org).
 
 - Disk housekeeping is bounded per tick by a count and a wall-clock budget
   (a few workspaces or ~2 minutes on a healthy disk; more but still
-  time-boxed when the disk is failing). Removing a workspace is `rm -rf` of
-  tens of thousands of files over a networked filesystem, and an unbounded
-  batch ran long enough to trip the tick's own 15-minute timeout, so the
-  tick was killed before it published (2026-09-03). The backlog now drains
-  over several ticks and every tick finishes.
+  time-boxed when the disk is failing), covering both finding candidates and
+  deleting them. Removing a workspace is `rm -rf` of tens of thousands of
+  files over a networked filesystem, and an unbounded batch, plus reading
+  every record to find candidates, ran long enough to trip the tick's own
+  15-minute timeout, so the tick was killed before it published (2026-09-03).
+  The backlog drains over several ticks instead.
 - A session that reshapes the workspace's `.git` (a symlink or gitdir file
   in place of `.git`, a symlinked or missing object store, pack directory, or
   refs, a FIFO or missing control file, object alternates) now ends the run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- Disk housekeeping is bounded per tick by a count and a wall-clock budget
+  (a few workspaces or ~2 minutes on a healthy disk; more but still
+  time-boxed when the disk is failing). Removing a workspace is `rm -rf` of
+  tens of thousands of files over a networked filesystem, and an unbounded
+  batch ran long enough to trip the tick's own 15-minute timeout, so the
+  tick was killed before it published (2026-09-03). The backlog now drains
+  over several ticks and every tick finishes.
 - A session that reshapes the workspace's `.git` (a symlink or gitdir file
   in place of `.git`, a symlinked or missing object store, pack directory, or
   refs, a FIFO or missing control file, object alternates) now ends the run

--- a/src/autoresearch/housekeeping.py
+++ b/src/autoresearch/housekeeping.py
@@ -131,6 +131,11 @@ def shed_ended_workspaces(
         )
     except OSError:
         return []
+    # One readdir + an in-memory sort is cheap even for thousands of run dirs,
+    # but never start shedding if it somehow overran the budget: the tick then
+    # spends the rest of its time publishing, not deleting.
+    if monotonic() - start >= time_budget_s:
+        return []
     shed: list[str] = []
     for run_id in run_ids:
         if len(shed) >= limit:

--- a/src/autoresearch/housekeeping.py
+++ b/src/autoresearch/housekeeping.py
@@ -23,6 +23,8 @@ Rules (docs/design/disk-maintenance.md):
 from __future__ import annotations
 
 import logging
+import os
+import re
 import shutil
 import time
 from dataclasses import replace
@@ -71,6 +73,14 @@ def shed_workspace(root: Path, record: RunRecord, now: float) -> bool:
     return True
 
 
+_TS_RE = re.compile(r"(\d{8}-\d{6})")
+
+
+def _run_id_timestamp(run_id: str) -> str | None:
+    m = _TS_RE.search(run_id)
+    return m.group(1) if m else None
+
+
 def _is_shed_candidate(
     root: Path, record: RunRecord, now: float, grace_s: float, force: bool
 ) -> bool:
@@ -101,19 +111,24 @@ def shed_ended_workspaces(
     filesystem, tens of thousands of tiny files each on a networked FS, so an
     unbounded batch inside a tick can run for many minutes and blow the tick's
     own timeout (2026-09-03: a 50-run batch, and reading every record to find
-    candidates, killed the tick before it could publish). Run ids are
-    timestamp-prefixed, so oldest-first needs no upfront scan: iterate the run
-    directory in name order and load one record at a time, checking the budget
-    EACH step, so both discovery and deletion are bounded. The backlog drains
-    over several ticks. With `until_ok` a forced sweep also stops as soon as
-    the disk reports healthy."""
+    candidates, killed the tick before it could publish). Discovery is ONE
+    directory read, sorted oldest-first by the timestamp embedded in each run
+    id (no per-entry stat, no record load); the loop then loads one record at
+    a time and checks the budget EACH step, so both are bounded. The backlog
+    drains over several ticks. With `until_ok` a forced sweep also stops as
+    soon as the disk reports healthy."""
     monotonic = clock if callable(clock) else time.monotonic
     start = monotonic()
     runs_root = root / "runs"
-    if not runs_root.is_dir():
-        return []
     try:
-        run_ids = sorted(p.name for p in runs_root.iterdir() if p.is_dir())
+        # ONE directory read (no per-entry stat), sorted oldest-first by the
+        # timestamp every run id carries (`<name>-YYYYMMDD-HHMMSS-...`), which
+        # is chronological across benchmark prefixes where a lexical sort is
+        # not; ids without one sort last so they never block the backlog.
+        run_ids = sorted(
+            (e.name for e in os.scandir(runs_root)),
+            key=lambda name: (_run_id_timestamp(name) or "99999999-999999", name),
+        )
     except OSError:
         return []
     shed: list[str] = []

--- a/src/autoresearch/housekeeping.py
+++ b/src/autoresearch/housekeeping.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import logging
 import shutil
+import time
 from dataclasses import replace
 from pathlib import Path
 
@@ -76,15 +77,32 @@ def shed_ended_workspaces(
     *,
     grace_s: float = DEFAULT_SHED_GRACE_S,
     force: bool = False,
-    limit: int = 50,
+    limit: int = 3,
+    time_budget_s: float = 120.0,
     until_ok: object = None,
+    clock: object = None,
 ) -> list[str]:
-    """Shed due workspaces, at most `limit` per call. With `until_ok` (a
-    callable returning True once the disk is healthy again) the sweep stops
-    as soon as it reports True, so a forced sweep frees only what it must."""
+    """Shed due workspaces, bounded by BOTH a count (`limit`) and a wall-clock
+    budget (`time_budget_s`). Removing a workspace is `rm -rf` over the state
+    filesystem, tens of thousands of tiny files each on a networked FS, so an
+    unbounded batch inside a tick can run for many minutes and blow the tick's
+    own timeout (2026-09-03: a 50-run batch killed the tick before it could
+    publish). The budget is checked between runs, so at most one extra
+    workspace's delete overruns it; the backlog drains over several ticks
+    instead of one. With `until_ok` a forced sweep also stops as soon as the
+    disk reports healthy."""
+    monotonic = clock if callable(clock) else time.monotonic
+    start = monotonic()
     shed: list[str] = []
     for record in shed_candidates(root, now, grace_s, force):
         if len(shed) >= limit:
+            break
+        if monotonic() - start >= time_budget_s:
+            log.info(
+                "housekeeping: time budget (%.0fs) reached; %d shed this tick",
+                time_budget_s,
+                len(shed),
+            )
             break
         if until_ok is not None and callable(until_ok) and until_ok():
             break

--- a/src/autoresearch/housekeeping.py
+++ b/src/autoresearch/housekeeping.py
@@ -28,7 +28,7 @@ import time
 from dataclasses import replace
 from pathlib import Path
 
-from autoresearch.runstate import ENDED, RunRecord, list_runs, run_dir, save_record
+from autoresearch.runstate import ENDED, RunRecord, list_runs, load_record, run_dir, save_record
 
 log = logging.getLogger(__name__)
 
@@ -71,6 +71,16 @@ def shed_workspace(root: Path, record: RunRecord, now: float) -> bool:
     return True
 
 
+def _is_shed_candidate(
+    root: Path, record: RunRecord, now: float, grace_s: float, force: bool
+) -> bool:
+    if record.state != ENDED or record.workspace_shed:
+        return False
+    if not force and now - record.updated < grace_s:
+        return False
+    return any((run_dir(root, record.run_id) / d).exists() for d in WORKSPACE_DIRS)
+
+
 def shed_ended_workspaces(
     root: Path,
     now: float,
@@ -82,19 +92,32 @@ def shed_ended_workspaces(
     until_ok: object = None,
     clock: object = None,
 ) -> list[str]:
-    """Shed due workspaces, bounded by BOTH a count (`limit`) and a wall-clock
-    budget (`time_budget_s`). Removing a workspace is `rm -rf` over the state
+    """Shed due workspaces until `limit` is reached or `time_budget_s`
+    elapses, checking the budget between runs; a forced sweep also stops when
+    `until_ok` reports a healthy disk.
+
+    Bounded by BOTH a count (`limit`) and a wall-clock budget
+    (`time_budget_s`). Removing a workspace is `rm -rf` over the state
     filesystem, tens of thousands of tiny files each on a networked FS, so an
     unbounded batch inside a tick can run for many minutes and blow the tick's
-    own timeout (2026-09-03: a 50-run batch killed the tick before it could
-    publish). The budget is checked between runs, so at most one extra
-    workspace's delete overruns it; the backlog drains over several ticks
-    instead of one. With `until_ok` a forced sweep also stops as soon as the
-    disk reports healthy."""
+    own timeout (2026-09-03: a 50-run batch, and reading every record to find
+    candidates, killed the tick before it could publish). Run ids are
+    timestamp-prefixed, so oldest-first needs no upfront scan: iterate the run
+    directory in name order and load one record at a time, checking the budget
+    EACH step, so both discovery and deletion are bounded. The backlog drains
+    over several ticks. With `until_ok` a forced sweep also stops as soon as
+    the disk reports healthy."""
     monotonic = clock if callable(clock) else time.monotonic
     start = monotonic()
+    runs_root = root / "runs"
+    if not runs_root.is_dir():
+        return []
+    try:
+        run_ids = sorted(p.name for p in runs_root.iterdir() if p.is_dir())
+    except OSError:
+        return []
     shed: list[str] = []
-    for record in shed_candidates(root, now, grace_s, force):
+    for run_id in run_ids:
         if len(shed) >= limit:
             break
         if monotonic() - start >= time_budget_s:
@@ -106,8 +129,14 @@ def shed_ended_workspaces(
             break
         if until_ok is not None and callable(until_ok) and until_ok():
             break
-        if shed_workspace(root, record, now):
-            shed.append(record.run_id)
+        try:
+            record = load_record(root, run_id)
+        except (OSError, ValueError, TypeError, KeyError):
+            continue
+        if _is_shed_candidate(root, record, now, grace_s, force) and shed_workspace(
+            root, record, now
+        ):
+            shed.append(run_id)
     if shed:
         log.info(
             "shed %d ended workspace(s)%s: %s",

--- a/src/autoresearch/tick.py
+++ b/src/autoresearch/tick.py
@@ -1646,10 +1646,16 @@ def tick(
     shed: list[str] = []
     if not dry_run:
         cannot_write = not disk_health.state_root.writable
+        # Bounded per tick so shedding (rm -rf of tens of thousands of files
+        # per workspace on a networked FS) never blows the tick's own timeout:
+        # a few runs on a healthy disk, more but still time-boxed when it is
+        # failing. The backlog drains over several ticks.
         shed = shed_ended_workspaces(
             root,
             now,
             force=cannot_write,
+            limit=25 if cannot_write else 3,
+            time_budget_s=300.0 if cannot_write else 120.0,
             until_ok=(lambda: check_disk(root, min_free_bytes=min_free_bytes).state_root.writable)
             if cannot_write
             else None,

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -133,3 +133,27 @@ def test_a_dry_run_tick_sheds_nothing(tmp_path: Path, monkeypatch) -> None:
     assert report.shed == ()
     assert (run_dir(root, "old-ended") / "ws").exists()
     assert load_record(root, "old-ended").workspace_shed == 0.0
+
+
+def test_shedding_stops_at_the_time_budget(tmp_path: Path) -> None:
+    """The per-tick wall-clock budget bounds shedding so a slow networked
+    delete cannot blow the tick's timeout: with a fake clock that jumps past
+    the budget after one shed, only one workspace goes even though more are
+    due."""
+    root = tmp_path / "state"
+    for i in range(5):
+        _run(root, f"r{i}", ENDED, NOW - DEFAULT_SHED_GRACE_S - 100 + i)
+    ticks = iter([0.0, 0.0, 200.0, 200.0, 200.0, 200.0])  # jumps past 120s budget after run 1
+    shed = shed_ended_workspaces(
+        root, NOW, time_budget_s=120.0, limit=50, clock=lambda: next(ticks)
+    )
+    assert len(shed) == 1  # budget stopped it after the first, though 5 were due
+    assert sum(1 for i in range(5) if (run_dir(root, f"r{i}") / "ws").exists()) == 4
+
+
+def test_the_count_limit_defaults_small(tmp_path: Path) -> None:
+    """A tick sheds only a few by default, so the batch never dominates it."""
+    root = tmp_path / "state"
+    for i in range(10):
+        _run(root, f"r{i}", ENDED, NOW - DEFAULT_SHED_GRACE_S - 100 + i)
+    assert len(shed_ended_workspaces(root, NOW)) == 3  # default limit

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -157,3 +157,13 @@ def test_the_count_limit_defaults_small(tmp_path: Path) -> None:
     for i in range(10):
         _run(root, f"r{i}", ENDED, NOW - DEFAULT_SHED_GRACE_S - 100 + i)
     assert len(shed_ended_workspaces(root, NOW)) == 3  # default limit
+
+
+def test_forced_sweep_is_oldest_first_across_benchmark_prefixes(tmp_path: Path) -> None:
+    """Oldest-first is by the timestamp in the run id, not lexical: a newer
+    `speedrun-` must not be shed before an older `tsp-` just because 's' < 't'."""
+    root = tmp_path / "state"
+    _run(root, "tsp-20260820-201843", ENDED, NOW - 500)  # older by timestamp
+    _run(root, "speedrun-20260903-063055-agent-03", ENDED, NOW - 100)  # newer
+    shed = shed_ended_workspaces(root, NOW, force=True, limit=1)
+    assert shed == ["tsp-20260820-201843"]  # the older id, though it sorts later lexically

--- a/tests/test_housekeeping.py
+++ b/tests/test_housekeeping.py
@@ -143,7 +143,7 @@ def test_shedding_stops_at_the_time_budget(tmp_path: Path) -> None:
     root = tmp_path / "state"
     for i in range(5):
         _run(root, f"r{i}", ENDED, NOW - DEFAULT_SHED_GRACE_S - 100 + i)
-    ticks = iter([0.0, 0.0, 200.0, 200.0, 200.0, 200.0])  # jumps past 120s budget after run 1
+    ticks = iter([0.0, 0.0, 0.0, 200.0, 200.0, 200.0])  # start, belt, run 1, then past 120s
     shed = shed_ended_workspaces(
         root, NOW, time_budget_s=120.0, limit=50, clock=lambda: next(ticks)
     )


### PR DESCRIPTION
Hotfix. #248's housekeeping deletes ended workspaces synchronously inside the tick, and `rm -rf` of a workspace is tens of thousands of tiny files over the networked state filesystem. A batch of up to 50 per tick ran for many minutes and tripped the tick's own 15-minute timeout, so from 2026-09-03 16:31Z the tick was killed (exit 124) before it reached the board/research-log publish step: the fleet kept running but stopped publishing.

`shed_ended_workspaces` is now bounded by BOTH a count and a wall-clock budget, checked between runs (so at most one extra workspace's delete overruns the budget): 3 runs / ~120s on a healthy disk, 25 / ~300s when the write probe fails and space must be freed. The backlog drains over several ticks and every tick finishes and publishes. Tests: a fake clock that jumps past the budget stops shedding after one workspace though more are due; the default count limit is small.
