### PR TITLE
Partition: optional + comma-separated list (Amelia's request)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- `AUTORESEARCH_PARTITION` is now **optional** — leave it unset and Slurm places
+  jobs on its default partition. It also accepts a **comma-separated list**
+  (`a,b` = "whichever frees up first"): the resident's knobs now ride the
+  inherited environment (`sbatch --export=ALL`) instead of a comma-joined
+  `--export=K=V,…` list, so a comma in a value no longer corrupts the delimiter.
+
 ### Added
 
 - PyPI release via Trusted Publishing: a tag-triggered `release.yml` builds and

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -41,10 +41,14 @@ CADENCE_MIN="${AUTORESEARCH_CADENCE_MIN:-30}"
 JOB_NAME="autoresearch-tick"
 RESIDENT_JOB_NAME="autoresearch-resident"
 missing=""
-for var in AUTORESEARCH_HOME AUTORESEARCH_ROOT AUTORESEARCH_ACCOUNT AUTORESEARCH_PARTITION; do
+for var in AUTORESEARCH_HOME AUTORESEARCH_ROOT AUTORESEARCH_ACCOUNT; do
     eval "val=\${$var:-}"
     [ -z "$val" ] && missing="$missing $var"
 done
+# Partition is optional: unset lets Slurm place the job on its default
+# partition. When set (including a comma-list like "a,b"), pass it through.
+part_arg=""
+[ -n "${AUTORESEARCH_PARTITION:-}" ] && part_arg="--partition=${AUTORESEARCH_PARTITION}"
 
 # --- 0. the resident tick: hand the whole job to the loop ---
 # A resident job has no queued successor to protect yet, so a misconfigured
@@ -95,7 +99,7 @@ while [ "$i" -le "$need" ]; do
             || date -r "$begin_epoch" +%Y-%m-%dT%H:%M:%S)
     for attempt in 1 2 3; do
         if sbatch --dependency=singleton --begin="$begin" \
-                  --account="${AUTORESEARCH_ACCOUNT:-}" --partition="${AUTORESEARCH_PARTITION:-}" \
+                  --account="${AUTORESEARCH_ACCOUNT:-}" ${part_arg:+"$part_arg"} \
                   "${AUTORESEARCH_HOME:-}/scripts/tick_chain.sbatch"; then
             break
         fi

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -41,11 +41,14 @@ submit_successor() {
     # singleton keeps two residents from ever running together
     local dep="singleton"
     [ -n "$self" ] && dep="afterany:${self},singleton"
+    # Partition is optional (unset -> Slurm's default); pass it only when set.
+    local part_arg=""
+    [ -n "${AUTORESEARCH_PARTITION:-}" ] && part_arg="--partition=${AUTORESEARCH_PARTITION}"
     local out="" attempt
     for attempt in 1 2 3; do
         if out=$(sbatch --parsable --dependency="$dep" --time="$resident_minutes" \
                     --job-name="$RESIDENT_JOB_NAME" --export=ALL \
-                    --account="${AUTORESEARCH_ACCOUNT:-}" --partition="${AUTORESEARCH_PARTITION:-}" \
+                    --account="${AUTORESEARCH_ACCOUNT:-}" ${part_arg:+"$part_arg"} \
                     "$shim" 2>/dev/null); then
             printf '%s' "${out%%;*}"
             return 0

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -112,33 +112,44 @@ class StartPlan:
     resident_minutes: int = DEFAULT_RESIDENT_MINUTES
     pat_file: str = ""
 
+    def export_env(self) -> dict[str, str]:
+        """The knobs the resident job needs. They ride the inherited environment
+        (sbatch `--export=ALL`), NOT a comma-joined `--export=K=V,K=V` list — so a
+        value may itself contain a comma (e.g. a multi-partition `a,b`, which Slurm
+        reads as "whichever frees up first") without corrupting the export
+        delimiter. start() merges these into the environment it hands sbatch."""
+        env = {
+            "AUTORESEARCH_RESIDENT": "1",
+            "AUTORESEARCH_HOME": str(self.home),
+            "AUTORESEARCH_ROOT": str(self.root),
+            "AUTORESEARCH_ACCOUNT": self.account,
+            "AUTORESEARCH_RESIDENT_MINUTES": str(self.resident_minutes),  # successors reuse it
+        }
+        if self.partition:
+            env["AUTORESEARCH_PARTITION"] = self.partition
+        if self.cadence_min:
+            env["AUTORESEARCH_CADENCE_MIN"] = self.cadence_min
+        if self.pat_file:
+            env["AUTORESEARCH_PAT_FILE"] = self.pat_file
+        return env
+
     def command(self) -> list[str]:
         if self.mode == "local":
             return [sys.executable, "-m", "outerloop.tick", "--root", str(self.root), "--loop"]
-        exports = [
-            "ALL",
-            "AUTORESEARCH_RESIDENT=1",
-            f"AUTORESEARCH_HOME={self.home}",
-            f"AUTORESEARCH_ROOT={self.root}",
-            f"AUTORESEARCH_ACCOUNT={self.account}",
-            f"AUTORESEARCH_PARTITION={self.partition}",
-            f"AUTORESEARCH_RESIDENT_MINUTES={self.resident_minutes}",  # successors reuse it
-        ]
-        if self.cadence_min:
-            exports.append(f"AUTORESEARCH_CADENCE_MIN={self.cadence_min}")
-        if self.pat_file:
-            exports.append(f"AUTORESEARCH_PAT_FILE={self.pat_file}")
-        return [
+        argv = [
             "sbatch",
             "--parsable",
             "--dependency=singleton",  # two starts can both submit; only one ever runs
             f"--time={self.resident_minutes}",
             f"--job-name={RESIDENT_JOB_NAME}",
             f"--account={self.account}",
-            f"--partition={self.partition}",
-            "--export=" + ",".join(exports),
-            str(self.home / "scripts" / "tick_chain.sbatch"),
         ]
+        if self.partition:  # unset lets Slurm choose its default partition
+            argv.append(f"--partition={self.partition}")
+        # --export=ALL carries export_env() from the inherited environment; a
+        # comma-joined K=V list here would break on any value containing a comma.
+        argv += ["--export=ALL", str(self.home / "scripts" / "tick_chain.sbatch")]
+        return argv
 
 
 def _setting(key: str, flag: str, environ: dict[str, str], from_file: dict[str, str]) -> str:
@@ -210,16 +221,10 @@ def plan_start(
         )
     acc = _setting("AUTORESEARCH_ACCOUNT", account, environ, from_file)
     part = _setting("AUTORESEARCH_PARTITION", partition, environ, from_file)
-    missing = [
-        name
-        for name, value in (
-            ("--account / AUTORESEARCH_ACCOUNT", acc),
-            ("--partition / AUTORESEARCH_PARTITION", part),
-        )
-        if not value
-    ]
-    if missing:
-        raise StartError("Slurm mode needs " + " and ".join(missing))
+    # Partition is optional: left unset, Slurm places the job on its default
+    # partition. Account stays required (clusters bill by it).
+    if not acc:
+        raise StartError("Slurm mode needs --account / AUTORESEARCH_ACCOUNT")
     minutes_s = _setting("AUTORESEARCH_RESIDENT_MINUTES", "", environ, from_file)
     try:
         minutes = int(minutes_s) if minutes_s else DEFAULT_RESIDENT_MINUTES
@@ -229,6 +234,9 @@ def plan_start(
         ) from None
     if minutes <= 0:
         raise StartError("AUTORESEARCH_RESIDENT_MINUTES must be positive")
+    # These ride the inherited environment (sbatch --export=ALL), so a comma is
+    # safe now (a multi-partition `a,b` is valid) — only a newline would corrupt
+    # the environment or the sbatch argv.
     for name, value in (
         ("root", root_s),
         ("account", acc),
@@ -237,10 +245,8 @@ def plan_start(
         ("PAT file", pat),
         ("checkout path", str(home)),
     ):
-        if "," in value or any(c.isspace() for c in value):
-            raise StartError(
-                f"{name} {value!r} cannot contain commas or whitespace: it rides in sbatch --export"
-            )
+        if "\n" in value or "\r" in value:
+            raise StartError(f"{name} {value!r} cannot contain a newline")
     return StartPlan(
         mode="slurm",
         root=Path(root_s).expanduser(),
@@ -349,7 +355,10 @@ def start(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 0
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    # sbatch --export=ALL carries these to the resident job from the environment
+    # we hand it here (so a comma in a value never breaks a --export delimiter).
+    submit_env = {**os.environ, **plan.export_env()}
+    proc = subprocess.run(cmd, capture_output=True, text=True, env=submit_env)
     if proc.returncode != 0:
         print(
             f"outerloop start: sbatch failed: {(proc.stderr or proc.stdout).strip()}",

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -105,12 +105,13 @@ class JobSpec:
             "--parsable",
             f"--job-name={self.job_name}",
             f"--account={self.account}",
-            f"--partition={self.partition}",
             f"--time={self.time_minutes}",
             f"--cpus-per-task={self.cpus}",
             f"--mem={self.mem}",
             f"--output={self.output}",
         ]
+        if self.partition:  # unset lets Slurm pick its default partition
+            argv.append(f"--partition={self.partition}")
         if self.gpus:
             # per-NODE, not per-job (--gpus): every job here is single-node,
             # and Slurm submit plugins commonly classify a job by its

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -46,6 +46,13 @@ def test_submit_parses_job_id() -> None:
     assert "--wrap=echo hi" in argv
 
 
+def test_partition_is_optional_in_the_argv() -> None:
+    with_part = JobSpec(job_name="j", account="a", partition="cpu,gpu", time_minutes=1, command="x")
+    assert "--partition=cpu,gpu" in with_part.to_argv()  # comma-list passes through
+    without = JobSpec(job_name="j", account="a", partition="", time_minutes=1, command="x")
+    assert not any(a.startswith("--partition") for a in without.to_argv())
+
+
 def test_submit_parses_cluster_suffixed_id() -> None:
     runner = FakeRunner([CommandResult(0, "12345;torch\n", "")])
     assert SlurmCompute(runner=runner).submit(SPEC) == "12345"

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -156,13 +156,20 @@ def test_slurm_composes_the_resident_submit(tmp_path: Path) -> None:
         f"--job-name={RESIDENT_JOB_NAME}",
         "--account=pr_1_general",
         "--partition=cpu_short",
-        "--export=ALL,AUTORESEARCH_RESIDENT=1,"
-        f"AUTORESEARCH_HOME={home},AUTORESEARCH_ROOT=/scratch/me/ar,"
-        "AUTORESEARCH_ACCOUNT=pr_1_general,AUTORESEARCH_PARTITION=cpu_short,"
-        f"AUTORESEARCH_RESIDENT_MINUTES={DEFAULT_RESIDENT_MINUTES},"
-        "AUTORESEARCH_CADENCE_MIN=20,AUTORESEARCH_PAT_FILE=/home/me/.config/autoresearch/bot_pat",
+        "--export=ALL",
         str(home / "scripts" / "tick_chain.sbatch"),
     ]
+    # The knobs ride the inherited environment, not a comma-joined --export list.
+    assert p.export_env() == {
+        "AUTORESEARCH_RESIDENT": "1",
+        "AUTORESEARCH_HOME": str(home),
+        "AUTORESEARCH_ROOT": "/scratch/me/ar",
+        "AUTORESEARCH_ACCOUNT": "pr_1_general",
+        "AUTORESEARCH_RESIDENT_MINUTES": str(DEFAULT_RESIDENT_MINUTES),
+        "AUTORESEARCH_PARTITION": "cpu_short",
+        "AUTORESEARCH_CADENCE_MIN": "20",
+        "AUTORESEARCH_PAT_FILE": "/home/me/.config/autoresearch/bot_pat",
+    }
 
 
 def test_precedence_is_flag_then_environment_then_file(tmp_path: Path) -> None:
@@ -195,23 +202,28 @@ def test_home_from_env_or_cwd_and_must_be_a_checkout_in_both_modes(tmp_path: Pat
         plan(tmp_path, cwd=tmp_path, local=True)
 
 
-def test_slurm_requires_root_account_and_partition(tmp_path: Path) -> None:
+def test_slurm_requires_root_and_account_but_partition_is_optional(tmp_path: Path) -> None:
     with pytest.raises(StartError, match="state root"):
         plan(tmp_path)
-    with pytest.raises(
-        StartError,
-        match="--account / AUTORESEARCH_ACCOUNT and --partition / AUTORESEARCH_PARTITION",
-    ):
+    with pytest.raises(StartError, match="--account / AUTORESEARCH_ACCOUNT"):
         plan(tmp_path, root="/r")
-    with pytest.raises(StartError, match="--partition / AUTORESEARCH_PARTITION"):
-        plan(tmp_path, root="/r", account="a")
+    # partition unset is fine: Slurm places on its default, and neither the
+    # sbatch command nor export_env carries an AUTORESEARCH_PARTITION.
+    p = plan(tmp_path, root="/r", account="a")
+    assert p.partition == ""
+    assert not any(a.startswith("--partition=") for a in p.command())
+    assert "AUTORESEARCH_PARTITION" not in p.export_env()
 
 
-def test_slurm_rejects_values_that_would_break_export(tmp_path: Path) -> None:
-    with pytest.raises(StartError, match="commas or whitespace"):
-        plan(tmp_path, root="/r", account="a,b", partition="p")
-    with pytest.raises(StartError, match="commas or whitespace"):
-        plan(tmp_path, root="/my root", account="a", partition="p")
+def test_slurm_accepts_a_comma_list_partition(tmp_path: Path) -> None:
+    # a multi-partition "a,b" now rides the inherited env, not the --export
+    # delimiter, so it is accepted and passed through verbatim.
+    p = plan(tmp_path, root="/r", account="a", partition="cpu_short,cpu_long")
+    assert p.export_env()["AUTORESEARCH_PARTITION"] == "cpu_short,cpu_long"
+    assert "--partition=cpu_short,cpu_long" in p.command()
+    # a newline would still corrupt the environment / sbatch argv.
+    with pytest.raises(StartError, match="newline"):
+        plan(tmp_path, root="/r", account="a", partition="cpu\nlong")
 
 
 @pytest.mark.parametrize("bad", ["0", "-5", "30m", ""])
@@ -238,7 +250,7 @@ def test_slurm_resident_minutes_must_be_a_positive_integer(tmp_path: Path) -> No
     p = plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "240"})
     assert p.resident_minutes == 240
     assert "--time=240" in p.command()
-    assert any("AUTORESEARCH_RESIDENT_MINUTES=240" in a for a in p.command())  # successors keep it
+    assert p.export_env()["AUTORESEARCH_RESIDENT_MINUTES"] == "240"  # successors keep it
     with pytest.raises(StartError, match="whole number"):
         plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "4h"})
     with pytest.raises(StartError, match="positive"):
@@ -322,7 +334,14 @@ def test_slurm_start_submits_once_and_reports(
     bin_dir = clean_env / "bin"
     bin_dir.mkdir()
     log = clean_env / "sbatch.log"
-    shim(bin_dir, "sbatch", f'printf "%s\\n" "$@" > {log}\necho "4242;torch"\n')
+    envlog = clean_env / "sbatch.env"
+    shim(
+        bin_dir,
+        "sbatch",
+        f'printf "%s\\n" "$@" > {log}\n'
+        f'printf "%s:%s" "$AUTORESEARCH_RESIDENT" "$AUTORESEARCH_HOME" > {envlog}\n'
+        'echo "4242;torch"\n',
+    )
     shim(bin_dir, "squeue", "exit 0\n")
     monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
     monkeypatch.chdir(home)
@@ -335,10 +354,8 @@ def test_slurm_start_submits_once_and_reports(
     argv = log.read_text().split("\n")
     assert argv[0] == "--parsable" and f"--job-name={RESIDENT_JOB_NAME}" in argv
     assert "--dependency=singleton" in argv
-    assert any(
-        a.startswith("--export=ALL,AUTORESEARCH_RESIDENT=1,") and f"AUTORESEARCH_HOME={home}" in a
-        for a in argv
-    )
+    assert "--export=ALL" in argv  # the knobs ride the inherited env, asserted next
+    assert envlog.read_text() == f"1:{home}"  # export_env reached sbatch's environment
     assert argv[-2] == str(home / "scripts" / "tick_chain.sbatch")
 
 

--- a/tests/test_tick_chain_successors.py
+++ b/tests/test_tick_chain_successors.py
@@ -23,7 +23,10 @@ def test_successors_are_singleton_on_the_grid_without_a_deadline() -> None:
     assert "--dependency=singleton" in line
     assert '--begin="$begin"' in line
     assert "--deadline" not in line and "--deadline" not in CHAIN
-    assert '--partition="${AUTORESEARCH_PARTITION:-}"' in line
+    # partition is optional now: passed through only when set (part_arg is
+    # derived from AUTORESEARCH_PARTITION near the top of the chain).
+    assert '${part_arg:+"$part_arg"}' in line
+    assert 'part_arg="--partition=${AUTORESEARCH_PARTITION}"' in CHAIN
 
 
 def _grid(epoch_now: int, cadence_s: int, pending: int, i: int) -> int:


### PR DESCRIPTION
Addresses the two partition asks from a collaborator:

**1. `AUTORESEARCH_PARTITION` is now optional** — leave it unset and Slurm places jobs on its default partition. Previously required by `outerloop start`, `tick_chain.sbatch`, and always emitted as `--partition=`. Now: dropped from the required checks; `compute.py`, `tick_chain`, and `tick_resident` emit `--partition` only when set. (Account stays required.)

**2. Comma-separated partitions now work** (`a,b` = "whichever frees up first"). Root cause of the rejection: the resident's config rode a comma-joined `sbatch --export=K=V,…` list, where a comma in a value corrupts the export delimiter — hence the defensive reject in `cli.py`. Fixed properly: the knobs now ride the **inherited environment** (`--export=ALL`), and `start()` hands them to sbatch via `env=`. So commas (and spaces) are safe; only a newline is still rejected.

Tests: updated `test_start` (new `export_env()`, optional + comma-list cases), `test_compute` (optional partition in argv), `test_tick_chain_successors` (conditional `part_arg`). Verified: ruff + format + mypy, full pytest **1163 passed**.

The env-passing change is fleet-launch code, so worth a tick verification after merge.