### PR TITLE
Convention pass 2/5: labels and markers are outerloop:* (legacy still recognized)

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -62,7 +62,7 @@ jobs:
 
   # --- convergence rounds: one full-rubric session, label-triggered ---
   review:
-    if: github.event.action == 'labeled' && github.event.label.name == 'autoresearch:review'
+    if: github.event.action == 'labeled' && (github.event.label.name == 'outerloop:review' || github.event.label.name == 'autoresearch:review')
     uses: outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@main
     with:
       bot_login: 'outerloop-science[bot]'

--- a/.github/workflows/verify-agent.yml
+++ b/.github/workflows/verify-agent.yml
@@ -105,7 +105,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       needs.gate.outputs.bot_authored == 'true' &&
       (github.event.action != 'labeled' ||
-       (github.event.label.name == 'autoresearch:review' &&
+       ((github.event.label.name == 'outerloop:review' || github.event.label.name == 'autoresearch:review') &&
         github.event.sender.login != github.event.pull_request.user.login))
     # Read-only: the session (and its shell judge) runs here, so its token must
     # not be worth stealing — the write token lives in the post job.
@@ -199,7 +199,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       needs.gate.outputs.bot_authored == 'true' &&
       (github.event.action != 'labeled' ||
-       (github.event.label.name == 'autoresearch:review' &&
+       ((github.event.label.name == 'outerloop:review' || github.event.label.name == 'autoresearch:review') &&
         github.event.sender.login != github.event.pull_request.user.login))
     continue-on-error: true
     timeout-minutes: 15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Labels and body markers are now `outerloop:*` (`outerloop:review`,
+  `outerloop:no-review`, `outerloop:steward`; `<!-- outerloop:advisory-review -->`
+  and the other markers the kernel writes). The `autoresearch:*` forms are still
+  **recognized** everywhere they are read (`markers.has_marker` / `has_label`), so
+  existing labelled issues, PRs, and the kernel's own earlier comments keep working —
+  a reviewer never duplicates a review it posted before the rename.
+
+### Changed
+
 - The contract file is now **`.outerloop.yaml`** (docs, `contract_cli`, the
   author's brief). `.autoresearch.yaml` is still read: every read site — GitHub
   API, `git show <sha>:…`, working tree — goes through `find_contract`, which

--- a/docs/design/public-surface.md
+++ b/docs/design/public-surface.md
@@ -77,7 +77,7 @@ workflow files of the repo being flipped, not on memory of them):
    env, so no write token may be there); the separate post JOB holds
    `pull-requests: write` and runs no session. Verify per-job `permissions:`,
    not just top-level.
-4. Labels that trigger privileged runs (`autoresearch:review`): GitHub
+4. Labels that trigger privileged runs (`outerloop:review`): GitHub
    allows label application at TRIAGE, not write — so GitHub's own
    permission model is NOT sufficient gating on a public repo with triage
    grants. Verify the code-side provenance check (labeler permission via

--- a/docs/design/review-placement.md
+++ b/docs/design/review-placement.md
@@ -6,7 +6,7 @@ standalone GitHub-side workflow; the verifier is the second half of the climb
 transaction and lives in the orchestrator. This note settles a narrower
 question that one left open: *where the reviewer's runner physically executes.*
 The trigger stays a GitHub workflow (`pull_request_target` + the
-`autoresearch:review` label); what can move is the compute behind it.
+`outerloop:review` label); what can move is the compute behind it.
 Pairs with `reviewer-infra.md` (the seams and the threat model) and
 `dispatcher.md` (the containment this reuses).
 

--- a/docs/design/roles.md
+++ b/docs/design/roles.md
@@ -192,7 +192,7 @@ flowchart LR
     BPR["PR by the bot"] --> VF["verifier<br/>(gaming lens) - deploy pending"]
     AR --> HM{human merges}
     VF --> HM
-    L["autoresearch:review label<br/>= one fresh round on the head"] --> AR
+    L["outerloop:review label<br/>= one fresh round on the head"] --> AR
     L -->|"on bot PRs (once deployed)"| VF
 ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -33,8 +33,8 @@ permissions:
   pull-requests: write
 jobs:
   advisory:
-    # a labeled event only runs for the autoresearch:review label (manual re-review)
-    if: github.event.action != 'labeled' || github.event.label.name == 'autoresearch:review'
+    # a labeled event only runs for the outerloop:review label (manual re-review)
+    if: github.event.action != 'labeled' || github.event.label.name == 'outerloop:review'
     uses: outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@main
     with:
       bot_login: my-bot            # PRs by this login are never reviewed
@@ -54,7 +54,7 @@ same reusable, different backend. Each opinion posts its own labeled round:
 
 ```yaml
   second-opinion:
-    if: github.event.action != 'labeled' || github.event.label.name == 'autoresearch:review'
+    if: github.event.action != 'labeled' || github.event.label.name == 'outerloop:review'
     uses: outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@main
     with:
       bot_login: my-bot
@@ -89,7 +89,8 @@ That's the whole setup. Notes:
   `with:` — otherwise your fork's changes never run.
 - **Pin the version in production**: `reviewer_ref: v0.1.0` (or a commit SHA).
   The default `main` moves.
-- Silence it on one PR with the `autoresearch:no-review` label.
+- Silence it on one PR with the `outerloop:no-review` label. (A repo that already
+  uses the `autoresearch:*` labels keeps working — both prefixes are recognized.)
 - Fork PRs are skipped by design: they must not reach your API key.
 - Nothing from the pull request is ever executed. The workflow checks out the
   reviewer, not your PR's code.

--- a/docs/reviewer.md
+++ b/docs/reviewer.md
@@ -29,9 +29,9 @@ That's it. Open a PR and the reviewer posts a round.
 ## Using it
 
 - **First round** runs automatically when a PR opens.
-- **Re-review** after you push fixes by (re)applying the `autoresearch:review` label
+- **Re-review** after you push fixes by (re)applying the `outerloop:review` label
   — the round stamp increments so you can follow the fix→review→fix loop.
-- Findings are **advisory**: the code owner decides. The `autoresearch:no-review`
+- Findings are **advisory**: the code owner decides. The `outerloop:no-review`
   label opts a PR out entirely.
 
 ## Backends

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -204,7 +204,7 @@ Research findings sync through GitHub; job state never leaves its cluster.
       steward agent does env work, not hand edits): separate identity
       (`steward-01`, own key), territory = the contract's `steward.allowed`
       with the solver's scope forbidden in code, work orders =
-      standing-gated `autoresearch:steward` issues, validation ruler run by
+      standing-gated `outerloop:steward` issues, validation ruler run by
       the orchestrator (suite + re-measure + orchestrator-written record
       resets), verifier reads its PRs adversarially. DEPLOY pending:
       steward key + pilot contract `steward:` section + the four work-order
@@ -299,7 +299,7 @@ Roles/flow reference for this whole section: design/roles.md.
 ## Actions economy (decided 2026-08-07)
 
 - [x] Single `ci` job (job-minute rounding was 5x the real usage); advisory
-      review on open + `autoresearch:review` label, never per push
+      review on open + `outerloop:review` label, never per push
 - [ ] Same consolidation on the target repos' workflows
 - [ ] Mid-term: self-hosted runner on the lab workstation (outbound-only
       polling; frees private-repo minutes entirely). When repos go public,

--- a/examples/review.yml
+++ b/examples/review.yml
@@ -21,7 +21,7 @@ jobs:
   review:
     if: >-
       github.event.action != 'labeled'
-      || github.event.label.name == 'autoresearch:review'
+      || github.event.label.name == 'outerloop:review'
     uses: outerloop-science/outerloop/.github/workflows/advisory-review-agent.yml@v1
     with:
       # PRs authored by this login are never reviewed (so the bot never

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -45,6 +45,7 @@ from outerloop.github import (
     ensure_regular_git_dir,
 )
 from outerloop.harness import Harness, SessionResult, redact
+from outerloop.markers import has_marker
 from outerloop.measure import DispatchedMeasurer, DispatchSettings
 from outerloop.orchestrator import (
     AttemptResult,
@@ -2554,7 +2555,7 @@ def live_attempt(
             from outerloop.intake import CLAIM_MARKER
 
             already = any(
-                CLAIM_MARKER in str(c.get("body", ""))
+                has_marker(str(c.get("body", "")), "claimed")
                 for c in github.list_comments(config.target, issue_number)
             )
             if not already:  # manual CLI runs claim here; tick runs claimed at submit

--- a/src/outerloop/climbboard.py
+++ b/src/outerloop/climbboard.py
@@ -28,6 +28,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+from outerloop.markers import marker
 from outerloop.runstate import ENDED, list_runs, run_dir
 
 log = logging.getLogger("outerloop.climbboard")
@@ -262,7 +263,7 @@ def render_md(
     """CLIMB.md: per benchmark, the headline numbers and the attempts table
     (newest first). Plain markdown; the chart lives in index.html."""
     lines = [
-        "<!-- autoresearch:climb-board -->",
+        marker("climb-board"),
         f"# Climb — {target}",
         "",
         "Written by the kernel when runs end. Data: `climb/data/<benchmark>.json`;",

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -38,6 +38,7 @@ from outerloop.github import (
     is_own_login,
 )
 from outerloop.harness import Harness, outage, redact
+from outerloop.markers import has_marker, marker
 from outerloop.orchestrator import (
     Evaluator,
     benchmark_floor,
@@ -82,7 +83,7 @@ PANEL_WAKE_CAP = 2
 MAX_COMMENTS_PER_WAKE = 5
 MAX_REPLY_CHARS = 20_000
 
-REPLY_MARKER = "<!-- autoresearch:followup -->"
+REPLY_MARKER = marker("followup")
 
 
 @dataclass(frozen=True)
@@ -206,7 +207,7 @@ def qualifying_comments(
         body = str(comment.get("body") or "")
         if not body.strip():
             continue  # e.g. a review submission with no text
-        if REPLY_MARKER in body or "autoresearch:advisory-review" in body:
+        if has_marker(body, "followup") or has_marker(body, "advisory-review"):
             continue
         if str(comment.get("author_association", "")) not in QUALIFYING_ASSOCIATIONS:
             continue

--- a/src/outerloop/github.py
+++ b/src/outerloop/github.py
@@ -35,6 +35,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from outerloop.contract import CONTRACT_NAMES, find_contract
+from outerloop.markers import legacy_marker, marker
 
 DEFAULT_BOT_LOGIN = "agentic-learning-bot"
 
@@ -317,7 +318,7 @@ class GitHubClient:
                     return item
         return None
 
-    BODY_EDIT_MARKER = "<!-- autoresearch:body-edit -->"
+    BODY_EDIT_MARKER = marker("body-edit")
     # the orchestrator-owned candidate row in pr_body's results table
     # \r-tolerant: a human web-UI edit can normalize the body to CRLF
     _CANDIDATE_ROW = re.compile(r"^\| candidate \| .* \|(\r?)$", re.MULTILINE)
@@ -378,9 +379,12 @@ class GitHubClient:
         # string (it is public), and splitting on it blindly would truncate
         # the frozen report — the history this method exists to preserve.
         base = current
-        idx = current.rfind(self.BODY_EDIT_MARKER)
-        if idx != -1 and current[idx + len(self.BODY_EDIT_MARKER) :].lstrip().startswith("---"):
-            base = current[:idx].rstrip()
+        # a previous addendum of ours may carry the pre-rename marker
+        for old in (self.BODY_EDIT_MARKER, legacy_marker("body-edit")):
+            idx = current.rfind(old)
+            if idx != -1 and current[idx + len(old) :].lstrip().startswith("---"):
+                base = current[:idx].rstrip()
+                break
         self._request("PATCH", path, {"body": f"{base}\n\n{self.BODY_EDIT_MARKER}\n{addendum}"})
 
     def _graphql(self, query: str, variables: dict[str, Any]) -> dict[str, Any]:

--- a/src/outerloop/intake.py
+++ b/src/outerloop/intake.py
@@ -17,20 +17,21 @@ from outerloop.brief import MAX_TASK_CHARS, _cap, _fence
 from outerloop.contract import Contract
 from outerloop.followup import QUALIFYING_ASSOCIATIONS
 from outerloop.github import is_own_login
+from outerloop.markers import has_label, has_marker, label_name, marker
 
 log = logging.getLogger(__name__)
 
-CLAIM_MARKER = "<!-- autoresearch:claimed -->"
+CLAIM_MARKER = marker("claimed")
 # Posted (by the bot only) to undo a claim whose run never started — a failed
 # submit must not strand the issue, since the claim scan skips claimed issues.
-RELEASE_MARKER = "<!-- autoresearch:claim-released -->"
+RELEASE_MARKER = marker("claim-released")
 # Claim attempts per issue before intake gives up on it: a durable submit
 # failure must not claim/release (and comment) forever. Same idea as the
 # steward lane's MAX_STEWARD_ATTEMPTS.
 MAX_INTAKE_ATTEMPTS = 3
 # steward work orders carry this label; they are the STEWARD lane's,
 # never the solver's (a solver climb cannot touch env paths anyway)
-STEWARD_LABEL = "autoresearch:steward"
+STEWARD_LABEL = label_name("steward")
 
 
 @dataclass(frozen=True)
@@ -75,7 +76,7 @@ def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTa
             for label in issue.get("labels", [])
             if isinstance(label, dict)
         }
-        if STEWARD_LABEL in labels:
+        if has_label(labels, "steward"):
             continue  # the steward lane's, never the solver's
         if not qualifying_issue(issue, bot_login):
             continue
@@ -87,10 +88,10 @@ def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTa
             if not is_own_login(author, bot_login):
                 continue  # only the bot's own markers count — no forged releases
             body = str(c.get("body", ""))
-            if CLAIM_MARKER in body:
+            if has_marker(body, "claimed"):
                 claimed = True
                 attempts += 1
-            if RELEASE_MARKER in body:
+            if has_marker(body, "claim-released"):
                 claimed = False
         if claimed:
             continue  # already claimed by a run

--- a/src/outerloop/markers.py
+++ b/src/outerloop/markers.py
@@ -1,0 +1,48 @@
+"""Body markers and labels the kernel writes and later recognizes.
+
+The kernel finds its own past comments, issues, and claims by an HTML-comment
+marker (`<!-- outerloop:advisory-review -->`), and routes work by labels
+(`outerloop:review`). Both are WRITTEN under the new `outerloop:` prefix and
+RECOGNIZED under both prefixes — a reviewer that failed to see its own earlier
+`autoresearch:` comment would post a duplicate, and a target's existing
+`autoresearch:steward` issues must keep routing. Reads go through `has_marker` /
+`has_label`; writes and documentation use `marker` / `label_name`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+NEW = "outerloop"
+LEGACY = "autoresearch"
+PREFIXES: tuple[str, ...] = (NEW, LEGACY)
+
+
+def marker(kind: str) -> str:
+    """The marker we write for `kind`, e.g. `<!-- outerloop:followup -->`."""
+    return f"<!-- {NEW}:{kind} -->"
+
+
+def legacy_marker(kind: str) -> str:
+    """The pre-rename marker for `kind`; only for finding old text of ours."""
+    return f"<!-- {LEGACY}:{kind} -->"
+
+
+def has_marker(body: str, kind: str) -> bool:
+    """Does `body` carry the `kind` marker under either prefix?"""
+    return any(f"<!-- {prefix}:{kind} -->" in body for prefix in PREFIXES)
+
+
+def label_name(kind: str) -> str:
+    """The label we apply and document for `kind`, e.g. `outerloop:review`."""
+    return f"{NEW}:{kind}"
+
+
+def is_label(name: str, kind: str) -> bool:
+    """Is `name` the `kind` label under either prefix? Case-insensitive, as
+    GitHub label matching is."""
+    return name.casefold() in {f"{prefix}:{kind}" for prefix in PREFIXES}
+
+
+def has_label(labels: Iterable[str], kind: str) -> bool:
+    return any(is_label(name, kind) for name in labels)

--- a/src/outerloop/posting.py
+++ b/src/outerloop/posting.py
@@ -12,6 +12,7 @@ import logging
 
 from outerloop.github import GitHubClient, GitHubError
 from outerloop.harness import redact
+from outerloop.markers import marker
 
 log = logging.getLogger(__name__)
 
@@ -121,7 +122,7 @@ def post_round_review(
     return round_label
 
 
-SKIP_MARKER = "<!-- autoresearch:round-skipped -->"
+SKIP_MARKER = marker("round-skipped")
 
 
 def post_skip_stub(

--- a/src/outerloop/review.py
+++ b/src/outerloop/review.py
@@ -23,12 +23,13 @@ from dataclasses import dataclass, field, replace
 from typing import Any, Literal
 
 from outerloop.github import is_own_login
+from outerloop.markers import has_label, label_name, marker
 from outerloop.style import PLAIN_STYLE
 
 log = logging.getLogger(__name__)
 
-MARKER = "<!-- autoresearch:advisory-review -->"
-OPT_OUT_LABEL = "autoresearch:no-review"
+MARKER = marker("advisory-review")
+OPT_OUT_LABEL = label_name("no-review")
 
 # One calm line: the mechanical defense against forged endorsements is the
 # approval-language redaction in sanitize(), not header volume.
@@ -172,7 +173,7 @@ def skip_reason(pr: PullRequest, bot_login: str) -> str | None:
     suppresses review on any PR."""
     if is_own_login(pr.author, bot_login):
         return "bot-authored PR: the reviewer never comments on its own work"
-    if any(label.casefold() == OPT_OUT_LABEL for label in pr.labels):
+    if has_label(pr.labels, "no-review"):
         return f"opted out via the {OPT_OUT_LABEL} label"
     if not pr.diff.strip():
         return "empty diff"

--- a/src/outerloop/steward.py
+++ b/src/outerloop/steward.py
@@ -1,7 +1,7 @@
 """The benchmark steward: keeps rulers discriminating, never touches solvers.
 
 One live stewardship, end to end: a maintainer files a work-order issue
-(labeled `autoresearch:steward`, e.g. "denoise: the frozen clean signal was
+(labeled `outerloop:steward`, e.g. "denoise: the frozen clean signal was
 reverse-engineered — make it a generator"), the tick claims it, and this
 glue runs a session whose territory is the INVERSE of the solver's —
 `contract.steward.allowed` (env generators, eval harness, tests), with the
@@ -47,11 +47,11 @@ from outerloop.harness import Harness, budget_exhausted, outage, redact
 from outerloop.intake import (
     CLAIM_MARKER,
     RELEASE_MARKER,
-    STEWARD_LABEL,
     IssueTask,
     infer_benchmark,
     qualifying_issue,
 )
+from outerloop.markers import has_label, has_marker, marker
 from outerloop.orchestrator import draw_run_seed, steward_out_of_scope
 from outerloop.progress import (
     PROGRESS_PATHS,
@@ -82,7 +82,7 @@ log = logging.getLogger(__name__)
 # claim is released AND does not count toward MAX_STEWARD_ATTEMPTS — the
 # API being down is the orchestrator's failure, not the work order's.
 # (RELEASE_MARKER itself lives in intake.py, next to CLAIM_MARKER.)
-OUTAGE_MARKER = "<!-- autoresearch:outage-release -->"
+OUTAGE_MARKER = marker("outage-release")
 # TOTAL claims after which the lane stops retrying a work order: a
 # persistently-failing order must not become a paid retry loop — three
 # sessions is the escalate-to-a-human point
@@ -246,7 +246,7 @@ def pick_steward_issue(
             for label in issue.get("labels", [])
             if isinstance(label, dict)
         }
-        if STEWARD_LABEL not in labels:
+        if not has_label(labels, "steward"):
             continue
         if not qualifying_issue(issue, bot_login):
             continue
@@ -268,12 +268,12 @@ def pick_steward_issue(
             if not is_own_login(author, bot_login):
                 continue
             body = str(c.get("body", ""))
-            if CLAIM_MARKER in body:
+            if has_marker(body, "claimed"):
                 claimed = True
                 attempts += 1
-            if RELEASE_MARKER in body:
+            if has_marker(body, "claim-released"):
                 claimed = False
-                if OUTAGE_MARKER in body:
+                if has_marker(body, "outage-release"):
                     # an API outage is our failure, not the order's: the
                     # claim it released does not count toward the cap —
                     # but outage releases have their OWN cap, or a
@@ -330,7 +330,7 @@ def release_orphaned_claims(
             for label in issue.get("labels", [])
             if isinstance(label, dict)
         }
-        if STEWARD_LABEL not in labels:
+        if not has_label(labels, "steward"):
             continue
         number = int(issue.get("number", 0))
         claimed = False
@@ -340,10 +340,10 @@ def release_orphaned_claims(
             if not is_own_login(author, bot_login):
                 continue  # same identity gate as pick_steward_issue
             body = str(c.get("body", ""))
-            if CLAIM_MARKER in body:
+            if has_marker(body, "claimed"):
                 claimed = True
                 claim_time = str(c.get("created_at", ""))
-            if RELEASE_MARKER in body:
+            if has_marker(body, "claim-released"):
                 claimed = False
         if not claimed:
             continue
@@ -491,7 +491,7 @@ def live_steward(
 
         if issue_number:
             already = any(
-                CLAIM_MARKER in str(c.get("body", ""))
+                has_marker(str(c.get("body", "")), "claimed")
                 for c in github.list_comments(config.target, issue_number)
             )
             if not already:

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -44,6 +44,7 @@ from outerloop.disk import DEFAULT_MIN_FREE_BYTES, check_disk
 from outerloop.harness import DEFAULT_MAX_TURNS, redact
 from outerloop.housekeeping import shed_ended_workspaces
 from outerloop.limits import EffectiveLimits, effective_limits
+from outerloop.markers import has_marker, marker
 from outerloop.runstate import (
     ABORTED,
     ENDED,
@@ -355,7 +356,7 @@ def reap_flights(
     return reaped
 
 
-CONTRACT_ALARM_MARKER = "<!-- autoresearch:contract-alarm -->"
+CONTRACT_ALARM_MARKER = marker("contract-alarm")
 CONTRACT_ALARM_AFTER = 3  # consecutive failing ticks (~1.5 h) before alarming
 
 
@@ -421,7 +422,7 @@ def contract_alarm(
         try:
             number = _find_alarm_issue(github, target, bot_login) or github.create_issue(
                 target,
-                "autoresearch: launch lanes are paused",
+                "outerloop: launch lanes are paused",
                 f"{CONTRACT_ALARM_MARKER}\nThe orchestrator's launch lanes "
                 f"(intake, steward, self-initiated) have sat out {count} "
                 f"consecutive ticks. The error below names the cause — a "
@@ -476,7 +477,7 @@ def _find_alarm_issue(github: Any, target: str, bot_login: str) -> int:
         (
             int(issue.get("number", 0))
             for issue in github.list_open_issues(target, max_pages=10)
-            if CONTRACT_ALARM_MARKER in str(issue.get("body", ""))
+            if has_marker(str(issue.get("body", "")), "contract-alarm")
             and is_own_login(str((issue.get("user") or {}).get("login", "")), bot_login)
         ),
         0,
@@ -1124,7 +1125,7 @@ def sweep(
 
 
 RESEARCH_LOG_BRANCH = "research-log"
-RESEARCH_LOG_MARKER = "<!-- autoresearch:research-log -->"
+RESEARCH_LOG_MARKER = marker("research-log")
 RESEARCH_LOG_PER_TICK = 3
 
 
@@ -1260,7 +1261,7 @@ def _publish_ledger_entry(
         if bench:
             for issue in github.list_open_issues(target):
                 text = f"{issue.get('title', '')}\n{issue.get('body') or ''}"
-                if RESEARCH_LOG_MARKER in text or issue.get("pull_request"):
+                if has_marker(text, "research-log") or issue.get("pull_request"):
                     continue
                 if bench in text.casefold():
                     github.comment(target, int(issue["number"]), line)
@@ -1278,7 +1279,7 @@ def _publish_ledger_entry(
                 # (terra #170 r5: a failed cache write must not duplicate
                 # the rolling issue)
                 for issue in github.list_open_issues(target):
-                    if RESEARCH_LOG_MARKER in str(issue.get("body") or ""):
+                    if has_marker(str(issue.get("body") or ""), "research-log"):
                         log_issue = int(issue.get("number", 0))
                         break
             if not log_issue:

--- a/src/outerloop/verifier.py
+++ b/src/outerloop/verifier.py
@@ -23,6 +23,7 @@ import logging
 from typing import Any
 
 from outerloop.github import GitHubClient, is_own_login
+from outerloop.markers import has_label, marker
 from outerloop.review import (
     CONFIDENCES,
     MAX_DETAIL_CHARS,
@@ -41,7 +42,7 @@ from outerloop.review import (
 
 log = logging.getLogger(__name__)
 
-VERIFY_MARKER = "<!-- autoresearch:verification-review -->"
+VERIFY_MARKER = marker("verification-review")
 VERIFY_HEADER = (
     "*Integrity read of this bot PR (gaming, leakage, unsupported claims). "
     "Findings are leads for the code owner — a clean read does not certify "
@@ -231,7 +232,7 @@ def verify_skip_reason(pr: PullRequest, bot_login: str) -> str | None:
         return "bot login unknown: cannot identify bot-authored PRs (fail closed)"
     if not is_own_login(pr.author, bot_login):
         return "human-authored PR: integrity verification covers bot PRs only"
-    if any(label.casefold() == OPT_OUT_LABEL for label in pr.labels):
+    if has_label(pr.labels, "no-review"):
         return f"opted out via the {OPT_OUT_LABEL} label"
     if not pr.diff.strip():
         return "empty diff"

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -1145,7 +1145,7 @@ def test_issue_run_references_issue_and_reports_back(tmp_path, target_repo) -> N
     assert outcome.outcome == "improved"
     assert "Addresses #42." in github.prs[0]["body"]
     claim, report = github.issue_comments[0], github.issue_comments[-1]
-    assert claim[0] == 42 and "autoresearch:claimed" in claim[1]
+    assert claim[0] == 42 and "outerloop:claimed" in claim[1]
     assert report[0] == 42 and "finished (improved)" in report[1]
     assert "pull/1" in report[1]
     record = load_record(tmp_path / "state", "tsp-iss")

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,0 +1,26 @@
+"""Markers and labels: written under `outerloop:`, recognized under both prefixes."""
+
+from __future__ import annotations
+
+from outerloop.markers import has_label, has_marker, is_label, label_name, legacy_marker, marker
+
+
+def test_writes_the_new_prefix() -> None:
+    assert marker("followup") == "<!-- outerloop:followup -->"
+    assert legacy_marker("followup") == "<!-- autoresearch:followup -->"
+    assert label_name("review") == "outerloop:review"
+
+
+def test_recognizes_both_prefixes_and_exact_kinds() -> None:
+    assert has_marker("x <!-- outerloop:claimed --> y", "claimed")
+    assert has_marker("x <!-- autoresearch:claimed --> y", "claimed")  # pre-rename comments
+    assert not has_marker("<!-- outerloop:claimed -->", "claim-released")  # kind is exact
+    assert not has_marker("outerloop:claimed", "claimed")  # the HTML-comment form only
+
+
+def test_labels_match_either_prefix_case_insensitively() -> None:
+    assert has_label(["Bug", "OUTERLOOP:Review"], "review")  # GitHub labels are case-insensitive
+    assert has_label(["autoresearch:no-review"], "no-review")
+    assert not has_label(["outerloop:review"], "no-review")
+    assert is_label("Autoresearch:Steward", "steward")
+    assert not is_label("steward", "steward")  # a bare kind is not the label

--- a/tests/test_verify_agent.py
+++ b/tests/test_verify_agent.py
@@ -119,7 +119,7 @@ def test_bot_pr_is_verified_and_posts_issue_comment() -> None:
     assert label is not None
     assert len(client.comments) == 1
     body = client.comments[0]
-    assert "autoresearch:verification-review" in body
+    assert "outerloop:verification-review" in body
     assert "ruler-fishing" in body or "constant matched" in body
     # the brief carried the two-tree instruction and the base-branch contract
     assert "pr-head/" in harness.briefs[0] and "base/" in harness.briefs[0]
@@ -226,7 +226,7 @@ def test_tokenless_split_emits_then_posts(tmp_path: Path) -> None:
     round_label = post_from_file(post_client, "org/repo", 9, BOT, emit)  # type: ignore[arg-type]
     assert round_label is not None
     assert len(post_client.comments) == 1
-    assert "autoresearch:verification-review" in post_client.comments[0]
+    assert "outerloop:verification-review" in post_client.comments[0]
 
 
 def test_post_from_file_refuses_a_mismatched_pr(tmp_path: Path) -> None:


### PR DESCRIPTION
Second staged convention pass — **non-breaking** for every existing target.

**What changes:** the kernel writes `outerloop:*` — labels `outerloop:review`, `outerloop:no-review`, `outerloop:steward`, and the 10 body markers (`<!-- outerloop:advisory-review -->` etc.). Docs and `examples/review.yml` use the new names.

**Why dual-recognition matters here:** the kernel *finds its own past output* by marker (is there already an advisory review to update? which issues are claimed? which issue is the alarm?) and routes work by label. If reads only knew the new prefix, a reviewer would post a duplicate review under every pre-rename comment, and existing `autoresearch:steward` issues would stop routing. So new `markers.py`: `marker()`/`label_name()` for writes, `has_marker()`/`has_label()` (both prefixes, labels case-insensitive) for reads — every read site switched. The one index-based read (`append_pull_body`'s addendum strip) tries the new then legacy marker. Our own workflows accept either `review` label (this repo has legacy-labelled PRs).

**Tests:** new `test_markers.py`; three tests that asserted the *old written* text now expect the new; the many fixtures that feed legacy markers/labels as *input* (test_steward ×17, test_verifier, …) now exercise the fallback and pass unchanged. ruff/format/fresh-mypy clean; **full suite 1200 passed**.

Next: config dir, env vars (with fallback), then the ABI-sensitive `.autoresearch/` channel last.