### PR TITLE
Reviewer: skip the old App bot's PRs (add outerloop-autoresearch[bot] to bot_aliases)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,7 +30,7 @@ jobs:
     uses: outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@main
     with:
       bot_login: 'outerloop-science[bot]'
-      bot_aliases: agentic-learning-bot
+      bot_aliases: 'outerloop-autoresearch[bot], agentic-learning-bot'
       backend: hermes
       # openai-direct: same token rate, no OpenRouter platform fee (the org's
       # OpenAI account is tax-exempt); model id is provider-native
@@ -50,7 +50,7 @@ jobs:
     uses: outerloop-science/outerloop/.github/workflows/advisory-review-summarize.yml@main
     with:
       bot_login: 'outerloop-science[bot]'
-      bot_aliases: agentic-learning-bot
+      bot_aliases: 'outerloop-autoresearch[bot], agentic-learning-bot'
       backend: hermes
       hermes_provider: openai
       model: gpt-5.6-terra
@@ -66,7 +66,7 @@ jobs:
     uses: outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@main
     with:
       bot_login: 'outerloop-science[bot]'
-      bot_aliases: agentic-learning-bot
+      bot_aliases: 'outerloop-autoresearch[bot], agentic-learning-bot'
       backend: hermes
       hermes_provider: openai
       model: gpt-5.6-terra


### PR DESCRIPTION
The fleet's author bot has had two prior identities — the `agentic-learning-bot` user and the `outerloop-autoresearch[bot]` App (4797847) — before the flip to `outerloop-science[bot]`. #259 set `bot_login: outerloop-science[bot]` but only aliased `agentic-learning-bot`, so the reviewer would review the old App bot's still-open PRs. This adds `outerloop-autoresearch[bot]` to `bot_aliases` (confirmed as a real author on gpt-speedrun). Both former identities are now skipped.