### PR TITLE
Convention pass 1/5: contract file is .outerloop.yaml (legacy name still read)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- The contract file is now **`.outerloop.yaml`** (docs, `contract_cli`, the
+  author's brief). `.autoresearch.yaml` is still read: every read site — GitHub
+  API, `git show <sha>:…`, working tree — goes through `find_contract`, which
+  resolves whichever name the target has, new name first. No target has to
+  rename anything to keep working, and neither name is ever a writable path.
+
 ### Fixed
 
 - `outerloop init` no longer overwrites an existing `~/.config/autoresearch/.env`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Nothing reports back to us.
 - **Advisory PR reviews** — comments on pull requests with concrete findings.
   It never approves, never blocks, and never fails your CI. Five minutes to
   set up.
-- **Benchmark climbing** — given a contract (`.autoresearch.yaml`) declaring
+- **Benchmark climbing** — given a contract (`.outerloop.yaml`) declaring
   what "better" means and where the agent may write, authors propose changes
   and the orchestrator measures them itself: the base tree and the candidate
   are evaluated on your cluster (under one fresh shared seed when the
@@ -107,7 +107,7 @@ draw on it, and the author sets how long its final eval may run
 is never the metric. CPU benchmarks are not metered.
 
 ```bash
-uv run python -m outerloop.contract_cli .autoresearch.yaml   # validate before you push
+uv run python -m outerloop.contract_cli .outerloop.yaml   # validate before you push
 ```
 
 ## Getting started

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -21,7 +21,7 @@ reports weekly. Humans keep the merge button.
 
 ## Target-repo contract
 
-A repo opts in with two things: bot access, and `.autoresearch.yaml` at its root.
+A repo opts in with two things: bot access, and `.outerloop.yaml` at its root.
 Target repos never import this repo.
 
 ```yaml
@@ -282,7 +282,7 @@ grep + recency + distillation until that provably fails.
 
 | Module | Job |
 | --- | --- |
-| `contract` | Schema + loader for `.autoresearch.yaml`, incl. the hard-coded invariants |
+| `contract` | Schema + loader for `.outerloop.yaml`, incl. the hard-coded invariants |
 | `harness` | Run one agent session in a scrubbed environment (no PAT, no billing keys; per-run HOME, fresh per run; brief on stdin, never argv); capture transcript and cost (the orchestrator captures the diff); secret-scan transcripts before storage. See "Harness and context engineering" below |
 | `orchestrator` | Tick logic: sentinel, lease, task selection, session dispatch, state sync |
 | `compute` | sbatch/squeue submit-and-poll behind one interface |
@@ -305,7 +305,7 @@ exactly what any given agent saw, and a bad run can be replayed from its brief:
 | Section | Source | Budgeted |
 | --- | --- | --- |
 | Task: one hypothesis, expected metric movement, done-criteria | task selection | fixed |
-| Contract: benchmarks, scope, budgets (verbatim) | `.autoresearch.yaml` | fixed |
+| Contract: benchmarks, scope, budgets (verbatim) | `.outerloop.yaml` | fixed |
 | Ruler: how the metric is computed, how claims get re-verified | target repo docs | fixed |
 | Lessons: distilled, bounded per-target lessons file | notebook `lessons/<target>.md` | hard cap |
 | Recent history: last N run reports for this target (incl. failures) | notebook `runs/<target>/` | hard cap, newest first |

--- a/docs/design/headline.md
+++ b/docs/design/headline.md
@@ -37,7 +37,7 @@ correction — interventions-per-accepted-step is measured per mode), under a
    val loss, frozen arch/data/batch (modded-nanogpt track 3 rules). Direct
    comparability with Prime Intellect's agent record (2,930 steps vs the
    2,990 human baseline; ~14k H200-hours; ~100 human interventions) without
-   requiring identical hardware. New target repo with an `.autoresearch.yaml`
+   requiring identical hardware. New target repo with an `.outerloop.yaml`
    contract; wall-clock track is a stretch goal pending Torch's GPU shape
    (OPEN: H100s per node, burnable budget).
 2. **Comparability — the RSI exam.** A slice of AI4AI-Bench (frozen research

--- a/docs/design/onboarding.md
+++ b/docs/design/onboarding.md
@@ -8,7 +8,7 @@ honest when it says three steps:
 
 1. **`init`** — one wizard mints the GitHub App, writes the config, and
    validates the host (two browser clicks and one paste).
-2. **A contract** — add `.autoresearch.yaml` + an eval ruler to the target
+2. **A contract** — add `.outerloop.yaml` + an eval ruler to the target
    repo.
 3. **Start** — one `sbatch` (cluster) or one foreground process
    (workstation).

--- a/docs/install.md
+++ b/docs/install.md
@@ -107,8 +107,9 @@ improves. This needs a bot identity and somewhere to run experiments.
 
 ### 2a. Write a contract
 
-`.autoresearch.yaml` at your repo root declares what "better" means and where
-the agent may write:
+`.outerloop.yaml` at your repo root declares what "better" means and where
+the agent may write (a repo set up before the rename can keep `.autoresearch.yaml` —
+the kernel reads either, new name first):
 
 ```yaml
 benchmarks:
@@ -127,7 +128,7 @@ roadmap: docs/roadmap.md
 **Check it before you push:**
 
 ```bash
-uv run python -m outerloop.contract_cli .autoresearch.yaml
+uv run python -m outerloop.contract_cli .outerloop.yaml
 ```
 
 It prints what the agent would be allowed to do, or exactly what is wrong.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -239,7 +239,7 @@ Research findings sync through GitHub; job state never leaves its cluster.
       verifier key file at ~/.config/autoresearch/verifier_key on the tick
       account — a missing key fails climbs LOUDLY by design. GitHub-side
       verify.yml thins per target after the pilot runs clean
-- [ ] jepa-agent as the first research target: `.autoresearch.yaml` + bot Write
+- [ ] jepa-agent as the first research target: `.outerloop.yaml` + bot Write
       grant + token scope, once its benchmark harness lands and the pilot's
       PR-quality bar is met
 - [ ] egolearn as second research target; second harness backend if volume warrants

--- a/docs/validation/author-syscalls.md
+++ b/docs/validation/author-syscalls.md
@@ -16,7 +16,7 @@ Enablement is contract-driven; a one-off validation climb just needs:
 - **Dispatch coords** (`--image` + account/partition): launches are jailed
   Slurm jobs, so without them nothing launches (and the tool is not offered).
 - **A launch budget**: `depth_k` (default 10) caps launches; `depth_k: 0` in
-  the target's `.autoresearch.yaml` opts that benchmark out.
+  the target's `.outerloop.yaml` opts that benchmark out.
 
 Then run one climb by hand (not via the tick):
 
@@ -71,7 +71,7 @@ The lifecycle to confirm, in order:
 
 ## Kill switch
 
-Per-benchmark: `depth_k: 0` in the target's `.autoresearch.yaml`; per-deployment:
+Per-benchmark: `depth_k: 0` in the target's `.outerloop.yaml`; per-deployment:
 remove the dispatch coords. A parked run with no wake ends with a named
 `session-error`, never a silent stuck loop.
 

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -28,7 +28,7 @@ from typing import Any, cast
 from outerloop.appauth import resolve_bot_auth
 from outerloop.brief import BudgetState, distill_lessons
 from outerloop.compute import LocalCompute, local_mode
-from outerloop.contract import Benchmark, Contract, load_contract
+from outerloop.contract import Benchmark, Contract, contract_text_in_tree, load_contract
 from outerloop.dispatch import (
     Snapshot,
     afterany_ids,
@@ -41,6 +41,7 @@ from outerloop.github import (
     GitHubClient,
     TokenProvider,
     Workspace,
+    contract_at,
     ensure_regular_git_dir,
 )
 from outerloop.harness import Harness, SessionResult, redact
@@ -1492,8 +1493,8 @@ def resume_run(
     # The contract gates scope and names the eval command, so read it from the
     # BASE commit (the tree the run started on), NOT the working tree the
     # session left dirty — a session that widened its own scope in
-    # `.autoresearch.yaml` must not have the wake gate on the doctored rules.
-    contract_text = ws.git("show", f"{base_sha}:.autoresearch.yaml")
+    # its contract must not have the wake gate on the doctored rules.
+    contract_text = contract_at(ws, base_sha)
     contract = load_contract(contract_text, record.target)
     bench = _benchmark(contract, record.benchmark)
     config = RunConfig(target=record.target, benchmark=record.benchmark, agent_id=record.agent_id)
@@ -2409,7 +2410,7 @@ def live_attempt(
         # A missing base branch fails loudly as attempt-error.
         ws.git("checkout", "-q", "-B", base_branch, f"origin/{base_branch}")
         _exclude_merge_artifacts(workspace)
-        contract_text = (workspace / ".autoresearch.yaml").read_text()
+        contract_text = contract_text_in_tree(workspace)
         contract = load_contract(contract_text, config.target)
         # Load the brief budget from the contract and run state: callers do
         # not supply it (the dataclass default rendered "0.0 GPU-hours" and

--- a/src/outerloop/brief.py
+++ b/src/outerloop/brief.py
@@ -125,7 +125,7 @@ class BudgetState:
 @dataclass(frozen=True)
 class SessionBrief:
     task: Task
-    contract_text: str  # the target's .autoresearch.yaml, verbatim
+    contract_text: str  # the target's contract file, verbatim
     ruler: str  # how the metric is computed and how claims get re-verified
     lessons: str  # distilled per-target lessons, already bounded
     recent_reports: tuple[str, ...]  # newest first, already bounded
@@ -286,7 +286,7 @@ def render(brief: SessionBrief) -> str:
         f"Metric: {brief.task.expected_effect}",
         f"Finishing: {brief.task.done_criteria}",
         "",
-        "# Contract (.autoresearch.yaml — the scope and budget rules that bind you)",
+        "# Contract (the scope and budget rules that bind you)",
         brief.contract_text,
         "",
         "# Ruler (how the metric is computed and how your claim gets re-verified)",

--- a/src/outerloop/contract.py
+++ b/src/outerloop/contract.py
@@ -1,4 +1,4 @@
-"""Contract schema and loader for a target repo's `.autoresearch.yaml`.
+"""Contract schema and loader for a target repo's contract file (`.outerloop.yaml`).
 
 The contract is the opt-in declaration: benchmarks, budgets, scope. The loader
 enforces invariants no YAML can override (see the threat model in
@@ -14,16 +14,48 @@ from __future__ import annotations
 
 import posixpath
 import re
-from pathlib import PurePosixPath
+from collections.abc import Callable
+from pathlib import Path, PurePosixPath
 from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 SELF_REPO = "outerloop-science/outerloop"
-ALWAYS_FORBIDDEN: tuple[str, ...] = (".github", ".autoresearch.yaml")
+# The contract's filename in the target repo. New adopters write `.outerloop.yaml`;
+# `.autoresearch.yaml` (targets written before the rename) is still honored. Every
+# read goes through `find_contract`, which tries the new name first. Neither is
+# ever a writable path for the agent.
+CONTRACT_NAMES: tuple[str, ...] = (".outerloop.yaml", ".autoresearch.yaml")
+CONTRACT_NAME = CONTRACT_NAMES[0]  # what the docs and new contracts use
+ALWAYS_FORBIDDEN: tuple[str, ...] = (".github", *CONTRACT_NAMES)
 MAX_CONTRACT_BYTES = 64 * 1024
 _GLOB_CHARS = set("*?[]!")
+
+
+def find_contract(read: Callable[[str], str | None]) -> tuple[str, str] | None:
+    """(name, text) of the first contract file `read` yields, new name first; None
+    when the target has neither. `read(name)` returns the file's text, or None when
+    that name is absent — wrap a reader that raises instead."""
+    for name in CONTRACT_NAMES:
+        text = read(name)
+        if text is not None:
+            return name, text
+    return None
+
+
+def contract_in_tree(tree: Path) -> tuple[str, str] | None:
+    """The contract in a checked-out tree: (name, text), or None."""
+    return find_contract(lambda n: (tree / n).read_text() if (tree / n).is_file() else None)
+
+
+def contract_text_in_tree(tree: Path) -> str:
+    """The contract's text in a checked-out tree; raises FileNotFoundError (as a
+    direct read did) naming both candidates when the tree has neither."""
+    found = contract_in_tree(tree)
+    if found is None:
+        raise FileNotFoundError(f"no contract in {tree} ({' or '.join(CONTRACT_NAMES)})")
+    return found[1]
 
 
 class ContractError(ValueError):

--- a/src/outerloop/contract_cli.py
+++ b/src/outerloop/contract_cli.py
@@ -1,6 +1,6 @@
-"""Validate a `.autoresearch.yaml` before you push it.
+"""Validate a contract file (`.outerloop.yaml`) before you push it.
 
-    uv run python -m outerloop.contract_cli .autoresearch.yaml
+    uv run python -m outerloop.contract_cli .outerloop.yaml
 
 Prints what the agent would be allowed to do, or exactly what is wrong.
 """
@@ -10,12 +10,23 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
-from outerloop.contract import ContractError, forbidden_paths, load_contract
+from outerloop.contract import (
+    CONTRACT_NAME,
+    CONTRACT_NAMES,
+    ContractError,
+    forbidden_paths,
+    load_contract,
+)
 
 
 def main(argv: list[str] | None = None) -> int:
     args = argv if argv is not None else sys.argv[1:]
-    path = Path(args[0]) if args else Path(".autoresearch.yaml")
+    # no arg: whichever contract name the cwd has, new name first
+    path = (
+        Path(args[0])
+        if args
+        else next((Path(n) for n in CONTRACT_NAMES if Path(n).is_file()), Path(CONTRACT_NAME))
+    )
     repo = args[1] if len(args) > 1 else "your-org/your-repo"
 
     if not path.is_file():

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from outerloop.measure import DispatchSettings
 
 from outerloop.brief import render_review_wake
-from outerloop.contract import load_contract
+from outerloop.contract import CONTRACT_NAME, contract_in_tree, contract_text_in_tree, load_contract
 from outerloop.github import (
     GitError,
     GitHubClient,
@@ -34,6 +34,7 @@ from outerloop.github import (
     NothingToCommit,
     Workspace,
     bot_login_from_env,
+    contract_at,
     is_own_login,
 )
 from outerloop.harness import Harness, outage, redact
@@ -520,7 +521,7 @@ def _respond(
     from outerloop.attempt import _target_clone_url
 
     ws = Workspace(root=workspace, auth=github.auth, url=_target_clone_url(record.target))
-    contract_text = (workspace / ".autoresearch.yaml").read_text()
+    contract_text = contract_text_in_tree(workspace)
     contract = load_contract(contract_text, record.target)
     bench = next((b for b in contract.benchmarks if b.name == record.benchmark), None)
     if bench is None:
@@ -754,7 +755,8 @@ def _respond(
     # the sync-skip comparison, the scope check, the re-measure's bench —
     # must see the tree's contract, not the one loaded before the session
     # ran. An unparsable merged contract withholds the response outright.
-    contract_path = ".autoresearch.yaml"
+    found_contract = contract_in_tree(workspace)
+    contract_path = found_contract[0] if found_contract else CONTRACT_NAME
     post_contract = contract
     contract_broken = False
     if contract_path in changed:
@@ -1315,7 +1317,7 @@ def _reread_pushed_change(
                 lines = bool(getattr(bench, "lines", False))
                 # the judges' rules come from the TRUSTED base only — never the
                 # workspace copy, which the pushed tree controls (terra #229 r1)
-                contract_text = ws.git("show", f"{base}:.autoresearch.yaml")
+                contract_text = contract_at(ws, base)
                 runner = (panel_builder or build_panel_runner)(
                     ws,
                     run_dir(run_root, run_id),
@@ -1688,7 +1690,7 @@ def _resume_measure(
     # measured — never the live workspace file, which can change during the
     # wait (terra #241 r1)
     try:
-        contract_text = ws.git("show", f"{candidate_sha}:.autoresearch.yaml")
+        contract_text = contract_at(ws, candidate_sha)
     except GitError as exc:
         return FollowupOutcome(run_id, "error", f"sealed contract unreadable: {exc}")
     contract = load_contract(contract_text, record.target)

--- a/src/outerloop/github.py
+++ b/src/outerloop/github.py
@@ -34,6 +34,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Protocol
 
+from outerloop.contract import CONTRACT_NAMES, find_contract
+
 DEFAULT_BOT_LOGIN = "agentic-learning-bot"
 
 
@@ -1460,3 +1462,21 @@ class Workspace:
         # remote.origin.url, and "origin" would follow it.
         target = self.url or self.remote_url()
         self.git_network("push", target, "--", f"{branch}:{branch}")
+
+
+def contract_at(ws: Any, sha: str) -> str:
+    """The target's contract text at `sha` — `.outerloop.yaml`, else the legacy
+    `.autoresearch.yaml`. `ws` is a Workspace (anything with `.git(*args)`); a
+    missing path is a git failure, which is the fallback signal. Raises GitError
+    when the commit has neither, naming both candidates."""
+
+    def read(name: str) -> str | None:
+        try:
+            return ws.git("show", f"{sha}:{name}")
+        except GitError:
+            return None
+
+    found = find_contract(read)
+    if found is None:
+        raise GitError(f"no contract at {sha} ({' or '.join(CONTRACT_NAMES)})")
+    return found[1]

--- a/src/outerloop/steward.py
+++ b/src/outerloop/steward.py
@@ -35,7 +35,7 @@ from outerloop.attempt import (
     arm_self_deadline,
     arm_sigterm_containment,
 )
-from outerloop.contract import Contract, load_contract
+from outerloop.contract import Contract, contract_text_in_tree, load_contract
 from outerloop.github import (
     GitHubClient,
     TokenProvider,
@@ -468,7 +468,7 @@ def live_steward(
     tree_hashes: list[str] = []
     try:
         ws = Workspace.clone(f"https://github.com/{config.target}.git", workspace, auth=bot_auth)
-        contract_text = (workspace / ".autoresearch.yaml").read_text()
+        contract_text = contract_text_in_tree(workspace)
         contract = load_contract(contract_text, config.target)
         if contract.steward is None:
             raise ValueError(

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -452,6 +452,15 @@ def _client_secrets(github: Any) -> tuple[str, ...]:
     return ()
 
 
+def _contract_text(github: Any, target: str, ref: str) -> str | None:
+    """The target's contract at `ref` — `.outerloop.yaml`, else the legacy
+    `.autoresearch.yaml` — or None when it has neither."""
+    from outerloop.contract import find_contract
+
+    found = find_contract(lambda name: github.get_file_content(target, name, ref))
+    return found[1] if found else None
+
+
 def _fence(content: str) -> str:
     longest = max((len(run) for run in re.findall(r"`+", content)), default=0)
     return "`" * max(3, longest + 1)
@@ -505,7 +514,7 @@ def _base_dial(
     try:
         from outerloop.contract import load_contract
 
-        raw = github.get_file_content(target, ".autoresearch.yaml", base_ref)
+        raw = _contract_text(github, target, base_ref)
         if raw is None:
             return "manual"
         return str(getattr(load_contract(raw, target), "merge", "manual"))
@@ -1705,7 +1714,7 @@ def tick(
             try:
                 from outerloop.contract import load_contract
 
-                raw = github.get_file_content(followup_spec.target, ".autoresearch.yaml", "main")
+                raw = _contract_text(github, followup_spec.target, "main")
                 if raw is not None:
                     contract = load_contract(raw, followup_spec.target)
                     contract_error = None
@@ -2640,7 +2649,7 @@ def service_intake(
         return None
     try:
         if contract is None:
-            contract_raw = github.get_file_content(target, ".autoresearch.yaml", "main")
+            contract_raw = _contract_text(github, target, "main")
             if contract_raw is None:
                 return None
             contract = load_contract(contract_raw, target)

--- a/src/outerloop/verify_agent.py
+++ b/src/outerloop/verify_agent.py
@@ -16,6 +16,7 @@ import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
+from outerloop.contract import find_contract
 from outerloop.github import GitHubClient
 from outerloop.harness import Harness, backend_id, budget_exhausted, outage
 from outerloop.posting import EXPECTED_FAILURES, post_round, post_skip_stub
@@ -41,7 +42,8 @@ def _base_contract(client: GitHubClient, repo: str, pr_data: dict) -> str:
     base = pr_data.get("base")
     base_ref = str(base.get("ref", "")) if isinstance(base, dict) else ""
     try:
-        return client.get_file_content(repo, ".autoresearch.yaml", base_ref or "HEAD") or ""
+        found = find_contract(lambda n: client.get_file_content(repo, n, base_ref or "HEAD"))
+        return found[1] if found else ""
     except EXPECTED_FAILURES as exc:
         log.warning("verifying without the contract: %s", exc)
         return ""

--- a/tests/test_contract.py
+++ b/tests/test_contract.py
@@ -70,7 +70,12 @@ def test_self_target_refused_case_insensitive() -> None:
 
 def test_forbidden_paths_include_roadmap() -> None:
     contract = load_contract(PILOT_CONTRACT, "x/y")
-    assert set(forbidden_paths(contract)) == {".github", ".autoresearch.yaml", "README.md"}
+    assert set(forbidden_paths(contract)) == {
+        ".github",
+        ".outerloop.yaml",
+        ".autoresearch.yaml",
+        "README.md",
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/test_contract_names.py
+++ b/tests/test_contract_names.py
@@ -1,0 +1,86 @@
+"""The contract file is `.outerloop.yaml`; `.autoresearch.yaml` is still read.
+
+Every read site resolves the name through `find_contract` (new name first), so a
+target written before the rename keeps working without touching anything.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from outerloop.contract import (
+    ALWAYS_FORBIDDEN,
+    CONTRACT_NAME,
+    CONTRACT_NAMES,
+    contract_in_tree,
+    contract_text_in_tree,
+    find_contract,
+)
+from outerloop.github import GitError, contract_at
+
+
+def test_new_name_first_and_neither_is_writable() -> None:
+    assert CONTRACT_NAMES == (".outerloop.yaml", ".autoresearch.yaml")
+    assert CONTRACT_NAME == ".outerloop.yaml"
+    assert set(CONTRACT_NAMES) <= set(ALWAYS_FORBIDDEN)
+
+
+def test_find_contract_prefers_new_and_falls_back() -> None:
+    both = {".outerloop.yaml": "new", ".autoresearch.yaml": "old"}
+    assert find_contract(lambda n: both.get(n)) == (".outerloop.yaml", "new")
+    legacy = {".autoresearch.yaml": "old"}
+    assert find_contract(lambda n: legacy.get(n)) == (".autoresearch.yaml", "old")
+    assert find_contract(lambda n: None) is None
+
+
+def test_contract_in_tree_and_text(tmp_path: Path) -> None:
+    assert contract_in_tree(tmp_path) is None
+    (tmp_path / ".autoresearch.yaml").write_text("legacy: 1\n")
+    assert contract_in_tree(tmp_path) == (".autoresearch.yaml", "legacy: 1\n")
+    (tmp_path / ".outerloop.yaml").write_text("new: 1\n")
+    assert contract_text_in_tree(tmp_path) == "new: 1\n"  # new name wins when both exist
+
+
+def test_contract_text_in_tree_raises_naming_both(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match=r"\.outerloop\.yaml or \.autoresearch\.yaml"):
+        contract_text_in_tree(tmp_path)
+
+
+class _Ws:
+    """A Workspace stand-in: `git show <sha>:<path>` fails for a missing path."""
+
+    def __init__(self, files: dict[str, str]) -> None:
+        self.files = files
+
+    def git(self, *args: str) -> str:
+        assert args[0] == "show"
+        sha, _, name = args[1].partition(":")
+        if name not in self.files:
+            raise GitError(f"fatal: path '{name}' does not exist in '{sha}'")
+        return self.files[name]
+
+
+def test_contract_at_falls_back_over_git_show() -> None:
+    assert contract_at(_Ws({".autoresearch.yaml": "old"}), "abc") == "old"
+    assert contract_at(_Ws({".outerloop.yaml": "new", ".autoresearch.yaml": "old"}), "abc") == "new"
+    with pytest.raises(GitError, match="no contract at abc"):
+        contract_at(_Ws({}), "abc")
+
+
+def test_tick_contract_text_via_the_api() -> None:
+    from outerloop.tick import _contract_text
+
+    class GH:
+        def __init__(self, files: dict[str, str]) -> None:
+            self.files = files
+
+        def get_file_content(self, repo: str, path: str, ref: str) -> str | None:
+            return self.files.get(path)  # None = missing, like the real client
+
+    assert _contract_text(GH({".autoresearch.yaml": "old"}), "o/r", "main") == "old"
+    assert (
+        _contract_text(GH({".outerloop.yaml": "n", ".autoresearch.yaml": "o"}), "o/r", "x") == "n"
+    )
+    assert _contract_text(GH({}), "o/r", "main") is None


### PR DESCRIPTION
First of the staged convention passes (safest, adopter-facing, **non-breaking**).

**What changes:** the contract file is `.outerloop.yaml` — in the docs, `contract_cli`, and the author's brief. `.autoresearch.yaml` is still read.

**How, without breaking any target:** one resolver instead of 12 edits. `contract.py` gains `CONTRACT_NAMES = (".outerloop.yaml", ".autoresearch.yaml")`, `find_contract(read)` (tries the new name first), and tree helpers; `github.py` gains `contract_at(ws, sha)` for the `git show` reads; `tick.py` a tiny `_contract_text` for the API reads. Every read site — GitHub API (None on missing), `git show <sha>:…` (raises), working tree (raises) — goes through it. So a repo written before the rename (gpt-speedrun, the pilot) keeps working with zero changes, and a new adopter writes the new name. `ALWAYS_FORBIDDEN` carries both names; the PR-changed-contract check in `followup` resolves whichever the tree has.

**Tests:** new `test_contract_names.py` (order, fallback, tree helpers, `contract_at` over a fake `git show`, `_contract_text` over a fake API); `test_forbidden_paths_include_roadmap` now expects both names. ruff/format/fresh-mypy clean; full suite 1195 passed + the 400 contract-touching tests re-run green after the test fixes.

**Note:** `test_harness::test_timeout_kills_the_whole_process_group` failed once in the full run and passed on re-run alone — a pre-existing timing flake, unrelated.

Next stages: labels/markers (`autoresearch:`→`outerloop:`, dual-recognition), config dir, env vars (with fallback), and the ABI-sensitive `.autoresearch/` channel last at a quiet point.