### PR TITLE
Cleanups: skip non-run dirs; end runs whose PR was deleted (404)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- The tick no longer logs `unreadable run record` for non-run directories under
+  `runs/` (e.g. the `baselines` eval cache): `list_runs` skips entries with no
+  record file, and still warns on a record that exists but fails to parse.
+- A run whose PR was deleted (GitHub 404) now ends cleanly instead of the
+  in-review service re-fetching the missing PR and logging a failure every tick.
+
 ### Added
 
 - PyPI release via Trusted Publishing: a tag-triggered `release.yml` builds and

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -30,6 +30,7 @@ from outerloop.contract import load_contract
 from outerloop.github import (
     GitError,
     GitHubClient,
+    GitHubError,
     NothingToCommit,
     Workspace,
     bot_login_from_env,
@@ -293,7 +294,16 @@ def _end_run(
 def close_if_done(run_root: Path, record: RunRecord, github: GitHubClient, now: float) -> str:
     """End the run if its PR is merged/closed. Returns the ending or ""."""
     number = _pr_number(record.pr_url)
-    pr = github.get_pull_request(record.target, number)
+    try:
+        pr = github.get_pull_request(record.target, number)
+    except GitHubError as exc:
+        if exc.status == 404:
+            # The PR was deleted out from under us — nothing left to review or
+            # merge. End the run (state transition + a courtesy note on the
+            # issue, not the gone PR) rather than re-fetching a 404 every tick.
+            _end_run(run_root, record, github, REJECTED, "PR no longer exists", now)
+            return REJECTED
+        raise
     if pr.get("merged") or pr.get("merged_at"):
         _end_run(run_root, record, github, MERGED, "", now)
         return MERGED

--- a/src/outerloop/runstate.py
+++ b/src/outerloop/runstate.py
@@ -252,6 +252,12 @@ def list_runs(root: Path) -> list[RunRecord]:
     if not runs_root.is_dir():
         return []
     for directory in sorted(runs_root.iterdir()):
+        # Skip entries that are not runs (no record file) — e.g. the `baselines`
+        # eval cache lives under runs/ but has no state.json and is not a run.
+        # A dir that HAS a record which fails to parse still logs below: a
+        # corrupt run is a real signal; a missing record is not.
+        if not (directory / RECORD_NAME).is_file():
+            continue
         try:
             records.append(load_record(root, directory.name))
         except (OSError, ValueError, TypeError, KeyError) as exc:

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from typing import cast
 
 import pytest
 
 from outerloop.followup import (
     REPLY_MARKER,
+    close_if_done,
     qualifying_comments,
     respond_once,
 )
+from outerloop.github import GitHubClient, GitHubError
 from outerloop.harness import SessionResult
 from outerloop.review import MARKER as ADVISORY_MARKER
 from outerloop.runstate import (
@@ -207,6 +210,21 @@ def test_closed_pr_ends_rejected(review_run) -> None:
     root, _ = review_run
     outcome = respond(root, FakeGitHub(pr={"state": "closed", "merged": False}))
     assert outcome.action == "ended-rejected"
+    assert load_record(root, "tsp-r1").ending == "rejected"
+
+
+def test_deleted_pr_404_ends_rejected(review_run) -> None:
+    root, _ = review_run
+
+    class GonePR(FakeGitHub):
+        def get_pull_request(self, repo, number):
+            raise GitHubError(404, f"/repos/{repo}/pulls/{number}", "Not Found")
+
+    # close_if_done is what the tick calls every cycle; a deleted PR (404) is
+    # terminal — end the run rather than re-fetching a 404 forever.
+    record = load_record(root, "tsp-r1")
+    ending = close_if_done(root, record, cast(GitHubClient, GonePR()), NOW)
+    assert ending == "rejected"
     assert load_record(root, "tsp-r1").ending == "rejected"
 
 

--- a/tests/test_runstate.py
+++ b/tests/test_runstate.py
@@ -73,6 +73,18 @@ def test_list_runs_skips_corrupt_records(tmp_path: Path, caplog) -> None:
     assert "unreadable" in caplog.text
 
 
+def test_list_runs_skips_non_run_dirs(tmp_path: Path, caplog) -> None:
+    save_record(tmp_path, make_record(run_id="good"), now=1.0)
+    # A dir under runs/ with no state.json is not a run (e.g. the baselines
+    # eval cache); it must be skipped silently, not warned about every sweep.
+    cache = run_dir(tmp_path, "baselines")
+    cache.mkdir(parents=True)
+    (cache / "speedrun@abc.json").write_text("{}")
+    records = list_runs(tmp_path)
+    assert [r.run_id for r in records] == ["good"]
+    assert "unreadable" not in caplog.text
+
+
 def test_lease_exactly_one_winner(tmp_path: Path) -> None:
     assert acquire_lease(tmp_path, "r1", "tick:a", "", now=1.0)
     assert not acquire_lease(tmp_path, "r1", "tick:b", "", now=2.0)


### PR DESCRIPTION
Two pre-existing log-noise fixes surfaced during the flip work (each with a regression test):

- **`list_runs` skips non-run dirs** — a dir under `runs/` with no `state.json` (e.g. the `baselines` eval cache) is not a run; it's skipped rather than logged as `unreadable run record` every tick. A dir that *has* a record which fails to parse still warns (a corrupt run is a real signal).
- **Deleted-PR runs end cleanly** — `close_if_done` treats a 404 from `get_pull_request` as terminal (PR gone → end rejected), instead of the in-review service re-fetching the missing PR and logging `in-review service failed … 404` every cycle. Once the tick ends the run, no followup job is submitted for it, so the job path is unreachable for gone PRs.

Verified: ruff + format + mypy, full pytest (1162+2 new).