### PR TITLE
init: never overwrite an existing .env silently (ask, or --force)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- `outerloop init` no longer overwrites an existing `~/.config/autoresearch/.env`
+  silently: interactively it asks; with `--yes` it refuses unless `--force` is
+  passed. The check runs before any GitHub App is created.
+
 ### Added
 
 - `outerloop init --github-app` — the **recommended** auth path: one-click

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -1,12 +1,13 @@
 """`outerloop init` — the guided setup.
 
 Collects placement (Slurm or local), the target repo, and bot auth, then writes
-`~/.config/autoresearch/.env` (and the PAT file), so a new adopter never
+`~/.config/autoresearch/.env` (plus the credential files), so a new adopter never
 hand-edits config or reasons about which `AUTORESEARCH_*` keys to set. Flags fill
 answers non-interactively; anything left out is prompted for (a secret via
-getpass, never echoed). The App-manifest auth path — one-click creation of the
-adopter's own GitHub App — is a later stage; today init writes a PAT you paste or
-point at, and `resolve_bot_auth` reads it exactly as `outerloop start` does.
+getpass, never echoed). Auth is the adopter's own GitHub App by default —
+`--github-app`, one click via the manifest flow in `appmanifest.py` — with a PAT
+as the fallback; either way `resolve_bot_auth` reads the result exactly as
+`outerloop start` does. An existing `.env` is never overwritten without asking.
 
 The config location is `cli.ENV_FILE`, the same file `start` reads — one source
 of truth, so a rename of the config dir moves both together.
@@ -245,6 +246,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--yes", "-y", action="store_true", help="non-interactive: use flags, do not prompt"
     )
+    parser.add_argument(
+        "--force", action="store_true", help="overwrite an existing config without asking"
+    )
     args = parser.parse_args(sys.argv[2:] if argv is None else argv)
     interactive = not args.yes
 
@@ -261,6 +265,20 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+
+    # Never clobber a working setup silently: a re-run of init on a configured
+    # machine must ask (or be told --force). Checked before any App is created.
+    env_path = CONFIG_DIR / ENV_FILE.name
+    if env_path.exists() and not args.force:
+        if not interactive:
+            print(f"outerloop init: {env_path} exists; pass --force to overwrite", file=sys.stderr)
+            return 1
+        if not _ask(f"{env_path} exists — overwrite it? (y/N)", "n").lower().startswith("y"):
+            print(
+                "outerloop init: kept the existing config (--force skips this check)",
+                file=sys.stderr,
+            )
+            return 1
 
     # The App is the recommended credential (scoped, revocable, no plaintext
     # token); the PAT is the fallback. Offer it first when interactive.

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -192,3 +192,51 @@ def test_main_github_app_writes_app_env(tmp_path: Path, monkeypatch, capsys) -> 
     env = (tmp_path / ".env").read_text()
     assert f"AUTORESEARCH_GITHUB_APP_FILE={app_json}" in env
     assert "AUTORESEARCH_PAT_FILE" not in env
+
+
+KEEP = "AUTORESEARCH_TARGET=keep/me\n"
+
+
+def test_init_refuses_to_overwrite_an_existing_env_non_interactively(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    (tmp_path / ".env").write_text(KEEP)
+    rc = init.main(["--yes", "--compute", "local", "--target", "o/r", "--pat-file", "/p"])
+    assert rc == 1
+    assert "exists; pass --force" in capsys.readouterr().err
+    assert (tmp_path / ".env").read_text() == KEEP  # untouched
+
+
+def test_init_force_overwrites_an_existing_env(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(init, "validate_pat", lambda pf, t: "")
+    (tmp_path / ".env").write_text(KEEP)
+    rc = init.main(
+        ["--yes", "--force", "--compute", "local", "--target", "o/r", "--pat-file", "/p"]
+    )
+    assert rc == 0
+    assert "AUTORESEARCH_TARGET=o/r" in (tmp_path / ".env").read_text()
+
+
+def test_init_interactive_declined_overwrite_keeps_the_config(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    (tmp_path / ".env").write_text(KEEP)
+    # every other answer comes from flags, so the overwrite question is the one prompt
+    monkeypatch.setattr(init, "_ask", lambda *a, **k: "n")
+    rc = init.main(
+        [
+            "--compute",
+            "local",
+            "--target",
+            "o/r",
+            "--pat-file",
+            "/p",
+            "--author-backend",
+            "claude",
+            "--author-model",
+            "m",
+        ]
+    )
+    assert rc == 1
+    assert (tmp_path / ".env").read_text() == KEEP


### PR DESCRIPTION
Closes the footgun noted while writing the test runbook: `outerloop init` overwrote `~/.config/autoresearch/.env` without asking, so a re-run on a configured machine silently lost a working setup.

- Interactive: asks `<path> exists — overwrite it? (y/N)`, default no.
- `--yes`: refuses with a clear message unless `--force` is passed.
- The check runs **before** any GitHub App is created, so an aborted run leaves no stray App.
- Refreshes the module docstring (the App path is the recommended default now, not "a later stage").

Tests: 3 new (non-interactive refuse + untouched file, `--force` overwrites, interactive decline keeps config). ruff/format/fresh-mypy clean; init + appmanifest suites green.