### PR TITLE
Share the agent's uv cache across runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- The agent's `uv` cache is now shared across runs instead of re-downloaded
+  into every per-run home. Each session's own `uv` calls wrote wheels into
+  `.cache/uv` under the run home — tens of thousands of files per run that came
+  to dominate the home and slow the housekeeper. All three backends now point
+  `UV_CACHE_DIR` at one content-addressed cache under `<root>/caches/uv` (on
+  the runs' filesystem, bound into the container), so wheels are fetched once
+  and a run's venv hardlinks out of the shared cache.
 - Codex sessions no longer leak temp directories into the per-run home. Codex
   writes scratch to `.codex/.tmp` and fails to remove it (the "stale arg0 temp
   dirs: Directory not empty" aborts), so across a run's wakes it grew to tens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- Codex sessions no longer leak temp directories into the per-run home. Codex
+  writes scratch to `.codex/.tmp` and fails to remove it (the "stale arg0 temp
+  dirs: Directory not empty" aborts), so across a run's wakes it grew to tens
+  of thousands of files — most of the per-run home. The session now clears
+  that scratch before each run, keeping codex's durable state.
 - Disk housekeeping is bounded per tick by a count and a wall-clock budget
   (a few workspaces or ~2 minutes on a healthy disk; more but still
   time-boxed when the disk is failing), covering both finding candidates and

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -950,9 +950,15 @@ class CodexHarness:
         # a run's wakes they pile up into tens of thousands of files, the bulk
         # of the per-run home. Clear codex's scratch before each run — its
         # durable state (auth.json, sessions, the sqlite) is elsewhere under
-        # .codex and untouched.
-        for scratch in (session_home / ".codex" / ".tmp", session_home / ".codex" / "tmp"):
-            shutil.rmtree(scratch, ignore_errors=True)
+        # .codex and untouched. A prior session owns this home, so if it
+        # replaced .codex with a symlink, deleting scratch "under" it would
+        # follow the link out of the run home: only clean a real directory
+        # (rmtree itself refuses a symlink AT a scratch path, so those are
+        # never followed either).
+        codex_home = session_home / ".codex"
+        if codex_home.is_dir() and not codex_home.is_symlink():
+            for scratch in (codex_home / ".tmp", codex_home / "tmp"):
+                shutil.rmtree(scratch, ignore_errors=True)
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
         # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -17,6 +17,7 @@ import contextlib
 import json
 import logging
 import os
+import shutil
 import signal
 import subprocess
 import uuid
@@ -944,6 +945,14 @@ class CodexHarness:
         except OSError as exc:
             log.warning("could not create session home %s: %s", session_home, exc)
             return _error_result("workspace-error")
+        # Codex leaks temp directories into .codex/.tmp and fails to remove
+        # them (the "stale arg0 temp dirs: Directory not empty" aborts); across
+        # a run's wakes they pile up into tens of thousands of files, the bulk
+        # of the per-run home. Clear codex's scratch before each run — its
+        # durable state (auth.json, sessions, the sqlite) is elsewhere under
+        # .codex and untouched.
+        for scratch in (session_home / ".codex" / ".tmp", session_home / ".codex" / "tmp"):
+            shutil.rmtree(scratch, ignore_errors=True)
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
         # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`

--- a/src/autoresearch/harness.py
+++ b/src/autoresearch/harness.py
@@ -102,6 +102,37 @@ def session_env(api_key: str, key_variable: str, home: Path) -> dict[str, str]:
     return env
 
 
+def _uv_cache_binding(session_home: Path) -> tuple[Path, list[str]]:
+    """The uv cache the agent's own `uv` calls populate, and the apptainer
+    `--bind` args that expose it inside a contained session.
+
+    When the run home sits in the orchestrator's `<root>/runs/<id>/` layout,
+    every run shares one content-addressed cache at `<root>/caches/uv`. Without
+    it each run re-downloads the same wheels into its per-run home — tens of
+    thousands of files that come to dominate the home and stall the
+    housekeeper. The shared cache is on the same filesystem as the runs, so a
+    run's venv hardlinks out of it (few new inodes) and shedding a run's home
+    frees nothing the next run needs.
+
+    Falls back to a per-run cache under the home for an ad-hoc layout (tests, a
+    bare local tree) or when the shared directory cannot be created; that path
+    is inside the `--home` mount already, so it needs no extra bind.
+    """
+    runs_dir = session_home.parent.parent
+    if runs_dir.name == "runs":
+        shared = runs_dir.parent / "caches" / "uv"
+        try:
+            shared.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass  # fall back to the per-run cache below
+        else:
+            return shared, ["--bind", f"{shared}:{shared}"]
+    per_run = session_home / ".cache" / "uv"
+    with contextlib.suppress(OSError):
+        per_run.mkdir(parents=True, exist_ok=True)
+    return per_run, []
+
+
 @dataclass(frozen=True)
 class VertexConfig:
     """Claude-on-Vertex auth (ADC): set to bill Anthropic sessions to a GCP
@@ -476,6 +507,7 @@ class ClaudeCodeHarness:
         # A read-only session (no mutating tool) gets a permission mode that
         # denies edits rather than auto-accepting them — defense in depth
         # behind the tool allowlist, so a stray edit tool cannot auto-apply.
+        uv_cache, uv_binds = _uv_cache_binding(session_home)
         mutating = {"Write", "Edit", "Bash"}.intersection(self.allowed_tools)
         permission_mode = "acceptEdits" if mutating else "default"
         claude_argv = [
@@ -515,6 +547,7 @@ class ClaudeCodeHarness:
                 "--cleanenv",
                 "--bind",
                 f"{workspace}:{workspace}",
+                *uv_binds,
                 # --home (NOT --env HOME=..., which apptainer silently
                 # refuses): mounts the per-run home at the same path inside
                 # and sets $HOME to it — native resume state survives
@@ -561,6 +594,9 @@ class ClaudeCodeHarness:
                     # with the prefix stripped — the key travels via the
                     # environment, never argv (argv is world-readable in /proc).
                     env["APPTAINERENV_ANTHROPIC_API_KEY"] = self.api_key
+            env["UV_CACHE_DIR"] = str(uv_cache)
+            if self.container_image:
+                env["APPTAINERENV_UV_CACHE_DIR"] = str(uv_cache)
             process = subprocess.Popen(
                 command,
                 cwd=workspace,
@@ -860,7 +896,11 @@ class CodexHarness:
     supports_resume = True
 
     def _apptainer_argv(
-        self, inner: list[str], session_home: Path, workspace: Path | None
+        self,
+        inner: list[str],
+        session_home: Path,
+        workspace: Path | None,
+        uv_binds: list[str] | None = None,
     ) -> list[str]:
         """Wrap a codex argv in `apptainer exec --containall --cleanenv`. The
         run-home is bound via `--home` (auth.json survives login->exec and lands
@@ -878,6 +918,7 @@ class CodexHarness:
             f"{self.binary}:{self.CONTAINER_CODEX}:ro",
         ]
         if workspace is not None:
+            argv += uv_binds or []
             argv += ["--bind", f"{workspace}:{workspace}", "--pwd", str(workspace)]
         return [*argv, self.container_image, *inner]
 
@@ -959,6 +1000,7 @@ class CodexHarness:
         if codex_home.is_dir() and not codex_home.is_symlink():
             for scratch in (codex_home / ".tmp", codex_home / "tmp"):
                 shutil.rmtree(scratch, ignore_errors=True)
+        uv_cache, uv_binds = _uv_cache_binding(session_home)
         # Codex authenticates from ~/.codex/auth.json, not OPENAI_API_KEY alone
         # (the responses endpoint 401s on env-only). Write auth.json
         # into the scrubbed per-run HOME with `codex login --with-api-key`
@@ -985,7 +1027,7 @@ class CodexHarness:
             self.extra_args,
         )
         command = (
-            self._apptainer_argv(codex_argv, session_home, workspace)
+            self._apptainer_argv(codex_argv, session_home, workspace, uv_binds)
             if self.container_image
             else codex_argv
         )
@@ -993,6 +1035,9 @@ class CodexHarness:
             env = session_env(self.api_key, "OPENAI_API_KEY", session_home)
             if self.container_image:
                 env["APPTAINERENV_OPENAI_API_KEY"] = self.api_key
+            env["UV_CACHE_DIR"] = str(uv_cache)
+            if self.container_image:
+                env["APPTAINERENV_UV_CACHE_DIR"] = str(uv_cache)
             process = subprocess.Popen(
                 command,
                 cwd=workspace,
@@ -1210,9 +1255,10 @@ class HermesHarness:
     # Apptainer image for session containment, same stance as the other
     # backends: when set, the session runs under `apptainer exec --containall
     # --cleanenv` seeing only the workspace, the per-run home, and a read-only
-    # bind of the pinned hermes repo. The project venv and uv cache live in
-    # the per-run home (UV_PROJECT_ENVIRONMENT/UV_CACHE_DIR), so the repo
-    # bind stays read-only and nothing survives across runs.
+    # bind of the pinned hermes repo. The project venv lives in the per-run
+    # home (UV_PROJECT_ENVIRONMENT) so the repo bind stays read-only; the uv
+    # download cache (UV_CACHE_DIR) is the fleet-shared one, like the other
+    # backends.
     container_image: str = ""
     apptainer_binary: str = "apptainer"
 
@@ -1227,6 +1273,7 @@ class HermesHarness:
         except OSError as exc:
             log.warning("could not create session home %s: %s", session_home, exc)
             return _error_result("workspace-error")
+        uv_cache, uv_binds = _uv_cache_binding(session_home)
         # Resume: rehydrate the prior conversation into this brief. A missing
         # transcript is a hard error, NOT a blind fresh start (the deployment
         # must preserve the per-run home for resume, same as claude's $HOME /
@@ -1291,6 +1338,7 @@ class HermesHarness:
                 "--cleanenv",
                 "--bind",
                 f"{workspace_abs}:{workspace_abs}",
+                *uv_binds,
                 # --home mounts the per-run home at the same path inside and
                 # sets $HOME to it — hermes config, brief, samples, and the
                 # resume transcript all persist on the shared FS
@@ -1309,7 +1357,7 @@ class HermesHarness:
             # cache in the per-run home instead (fresh per run; nothing shared
             # across sessions)
             env["UV_PROJECT_ENVIRONMENT"] = str(session_home / "venv")
-            env["UV_CACHE_DIR"] = str(session_home / "uv-cache")
+            env["UV_CACHE_DIR"] = str(uv_cache)
             env["UV_LINK_MODE"] = "copy"
             if self.container_image:
                 # --cleanenv drops the host env inside the container EXCEPT

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -115,6 +115,9 @@ def test_run_clears_codex_scratch_but_keeps_durable_state(monkeypatch: Any, tmp_
     tmp = home / ".codex" / ".tmp" / "leaked-dir"
     tmp.mkdir(parents=True)
     (tmp / "junk").write_text("x")
+    tmp_alt = home / ".codex" / "tmp" / "leaked-dir"  # the alternate scratch name
+    tmp_alt.mkdir(parents=True)
+    (tmp_alt / "junk").write_text("x")
     sessions = home / ".codex" / "sessions"
     sessions.mkdir(parents=True)
     (sessions / "s.json").write_text("keep")
@@ -132,4 +135,38 @@ def test_run_clears_codex_scratch_but_keeps_durable_state(monkeypatch: Any, tmp_
     monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
     CodexHarness(api_key="k").run("brief", workspace)
     assert not (home / ".codex" / ".tmp").exists()  # scratch cleared
+    assert not (home / ".codex" / "tmp").exists()  # alternate scratch cleared too
     assert (sessions / "s.json").read_text() == "keep"  # durable state kept
+
+
+def test_run_does_not_follow_a_symlinked_codex_out_of_home(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """A prior session owns its home; if it replaced .codex with a symlink to
+    an external directory, the scratch cleanup must not follow the link and
+    delete the target's .tmp."""
+    from autoresearch import harness as harness_mod
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    home = tmp_path / "ws-home"
+    home.mkdir()
+    outside = tmp_path / "outside"
+    keep = outside / ".tmp" / "keep"
+    keep.mkdir(parents=True)
+    (keep / "f").write_text("x")
+    (home / ".codex").symlink_to(outside)
+
+    class FakePopen:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def communicate(self, *a: Any, **k: Any) -> Any:
+            return ("", "")
+
+        returncode = 1
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
+    CodexHarness(api_key="k").run("brief", workspace)
+    assert (keep / "f").read_text() == "x"  # symlink target untouched

--- a/tests/test_codex_harness.py
+++ b/tests/test_codex_harness.py
@@ -102,3 +102,34 @@ def test_parse_skips_timestamped_log_lines() -> None:
     result = _parse_codex_result(stdout, "ok", 0)
     assert result.session_id == "t1"
     assert result.is_error is False
+
+
+def test_run_clears_codex_scratch_but_keeps_durable_state(monkeypatch: Any, tmp_path: Path) -> None:
+    """Codex leaks temp dirs into .codex/.tmp across a run's wakes; run() clears
+    that scratch each time, while its durable state (sessions, sqlite) stays."""
+    from autoresearch import harness as harness_mod
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    home = tmp_path / "ws-home"
+    tmp = home / ".codex" / ".tmp" / "leaked-dir"
+    tmp.mkdir(parents=True)
+    (tmp / "junk").write_text("x")
+    sessions = home / ".codex" / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "s.json").write_text("keep")
+
+    class FakePopen:
+        def __init__(self, *a: Any, **k: Any) -> None:
+            pass
+
+        def communicate(self, *a: Any, **k: Any) -> Any:
+            return ("", "")
+
+        returncode = 1
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
+    CodexHarness(api_key="k").run("brief", workspace)
+    assert not (home / ".codex" / ".tmp").exists()  # scratch cleared
+    assert (sessions / "s.json").read_text() == "keep"  # durable state kept

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -884,12 +884,13 @@ def test_codex_container_run_binds_and_exports_the_shared_uv_cache(
     binary = tmp_path / "codex"
     binary.write_text("#!/bin/sh\n")
 
-    seen: dict[str, object] = {}
+    captured_argv: list[list[str]] = []
+    captured_env: list[dict[str, str]] = []
 
     class FakePopen:
         def __init__(self, argv: list[str], *a: object, env: dict[str, str], **k: object) -> None:
-            seen["argv"] = argv
-            seen["env"] = env
+            captured_argv.append(argv)
+            captured_env.append(env)
 
         def communicate(self, *a: object, **k: object) -> tuple[str, str]:
             return ("", "")
@@ -903,9 +904,8 @@ def test_codex_container_run_binds_and_exports_the_shared_uv_cache(
     )
 
     cache = root / "caches" / "uv"
-    argv = " ".join(str(a) for a in seen["argv"])  # type: ignore[arg-type]
+    argv = " ".join(captured_argv[0])
     assert f"--bind {cache}:{cache}" in argv
-    env = seen["env"]
-    assert isinstance(env, dict)
+    env = captured_env[0]
     assert env["UV_CACHE_DIR"] == str(cache)
     assert env["APPTAINERENV_UV_CACHE_DIR"] == str(cache)

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -842,3 +842,70 @@ def test_role_key_tolerates_a_missing_file_only_under_vertex(tmp_path, monkeypat
     assert role_key(missing) == ""  # ADC-only claude deployment
     with pytest.raises(ValueError):
         role_key(missing, "codex")  # vertex never excuses a non-claude backend
+
+
+def test_uv_cache_binding_shares_one_cache_under_the_run_root(tmp_path: Path) -> None:
+    """In the orchestrator's <root>/runs/<id>/ layout every run points its uv
+    cache at one shared <root>/caches/uv, with the bind that exposes it."""
+    from autoresearch.harness import _uv_cache_binding
+
+    root = tmp_path
+    session_home = root / "runs" / "speedrun-20260903-x-agent-01" / "ws-home"
+    session_home.mkdir(parents=True)
+    cache, binds = _uv_cache_binding(session_home)
+    assert cache == root / "caches" / "uv"
+    assert cache.is_dir()  # created, so the --bind source exists at mount time
+    assert binds == ["--bind", f"{cache}:{cache}"]
+
+
+def test_uv_cache_binding_falls_back_per_run_for_an_adhoc_layout(tmp_path: Path) -> None:
+    """Without the runs/<id> layout (tests, a bare local tree) the cache stays
+    per-run under the home, which the --home mount already exposes (no bind)."""
+    from autoresearch.harness import _uv_cache_binding
+
+    session_home = tmp_path / "ws-home"  # no `runs` ancestor
+    session_home.mkdir()
+    cache, binds = _uv_cache_binding(session_home)
+    assert cache == session_home / ".cache" / "uv"
+    assert binds == []
+
+
+def test_codex_container_run_binds_and_exports_the_shared_uv_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A contained codex run exposes the shared cache to the agent's own uv:
+    the exec argv binds <root>/caches/uv and the env crosses --cleanenv via
+    APPTAINERENV_UV_CACHE_DIR."""
+    import autoresearch.harness as harness_mod
+
+    root = tmp_path
+    workspace = root / "runs" / "speedrun-20260903-x-agent-01" / "ws"
+    workspace.mkdir(parents=True)
+    binary = tmp_path / "codex"
+    binary.write_text("#!/bin/sh\n")
+
+    seen: dict[str, object] = {}
+
+    class FakePopen:
+        def __init__(self, argv: list[str], *a: object, env: dict[str, str], **k: object) -> None:
+            seen["argv"] = argv
+            seen["env"] = env
+
+        def communicate(self, *a: object, **k: object) -> tuple[str, str]:
+            return ("", "")
+
+        returncode = 1
+
+    monkeypatch.setattr(harness_mod.subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(CodexHarness, "_login", lambda self, hm: None)
+    CodexHarness(api_key="k", binary=str(binary), container_image="/img/agent.sif").run(
+        "brief", workspace
+    )
+
+    cache = root / "caches" / "uv"
+    argv = " ".join(str(a) for a in seen["argv"])  # type: ignore[arg-type]
+    assert f"--bind {cache}:{cache}" in argv
+    env = seen["env"]
+    assert isinstance(env, dict)
+    assert env["UV_CACHE_DIR"] == str(cache)
+    assert env["APPTAINERENV_UV_CACHE_DIR"] == str(cache)


### PR DESCRIPTION
Fix 2 of the per-run inode reduction (the uv-cache half; the codex-temp half is #250).

Each session's own `uv` calls — the agent running `uv sync`/`uv run` while it works — wrote wheels into `.cache/uv` under the per-run home. That was ~19k files per run, the bulk of what an ended run's `ws-home` holds, and it is re-downloaded from scratch every run because the home is per-run. With tens of runs a day it dominates the scratch inode quota and slows the housekeeper's `rm -rf`.

All three backends now point the agent's `UV_CACHE_DIR` at one content-addressed cache under `<root>/caches/uv`:

- New `_uv_cache_binding(session_home)` returns the cache dir and the apptainer `--bind` args. When the run home is in the orchestrator's `<root>/runs/<id>/` layout it shares `<root>/caches/uv`; for an ad-hoc layout (tests, a bare local tree) or if that dir can't be created it falls back to the per-run `.cache/uv`, which the `--home` mount already exposes (no bind).
- Claude, Codex, and Hermes each set `UV_CACHE_DIR` (+ `APPTAINERENV_UV_CACHE_DIR` across `--cleanenv`) and add the bind when contained. The cache sits on the runs' filesystem, so a run's venv hardlinks out of it (few new inodes) rather than copying.
- Hermes keeps its per-run `UV_PROJECT_ENVIRONMENT` venv and copy link-mode as before; only its download cache moves to the shared one, matching the other backends.

The wheels are fetched once and reused; shedding a run's home no longer throws away the cache the next run needs. Same apptainer bind + `APPTAINERENV_UV_CACHE_DIR` pattern the eval path already uses.

Tests: `_uv_cache_binding` shares under the run-root layout and falls back per-run for an ad-hoc one; a contained codex run binds `<root>/caches/uv` and exports it across `--cleanenv`.
