### PR TITLE
Add outerloop init: guided setup (full-fleet on-ramp, Stage 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Added
+
+- `outerloop init` — a guided setup that collects placement (Slurm or local),
+  the target repo, and a bot token, then writes `~/.config/autoresearch/.env`
+  and the token file (both `0600`) and checks the token can reach the target.
+  Flags fill answers non-interactively (`--yes`); a pasted token is read via
+  getpass, never echoed. Replaces hand-editing `.env` for a new adopter.
+
 ### Changed
 
 - `AUTORESEARCH_PARTITION` is now **optional** — leave it unset and Slurm places

--- a/docs/install.md
+++ b/docs/install.md
@@ -127,7 +127,7 @@ roadmap: docs/roadmap.md
 **Check it before you push:**
 
 ```bash
-uv run python -m autoresearch.contract_cli .autoresearch.yaml
+uv run python -m outerloop.contract_cli .autoresearch.yaml
 ```
 
 It prints what the agent would be allowed to do, or exactly what is wrong.
@@ -138,7 +138,7 @@ The optional knobs — paired seeding and the significance floor
 (`depth_k`, `sleep_k`), width and pacing (`max_active_attempts`,
 `attempt_cooldown_minutes`), a stewardship scope, and `merge: manual|auto` —
 are listed in the README's contract table; the schema's own docstrings
-(`src/autoresearch/contract.py`) are the reference. A GPU benchmark needs a
+(`src/outerloop/contract.py`) are the reference. A GPU benchmark needs a
 dispatched eval (`eval_minutes` above the in-job threshold) and a cached
 baseline needs a positive floor — the validator says so — and for GPU
 benchmarks `gpu_hours_per_run` is a real meter: launches and evals draw on
@@ -181,6 +181,18 @@ Add the bot as a direct collaborator (**Write**) on each opted-in repo. Don't
 add it to a team — teams grant more than it needs and inherit future grants.
 
 ### 2c. Run the loop
+
+The quickest path is the guided setup:
+
+```bash
+outerloop init      # asks for compute, target repo, Slurm account/partition, a token
+outerloop start
+```
+
+`init` writes `~/.config/autoresearch/.env` and the token file (both `0600`) —
+everything the prose below otherwise sets by hand — and checks the token can
+reach your target repo. The rest of this section documents what it writes, for
+when you'd rather set it directly.
 
 The orchestrator is CPU-only and makes outbound connections only. Anywhere
 that can reach GitHub and your LLM provider works.

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -411,6 +411,10 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.add_argument("--dry-run", action="store_true", help="print the command and exit")
     sub.add_parser("tick", help="one tick, or --loop; the chain's own entry", add_help=False)
+    sub.add_parser(
+        "init", help="guided setup: write ~/.config/autoresearch/.env and the PAT file",
+        add_help=False,
+    )
     argv = sys.argv[1:] if argv is None else list(argv)
     if argv[:1] == ["tick"]:
         # the tick entry owns its own parser; hand it the rest untouched
@@ -418,6 +422,11 @@ def main(argv: list[str] | None = None) -> int:
 
         sys.argv = ["outerloop tick", *argv[1:]]
         return tick.main()
+    if argv[:1] == ["init"]:
+        # init owns its own parser too; hand it the args after "init"
+        from outerloop import init
+
+        return init.main(argv[1:])
     return start(parser.parse_args(argv))
 
 

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -412,7 +412,8 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--dry-run", action="store_true", help="print the command and exit")
     sub.add_parser("tick", help="one tick, or --loop; the chain's own entry", add_help=False)
     sub.add_parser(
-        "init", help="guided setup: write ~/.config/autoresearch/.env and the PAT file",
+        "init",
+        help="guided setup: write ~/.config/autoresearch/.env and the PAT file",
         add_help=False,
     )
     argv = sys.argv[1:] if argv is None else list(argv)

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -1,0 +1,206 @@
+"""`outerloop init` — the guided setup.
+
+Collects placement (Slurm or local), the target repo, and bot auth, then writes
+`~/.config/autoresearch/.env` (and the PAT file), so a new adopter never
+hand-edits config or reasons about which `AUTORESEARCH_*` keys to set. Flags fill
+answers non-interactively; anything left out is prompted for (a secret via
+getpass, never echoed). The App-manifest auth path — one-click creation of the
+adopter's own GitHub App — is a later stage; today init writes a PAT you paste or
+point at, and `resolve_bot_auth` reads it exactly as `outerloop start` does.
+
+The config location is `cli.ENV_FILE`, the same file `start` reads — one source
+of truth, so a rename of the config dir moves both together.
+"""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+
+from outerloop.cli import ENV_FILE
+
+CONFIG_DIR = ENV_FILE.parent
+DEFAULT_PAT_FILE = CONFIG_DIR / "bot_pat"
+API = "https://api.github.com"
+
+
+@dataclass
+class InitAnswers:
+    compute: str  # "slurm" | "local"
+    target: str  # "owner/repo"
+    root: str = ""  # Slurm state root on the shared filesystem
+    account: str = ""  # Slurm account (required for Slurm)
+    partition: str = ""  # Slurm partition (optional; unset -> Slurm default)
+    author_backend: str = ""  # optional: the climbing author's harness
+    author_model: str = ""  # optional
+
+
+def render_env(a: InitAnswers, pat_file: str) -> str:
+    """The `.env` body for these answers — only the keys that have a value, so
+    the file stays minimal and every line means something. Ordered placement →
+    target → auth → author to read top-to-bottom like the setup itself."""
+    lines = [f"AUTORESEARCH_COMPUTE={a.compute}"]
+    if a.compute == "slurm":
+        lines.append(f"AUTORESEARCH_ROOT={a.root}")
+        lines.append(f"AUTORESEARCH_ACCOUNT={a.account}")
+        if a.partition:  # optional: unset lets Slurm pick its default partition
+            lines.append(f"AUTORESEARCH_PARTITION={a.partition}")
+    lines.append(f"AUTORESEARCH_TARGET={a.target}")
+    if pat_file:
+        lines.append(f"AUTORESEARCH_PAT_FILE={pat_file}")
+    if a.author_backend:
+        lines.append(f"AUTORESEARCH_AUTHOR_BACKEND={a.author_backend}")
+    if a.author_model:
+        lines.append(f"AUTORESEARCH_AUTHOR_MODEL={a.author_model}")
+    return "\n".join(lines) + "\n"
+
+
+def write_config(
+    a: InitAnswers, token: str, pat_file: str, *, config_dir: Path = CONFIG_DIR
+) -> tuple[Path, Path | None]:
+    """Write the PAT file (only when a token is pasted) and the `.env`, both
+    owner-only (0600) — `start`/`tick_deploy` refuse a group/world-readable
+    `.env`, and a token file must never be wider. Returns (env_path, pat_path)."""
+    config_dir.mkdir(parents=True, exist_ok=True)
+    written_pat: Path | None = None
+    if token:
+        pat_path = config_dir / DEFAULT_PAT_FILE.name
+        # printf-style: no trailing newline — the deploy `cat`s this file into
+        # the git credential, and a trailing newline rides along and breaks auth.
+        pat_path.write_text(token)
+        pat_path.chmod(0o600)
+        written_pat = pat_path
+        pat_file = str(pat_path)
+    env_path = config_dir / ENV_FILE.name
+    env_path.write_text(render_env(a, pat_file))
+    env_path.chmod(0o600)
+    return env_path, written_pat
+
+
+def validate_pat(pat_file: str, target: str) -> str:
+    """Best-effort: can this token read the target repo? Returns "" on success,
+    else a short reason. Never raises — a check failure is a warning, not a
+    reason to abandon a written config."""
+    try:
+        token = Path(pat_file).expanduser().read_text().strip()
+    except OSError as exc:
+        return f"could not read {pat_file}: {exc}"
+    if not token:
+        return f"{pat_file} is empty"
+    req = urllib.request.Request(
+        f"{API}/repos/{target}",
+        headers={"Authorization": f"token {token}", "Accept": "application/vnd.github+json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            body = json.loads(resp.read())
+        perms = body.get("permissions") or {}
+        if not perms.get("push"):
+            return f"the token reads {target} but lacks write access (it opens PRs)"
+        return ""
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return f"{target} not found, or the token cannot see it"
+        return f"GitHub returned {exc.code} for {target}"
+    except urllib.error.URLError as exc:
+        return f"could not reach GitHub: {exc.reason}"
+
+
+def _ask(prompt: str, default: str = "", *, required: bool = False) -> str:
+    """One interactive prompt with an optional default; re-asks while a required
+    answer is blank."""
+    suffix = f" [{default}]" if default else ""
+    while True:
+        got = input(f"{prompt}{suffix}: ").strip() or default
+        if got or not required:
+            return got
+        print("  (required)")
+
+
+def _collect(args: argparse.Namespace, interactive: bool) -> tuple[InitAnswers, str]:
+    """Merge flags with prompts (when interactive) into answers + a PAT-file
+    path. `args.pat_file` names an existing file; otherwise, interactively, a
+    pasted token is returned separately to be written 0600."""
+    compute = args.compute or (_ask("Compute: slurm or local", "slurm") if interactive else "slurm")
+    compute = compute.lower()
+    target = args.target or (_ask("Target repo (owner/repo)", required=True) if interactive else "")
+    root = account = partition = ""
+    if compute == "slurm":
+        root = args.root or (
+            _ask("Slurm state root (shared filesystem)", required=True) if interactive else ""
+        )
+        account = args.account or (_ask("Slurm account", required=True) if interactive else "")
+        partition = args.partition or (
+            _ask("Slurm partition (blank = Slurm default; a,b for a list)") if interactive else ""
+        )
+    backend = args.author_backend or (
+        _ask("Author backend (blank to set later)") if interactive else ""
+    )
+    model = args.author_model or (_ask("Author model (blank to set later)") if interactive else "")
+    answers = InitAnswers(
+        compute=compute,
+        target=target,
+        root=root,
+        account=account,
+        partition=partition,
+        author_backend=backend,
+        author_model=model,
+    )
+    return answers, (args.pat_file or "")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="outerloop init", description="guided setup for outerloop"
+    )
+    parser.add_argument("--compute", choices=["slurm", "local"], help="where the loop runs")
+    parser.add_argument("--target", help="the repo the agents work on, owner/repo")
+    parser.add_argument("--root", help="Slurm state root on the shared filesystem")
+    parser.add_argument("--account", help="Slurm account")
+    parser.add_argument(
+        "--partition", help="Slurm partition (optional; blank = default; a,b = list)"
+    )
+    parser.add_argument(
+        "--pat-file", dest="pat_file", help="path to an existing file holding a PAT"
+    )
+    parser.add_argument("--author-backend", dest="author_backend", help="climbing author's backend")
+    parser.add_argument("--author-model", dest="author_model", help="climbing author's model")
+    parser.add_argument(
+        "--yes", "-y", action="store_true", help="non-interactive: use flags, do not prompt"
+    )
+    args = parser.parse_args(sys.argv[2:] if argv is None else argv)
+    interactive = not args.yes
+
+    answers, pat_file = _collect(args, interactive)
+    if not answers.target:
+        print("outerloop init: a target repo is required (--target owner/repo)", file=sys.stderr)
+        return 2
+    if answers.compute == "slurm" and not (answers.root and answers.account):
+        print("outerloop init: Slurm needs --root and --account", file=sys.stderr)
+        return 2
+
+    token = ""
+    if not pat_file and interactive:
+        # re-collect only the token here so _collect stays pure of getpass in tests
+        token = getpass.getpass(
+            "Paste a GitHub PAT with write access to the target (hidden; blank to skip): "
+        ).strip()
+
+    env_path, pat_path = write_config(answers, token, pat_file, config_dir=CONFIG_DIR)
+    print(f"wrote {env_path}")
+    if pat_path:
+        print(f"wrote {pat_path} (0600)")
+    effective_pat = str(pat_path) if pat_path else pat_file
+    if effective_pat:
+        problem = validate_pat(effective_pat, answers.target)
+        print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
+    else:
+        print("  no PAT set — add AUTORESEARCH_PAT_FILE before the agents can open PRs")
+    print("next: outerloop start")
+    return 0

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -79,8 +79,8 @@ class _Resp:
     def __enter__(self) -> _Resp:
         return self
 
-    def __exit__(self, *a: object) -> bool:
-        return False
+    def __exit__(self, *a: object) -> None:
+        return None
 
 
 def test_validate_pat_ok_and_no_push(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,139 @@
+"""`outerloop init` — the guided setup writes a minimal, correct .env + PAT."""
+
+from __future__ import annotations
+
+import json
+import stat
+from pathlib import Path
+
+from outerloop import init
+from outerloop.init import InitAnswers, render_env, validate_pat, write_config
+
+
+def test_render_env_slurm_full() -> None:
+    a = InitAnswers(
+        compute="slurm",
+        target="o/r",
+        root="/scratch/r",
+        account="acct",
+        partition="cpu,gpu",
+        author_backend="claude",
+        author_model="opus",
+    )
+    env = render_env(a, "/home/me/.config/autoresearch/bot_pat")
+    assert "AUTORESEARCH_COMPUTE=slurm" in env
+    assert "AUTORESEARCH_ROOT=/scratch/r" in env
+    assert "AUTORESEARCH_ACCOUNT=acct" in env
+    assert "AUTORESEARCH_PARTITION=cpu,gpu" in env  # comma-list preserved verbatim
+    assert "AUTORESEARCH_TARGET=o/r" in env
+    assert "AUTORESEARCH_PAT_FILE=/home/me/.config/autoresearch/bot_pat" in env
+    assert "AUTORESEARCH_AUTHOR_BACKEND=claude" in env
+
+
+def test_render_env_omits_the_optional_keys() -> None:
+    env = render_env(InitAnswers(compute="slurm", target="o/r", root="/r", account="a"), "")
+    assert "AUTORESEARCH_PARTITION" not in env  # optional -> Slurm default
+    assert "AUTORESEARCH_PAT_FILE" not in env
+    assert "AUTORESEARCH_AUTHOR_BACKEND" not in env
+
+
+def test_render_env_local_has_no_slurm_placement() -> None:
+    env = render_env(InitAnswers(compute="local", target="o/r"), "")
+    assert "AUTORESEARCH_COMPUTE=local" in env
+    assert "AUTORESEARCH_ROOT" not in env and "AUTORESEARCH_ACCOUNT" not in env
+
+
+def test_write_config_writes_env_and_pat_0600(tmp_path: Path) -> None:
+    a = InitAnswers(compute="slurm", target="o/r", root="/r", account="a")
+    env_path, pat_path = write_config(a, "ghp_secrettoken", "", config_dir=tmp_path)
+    assert env_path == tmp_path / ".env"
+    assert pat_path == tmp_path / "bot_pat"
+    assert pat_path.read_text() == "ghp_secrettoken"  # no trailing newline
+    assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
+    assert stat.S_IMODE(pat_path.stat().st_mode) == 0o600
+    assert f"AUTORESEARCH_PAT_FILE={pat_path}" in env_path.read_text()
+
+
+def test_write_config_no_token_keeps_the_given_pat_file(tmp_path: Path) -> None:
+    env_path, pat_path = write_config(
+        InitAnswers(compute="local", target="o/r"), "", "/existing/pat", config_dir=tmp_path
+    )
+    assert pat_path is None
+    assert "AUTORESEARCH_PAT_FILE=/existing/pat" in env_path.read_text()
+
+
+def test_validate_pat_read_errors(tmp_path: Path) -> None:
+    assert "could not read" in validate_pat(str(tmp_path / "nope"), "o/r")
+    empty = tmp_path / "empty"
+    empty.write_text("")
+    assert "empty" in validate_pat(str(empty), "o/r")
+
+
+class _Resp:
+    def __init__(self, body: dict) -> None:
+        self._b = body
+
+    def read(self) -> bytes:
+        return json.dumps(self._b).encode()
+
+    def __enter__(self) -> _Resp:
+        return self
+
+    def __exit__(self, *a: object) -> bool:
+        return False
+
+
+def test_validate_pat_ok_and_no_push(tmp_path: Path, monkeypatch) -> None:
+    pat = tmp_path / "pat"
+    pat.write_text("ghp_x")
+    monkeypatch.setattr(
+        init.urllib.request,
+        "urlopen",
+        lambda req, timeout=15: _Resp({"permissions": {"push": True}}),
+    )
+    assert validate_pat(str(pat), "o/r") == ""
+    monkeypatch.setattr(
+        init.urllib.request,
+        "urlopen",
+        lambda req, timeout=15: _Resp({"permissions": {"push": False}}),
+    )
+    assert "lacks write" in validate_pat(str(pat), "o/r")
+
+
+def test_main_yes_writes_config(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(init, "validate_pat", lambda pf, t: "")
+    rc = init.main(
+        [
+            "--yes",
+            "--compute",
+            "slurm",
+            "--target",
+            "o/r",
+            "--root",
+            "/r",
+            "--account",
+            "a",
+            "--partition",
+            "cpu,gpu",
+            "--pat-file",
+            "/some/pat",
+        ]
+    )
+    assert rc == 0
+    env = (tmp_path / ".env").read_text()
+    assert "AUTORESEARCH_TARGET=o/r" in env
+    assert "AUTORESEARCH_PARTITION=cpu,gpu" in env  # comma-list survives the wizard
+    assert "AUTORESEARCH_PAT_FILE=/some/pat" in env
+
+
+def test_main_yes_requires_target(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    assert init.main(["--yes", "--compute", "local"]) == 2
+    assert "target repo is required" in capsys.readouterr().err
+
+
+def test_main_yes_slurm_requires_root_and_account(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    assert init.main(["--yes", "--compute", "slurm", "--target", "o/r"]) == 2
+    assert "Slurm needs --root and --account" in capsys.readouterr().err


### PR DESCRIPTION
Closes the gap between the full-fleet setup and the website's '3-step' promise — a new adopter no longer hand-edits `.env` or reasons about which `AUTORESEARCH_*` keys to set.

**`outerloop init`** collects compute (Slurm/local), target repo, Slurm account + **optional** partition (comma-lists work), and a bot token; then writes `~/.config/autoresearch/.env` + the token file (both `0600`) and checks the token can reach the target repo.
- Token read via **getpass** (never echoed); `--yes` + flags for non-interactive use.
- Config location is `cli.ENV_FILE` — one source of truth with `start`.
- Wired into the CLI dispatch (`outerloop init --help`).

**Docs:** `install.md` Level 2 now headlines `outerloop init`; fixed two rename-broken refs there (`python -m autoresearch.contract_cli` → `outerloop.contract_cli`, `src/autoresearch/contract.py` → `src/outerloop/`).

**Tests:** 10 new (render/write-0600/validate/main paths). Verified: ruff + format + mypy, full pytest **1175 passed**.

**Stage 2 (next):** the GitHub App-manifest one-click auth plugged into `init` — removes the token step entirely. This stage keeps the PAT path as the fallback.