### PR TITLE
README: brand as Outerloop (title, logo alt, src path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/assets/icon-dark.svg">
-  <img alt="autoresearch" src="docs/assets/icon-light.svg" width="132">
+  <img alt="Outerloop" src="docs/assets/icon-light.svg" width="132">
 </picture>
 
-# autoresearch
+# Outerloop
 
 [![ci](https://github.com/outerloop-science/outerloop/actions/workflows/ci.yml/badge.svg)](https://github.com/outerloop-science/outerloop/actions/workflows/ci.yml)
 
@@ -157,7 +157,7 @@ uv run pytest
 
 | Path | Purpose |
 | --- | --- |
-| `src/autoresearch/` | The kernel: contract, tick (the Slurm chain), attempt/orchestrator (the climb), measure/dispatch (evals as jobs), syscall (the author's tool), panel/verifier/review, github, harness backends |
+| `src/outerloop/` | The kernel: contract, tick (the Slurm chain), attempt/orchestrator (the climb), measure/dispatch (evals as jobs), syscall (the author's tool), panel/verifier/review, github, harness backends |
 | `tests/` | Tiers: unit (default), `slow`, `llm`, `slurm` markers |
 | `scripts/` | Committed operational scripts (the tick chain, provisioning) |
 | `docs/` | Install guide, architecture and design notes, roadmap |


### PR DESCRIPTION
Public-facing branding for the flipped repo: title `# autoresearch` → `# Outerloop`, logo alt text → Outerloop, and the stale `src/autoresearch/` layout ref → `src/outerloop/` (the rename #257 missed this one line). The `.autoresearch.yaml` contract-file name is intentionally left — renaming it is a deferred convention change (it lives in every target repo), same class as the `.autoresearch/` channel and `AUTORESEARCH_*` env vars.