### PR TITLE
Reviewer adoption on-ramp (examples/review.yml + docs/reviewer.md)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ uv run python -m autoresearch.contract_cli .autoresearch.yaml   # validate befor
 ## Getting started
 
 See **[docs/install.md](docs/install.md)**. Level 1 (advisory reviews) needs
-only an LLM API key and one workflow file. Level 2 (the climber) adds a bot
-account, a contract, and a Slurm cluster with Apptainer.
+only an LLM API key and one workflow file — **[docs/reviewer.md](docs/reviewer.md)**
+walks through it in three steps. Level 2 (the climber) adds a bot account, a
+contract, and a Slurm cluster with Apptainer.
 
 ## Design principles
 

--- a/docs/reviewer.md
+++ b/docs/reviewer.md
@@ -2,9 +2,9 @@
 
 An advisory AI code reviewer for your pull requests. It posts findings as a PR
 review — it **never approves, never blocks your CI, and never runs your PR's
-code** (it reads the diff as data). It reviews both same-repo and fork PRs; the
-model key lives only in a read-only, write-tokenless job, so a fork PR cannot
-reach it.
+code** (it reads the diff as data). It reviews pull requests from branches in
+**your own repository**; PRs from forks are skipped for now (fork-PR review is a
+planned addition). The model key lives only in a read-only, write-tokenless job.
 
 ## Three steps
 
@@ -19,18 +19,19 @@ reach it.
    reviewer code.
 
 3. **Set the secret.** Add a repository secret `ANTHROPIC_REVIEWER_KEY` with your
-   Anthropic key (`Settings → Secrets and variables → Actions`). For `hermes` or
-   `codex`, set `OPENAI_REVIEWER_KEY` / `OPENROUTER_API_KEY` instead and point
-   the `secrets:` block at it.
+   Anthropic key (`Settings → Secrets and variables → Actions`). For other
+   backends set the matching key instead: `codex` and `hermes` with
+   `hermes_provider: openai` use `OPENAI_REVIEWER_KEY`; `hermes` on its default
+   OpenRouter provider uses `OPENROUTER_API_KEY`.
 
 That's it. Open a PR and the reviewer posts a round.
 
 ## Using it
 
 - **First round** runs automatically when a PR opens.
-- **Re-review** after you push fixes by (re)applying the `outerloop:review` label
+- **Re-review** after you push fixes by (re)applying the `autoresearch:review` label
   — the round stamp increments so you can follow the fix→review→fix loop.
-- Findings are **advisory**: the code owner decides. The `outerloop:no-review`
+- Findings are **advisory**: the code owner decides. The `autoresearch:no-review`
   label opts a PR out entirely.
 
 ## Backends
@@ -42,8 +43,10 @@ in
 
 ## Safety
 
-- The reviewer checks out your PR head **read-only and never executes it** — no
-  build, no test, no install of your PR tree. It only reads the diff.
+- Fork PRs are skipped, so today the reviewer only runs on branches a
+  collaborator pushed to your repo. When it does run, it checks out the PR head
+  **read-only and never executes it** — no build, no test, no install of your
+  PR tree. It only reads the diff.
 - The job holding the model key has **no write permission**; a separate job with
   `pull-requests: write` runs no model and only posts the review.
 - The reviewer is **advisory** — it cannot approve, merge, or fail your CI. The

--- a/docs/reviewer.md
+++ b/docs/reviewer.md
@@ -1,0 +1,51 @@
+# Add the Outerloop reviewer to your repo
+
+An advisory AI code reviewer for your pull requests. It posts findings as a PR
+review — it **never approves, never blocks your CI, and never runs your PR's
+code** (it reads the diff as data). It reviews both same-repo and fork PRs; the
+model key lives only in a read-only, write-tokenless job, so a fork PR cannot
+reach it.
+
+## Three steps
+
+1. **Pick the bot identity and get a model key.** Choose the account whose PRs
+   should be skipped (so the reviewer never reviews its own bot's PRs) — that's
+   the `bot_login`. Get an API key for your chosen backend (an Anthropic key for
+   `claude`).
+
+2. **Add the workflow.** Copy [`examples/review.yml`](../examples/review.yml) to
+   `.github/workflows/review.yml` in your repo and set `bot_login` to your bot's
+   login. It calls the public reviewer with `uses:` — you never vendor the
+   reviewer code.
+
+3. **Set the secret.** Add a repository secret `ANTHROPIC_REVIEWER_KEY` with your
+   Anthropic key (`Settings → Secrets and variables → Actions`). For `hermes` or
+   `codex`, set `OPENAI_REVIEWER_KEY` / `OPENROUTER_API_KEY` instead and point
+   the `secrets:` block at it.
+
+That's it. Open a PR and the reviewer posts a round.
+
+## Using it
+
+- **First round** runs automatically when a PR opens.
+- **Re-review** after you push fixes by (re)applying the `outerloop:review` label
+  — the round stamp increments so you can follow the fix→review→fix loop.
+- Findings are **advisory**: the code owner decides. The `outerloop:no-review`
+  label opts a PR out entirely.
+
+## Backends
+
+`backend: claude` (default) uses Anthropic; `hermes` and `codex` are also
+supported — set the matching key and, for `hermes`, the provider. See the inputs
+in
+[`advisory-review-agent.yml`](../.github/workflows/advisory-review-agent.yml).
+
+## Safety
+
+- The reviewer checks out your PR head **read-only and never executes it** — no
+  build, no test, no install of your PR tree. It only reads the diff.
+- The job holding the model key has **no write permission**; a separate job with
+  `pull-requests: write` runs no model and only posts the review.
+- The reviewer is **advisory** — it cannot approve, merge, or fail your CI. The
+  most a crafted PR can do is elicit a misleading advisory comment, which you
+  read with the same skepticism as any review.

--- a/examples/review.yml
+++ b/examples/review.yml
@@ -2,9 +2,10 @@
 # .github/workflows/review.yml to get an AI code review on every pull request.
 #
 # It posts advisory findings as a PR review. It NEVER approves, never blocks
-# your CI, and never runs your PR's code — it only reads the diff. Same-repo
-# and fork PRs are both reviewed; the reviewer's model key lives only in a
-# read-only, write-tokenless job, so a fork PR cannot reach it.
+# your CI, and never runs your PR's code — it only reads the diff. It reviews
+# pull requests from branches in THIS repository; PRs from forks are skipped
+# (fork-PR review is a planned addition). The model key lives only in a
+# read-only, write-tokenless job.
 #
 # Setup (see docs/reviewer.md): (1) have a bot account whose PRs are skipped,
 # (2) add this file, (3) set the ANTHROPIC_REVIEWER_KEY repo secret.
@@ -20,7 +21,7 @@ jobs:
   review:
     if: >-
       github.event.action != 'labeled'
-      || github.event.label.name == 'outerloop:review'
+      || github.event.label.name == 'autoresearch:review'
     uses: outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@v1
     with:
       # PRs authored by this login are never reviewed (so the bot never

--- a/examples/review.yml
+++ b/examples/review.yml
@@ -1,0 +1,32 @@
+# Outerloop advisory reviewer — drop this into your repo at
+# .github/workflows/review.yml to get an AI code review on every pull request.
+#
+# It posts advisory findings as a PR review. It NEVER approves, never blocks
+# your CI, and never runs your PR's code — it only reads the diff. Same-repo
+# and fork PRs are both reviewed; the reviewer's model key lives only in a
+# read-only, write-tokenless job, so a fork PR cannot reach it.
+#
+# Setup (see docs/reviewer.md): (1) have a bot account whose PRs are skipped,
+# (2) add this file, (3) set the ANTHROPIC_REVIEWER_KEY repo secret.
+name: outerloop-review
+on:
+  pull_request_target:
+    # first round when a PR opens; re-review by (re)applying the label below
+    types: [opened, reopened, labeled]
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  review:
+    if: >-
+      github.event.action != 'labeled'
+      || github.event.label.name == 'outerloop:review'
+    uses: outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@v1
+    with:
+      # PRs authored by this login are never reviewed (so the bot never
+      # reviews its own PRs). Use your own bot/app login.
+      bot_login: your-bot-login
+      backend: claude          # claude | hermes | codex
+      # model: claude-opus-5   # optional; the backend default is used if unset
+    secrets:
+      anthropic_reviewer_key: ${{ secrets.ANTHROPIC_REVIEWER_KEY }}


### PR DESCRIPTION
Phase A item 3 (adoption on-ramp), the bounded first slice: the **reviewer** on-ramp — "copy the caller, set the key" (roadmap line 202), the same path relay would use.

- **`examples/review.yml`** — a ready-to-copy caller workflow an adopter drops into `.github/workflows/`. Calls the public reviewer with `uses:` (no vendoring), one `bot_login`, `ANTHROPIC_REVIEWER_KEY` secret, re-review via the `outerloop:review` label.
- **`docs/reviewer.md`** — the 3-step guide + how-to-use + the safety story (no exec of PR code, key in a tokenless job, advisory-only, fork-safe).
- README "Getting started" now links the Level-1 line to the new guide.

Forward-looking: the template targets `outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@v1`, which goes live at the flip. Docs/examples only — no code, no fleet impact.

Not included (bigger, separate): the full `init` wizard (Level 2 / the climber on-ramp — App-manifest exchange + doctor), which is still a design note in `docs/design/onboarding.md`.
