### PR TITLE
Surface a launch's scheduler state on wake (diagnose silent SIGKILL/OOM/timeout)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- A launched experiment that the scheduler SIGKILLs (out-of-memory, a hard
+  walltime kill, a node failure) left no exit code, so the woken author saw
+  only "exit code: none (job failure)" with empty output and could not tell
+  why. The wake now surfaces the job's terminal scheduler state
+  (`OUT_OF_MEMORY` / `TIMEOUT` / `NODE_FAIL`) with a one-line reading, using
+  the state the backend already knows — turning an invisible death into a
+  diagnosable one.
 - Codex sessions no longer leak temp directories into the per-run home. Codex
   writes scratch to `.codex/.tmp` and fails to remove it (the "stale arg0 temp
   dirs: Directory not empty" aborts), so across a run's wakes it grew to tens

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,8 @@ Versions follow [SemVer](https://semver.org).
   only "exit code: none (job failure)" with empty output and could not tell
   why. The wake now surfaces the job's terminal scheduler state
   (`OUT_OF_MEMORY` / `TIMEOUT` / `NODE_FAIL`) with a one-line reading, using
-  the state the backend already knows — turning an invisible death into a
-  diagnosable one.
+  the state the backend already knows, so the author can see why the launch
+  died and adjust, instead of retrying a config that will fail the same way.
 - Codex sessions no longer leak temp directories into the per-run home. Codex
   writes scratch to `.codex/.tmp` and fails to remove it (the "stale arg0 temp
   dirs: Directory not empty" aborts), so across a run's wakes it grew to tens

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -677,7 +677,12 @@ def _wake_author_sleep(
     author to act on; `sleep_ref` is whichever snapshot ref this park holds
     (the sleep seal, or the submitted candidate)."""
     from autoresearch.syscall import Launch as SyscallLaunch
-    from autoresearch.syscall import gather_results, render_wake, write_budget
+    from autoresearch.syscall import (
+        annotate_launch_states,
+        gather_results,
+        render_wake,
+        write_budget,
+    )
 
     def _end(result: AttemptResult, drop_refs: list[str]) -> AttemptOutcome:
         # a terminal from the resumed climb: report, ending record, issue note —
@@ -751,6 +756,15 @@ def _wake_author_sleep(
         for item in _stage_launches(record)
     )
     results = gather_results(run_dir, workspace, launches)
+    # A launch that left no exit code was SIGKILL'd before its wrapper ran (the
+    # cgroup OOM killer, a hard walltime kill, a node failure). The scheduler
+    # still knows which; surface it so the author reads "OOM"/"timeout" instead
+    # of a blank "job failure". The park's launch job ids align positionally
+    # with the results (same launch/array order). Best-effort — the wake never
+    # blocks on the scheduler query.
+    status_of = getattr(dispatch.compute, "status", None)
+    if status_of is not None:
+        results = annotate_launch_states(results, _stage_launch_job_ids(record), status_of)
     launches_used = int(record.stage.get("launches_used", 0))  # type: ignore[call-overload]
     sleeps_used = int(record.stage.get("sleeps_used", 0))  # type: ignore[call-overload]
     gpu_hours_used = _reconcile_launch_hours(record, dispatch, bench.gpus, launches)

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -36,8 +36,8 @@ import contextlib
 import json
 import os
 import re
-from collections.abc import Iterable
-from dataclasses import dataclass
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
@@ -139,6 +139,10 @@ class LaunchResult:
     stderr_tail: str
     delivered: tuple[str, ...]  # workspace-relative artifact paths delivered
     skipped: tuple[str, ...]  # declared artifacts not delivered (with reason)
+    # The scheduler's terminal state, filled in only when the job left no exit
+    # code (an untrappable SIGKILL — OOM, walltime kill, node failure — writes
+    # none). "" when known from the exit code, unavailable, or unqueried.
+    slurm_state: str = ""
 
 
 def launch_jobs(launch: Launch) -> tuple[tuple[str, dict[str, str]], ...]:
@@ -719,6 +723,58 @@ def _read_tail(path: Path, max_chars: int) -> str:
     return data.decode("utf-8", "replace")[-max_chars:]
 
 
+def annotate_launch_states(
+    results: tuple[LaunchResult, ...],
+    job_ids: list[str],
+    status_of: Callable[[str], str],
+) -> tuple[LaunchResult, ...]:
+    """Attach each launch's terminal scheduler state to the results that left
+    NO exit code. An untrappable SIGKILL — the cgroup OOM killer, a hard
+    walltime kill, a node failure — writes no exit-code file, so the exit code
+    alone cannot say why the job died; the scheduler still knows. Results and
+    job_ids are both in launch/array submission order, so they align
+    positionally. Best-effort: a failed query (or a backend that cannot say)
+    leaves the state blank and the wake falls back to the bare exit-code line."""
+    if len(job_ids) != len(results):
+        return results  # the positional mapping is unsafe — never guess one
+    annotated: list[LaunchResult] = []
+    for result, job_id in zip(results, job_ids, strict=True):
+        if result.exit_code is None and job_id:
+            try:
+                state = status_of(job_id)
+            except Exception:
+                state = ""
+            if state:
+                result = replace(result, slurm_state=state)
+        annotated.append(result)
+    return tuple(annotated)
+
+
+def _state_hint(state: str) -> str:
+    """A one-line, honest reading of a terminal state for a launch that left no
+    exit code — the untrappable-SIGKILL causes an author otherwise cannot tell
+    apart."""
+    upper = state.upper()
+    if upper.startswith("OUT_OF_MEMORY"):
+        return " (killed for running out of memory — reduce the config's memory footprint)"
+    if upper.startswith(("TIMEOUT", "DEADLINE")):
+        return " (killed at the walltime cap before it finished)"
+    if upper.startswith(("NODE_FAIL", "BOOT_FAIL")):
+        return " (a node failure, not your code — worth a retry)"
+    return ""
+
+
+def _exit_code_line(result: LaunchResult) -> str:
+    """The exit-code text for one launch. A missing exit code is a job that
+    died without its wrapper running; the scheduler state, when known, says
+    why (OOM / walltime / node) instead of a bare 'job failure'."""
+    if result.exit_code is not None:
+        return str(result.exit_code)
+    if result.slurm_state:
+        return f"none — scheduler state {result.slurm_state}{_state_hint(result.slurm_state)}"
+    return "none (job failure)"
+
+
 def _tail(text: str) -> str:
     return text[-MAX_OUTPUT_CHARS:] if len(text) > MAX_OUTPUT_CHARS else text
 
@@ -739,11 +795,7 @@ def render_wake(
     data-fenced exactly like panel findings."""
     blocks: list[str] = []
     for r in results:
-        lines = [
-            "launch `{}` — exit code: {}".format(
-                r.name, r.exit_code if r.exit_code is not None else "none (job failure)"
-            )
-        ]
+        lines = [f"launch `{r.name}` — exit code: {_exit_code_line(r)}"]
         if r.delivered:
             lines.append("artifacts delivered: " + ", ".join(f"`{p}`" for p in r.delivered))
         if r.skipped:

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -39,9 +39,11 @@ import re
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
+from time import monotonic
 from typing import Any
 
 from autoresearch.brief import _fence
+from autoresearch.compute import GONE
 
 SYSCALL_DIR = ".autoresearch"
 SYSCALL_FILE = "syscall.json"
@@ -727,25 +729,41 @@ def annotate_launch_states(
     results: tuple[LaunchResult, ...],
     job_ids: list[str],
     status_of: Callable[[str], str],
+    *,
+    time_budget_s: float = 30.0,
+    clock: Callable[[], float] = monotonic,
 ) -> tuple[LaunchResult, ...]:
     """Attach each launch's terminal scheduler state to the results that left
     NO exit code. An untrappable SIGKILL — the cgroup OOM killer, a hard
     walltime kill, a node failure — writes no exit-code file, so the exit code
     alone cannot say why the job died; the scheduler still knows. Results and
     job_ids are both in launch/array submission order, so they align
-    positionally. Best-effort: a failed query (or a backend that cannot say)
-    leaves the state blank and the wake falls back to the bare exit-code line."""
+    positionally.
+
+    Bounded: the whole annotation spends at most ~`time_budget_s` querying the
+    scheduler (one in-flight query may still overrun by its own timeout), so a
+    stalled `sacct` across the many jobs a wake can carry (up to depth_k x the
+    array width) can never burn the author's wake walltime — jobs past the
+    budget keep the blank fallback. Best-effort throughout: a failed query, a
+    backend that cannot say, or a GONE record (the scheduler forgot the job —
+    not a failure state) also leaves the state blank and the wake falls back to
+    the bare exit-code line."""
     if len(job_ids) != len(results):
         return results  # the positional mapping is unsafe — never guess one
     annotated: list[LaunchResult] = []
+    start = clock()
+    over_budget = False
     for result, job_id in zip(results, job_ids, strict=True):
-        if result.exit_code is None and job_id:
-            try:
-                state = status_of(job_id)
-            except Exception:
-                state = ""
-            if state:
-                result = replace(result, slurm_state=state)
+        if result.exit_code is None and job_id and not over_budget:
+            if clock() - start >= time_budget_s:
+                over_budget = True  # stop querying; the rest keep the fallback
+            else:
+                try:
+                    state = status_of(job_id)
+                except Exception:
+                    state = ""
+                if state and state != GONE:
+                    result = replace(result, slurm_state=state)
         annotated.append(result)
     return tuple(annotated)
 

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -310,6 +310,34 @@ def test_annotate_launch_states_bails_on_a_length_mismatch() -> None:
     assert out == results  # no positional mapping -> nothing guessed
 
 
+def test_annotate_launch_states_skips_a_gone_record() -> None:
+    # GONE = the scheduler forgot the job; it is not a failure state to show
+    out = annotate_launch_states((_lr("a", None),), ["j-a"], lambda j: "GONE")
+    assert out[0].slurm_state == ""
+
+
+def test_annotate_launch_states_stops_at_the_time_budget() -> None:
+    # a stalled sacct must not burn the wake: once the budget is spent, the
+    # remaining exit-less jobs keep the blank fallback and are never queried.
+    queried: list[str] = []
+
+    def status_of(job_id: str) -> str:
+        queried.append(job_id)
+        return "OUT_OF_MEMORY"
+
+    # clock: start=0, then every check is already past the 30s budget
+    ticks = iter([0.0, 100.0, 100.0, 100.0])
+    out = annotate_launch_states(
+        (_lr("a", None), _lr("b", None)),
+        ["j-a", "j-b"],
+        status_of,
+        time_budget_s=30.0,
+        clock=lambda: next(ticks),
+    )
+    assert queried == []  # budget already spent at the first check -> no queries
+    assert all(r.slurm_state == "" for r in out)
+
+
 def test_wake_text_names_the_scheduler_state_for_an_exitless_job() -> None:
     res = _lr("width1024", None, state="OUT_OF_MEMORY")
     text = render_wake((res,), "", launches_used=1, launch_budget=4, sleeps_used=1, sleep_budget=4)

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -16,6 +16,7 @@ from autoresearch.syscall import (
     SyscallError,
     SyscallRequest,
     VerdictError,
+    annotate_launch_states,
     budget_error,
     ensure_excluded,
     install_tool,
@@ -272,6 +273,49 @@ def test_wake_text_flags_the_last_sleep() -> None:
     text = render_wake((), "", launches_used=0, launch_budget=4, sleeps_used=4, sleep_budget=4)
     assert "LAST sleep" in text
     assert "checkpoint sleep" in text  # no launches -> says so
+
+
+def _lr(name: str, exit_code, state: str = "") -> LaunchResult:
+    return LaunchResult(
+        name=name,
+        exit_code=exit_code,
+        stdout_tail="",
+        stderr_tail="",
+        delivered=(),
+        skipped=(),
+        slurm_state=state,
+    )
+
+
+def test_annotate_launch_states_fills_only_exitless_jobs() -> None:
+    results = (_lr("a", 0), _lr("b", None), _lr("c", 137))
+    states = {"j-a": "COMPLETED", "j-b": "OUT_OF_MEMORY", "j-c": "FAILED"}
+    out = annotate_launch_states(results, ["j-a", "j-b", "j-c"], lambda j: states[j])
+    assert out[0].slurm_state == ""  # had an exit code: untouched, unqueried
+    assert out[1].slurm_state == "OUT_OF_MEMORY"  # the exitless one is annotated
+    assert out[2].slurm_state == ""  # had an exit code
+
+
+def test_annotate_launch_states_survives_a_failing_query() -> None:
+    def boom(_job_id: str) -> str:
+        raise RuntimeError("sacct down")
+
+    out = annotate_launch_states((_lr("a", None),), ["j-a"], boom)
+    assert out[0].slurm_state == ""  # best-effort: blank, not a crash
+
+
+def test_annotate_launch_states_bails_on_a_length_mismatch() -> None:
+    results = (_lr("a", None), _lr("b", None))
+    out = annotate_launch_states(results, ["only-one-id"], lambda j: "OUT_OF_MEMORY")
+    assert out == results  # no positional mapping -> nothing guessed
+
+
+def test_wake_text_names_the_scheduler_state_for_an_exitless_job() -> None:
+    res = _lr("width1024", None, state="OUT_OF_MEMORY")
+    text = render_wake((res,), "", launches_used=1, launch_budget=4, sleeps_used=1, sleep_budget=4)
+    assert "scheduler state OUT_OF_MEMORY" in text
+    assert "running out of memory" in text  # the honest hint
+    assert "none (job failure)" not in text  # replaced by the diagnosable line
 
 
 def test_refusal_names_the_reason_and_the_remaining_budget() -> None:


### PR DESCRIPTION
Fix A of the "wasted climb budget" investigation (silent launch failures).

A launched experiment killed by an untrappable SIGKILL — the cgroup OOM killer, a hard walltime kill after the grace period, or a node failure — never runs the wrapper's `echo $? > exit-code`, so the wake read the exit code as absent and showed the author only `exit code: none (job failure)` with empty stdout/stderr. A host-RAM OOM during `torch.compile` is exactly this: killed mid-compile before Python prints. Agents can't diagnose it, so they back away from the (promising, capacity-heavy) configs that trigger it.

The scheduler already knows the cause — `compute.status()` returns `OUT_OF_MEMORY` / `TIMEOUT` / `NODE_FAIL` — and the wake already queries those same launch job ids for the GPU-hours refund. This surfaces it:

- `LaunchResult` gains a `slurm_state` field, filled only for jobs that left no exit code.
- `annotate_launch_states(results, job_ids, status_of)` (syscall.py) attaches the terminal state; results and job ids are both in launch/array submission order, so they align positionally, and it bails if the lengths ever disagree rather than guess a mapping. Best-effort: a failed query leaves the state blank and the wake falls back to today's line.
- `render_wake` turns `exit code: none (job failure)` into `exit code: none — scheduler state OUT_OF_MEMORY (killed for running out of memory…)`, with honest one-line hints for OOM / walltime / node-fail.
- The wake wires it in after `gather_results`, guarded by `getattr(dispatch.compute, "status", None)` so a backend without it (or `LocalCompute`) is a no-op.

Part of a set: B (git-HEAD wake hardening) and C (launch limits) follow as separate PRs.

Tests: annotate fills only exit-less jobs, survives a failing query, bails on a length mismatch; the wake text names the state and drops the blank "job failure".
