### PR TITLE
PyPI trusted publishing: outerloop-science distribution + release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+# Publish to PyPI on a version tag via Trusted Publishing (OIDC) — no API
+# token is stored anywhere; PyPI verifies the workflow's identity directly.
+# Setup (one-time, on PyPI): add a pending publisher for project
+# `outerloop-science`, owner `outerloop-science`, repo `outerloop`, workflow
+# `release.yml`, environment `pypi`. Then push a tag: `git tag vX.Y.Z && git
+# push origin vX.Y.Z` (the version comes from src/outerloop/__init__.py).
+name: release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # The environment gates the OIDC identity PyPI trusts; create it in repo
+    # Settings → Environments and name it in the PyPI pending publisher.
+    environment: pypi
+    permissions:
+      id-token: write # mint the OIDC token Trusted Publishing exchanges
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- PyPI release via Trusted Publishing: a tag-triggered `release.yml` builds and
+  publishes on `v*` tags with no stored token (OIDC, `id-token: write`). The
+  distribution is named `outerloop-science` (PyPI's `outerloop` is taken); the
+  import package and console command stay `outerloop` — `pip install
+  outerloop-science`, then `import outerloop`.
+
 ### Changed
 
 - Renamed the Python package `autoresearch` → `outerloop` (and the console

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "outerloop"
+name = "outerloop-science"
 dynamic = ["version"]
 description = "Autonomous research agent that co-develops the lab's benchmark-bearing repos"
 readme = "README.md"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -4,4 +4,4 @@ import outerloop
 
 
 def test_installed_metadata_matches_package_version() -> None:
-    assert version("outerloop") == outerloop.__version__
+    assert version("outerloop-science") == outerloop.__version__

--- a/uv.lock
+++ b/uv.lock
@@ -371,7 +371,7 @@ wheels = [
 ]
 
 [[package]]
-name = "outerloop"
+name = "outerloop-science"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Sets up PyPI release via **Trusted Publishing** (OIDC — no stored token).

- **Distribution name `outerloop-science`** (PyPI's `outerloop` is taken; this is the reserved on-brand fallback). Import package + console command stay `outerloop` — `pip install outerloop-science` then `import outerloop`. Distribution name ≠ import name.
- **`.github/workflows/release.yml`** — on `v*` tags: `uv build` then `pypa/gh-action-pypi-publish` with `id-token: write`, gated on a `pypi` environment.
- `uv.lock` regenerated for the renamed root; `test_version` asserts `version("outerloop-science") == outerloop.__version__`.

Verified locally (clean locked env): ruff check + format, mypy, **1162 tests pass**, `uv build` → `outerloop_science-0.1.0.dev0` sdist+wheel.

**One-time setup (repo owner, out of band):** PyPI pending publisher (project `outerloop-science`, owner `outerloop-science`, repo `outerloop`, workflow `release.yml`, env `pypi`) + a GitHub `pypi` environment. Publish happens only on a pushed `v*` tag.