### PR TITLE
Raise the launch walltime cap and add an agent-settable --mem (unblock capacity experiments)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Authors can size a launch's host memory with `launch --mem <GB>` (clamped),
+  and the launch walltime ceiling is raised to 360 minutes (matching the eval
+  ceiling). Capacity experiments — a larger model whose `torch.compile` workers
+  host-OOM at the default per-GPU floor, or that needs more than 240 minutes to
+  reach the target — were silently killed before; they can now ask for the room
+  they need. The default is unchanged, so ordinary launches are unaffected.
+
+### Added
+
 - Disk housekeeping: an ended run sheds its `ws/` and `ws-home/` directories
   once its tree is on GitHub, keeping the record, report, transcripts, and
   ledger. The tick sheds after a 24 h grace, oldest first; when the state

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -619,10 +619,14 @@ def _make_launcher(
                                 gpus=gpus,
                                 # a capacity experiment can ask for more host
                                 # RAM than the per-GPU floor (its compile OOMs
-                                # at the floor); eval_job_spec never SHRINKS the
-                                # floor, so this only ever raises it (the "8G"
-                                # default is below the floor, so it is a no-op).
-                                mem=f"{launch.mem_gb}G" if launch.mem_gb else "8G",
+                                # at the floor). mem_gb is PER GPU (like the
+                                # EVAL_MEM_GB_PER_GPU floor), so scale it by the
+                                # GPU count for the TOTAL Slurm request;
+                                # eval_job_spec never shrinks below its floor, so
+                                # the "8G" default (below the floor) is a no-op.
+                                mem=(
+                                    f"{launch.mem_gb * gpus}G" if launch.mem_gb and gpus else "8G"
+                                ),
                             )
                         )
                     )

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -617,6 +617,12 @@ def _make_launcher(
                                 partition=partition,
                                 eval_minutes=launch.minutes,
                                 gpus=gpus,
+                                # a capacity experiment can ask for more host
+                                # RAM than the per-GPU floor (its compile OOMs
+                                # at the floor); eval_job_spec never SHRINKS the
+                                # floor, so this only ever raises it (the "8G"
+                                # default is below the floor, so it is a no-op).
+                                mem=f"{launch.mem_gb}G" if launch.mem_gb else "8G",
                             )
                         )
                     )

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -387,7 +387,8 @@ def render(brief: SessionBrief) -> str:
             "inside your own session time — it costs no budget:",
             "",
             "    python .autoresearch/syscall launch --name <handle> "
-            "--minutes <N> [--array <K>] --artifact <repo-relative file> -- <command>",
+            "--minutes <N> [--array <K>] [--mem <GB>] "
+            "--artifact <repo-relative file> -- <command>",
             "    python .autoresearch/syscall submit [--minutes <N>]",
             "    python .autoresearch/syscall siblings",
             "    python .autoresearch/syscall sync",

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -69,7 +69,8 @@ MAX_COMMAND_CHARS = 2_000
 MAX_ARTIFACTS_PER_LAUNCH = 8
 MAX_NOTE_CHARS = 2_000
 # Per-job walltime ask, clamped to the same ceiling as dispatched evals.
-MAX_LAUNCH_MINUTES = 240
+MAX_LAUNCH_MINUTES = 360  # matches the eval walltime ceiling
+MAX_LAUNCH_MEM_GB = 128  # host-RAM an author may ask for per GPU (see EVAL_MEM_GB_PER_GPU floor)
 # a submit's declared eval walltime: bounded only by the GPU-hour budget the
 # author draws on, plus this backstop (the dispatcher's own ceiling matches)
 MAX_EVAL_MINUTES = 1440
@@ -108,6 +109,10 @@ class Launch:
     # a sweep: N jobs of this command, each told its index through SWEEP_INDEX;
     # one launch against depth_k, N times the walltime against GPU-hours
     array: int = 1
+    # host RAM (GB) to ask for, when the default per-GPU floor is too small
+    # (a large model's torch.compile workers host-OOM at the floor); None = the
+    # floor. Clamped to MAX_LAUNCH_MEM_GB; never shrinks the floor.
+    mem_gb: int | None = None
 
 
 @dataclass(frozen=True)
@@ -221,7 +226,7 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     for i, item in enumerate(raw_launches):
         if not isinstance(item, dict):
             raise SyscallError(f"launch #{i} must be an object")
-        bad = set(item) - {"name", "command", "minutes", "artifacts", "array"}
+        bad = set(item) - {"name", "command", "minutes", "artifacts", "array", "mem_gb"}
         if bad:
             raise SyscallError(f"launch #{i}: unknown keys {sorted(bad)}")
         name = item.get("name")
@@ -243,6 +248,11 @@ def read_request(workspace: Path) -> SyscallRequest | None:
         if not isinstance(array, int) or isinstance(array, bool) or array < 1:
             raise SyscallError(f"launch {name}: array must be a positive integer")
         array = min(array, MAX_LAUNCH_ARRAY)
+        mem_gb = item.get("mem_gb")
+        if mem_gb is not None:
+            if not isinstance(mem_gb, int) or isinstance(mem_gb, bool) or mem_gb < 1:
+                raise SyscallError(f"launch {name}: mem_gb must be a positive integer")
+            mem_gb = min(mem_gb, MAX_LAUNCH_MEM_GB)
         arts = item.get("artifacts", [])
         if not isinstance(arts, list) or len(arts) > MAX_ARTIFACTS_PER_LAUNCH:
             raise SyscallError(
@@ -255,7 +265,14 @@ def read_request(workspace: Path) -> SyscallRequest | None:
                     f"launch {name}: artifact {a!r} must be a repo-relative file path"
                 )
         launches.append(
-            Launch(name=name, command=command, minutes=minutes, artifacts=tuple(arts), array=array)
+            Launch(
+                name=name,
+                command=command,
+                minutes=minutes,
+                artifacts=tuple(arts),
+                array=array,
+                mem_gb=mem_gb,
+            )
         )
     # a sleep with no launches is legitimate: checkpoint-and-reschedule
     # (research-loop.md, "the session clock is visible") — it still burns a

--- a/src/autoresearch/syscall_cli.py
+++ b/src/autoresearch/syscall_cli.py
@@ -55,8 +55,9 @@ MAX_LAUNCHES = 8
 MAX_COMMAND_CHARS = 2_000
 MAX_ARTIFACTS = 8
 MAX_NOTE_CHARS = 2_000
-MAX_LAUNCH_MINUTES = 240
+MAX_LAUNCH_MINUTES = 360
 MAX_LAUNCH_ARRAY = 16  # jobs one launch may fan out to (a sweep)
+MAX_LAUNCH_MEM_GB = 128  # host RAM (GB) an author may ask for (kernel re-clamps)
 # a submit's declared eval walltime (matches the kernel's backstop)
 MAX_EVAL_MINUTES = 1440
 # judge (finding/conclude) bounds
@@ -148,6 +149,11 @@ def cmd_launch(root: Path, args: argparse.Namespace) -> str:
     if array < 1:
         raise ToolError("--array must be a positive integer")
     array = min(array, MAX_LAUNCH_ARRAY)
+    mem_gb = args.mem
+    if mem_gb is not None:
+        if mem_gb < 1:
+            raise ToolError("--mem must be a positive integer (GB)")
+        mem_gb = min(mem_gb, MAX_LAUNCH_MEM_GB)
     if len(args.artifact) > MAX_ARTIFACTS:
         raise ToolError(f"at most {MAX_ARTIFACTS} --artifact paths")
     for a in args.artifact:
@@ -165,6 +171,7 @@ def cmd_launch(root: Path, args: argparse.Namespace) -> str:
             "minutes": minutes,
             "artifacts": args.artifact,
             "array": array,
+            **({"mem_gb": mem_gb} if mem_gb is not None else {}),
         }
     )
     _save_staged(root, staged)
@@ -325,7 +332,9 @@ def build_parser() -> argparse.ArgumentParser:
     # author verbs
     la = sub.add_parser("launch", help="stage a job to run outside the sandbox")
     la.add_argument("--name", required=True, help="your handle for this job (a-z0-9-)")
-    la.add_argument("--minutes", type=int, default=30, help="walltime ask (clamped to 240)")
+    la.add_argument(
+        "--minutes", type=int, default=30, help="walltime ask in minutes (clamped to 360)"
+    )
     la.add_argument(
         "--array",
         type=int,
@@ -333,6 +342,13 @@ def build_parser() -> argparse.ArgumentParser:
         help="fan out to N jobs of this command, each with SWEEP_INDEX=0..N-1 "
         "and its own results/<name>/<i>/ (a sweep; counts as one launch, "
         "N times the GPU-hours)",
+    )
+    la.add_argument(
+        "--mem",
+        type=int,
+        default=None,
+        help="host RAM (GB) to request when a large model's compile host-OOMs "
+        "the default per-GPU floor (clamped); omit for the default",
     )
     la.add_argument(
         "--artifact",

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4847,3 +4847,38 @@ def test_panel_claim_diff_excludes_the_lines_memory(tmp_path, monkeypatch) -> No
     runner(13.0, 12.0, "report")
     assert "train.py" in seen["diff"]
     assert "AGENT_MEMORY" not in seen["diff"] and "agent_memory" not in seen["diff"]
+
+
+def test_launch_scales_mem_gb_by_gpu_count(tmp_path) -> None:
+    # mem_gb is PER GPU: the launcher must scale it by the GPU count for the
+    # total Slurm request, or eval_job_spec's per-GPU floor silently swallows it.
+    from autoresearch.attempt import _make_launcher
+    from autoresearch.syscall import Launch, SyscallRequest
+
+    run_dir = tmp_path / "runs" / "r1"
+    ws = run_dir / "ws"
+    ws.mkdir(parents=True)
+    import dataclasses
+
+    dispatch = dataclasses.replace(_fake_dispatch(), gpu_partition="gpu", gpu_account="gacct")
+    specs: list = []
+    real = dispatch.compute.submit
+
+    def rec(spec):
+        specs.append(spec)
+        return real(spec)
+
+    dispatch.compute.submit = rec
+    launcher = _make_launcher(dispatch, run_dir, ws, "run-1", gpus=8)
+    launcher(
+        "0" * 40,
+        SyscallRequest(
+            launches=(
+                Launch(name="wide", command="echo hi", minutes=30, mem_gb=128),
+                Launch(name="plain", command="echo hi", minutes=30),
+            )
+        ),
+    )
+    by = {Path(s.script).parent.name: s for s in specs}
+    assert by["eval-launch-wide"].mem == "1024G"  # 128 GB/GPU x 8 GPUs
+    assert by["eval-launch-plain"].mem == "512G"  # no --mem: the 64x8 floor

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -10,6 +10,8 @@ from pathlib import Path
 import pytest
 
 from autoresearch.syscall import (
+    MAX_LAUNCH_MEM_GB,
+    MAX_LAUNCH_MINUTES,
     SYSCALL_DIR,
     SYSCALL_FILE,
     LaunchResult,
@@ -82,6 +84,33 @@ def test_empty_launches_is_a_checkpoint_sleep(tmp_path: Path) -> None:
     assert req is not None and req.launches == ()
 
 
+def test_read_request_parses_and_clamps_mem_gb(tmp_path: Path) -> None:
+    write_req(
+        tmp_path,
+        {
+            "launches": [
+                {"name": "small", "command": "run", "minutes": 30},
+                {"name": "big", "command": "run", "minutes": 30, "mem_gb": 96},
+                {"name": "huge", "command": "run", "minutes": 30, "mem_gb": 9999},
+            ]
+        },
+    )
+    req = read_request(tmp_path)
+    assert req is not None
+    assert req.launches[0].mem_gb is None  # default: the per-GPU floor applies
+    assert req.launches[1].mem_gb == 96  # honored as asked
+    assert req.launches[2].mem_gb == MAX_LAUNCH_MEM_GB  # clamped to the ceiling
+
+
+def test_read_request_rejects_a_non_positive_mem_gb(tmp_path: Path) -> None:
+    write_req(
+        tmp_path,
+        {"launches": [{"name": "x", "command": "run", "minutes": 30, "mem_gb": 0}]},
+    )
+    with pytest.raises(SyscallError, match="mem_gb must be a positive integer"):
+        read_request(tmp_path)
+
+
 def test_malformed_request_raises_and_is_still_consumed(tmp_path: Path) -> None:
     f = write_req(tmp_path, "{not json")
     with pytest.raises(SyscallError, match="not valid JSON"):
@@ -146,7 +175,7 @@ def test_oversized_request_file_is_refused_before_parsing(tmp_path: Path) -> Non
 def test_minutes_are_clamped_to_the_ceiling(tmp_path: Path) -> None:
     write_req(tmp_path, {"launches": [{"name": "big", "command": "x", "minutes": 100000}]})
     req = read_request(tmp_path)
-    assert req is not None and req.launches[0].minutes == 240
+    assert req is not None and req.launches[0].minutes == MAX_LAUNCH_MINUTES
 
 
 def test_siblings_command_reads_the_fleet_snapshot(tmp_path: Path) -> None:

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -394,3 +394,24 @@ def test_reports_summary_and_full_views(tmp_path: Path, capsys) -> None:
     bare.mkdir(parents=True)
     assert run(bare, "reports", capsys=capsys) == 0
     assert "no report archive" in capsys.readouterr().out
+
+
+def test_launch_stages_and_clamps_mem(tmp_path: Path, capsys) -> None:
+    # a capacity experiment asks for more host RAM; the CLI clamps client-side
+    # and the kernel's reader carries it through.
+    assert run(tmp_path, "launch", "--name", "wide", "--mem", "9999", "--", "run", "it") == 0
+    capsys.readouterr()
+    assert run(tmp_path, "sleep") == 0
+    capsys.readouterr()
+    req = read_request(tmp_path)
+    assert req is not None
+    assert req.launches[0].mem_gb == 128  # clamped to MAX_LAUNCH_MEM_GB
+
+
+def test_launch_without_mem_leaves_it_default(tmp_path: Path, capsys) -> None:
+    assert run(tmp_path, "launch", "--name", "plain", "--", "run", "it") == 0
+    capsys.readouterr()
+    assert run(tmp_path, "sleep") == 0
+    capsys.readouterr()
+    req = read_request(tmp_path)
+    assert req is not None and req.launches[0].mem_gb is None


### PR DESCRIPTION
Fix C of the "wasted climb budget" investigation (launch limits box the promising direction).

The agents' own memory names capacity as the lead ("16 layers reached 8,960… capacity remains promising, needs a larger effect"), but capacity experiments were silently killed by two fixed launch limits, so agents learned to avoid the one direction that could clear the bar:

- **Walltime.** Launches were hard-capped at 240 minutes (`MAX_LAUNCH_MINUTES`), while the gate eval runs up to 360. A bigger model that needs longer than 240 min to cross the target timed out unmeasured. Raised to 360, matching the eval ceiling (an eval already runs that long on the same lane, so a 360-min launch is no worse a citizen).
- **Host memory.** Launches got a fixed `EVAL_MEM_GB_PER_GPU` (64 GB/GPU) floor with no way to ask for more, so a large model's `torch.compile` workers host-OOM'd (an untrappable SIGKILL — see #252 for why that was invisible). Authors can now pass `launch --mem <GB>`, clamped to `MAX_LAUNCH_MEM_GB` (128). `eval_job_spec` never shrinks the per-GPU floor, so `--mem` only ever raises it; the default is unchanged, so ordinary small launches are unaffected and stay cheap.

The `mem_gb` knob is agent-settable per launch (like `--minutes`/`--array`), so small experiments stay at the floor and only capacity experiments pay for more — good cluster citizenship. The kernel re-validates/clamps authoritatively in `read_request`; the standalone CLI clamps client-side for UX.

**Numbers for your call:** I matched the walltime cap to the eval (360) and set the memory ceiling to 128 GB/GPU — conservative for the H200 Courant nodes. If you want a higher ceiling (or a different walltime), those touch the shared 88-GPU lane, so tell me and I'll adjust.

Completes the set with #252 (launch observability, merged) and #253 (git-HEAD wake hardening). The torch-side compile-OOM mitigation (capping inductor workers) belongs in gpt-speedrun, not the kernel — a separate follow-up.

Tests: mem_gb parses/clamps/rejects in the kernel reader; the CLI stages and clamps `--mem`; minutes clamp to the raised 360.
