### PR TITLE
Harden the wake against git object-store tamper (symref-aware guard + clean refused wake)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- A wake no longer crashes into an `attempt-error` when a session emptied the
+  workspace's object store behind a symbolic ref. The `.git` integrity guard
+  now follows a symbolic loose ref (`HEAD -> refs/heads/link -> refs/heads/main`)
+  to verify HEAD's object, closing a blind spot where the object could be gone
+  yet the guard passed and a later `git reset` failed raw ("Could not parse
+  object 'HEAD'"). Any tamper-class `GitError` that still escapes the wake body
+  (a TOCTOU object removal) now ends the run cleanly as a refused wake instead
+  of crashing it into a re-park.
 - Codex sessions no longer leak temp directories into the per-run home. Codex
   writes scratch to `.codex/.tmp` and fails to remove it (the "stale arg0 temp
   dirs: Directory not empty" aborts), so across a run's wakes it grew to tens

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1352,6 +1352,24 @@ def _utc_date(now: float) -> str:
     return datetime.fromtimestamp(now, UTC).strftime("%Y-%m-%d")
 
 
+def _is_git_tamper(exc: GitError) -> bool:
+    """True when a GitError means the workspace's object store or refs are
+    damaged / session-altered — as opposed to an ordinary git failure (a push
+    conflict, a fetch outage). The guard raises its own `_altered(...)` for the
+    states it models; a raw object-store error ("Could not parse object", "bad
+    tree object") is the same class reaching a git command through a TOCTOU
+    window. Either way the wake cannot be trusted and must END, not crash."""
+    msg = str(exc).lower()
+    return (
+        "altered by the session" in msg  # the guard's own _altered signal
+        or "could not parse object" in msg
+        or "bad tree object" in msg
+        or "bad object" in msg
+        or "unable to read tree" in msg
+        or ("object file" in msg and "empty" in msg)
+    )
+
+
 def _end_refused_wake(
     run_root: Path, record: RunRecord, exc: Exception, now: float, secrets: tuple[str, ...]
 ) -> AttemptOutcome:
@@ -3253,6 +3271,7 @@ def main() -> int:
                 container_image=args.image,
                 codex_extra_args=codex_extra,
             )
+        wake_secrets = tuple(k for k in (bot_auth.token(), *wake_panel_secrets, wake_api_key) if k)
         try:
             resumed = resume_run(
                 args.run_root,
@@ -3261,13 +3280,27 @@ def main() -> int:
                 github=GitHubClient(auth=bot_auth),
                 bot_auth=bot_auth,
                 now=time.time(),
-                secrets=tuple(
-                    k for k in (bot_auth.token(), *wake_panel_secrets, wake_api_key) if k
-                ),
+                secrets=wake_secrets,
                 base_branch=args.base_branch,
                 panel_lenses=wake_lenses,
                 harness=wake_harness,
                 spec=wake_spec,
+            )
+        except GitError as exc:
+            # A tamper-class GitError that escaped the wake body (a TOCTOU
+            # object removal past the entry guard, or a git op that reached a
+            # damaged object) ends the run cleanly as a refused wake — "a
+            # refused wake ends the run" — instead of crashing the job into a
+            # re-park that only wakes into the same failure. A non-tamper
+            # GitError (push conflict, fetch outage) propagates unchanged.
+            if not _is_git_tamper(exc):
+                raise
+            resumed = _end_refused_wake(
+                args.run_root,
+                load_record(args.run_root, args.resume),
+                exc,
+                time.time(),
+                wake_secrets,
             )
         finally:
             # This wake job HOLDS the run's lease (the sweep transferred it on

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -1354,11 +1354,12 @@ def _utc_date(now: float) -> str:
 
 def _is_git_tamper(exc: GitError) -> bool:
     """True when a GitError means the workspace's object store or refs are
-    damaged / session-altered — as opposed to an ordinary git failure (a push
+    damaged or session-altered — as opposed to an ordinary git failure (a push
     conflict, a fetch outage). The guard raises its own `_altered(...)` for the
-    states it models; a raw object-store error ("Could not parse object", "bad
-    tree object") is the same class reaching a git command through a TOCTOU
-    window. Either way the wake cannot be trusted and must END, not crash."""
+    states it models; a raw object-store error ("could not parse object", "bad
+    tree object", a corrupt or unreadable pack) is the same damage reaching a
+    git command in the gap between the guard's check and the command. Either
+    way the wake cannot be trusted and must END, not crash."""
     msg = str(exc).lower()
     return (
         "altered by the session" in msg  # the guard's own _altered signal
@@ -1366,6 +1367,8 @@ def _is_git_tamper(exc: GitError) -> bool:
         or "bad tree object" in msg
         or "bad object" in msg
         or "unable to read tree" in msg
+        or "data stream error" in msg  # inflate: a corrupt pack
+        or "is corrupt" in msg  # "packed object ... is corrupt", loose too
         or ("object file" in msg and "empty" in msg)
     )
 
@@ -1848,6 +1851,10 @@ def resume_run(
                         ),
                     )(baseline, candidate, str(stage.get("report", "")))
                 except Exception as exc:
+                    if isinstance(exc, GitError) and _is_git_tamper(exc):
+                        # tamper during the panel is not a panel error to draft
+                        # around — end as a refused wake.
+                        return _end_refused_wake(run_root, record, exc, now, secrets)
                     log.warning(
                         "wake panel errored for %s (%s); opening a DRAFT",
                         run_id,
@@ -1952,6 +1959,11 @@ def resume_run(
                     panel_ran=result.panel_rounds > 0,
                 )
         except Exception as exc:
+            if isinstance(exc, GitError) and _is_git_tamper(exc):
+                # a concurrent object-store removal during the publish block is
+                # tamper, not a publish failure: end as a refused wake (the
+                # clean tamper terminal) rather than mask it as a publish-error.
+                return _end_refused_wake(run_root, record, exc, now, secrets)
             # push / PR / commit failed — end as an error. Save the ENDED record
             # BEFORE dropping the snapshot (same ordering as the other terminals):
             # a failed save then leaves the run WAITING with its snapshot intact

--- a/src/autoresearch/github.py
+++ b/src/autoresearch/github.py
@@ -1124,12 +1124,27 @@ def _read_small_regular(path: Path, limit: int = 512) -> str | None:
         raise _altered(f"{path.name} is unreadable ({exc.strerror})") from None
 
 
-def _ref_sha(git_dir: Path, ref: str) -> str | None:
-    """A ref's sha from its loose file (inside .git only) or packed-refs."""
+def _ref_sha(git_dir: Path, ref: str, _depth: int = 0) -> str | None:
+    """A ref's sha from its loose file (inside .git only) or packed-refs,
+    following a symbolic loose ref (`ref: refs/...`) the way git resolves it.
+    Without the chain, a HEAD -> refs/heads/X -> refs/heads/real symref left the
+    object unverified (the non-sha loose file read as unborn), so an emptied
+    object store behind `real` slipped past the guard and only failed later at a
+    raw `git reset` ("Could not parse object 'HEAD'"). A too-deep chain is a
+    cycle git never writes: tampering, not a state to resolve."""
+    if _depth > 8:
+        raise _altered("a ref symref chain is too deep (a cycle?)")
     loose = _read_small_regular(git_dir / ref)
     if loose is not None:
         value = loose.strip()
-        return value if _SHA_RE.fullmatch(value) else None
+        if _SHA_RE.fullmatch(value):
+            return value
+        if value.startswith("ref: "):
+            target = value[5:].strip()
+            if not _REF_RE.fullmatch(target) or ".." in target.split("/"):
+                raise _altered("a ref names a target outside refs/")
+            return _ref_sha(git_dir, target, _depth + 1)
+        return None  # neither a sha nor a symref: an unborn/placeholder ref
     packed = _read_small_regular(git_dir / "packed-refs", limit=PACKED_REFS_MAX_BYTES) or ""
     for line in packed.splitlines():
         if line.endswith(" " + ref) and _SHA_RE.fullmatch(line.split(" ", 1)[0]):

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -2394,6 +2394,35 @@ def test_resume_improved_pushes_and_opens_pr(tmp_path, monkeypatch) -> None:
     assert github.prs[0]["draft"] is False
 
 
+def test_resume_routes_tamper_in_publish_to_a_refused_wake(tmp_path, monkeypatch) -> None:
+    # a tamper-class GitError raised inside the publish block (a concurrent
+    # object-store removal) must END the run as a refused wake, ABORTED with the
+    # tamper as its note — never masked as a publish-error.
+    from autoresearch.github import GitError
+
+    state, run_id = _write_parked_candidate(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    github = FakeGitHub()
+
+    def boom(*a, **k):
+        raise GitError("fatal: packed object ab0123 is corrupt")
+
+    monkeypatch.setattr(github, "create_pull", boom)
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),
+        now=1_000_100.0,
+    )
+    assert outcome.outcome == "attempt-error"  # refused wake, not "publish-error"
+    rec = load_record(state, run_id)
+    assert rec.state == "ended" and rec.ending == "aborted"
+    assert "corrupt" in rec.ending_note
+
+
 def test_resume_blind_repark_keeps_wake_attempts_but_progress_resets(tmp_path, monkeypatch):
     # a no-progress re-park (blind: empty afterany) must KEEP wake_attempts so
     # the stuck cap still bites; a productive re-park (a NEW job set) resets it.
@@ -4894,6 +4923,8 @@ def test_is_git_tamper_classifies_object_store_damage_not_ordinary_failures() ->
     assert _is_git_tamper(GitError("workspace .git altered by the session: HEAD is empty"))
     assert _is_git_tamper(GitError("git reset failed: fatal: Could not parse object 'HEAD'."))
     assert _is_git_tamper(GitError("fatal: bad tree object 1234"))
+    assert _is_git_tamper(GitError("error: inflate: data stream error (incorrect header)"))
+    assert _is_git_tamper(GitError("fatal: packed object ab0123 (stored in .git/...) is corrupt"))
     # ordinary git failures a wake should NOT treat as tamper
     assert not _is_git_tamper(GitError("git push failed: ! [rejected] (non-fast-forward)"))
     assert not _is_git_tamper(GitError("git fetch failed: could not resolve host"))

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4847,3 +4847,53 @@ def test_panel_claim_diff_excludes_the_lines_memory(tmp_path, monkeypatch) -> No
     runner(13.0, 12.0, "report")
     assert "train.py" in seen["diff"]
     assert "AGENT_MEMORY" not in seen["diff"] and "agent_memory" not in seen["diff"]
+
+
+def test_guard_follows_a_symbolic_loose_ref_to_verify_heads_object(tmp_path) -> None:
+    """A HEAD -> refs/heads/link -> refs/heads/main symref chain must be
+    followed to verify HEAD's object. Before the fix the non-sha loose ref read
+    as unborn and the guard fell back to some OTHER present ref, so an emptied
+    object store behind HEAD slipped past and only failed later at a raw
+    `git reset` ("Could not parse object 'HEAD'")."""
+    from autoresearch.github import GitError, ensure_regular_git_dir
+
+    root = tmp_path / "ws"
+    root.mkdir()
+    (root / "train.py").write_text("v1\n")
+    _git(root, "init", "-q", "-b", "main")
+    _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(root, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "base")
+    base = _git(root, "rev-parse", "HEAD").strip()
+    git_dir = root / ".git"
+    # a real, present-object ref for the old fallback to (wrongly) bless
+    _git(root, "update-ref", "refs/remotes/origin/real", base)
+    ensure_regular_git_dir(root)  # clean, HEAD born on main
+
+    # HEAD now resolves through a symbolic loose ref to a branch whose object
+    # is gone, while origin/real still has a present object.
+    (git_dir / "refs" / "heads" / "link").write_text("ref: refs/heads/main\n")
+    (git_dir / "HEAD").write_text("ref: refs/heads/link\n")
+    (git_dir / "refs" / "heads" / "main").write_text("0" * 40 + "\n")  # object absent
+    with pytest.raises(GitError, match="object store was emptied or moved"):
+        ensure_regular_git_dir(root)
+
+    # pointed back at the real object, the chain resolves and the guard passes
+    (git_dir / "refs" / "heads" / "main").write_text(base + "\n")
+    ensure_regular_git_dir(root)
+
+    # a symref cycle is tampering, not a state to resolve
+    (git_dir / "refs" / "heads" / "main").write_text("ref: refs/heads/link\n")
+    with pytest.raises(GitError, match="too deep"):
+        ensure_regular_git_dir(root)
+
+
+def test_is_git_tamper_classifies_object_store_damage_not_ordinary_failures() -> None:
+    from autoresearch.attempt import _is_git_tamper
+    from autoresearch.github import GitError
+
+    assert _is_git_tamper(GitError("workspace .git altered by the session: HEAD is empty"))
+    assert _is_git_tamper(GitError("git reset failed: fatal: Could not parse object 'HEAD'."))
+    assert _is_git_tamper(GitError("fatal: bad tree object 1234"))
+    # ordinary git failures a wake should NOT treat as tamper
+    assert not _is_git_tamper(GitError("git push failed: ! [rejected] (non-fast-forward)"))
+    assert not _is_git_tamper(GitError("git fetch failed: could not resolve host"))


### PR DESCRIPTION
Fix B of the "wasted climb budget" investigation (git-HEAD wake crashes).

A fleet wake ended with `attempt-error — GitError: git reset failed: fatal: Could not parse object 'HEAD'` — the same class as the 09-03 codex `.git/objects/pack` symlink incident: a ref exists but the object behind it is gone. It slipped through the #246 integrity guard two ways, both fixed here:

- **Symbolic-loose-ref blind spot (fix #2, github.py).** The guard verified HEAD's object by reading the ref file with a sha regex; a `HEAD -> refs/heads/link -> refs/heads/main` chain (a *symbolic* loose ref) read as non-sha, so `_head_commit_sha` returned None and the guard fell back to verifying some *other* present ref — passing while HEAD's object was gone. `_ref_sha` now follows a symbolic loose ref the way git resolves it (depth-capped; a cycle is tampering), so the guard's already-wrapped entry check catches the emptied store and ends the run as a clean refused wake.

- **TOCTOU / later surfacing (fix #1, attempt.py).** The guard re-runs inside every kernel git call, but a tamper-class `GitError` raised *after* the entry guard (a concurrent object removal, or a git op reaching a damaged object) propagated as an uncaught `attempt-error`. `_is_git_tamper` classifies object-store/ref damage (the guard's own `_altered` signal, plus raw `Could not parse object` / `bad tree object`), and the `resume_run` call site routes such a GitError to `_end_refused_wake` — "a refused wake ends the run" — while an ordinary git failure (push conflict, fetch outage) propagates unchanged.

Part of a set: A (#252, launch observability) and C (launch limits) are the siblings.

Tests: an isolated symref chain to a missing object (old guard passes via the fallback, new one catches) plus a symref-cycle; `_is_git_tamper` classifies damage vs ordinary failures.
