### PR TITLE
Session wake pushes the author to keep going while budget remains (restore the depth pressure lines removed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- The session's wake now pushes the author to keep going while budget remains
+  instead of treating a single negative as a finished session. A negative or
+  inconclusive result is framed as a step, not the finish line: while launches,
+  sleeps, and GPU-hours remain, form the next hypothesis and launch again rather
+  than concluding. (Persistent research lines removed the old use-it-or-lose-it
+  pressure to go deep in one session; this restores it through the brief.)
+
 ### Added
 
 - Disk housekeeping: an ended run sheds its `ws/` and `ws-home/` directories

--- a/src/autoresearch/attempt.py
+++ b/src/autoresearch/attempt.py
@@ -778,6 +778,7 @@ def _wake_author_sleep(
         gpu_hours_remaining=(
             max(0.0, contract.budgets.gpu_hours_per_run - gpu_hours_used) if bench.gpus else None
         ),
+        gpus=bench.gpus,
     )
     if extra_update:
         # a submitted park's gate/panel feedback leads; launch results follow

--- a/src/autoresearch/brief.py
+++ b/src/autoresearch/brief.py
@@ -264,10 +264,10 @@ def render_wake(update: str, budget: BudgetState) -> str:
             f"Runs remaining this week: {budget.runs_remaining_this_week}",
             "",
             "Continue from your notes: interpret these results against your "
-            "hypothesis, then either iterate (if the budget allows and a "
-            "clear next step exists) or finish with your research report. If "
-            "the results are inconclusive or negative, say so plainly — a "
-            "negative result reported clearly is a success.",
+            "hypothesis, and report a negative or inconclusive result plainly. "
+            "A negative is a step, not the finish line: while budget remains, "
+            "form your next hypothesis and launch again rather than finishing "
+            "your research report.",
         ]
     )
 

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -806,6 +806,7 @@ def render_wake(
     sleeps_used: int,
     sleep_budget: int,
     gpu_hours_remaining: float | None = None,
+    gpus: int = 0,
 ) -> str:
     """The text a woken author sees: every job's results as fenced DATA, the
     author's own note echoed back, and the remaining budgets. Job output is
@@ -837,11 +838,14 @@ def render_wake(
         parts.append(f"Your note to yourself:\n{fence}\n{note}\n{fence}")
     gpu = f", {gpu_hours_remaining:.1f} GPU-hours" if gpu_hours_remaining is not None else ""
     # Push to keep going ONLY when another launch is actually possible: a launch
-    # needs a remaining launch count AND (for a GPU benchmark) remaining
-    # GPU-hours, or budget_error would reject the very launch this urges. When
-    # nothing more can launch, the honest instruction is to conclude.
+    # needs a remaining launch count AND enough GPU-hours to pay for even the
+    # cheapest one (a 1-minute job on `gpus` GPUs), or budget_error would reject
+    # the very launch this urges — a positive remainder below that floor cannot
+    # buy a launch. When nothing more can launch, the honest instruction is to
+    # conclude.
+    min_launch_gpu_hours = gpus / 60.0  # one minute on `gpus` GPUs
     can_launch = launches_used < launch_budget and (
-        gpu_hours_remaining is None or gpu_hours_remaining > 0
+        gpu_hours_remaining is None or gpu_hours_remaining >= min_launch_gpu_hours
     )
     if sleeps_used >= sleep_budget:
         tail = " This was your LAST sleep — conclude this session with your best result."

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -836,14 +836,22 @@ def render_wake(
         fence = _fence(note)
         parts.append(f"Your note to yourself:\n{fence}\n{note}\n{fence}")
     gpu = f", {gpu_hours_remaining:.1f} GPU-hours" if gpu_hours_remaining is not None else ""
+    if sleeps_used >= sleep_budget:
+        tail = " This was your LAST sleep — conclude this session with your best result."
+    else:
+        # The budget is there to be spent: a negative is a step, not a stopping
+        # point. Push the next hypothesis rather than concluding early — a
+        # session that ends with launches and GPU-hours in hand left the
+        # question half-answered.
+        tail = (
+            " A negative or a miss is a step, not a stopping point: while this "
+            "budget remains, form your next hypothesis and launch again — a new "
+            "direction or a sweep — rather than concluding. Finish only with an "
+            "improvement to submit or a genuinely spent budget."
+        )
     parts.append(
         f"Budgets: {launch_budget - launches_used} launches and "
-        f"{sleep_budget - sleeps_used} sleeps{gpu} remaining."
-        + (
-            " This was your LAST sleep — conclude this session with your best result."
-            if sleeps_used >= sleep_budget
-            else ""
-        )
+        f"{sleep_budget - sleeps_used} sleeps{gpu} remaining." + tail
     )
     return "\n\n".join(parts)
 

--- a/src/autoresearch/syscall.py
+++ b/src/autoresearch/syscall.py
@@ -836,8 +836,20 @@ def render_wake(
         fence = _fence(note)
         parts.append(f"Your note to yourself:\n{fence}\n{note}\n{fence}")
     gpu = f", {gpu_hours_remaining:.1f} GPU-hours" if gpu_hours_remaining is not None else ""
+    # Push to keep going ONLY when another launch is actually possible: a launch
+    # needs a remaining launch count AND (for a GPU benchmark) remaining
+    # GPU-hours, or budget_error would reject the very launch this urges. When
+    # nothing more can launch, the honest instruction is to conclude.
+    can_launch = launches_used < launch_budget and (
+        gpu_hours_remaining is None or gpu_hours_remaining > 0
+    )
     if sleeps_used >= sleep_budget:
         tail = " This was your LAST sleep — conclude this session with your best result."
+    elif not can_launch:
+        tail = (
+            " Your launch budget is spent — conclude this session with your best "
+            "result (submit your best candidate, or write your report)."
+        )
     else:
         # The budget is there to be spent: a negative is a step, not a stopping
         # point. Push the next hypothesis rather than concluding early — a

--- a/tests/test_brief.py
+++ b/tests/test_brief.py
@@ -242,6 +242,9 @@ def test_wake_prompt_is_bounded_and_asks_for_conclusion() -> None:
     assert "0.31" in text
     assert "GPU-hours remaining: 2.0" in text
     assert "research report" in text
+    # a negative is framed as a step, not the finish line: the wake pushes the
+    # next hypothesis while budget remains rather than concluding early
+    assert "not the finish line" in text and "launch again" in text
     huge = render_wake("x" * 100_000, budget)
     assert len(huge) < MAX_WAKE_CHARS + 600
     assert "[truncated" in huge

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -283,6 +283,25 @@ def test_wake_text_pushes_to_keep_going_while_budget_remains() -> None:
     assert "LAST sleep" not in text  # budget remains
 
 
+def test_wake_text_says_conclude_when_no_launch_is_possible() -> None:
+    # sleeps remain but the LAUNCH budget is spent (4/4): the wake must NOT tell
+    # the author to launch again (budget_error would reject it) — it concludes.
+    text = render_wake((), "", launches_used=4, launch_budget=4, sleeps_used=1, sleep_budget=8)
+    assert "launch budget is spent" in text and "conclude" in text
+    assert "launch again" not in text
+    # same when GPU-hours are exhausted though launches nominally remain
+    gpu_dry = render_wake(
+        (),
+        "",
+        launches_used=1,
+        launch_budget=8,
+        sleeps_used=1,
+        sleep_budget=8,
+        gpu_hours_remaining=0.0,
+    )
+    assert "launch again" not in gpu_dry and "conclude" in gpu_dry
+
+
 def _lr(name: str, exit_code, state: str = "") -> LaunchResult:
     return LaunchResult(
         name=name,

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -275,6 +275,14 @@ def test_wake_text_flags_the_last_sleep() -> None:
     assert "checkpoint sleep" in text  # no launches -> says so
 
 
+def test_wake_text_pushes_to_keep_going_while_budget_remains() -> None:
+    # a negative with budget left is a step, not a stopping point: the wake
+    # pushes the next hypothesis instead of letting the author conclude early.
+    text = render_wake((), "", launches_used=1, launch_budget=8, sleeps_used=1, sleep_budget=8)
+    assert "not a stopping point" in text and "launch again" in text
+    assert "LAST sleep" not in text  # budget remains
+
+
 def _lr(name: str, exit_code, state: str = "") -> LaunchResult:
     return LaunchResult(
         name=name,

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -289,7 +289,8 @@ def test_wake_text_says_conclude_when_no_launch_is_possible() -> None:
     text = render_wake((), "", launches_used=4, launch_budget=4, sleeps_used=1, sleep_budget=8)
     assert "launch budget is spent" in text and "conclude" in text
     assert "launch again" not in text
-    # same when GPU-hours are exhausted though launches nominally remain
+    # a positive GPU-hours remainder BELOW a one-minute launch cost (gpus/60)
+    # still cannot pay for a launch: conclude, don't urge one
     gpu_dry = render_wake(
         (),
         "",
@@ -297,9 +298,22 @@ def test_wake_text_says_conclude_when_no_launch_is_possible() -> None:
         launch_budget=8,
         sleeps_used=1,
         sleep_budget=8,
-        gpu_hours_remaining=0.0,
+        gpu_hours_remaining=0.01,  # < 1/60 (one minute on one GPU)
+        gpus=1,
     )
     assert "launch again" not in gpu_dry and "conclude" in gpu_dry
+    # ample GPU-hours -> keep going
+    gpu_ok = render_wake(
+        (),
+        "",
+        launches_used=1,
+        launch_budget=8,
+        sleeps_used=1,
+        sleep_budget=8,
+        gpu_hours_remaining=50.0,
+        gpus=1,
+    )
+    assert "launch again" in gpu_ok
 
 
 def _lr(name: str, exit_code, state: str = "") -> LaunchResult:


### PR DESCRIPTION
Restores the pressure to keep working within a session — the thing persistent research lines quietly removed.

**Diagnosis.** Since research lines flipped on (08-31), agents go one-shot: a single launch, a negative, conclude — sitting on ~396/400 GPU-hours and 15/16 launches. Lines made per-agent memory persist, so a run became a cheap increment ("test one thing, write a lesson, stop") instead of a use-it-or-lose-it deep session. The wake brief actively permitted this: it told the author to "either iterate **or** finish" and closed every wake with "a negative result reported clearly is a success" — so stopping at the first negative read as a win.

**Change (agent-facing framing only, no mechanism change).**
- The wake "Experiment update" (`brief.py`) now frames a negative as a *step, not the finish line*: report it plainly, but while budget remains, form the next hypothesis and launch again rather than finishing the research report.
- `render_wake` (`syscall.py`) — the launch/sleep loop wake — appends the same push to its budget line when sleeps remain ("a negative or a miss is a step, not a stopping point … launch again"), while the LAST-sleep case still says conclude.

Deliberately **not** rewarding launch count or number of rounds — the human-scientist test says the best session can be one long-thought decisive experiment. The pressure is only "don't quit with budget in hand," not "run more experiments for their own sake." This pairs with (and doesn't substitute for) making wins reachable (the metric/floor work) — that's tracked separately.

Tests: the wake pushes to keep going while budget remains, and still says conclude on the last sleep.
