### PR TITLE
Codex sessions clear their leaked temp scratch each run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- Codex sessions no longer leak temp directories into the per-run home. Codex
+  writes scratch to `.codex/.tmp` and fails to remove it (the "stale arg0 temp
+  dirs: Directory not empty" aborts), so across a run's wakes it grew to tens
+  of thousands of files — most of the per-run home. The session now clears
+  that scratch before each run, keeping codex's durable state.
 - Disk housekeeping is bounded per tick by a count and a wall-clock budget
   (a few workspaces or ~2 minutes on a healthy disk; more but still
   time-boxed when the disk is failing), covering both finding candidates and

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -950,9 +950,15 @@ class CodexHarness:
         # a run's wakes they pile up into tens of thousands of files, the bulk
         # of the per-run home. Clear codex's scratch before each run — its
         # durable state (auth.json, sessions, the sqlite) is elsewhere under
-        # .codex and untouched.
-        for scratch in (session_home / ".codex" / ".tmp", session_home / ".codex" / "tmp"):
-            shutil.rmtree(scratch, ignore_errors=True)
+        # .codex and untouched. A prior session owns this home, so if it
+        # replaced .codex with a symlink, deleting scratch "under" it would
+        # follow the link out of the run home: only clean a real directory
+        # (rmtree itself refuses a symlink AT a scratch path, so those are
+        # never followed either).
+        codex_home = session_home / ".codex"
+        if codex_home.is_dir() and not codex_home.is_symlink():
+            for scratch in (codex_home / ".tmp", codex_home / "tmp"):
+                shutil.rmtree(scratch, ignore_errors=True)
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
         # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -17,8 +17,8 @@ import contextlib
 import json
 import logging
 import os
-import shutil
 import signal
+import stat
 import subprocess
 import uuid
 from dataclasses import dataclass, field, replace
@@ -100,6 +100,34 @@ def session_env(api_key: str, key_variable: str, home: Path) -> dict[str, str]:
     env["HOME"] = str(home)
     env[key_variable] = api_key
     return env
+
+
+def _rmtree_at(dir_fd: int, name: str) -> None:
+    """Recursively delete directory `name` under `dir_fd`, anchored on file
+    descriptors and `O_NOFOLLOW` at every level. No path component is ever
+    resolved by name after the first open, so a session that swaps a directory
+    for a symlink mid-delete cannot divert it outside the tree (TOCTOU-safe).
+    Best-effort: a missing entry, a symlink, or a non-directory `name` is a
+    no-op."""
+    try:
+        fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY, dir_fd=dir_fd)
+    except OSError:
+        return  # gone, a symlink (ELOOP), or not a directory
+    try:
+        for child in os.listdir(fd):
+            try:
+                st = os.stat(child, dir_fd=fd, follow_symlinks=False)
+            except OSError:
+                continue
+            if stat.S_ISDIR(st.st_mode):
+                _rmtree_at(fd, child)
+            else:
+                with contextlib.suppress(OSError):
+                    os.unlink(child, dir_fd=fd)
+    finally:
+        os.close(fd)
+    with contextlib.suppress(OSError):
+        os.rmdir(name, dir_fd=dir_fd)
 
 
 @dataclass(frozen=True)
@@ -950,22 +978,27 @@ class CodexHarness:
         # a run's wakes they pile up into tens of thousands of files, the bulk
         # of the per-run home. Clear codex's scratch before each run — its
         # durable state (auth.json, sessions, the sqlite) is elsewhere under
-        # .codex and untouched. A prior session owns this home, so if it
-        # replaced .codex with a symlink, deleting scratch "under" it would
-        # follow the link out of the run home: only clean a real directory
-        # (rmtree itself refuses a symlink AT a scratch path, so those are
-        # never followed either).
-        codex_home = session_home / ".codex"
-        if codex_home.is_dir() and not codex_home.is_symlink():
-            for scratch in (codex_home / ".tmp", codex_home / "tmp"):
-                # Best-effort: this cleanup must never abort the run it precedes
-                # (the harness contract is to return a SessionResult, not raise).
-                # ignore_errors swallows the per-file OSErrors; the guard also
-                # catches a RecursionError from an adversarially deep leaked tree.
-                try:
-                    shutil.rmtree(scratch, ignore_errors=True)
-                except Exception as exc:
-                    log.warning("codex scratch cleanup skipped %s: %s", scratch, exc)
+        # .codex and untouched. A prior session owns this home, so pin the real
+        # .codex directory with O_NOFOLLOW and delete the scratch anchored on
+        # that fd: a session that swaps .codex (or a scratch dir) for a symlink
+        # can never divert the delete out of the run home. Best-effort — this
+        # must never abort the run it precedes (the contract is to return a
+        # SessionResult, not raise), so an adversarially deep tree's
+        # RecursionError or any other error is caught and logged.
+        try:
+            codex_fd = os.open(
+                session_home / ".codex", os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY
+            )
+        except OSError:
+            codex_fd = -1  # no .codex, or it is a symlink → nothing to clean
+        if codex_fd >= 0:
+            try:
+                for scratch in (".tmp", "tmp"):
+                    _rmtree_at(codex_fd, scratch)
+            except Exception as exc:
+                log.warning("codex scratch cleanup skipped: %s", exc)
+            finally:
+                os.close(codex_fd)
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
         # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -17,6 +17,7 @@ import contextlib
 import json
 import logging
 import os
+import shutil
 import signal
 import subprocess
 import uuid
@@ -944,6 +945,14 @@ class CodexHarness:
         except OSError as exc:
             log.warning("could not create session home %s: %s", session_home, exc)
             return _error_result("workspace-error")
+        # Codex leaks temp directories into .codex/.tmp and fails to remove
+        # them (the "stale arg0 temp dirs: Directory not empty" aborts); across
+        # a run's wakes they pile up into tens of thousands of files, the bulk
+        # of the per-run home. Clear codex's scratch before each run — its
+        # durable state (auth.json, sessions, the sqlite) is elsewhere under
+        # .codex and untouched.
+        for scratch in (session_home / ".codex" / ".tmp", session_home / ".codex" / "tmp"):
+            shutil.rmtree(scratch, ignore_errors=True)
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
         # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -958,7 +958,14 @@ class CodexHarness:
         codex_home = session_home / ".codex"
         if codex_home.is_dir() and not codex_home.is_symlink():
             for scratch in (codex_home / ".tmp", codex_home / "tmp"):
-                shutil.rmtree(scratch, ignore_errors=True)
+                # Best-effort: this cleanup must never abort the run it precedes
+                # (the harness contract is to return a SessionResult, not raise).
+                # ignore_errors swallows the per-file OSErrors; the guard also
+                # catches a RecursionError from an adversarially deep leaked tree.
+                try:
+                    shutil.rmtree(scratch, ignore_errors=True)
+                except Exception as exc:
+                    log.warning("codex scratch cleanup skipped %s: %s", scratch, exc)
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
         # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -102,6 +102,15 @@ def session_env(api_key: str, key_variable: str, home: Path) -> dict[str, str]:
     return env
 
 
+def _open_nofollow_dir(name: str, dir_fd: int) -> int:
+    """`openat` `name` as a directory under `dir_fd` without following a final
+    symlink; -1 if it is missing, a symlink (ELOOP), or not a directory."""
+    try:
+        return os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY, dir_fd=dir_fd)
+    except OSError:
+        return -1
+
+
 def _rmtree_at(dir_fd: int, name: str) -> None:
     """Recursively delete directory `name` under `dir_fd`, anchored on file
     descriptors and `O_NOFOLLOW` at every level. No path component is ever
@@ -109,9 +118,8 @@ def _rmtree_at(dir_fd: int, name: str) -> None:
     for a symlink mid-delete cannot divert it outside the tree (TOCTOU-safe).
     Best-effort: a missing entry, a symlink, or a non-directory `name` is a
     no-op."""
-    try:
-        fd = os.open(name, os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY, dir_fd=dir_fd)
-    except OSError:
+    fd = _open_nofollow_dir(name, dir_fd)
+    if fd < 0:
         return  # gone, a symlink (ELOOP), or not a directory
     try:
         for child in os.listdir(fd):
@@ -978,27 +986,34 @@ class CodexHarness:
         # a run's wakes they pile up into tens of thousands of files, the bulk
         # of the per-run home. Clear codex's scratch before each run — its
         # durable state (auth.json, sessions, the sqlite) is elsewhere under
-        # .codex and untouched. A prior session owns this home, so pin the real
-        # .codex directory with O_NOFOLLOW and delete the scratch anchored on
-        # that fd: a session that swaps .codex (or a scratch dir) for a symlink
-        # can never divert the delete out of the run home. Best-effort — this
-        # must never abort the run it precedes (the contract is to return a
-        # SessionResult, not raise), so an adversarially deep tree's
-        # RecursionError or any other error is caught and logged.
+        # .codex and untouched. A prior session owns this home, so resolve every
+        # component it can write — the run home and .codex — with O_NOFOLLOW,
+        # anchored on the run directory the orchestrator owns (a contained
+        # session's binds expose only the run home and workspace, never their
+        # parent; an uncontained session runs as a plain host process, so
+        # guarding these two components is the boundary either way). A swap of
+        # ws-home or .codex for a symlink then cannot divert the delete out of
+        # the run home. Best-effort — this must never abort the run it precedes
+        # (the contract is to return a SessionResult, not raise), so an
+        # adversarially deep tree's RecursionError or any other error is caught.
         try:
-            codex_fd = os.open(
-                session_home / ".codex", os.O_RDONLY | os.O_NOFOLLOW | os.O_DIRECTORY
-            )
+            run_fd = os.open(session_home.parent, os.O_RDONLY | os.O_DIRECTORY)
         except OSError:
-            codex_fd = -1  # no .codex, or it is a symlink → nothing to clean
-        if codex_fd >= 0:
-            try:
-                for scratch in (".tmp", "tmp"):
-                    _rmtree_at(codex_fd, scratch)
-            except Exception as exc:
-                log.warning("codex scratch cleanup skipped: %s", exc)
-            finally:
-                os.close(codex_fd)
+            run_fd = -1
+        if run_fd >= 0:
+            home_fd = _open_nofollow_dir(session_home.name, run_fd)
+            os.close(run_fd)
+            if home_fd >= 0:
+                codex_fd = _open_nofollow_dir(".codex", home_fd)
+                if codex_fd >= 0:
+                    try:
+                        for scratch in (".tmp", "tmp"):
+                            _rmtree_at(codex_fd, scratch)
+                    except Exception as exc:
+                        log.warning("codex scratch cleanup skipped: %s", exc)
+                    finally:
+                        os.close(codex_fd)
+                os.close(home_fd)
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
         # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -256,3 +256,32 @@ def test_run_does_not_follow_a_symlinked_scratch_dir(monkeypatch: Any, tmp_path:
     monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
     CodexHarness(api_key="k").run("brief", workspace)
     assert (outside / "keep" / "f").read_text() == "x"  # symlink target untouched
+
+
+def test_run_does_not_follow_a_symlinked_run_home(monkeypatch: Any, tmp_path: Path) -> None:
+    """A prior session (uncontained: a plain host process) replaces ws-home with
+    a symlink to an external dir; cleanup resolves the run home with O_NOFOLLOW
+    anchored on the run directory, so it does not follow the link and delete the
+    target's .codex/.tmp."""
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    workspace = run_dir / "ws"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    (outside / ".codex" / ".tmp" / "keep").mkdir(parents=True)
+    (outside / ".codex" / ".tmp" / "keep" / "f").write_text("x")
+    (run_dir / "ws-home").symlink_to(outside)  # session_home is a symlink
+
+    class FakePopen:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def communicate(self, *a: Any, **k: Any) -> Any:
+            return ("", "")
+
+        returncode = 1
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
+    CodexHarness(api_key="k").run("brief", workspace)
+    assert (outside / ".codex" / ".tmp" / "keep" / "f").read_text() == "x"  # untouched

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 import autoresearch.harness as harness_mod
-from autoresearch.harness import CodexHarness, _codex_command, _parse_codex_result
+from autoresearch.harness import CodexHarness, SessionResult, _codex_command, _parse_codex_result
 
 
 def test_command_has_expected_flags() -> None:
@@ -170,3 +170,31 @@ def test_run_does_not_follow_a_symlinked_codex_out_of_home(
     monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
     CodexHarness(api_key="k").run("brief", workspace)
     assert (keep / "f").read_text() == "x"  # symlink target untouched
+
+
+def test_run_survives_a_scratch_cleanup_that_raises(monkeypatch: Any, tmp_path: Path) -> None:
+    """Scratch cleanup is best-effort: even if rmtree raises (a RecursionError
+    on an adversarially deep leaked tree), run() returns a SessionResult rather
+    than aborting before login."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    home = tmp_path / "ws-home"
+    (home / ".codex" / ".tmp").mkdir(parents=True)
+
+    def boom(*a: Any, **k: Any) -> None:
+        raise RecursionError("too deep")
+
+    class FakePopen:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def communicate(self, *a: Any, **k: Any) -> Any:
+            return ("", "")
+
+        returncode = 1
+
+    monkeypatch.setattr(harness_mod.shutil, "rmtree", boom)
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
+    result = CodexHarness(api_key="k").run("brief", workspace)
+    assert isinstance(result, SessionResult)  # cleanup did not propagate

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -115,6 +115,9 @@ def test_run_clears_codex_scratch_but_keeps_durable_state(monkeypatch: Any, tmp_
     tmp = home / ".codex" / ".tmp" / "leaked-dir"
     tmp.mkdir(parents=True)
     (tmp / "junk").write_text("x")
+    tmp_alt = home / ".codex" / "tmp" / "leaked-dir"  # the alternate scratch name
+    tmp_alt.mkdir(parents=True)
+    (tmp_alt / "junk").write_text("x")
     sessions = home / ".codex" / "sessions"
     sessions.mkdir(parents=True)
     (sessions / "s.json").write_text("keep")
@@ -132,4 +135,38 @@ def test_run_clears_codex_scratch_but_keeps_durable_state(monkeypatch: Any, tmp_
     monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
     CodexHarness(api_key="k").run("brief", workspace)
     assert not (home / ".codex" / ".tmp").exists()  # scratch cleared
+    assert not (home / ".codex" / "tmp").exists()  # alternate scratch cleared too
     assert (sessions / "s.json").read_text() == "keep"  # durable state kept
+
+
+def test_run_does_not_follow_a_symlinked_codex_out_of_home(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """A prior session owns its home; if it replaced .codex with a symlink to
+    an external directory, the scratch cleanup must not follow the link and
+    delete the target's .tmp."""
+    from autoresearch import harness as harness_mod
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    home = tmp_path / "ws-home"
+    home.mkdir()
+    outside = tmp_path / "outside"
+    keep = outside / ".tmp" / "keep"
+    keep.mkdir(parents=True)
+    (keep / "f").write_text("x")
+    (home / ".codex").symlink_to(outside)
+
+    class FakePopen:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def communicate(self, *a: Any, **k: Any) -> Any:
+            return ("", "")
+
+        returncode = 1
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
+    CodexHarness(api_key="k").run("brief", workspace)
+    assert (keep / "f").read_text() == "x"  # symlink target untouched

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -12,7 +12,13 @@ from pathlib import Path
 from typing import Any
 
 import autoresearch.harness as harness_mod
-from autoresearch.harness import CodexHarness, SessionResult, _codex_command, _parse_codex_result
+from autoresearch.harness import (
+    CodexHarness,
+    SessionResult,
+    _codex_command,
+    _parse_codex_result,
+    _rmtree_at,
+)
 
 
 def test_command_has_expected_flags() -> None:
@@ -193,8 +199,60 @@ def test_run_survives_a_scratch_cleanup_that_raises(monkeypatch: Any, tmp_path: 
 
         returncode = 1
 
-    monkeypatch.setattr(harness_mod.shutil, "rmtree", boom)
+    monkeypatch.setattr(harness_mod, "_rmtree_at", boom)
     monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
     monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
     result = CodexHarness(api_key="k").run("brief", workspace)
     assert isinstance(result, SessionResult)  # cleanup did not propagate
+
+
+def test_rmtree_at_deletes_a_tree_but_never_follows_a_symlink(tmp_path: Path) -> None:
+    """_rmtree_at removes a real directory subtree, and when the named entry is
+    a symlink it deletes nothing (the target is left intact)."""
+    import os
+
+    parent = tmp_path / "parent"
+    (parent / "scratch" / "deep").mkdir(parents=True)
+    (parent / "scratch" / "deep" / "f").write_text("x")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "keep").write_text("y")
+    (parent / "link").symlink_to(outside)
+
+    fd = os.open(parent, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        _rmtree_at(fd, "scratch")  # real subtree: gone
+        _rmtree_at(fd, "link")  # symlink: not followed
+    finally:
+        os.close(fd)
+
+    assert not (parent / "scratch").exists()
+    assert (parent / "link").is_symlink()  # the link itself is left in place
+    assert (outside / "keep").read_text() == "y"  # target untouched
+
+
+def test_run_does_not_follow_a_symlinked_scratch_dir(monkeypatch: Any, tmp_path: Path) -> None:
+    """.codex is a real directory but .codex/.tmp is a symlink to an external
+    dir; cleanup must not follow it and delete the target."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    home = tmp_path / "ws-home"
+    (home / ".codex").mkdir(parents=True)
+    outside = tmp_path / "outside"
+    (outside / "keep").mkdir(parents=True)
+    (outside / "keep" / "f").write_text("x")
+    (home / ".codex" / ".tmp").symlink_to(outside)
+
+    class FakePopen:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def communicate(self, *a: Any, **k: Any) -> Any:
+            return ("", "")
+
+        returncode = 1
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
+    CodexHarness(api_key="k").run("brief", workspace)
+    assert (outside / "keep" / "f").read_text() == "x"  # symlink target untouched

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -102,3 +102,34 @@ def test_parse_skips_timestamped_log_lines() -> None:
     result = _parse_codex_result(stdout, "ok", 0)
     assert result.session_id == "t1"
     assert result.is_error is False
+
+
+def test_run_clears_codex_scratch_but_keeps_durable_state(monkeypatch: Any, tmp_path: Path) -> None:
+    """Codex leaks temp dirs into .codex/.tmp across a run's wakes; run() clears
+    that scratch each time, while its durable state (sessions, sqlite) stays."""
+    from autoresearch import harness as harness_mod
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    home = tmp_path / "ws-home"
+    tmp = home / ".codex" / ".tmp" / "leaked-dir"
+    tmp.mkdir(parents=True)
+    (tmp / "junk").write_text("x")
+    sessions = home / ".codex" / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "s.json").write_text("keep")
+
+    class FakePopen:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def communicate(self, *a: Any, **k: Any) -> Any:
+            return ("", "")
+
+        returncode = 1
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
+    CodexHarness(api_key="k").run("brief", workspace)
+    assert not (home / ".codex" / ".tmp").exists()  # scratch cleared
+    assert (sessions / "s.json").read_text() == "keep"  # durable state kept


### PR DESCRIPTION
Fix 1 of the per-run inode reduction (the codex half; the uv-cache half is a separate PR). An ended run's `ws-home` held ~28k files; `.codex/.tmp` was 9k of them — codex creates temp directories there and fails to clean them (those "failed to clean up stale arg0 temp dirs: Directory not empty" aborts are exactly this), and across a run's wakes they accumulate.

`CodexHarness.run()` now clears `.codex/.tmp` (and `.codex/tmp`) at the start of each run, before codex writes this run's scratch. Codex's durable state — `auth.json`, `sessions/`, the sqlite — lives elsewhere under `.codex` and is untouched, so resume still works. Test: a run with a pre-existing leaked `.codex/.tmp` and a `.codex/sessions/s.json` clears the scratch and keeps the session file.
