### PR TITLE
Convention pass 3/5: config dir is ~/.config/outerloop (pre-rename dir still honored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The operator config dir is now **`~/.config/outerloop/`** (`.env`, token or App
+  file, role keys). `~/.config/autoresearch/` is still honored: the code and the
+  chain's deploy resolve the new dir if present, else the pre-rename one, so a
+  machine set up before the rename keeps working untouched; `outerloop init` on a
+  fresh machine creates the new dir.
+
+### Changed
+
 - Labels and body markers are now `outerloop:*` (`outerloop:review`,
   `outerloop:no-review`, `outerloop:steward`; `<!-- outerloop:advisory-review -->`
   and the other markers the kernel writes). The `autoresearch:*` forms are still

--- a/docs/design/github-app-auth.md
+++ b/docs/design/github-app-auth.md
@@ -1,7 +1,7 @@
 # GitHub App auth: installation tokens replace the bot PAT
 
 The kernel authenticates to GitHub as a bot account holding a long-lived
-fine-grained PAT (`FileTokenProvider` over `~/.config/autoresearch/bot_pat`).
+fine-grained PAT (`FileTokenProvider` over `~/.config/outerloop/bot_pat`).
 This note designs its replacement by a **GitHub App**: the kernel mints
 short-lived installation tokens from the App's private key. It is the concrete
 form of the identity seam in [external.md](external.md) ("an App
@@ -112,7 +112,7 @@ Swapping the live fleet's identity mid-campaign is an ops event:
 
 ```json
 {"app_id": 1234, "installation_id": 5678,
- "private_key": "~/.config/autoresearch/outerloop-app.pem"}
+ "private_key": "~/.config/outerloop/outerloop-app.pem"}
 ```
 
 — and rides the rails the PAT already rides: role CLIs default their

--- a/docs/design/onboarding.md
+++ b/docs/design/onboarding.md
@@ -28,7 +28,7 @@ non-interactive use):
   one-time code, the operator pastes it back; the wizard exchanges the code —
   **the conversion response carries the App ID and the private key in-band**,
   so the wizard writes `github_app.json` + the PEM straight to
-  `~/.config/autoresearch/` (0600) on the host that will use them. No browser
+  `~/.config/outerloop/` (0600) on the host that will use them. No browser
   download, no file shuffling between machines. It then prints the install
   URL; after the operator installs the App on their repos, the wizard
   discovers the installation id itself (App JWT → `GET /app/installations`).
@@ -36,7 +36,7 @@ non-interactive use):
   prefer it.
 - **Collect the author key.** One path prompt per configured backend
   (`AUTORESEARCH_HARNESS_KEY_FILE` / codex equivalent), mode-600 enforced.
-- **Write `~/.config/autoresearch/.env`** — only keys the operator chose;
+- **Write `~/.config/outerloop/.env`** — only keys the operator chose;
   the tick chain's allowlist is the contract for what matters.
 - **Doctor.** Re-run every check the tick already preflights, plus the
   wizard-level ones, and print a pass/fail table: git reachable with the

--- a/docs/design/resident-tick.md
+++ b/docs/design/resident-tick.md
@@ -79,7 +79,7 @@ resident job (cpu_short, --time=06:00:00 passed at start, singleton)
 
 Starting it is `autoresearch start` (`src/autoresearch/cli.py`): it fills in the
 walltime, job name, placement, and exports from flags, the environment, or
-`~/.config/autoresearch/.env`, and refuses to submit beside a live resident.
+`~/.config/outerloop/.env`, and refuses to submit beside a live resident.
 
 ## What it does not fix
 

--- a/docs/design/scaling.md
+++ b/docs/design/scaling.md
@@ -219,7 +219,7 @@ headless auth two ways: an API key (today's path, works), or a long-lived
 OAuth token minted by `claude setup-token` from a subscription seat —
 designed for CI, no browser on the cluster needed. Proposed flow: a maintainer runs
 `setup-token` locally once per seat, the token lands in
-`~/.config/autoresearch/agents/<agent-id>/credential` (0600) on Torch, and
+`~/.config/outerloop/agents/<agent-id>/credential` (0600) on Torch, and
 the harness's existing env-injection seam passes it as
 `CLAUDE_CODE_OAUTH_TOKEN` instead of `ANTHROPIC_API_KEY` — a per-agent
 config switch, no code restructuring. Seat limits then meter per-agent by

--- a/docs/install.md
+++ b/docs/install.md
@@ -197,7 +197,7 @@ any browser (works from a headless cluster too — no localhost, no tunnel), cli
 **Create GitHub App**, and paste back the code the page shows. init writes the
 App's key + `github_app.<slug>.json`, helps you install it, and verifies it can
 reach your repo. A **PAT** is the fallback (`--pat-file`, or paste one at the
-prompt). Either way, `init` writes `~/.config/autoresearch/.env` (all `0600`) —
+prompt). Either way, `init` writes `~/.config/outerloop/.env` (all `0600`) —
 everything the prose below otherwise sets by hand. The rest of this section
 documents what it writes, for when you'd rather set it directly.
 
@@ -217,7 +217,7 @@ The deployment is configured by environment. Placement and paths are set
 when the chain is started: `AUTORESEARCH_ACCOUNT`/`AUTORESEARCH_PARTITION`
 place the CPU jobs (ticks, author sessions), `AUTORESEARCH_HOME`/
 `AUTORESEARCH_ROOT` locate the checkout and the state, `AUTORESEARCH_IMAGE`
-the container. The rest is re-read from `~/.config/autoresearch/.env` each
+the container. The rest is re-read from `~/.config/outerloop/.env` each
 tick, so changes take effect at the next cadence: `AUTORESEARCH_TARGET`
 names the repo being climbed; `AUTORESEARCH_GPU_PARTITION` (optionally
 `AUTORESEARCH_GPU_ACCOUNT`) is the lane for GPU evals and launches — a
@@ -243,7 +243,7 @@ useful when GCP credits are the budget. Config-driven, one env owner:
 ```bash
 AUTORESEARCH_VERTEX_PROJECT=your-gcp-project   # presence flips vertex ON
 AUTORESEARCH_VERTEX_REGION=global              # optional (default: global)
-AUTORESEARCH_VERTEX_ADC=~/.config/autoresearch/vertex_adc.json  # ADC file
+AUTORESEARCH_VERTEX_ADC=~/.config/outerloop/vertex_adc.json  # ADC file
 ```
 
 Enable the Claude models in the project's Model Garden, mint ADC

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -236,7 +236,7 @@ Research findings sync through GitHub; job state never leaves its cluster.
       never arms auto-merge; the transcript rides in the PR body. DEPLOYED
       in code: the tick passes --panel verify,review to every climb job by
       default (off-switch AUTORESEARCH_PANEL=""). Cluster prerequisite: the
-      verifier key file at ~/.config/autoresearch/verifier_key on the tick
+      verifier key file at ~/.config/outerloop/verifier_key on the tick
       account — a missing key fails climbs LOUDLY by design. GitHub-side
       verify.yml thins per target after the pilot runs clean
 - [ ] jepa-agent as the first research target: `.outerloop.yaml` + bot Write

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,7 +2,7 @@
 
 Operational scripts, always committed. Start the loop with `autoresearch start`:
 it submits `tick_chain.sbatch` as the resident tick where `sbatch` exists and
-runs the local loop elsewhere, reading placement from `~/.config/autoresearch/.env`.
+runs the local loop elsewhere, reading placement from `~/.config/outerloop/.env`.
 
 | Script | Purpose |
 | --- | --- |

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -24,7 +24,7 @@
 #                             --export=ALL,AUTORESEARCH_RESIDENT=1,...`. The
 #                             per-cadence chain drains itself once a resident
 #                             job exists. Unset = the per-cadence chain below.
-# Further config also loads from ~/.config/autoresearch/.env (0600) each tick, so
+# Further config also loads from ~/.config/outerloop/.env (0600) each tick, so
 # a live config change (e.g. AUTORESEARCH_AUTHOR_BACKEND=codex + its key file)
 # needs no chain restart — just an edit to that file.
 #

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -87,7 +87,9 @@ export AUTORESEARCH_DEPLOY_BROKEN
 # config and can never hijack the chain's identity or scheduling. And only from a
 # file that is ours and not group/world-writable (a writable one could still
 # inject a malicious VALUE, e.g. a bad codex binary path).
-ENV_FILE="$HOME/.config/autoresearch/.env"
+# the operator's config dir: ~/.config/outerloop (new) or ~/.config/autoresearch (pre-rename)
+ENV_FILE="$HOME/.config/outerloop/.env"
+[ -r "$ENV_FILE" ] || ENV_FILE="$HOME/.config/autoresearch/.env"
 if [ -r "$ENV_FILE" ]; then
     perms=$(stat -c "%a" "$ENV_FILE" 2>/dev/null || echo 777)
     owner=$(stat -c "%u" "$ENV_FILE" 2>/dev/null || echo -1)

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -59,6 +59,7 @@ from outerloop.orchestrator import (
     resume_attempt,
 )
 from outerloop.panel import PanelLens, PanelVerdict, run_panel
+from outerloop.paths import CONFIG_DIR
 from outerloop.progress import (
     PROGRESS_PATHS,
     load_leader,
@@ -95,9 +96,9 @@ log = logging.getLogger(__name__)
 # Where a climb job reads its keys unless the CLI flags say otherwise. The
 # tick preflights the panel key (and compares it against the author key —
 # role separation) before claiming/submitting.
-PANEL_KEY_DEFAULT = "~/.config/autoresearch/verifier_key"
-HARNESS_KEY_DEFAULT = "~/.config/autoresearch/harness_key"  # the claude author key
-CODEX_KEY_DEFAULT = "~/.config/autoresearch/codex_key"  # the codex author key
+PANEL_KEY_DEFAULT = str(CONFIG_DIR / "verifier_key")
+HARNESS_KEY_DEFAULT = str(CONFIG_DIR / "harness_key")  # the claude author key
+CODEX_KEY_DEFAULT = str(CONFIG_DIR / "codex_key")  # the codex author key
 
 
 def resolve_author_key_file(backend: str, explicit: str = "") -> str:
@@ -3190,7 +3191,7 @@ def main() -> int:
         default=120.0,
         help="how long before the walltime the self-deadline fires (floor 60)",
     )
-    parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
+    parser.add_argument("--pat-file", default=str(CONFIG_DIR / "bot_pat"))
     parser.add_argument(
         "--github-app-file",
         default=os.environ.get("AUTORESEARCH_GITHUB_APP_FILE", ""),

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -4,7 +4,7 @@ With `sbatch` on PATH it submits the resident tick
 (docs/design/resident-tick.md) and returns; without it, or with
 AUTORESEARCH_COMPUTE=local, it runs the local loop in the foreground.
 Settings come from flags, then the process environment, then
-~/.config/autoresearch/.env, read once here at launch. The running chain
+~/.config/outerloop/.env, read once here at launch. The running chain
 never takes identity or placement from that file (tick_deploy.sh reads an
 allowlist of author knobs per tick), so editing it later cannot move a chain.
 """
@@ -21,10 +21,12 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from outerloop import paths
+
 RESIDENT_JOB_NAME = "autoresearch-resident"
 DEFAULT_RESIDENT_MINUTES = 360  # cpu_short's ceiling on Torch; the loop hands over to itself
 DEFAULT_LOCAL_ROOT = Path.home() / ".autoresearch"
-ENV_FILE = Path.home() / ".config" / "autoresearch" / ".env"
+ENV_FILE = paths.ENV_FILE  # ~/.config/outerloop/.env, or the pre-rename dir (see paths.py)
 
 # What start itself decides from: mode, placement, root, cadence, walltime.
 START_KEYS = (
@@ -217,7 +219,7 @@ def plan_start(
     if not root_s:
         raise StartError(
             "Slurm mode needs the state root on the shared filesystem: "
-            "--root, AUTORESEARCH_ROOT, or AUTORESEARCH_ROOT= in ~/.config/autoresearch/.env"
+            "--root, AUTORESEARCH_ROOT, or AUTORESEARCH_ROOT= in ~/.config/outerloop/.env"
         )
     acc = _setting("AUTORESEARCH_ACCOUNT", account, environ, from_file)
     part = _setting("AUTORESEARCH_PARTITION", partition, environ, from_file)
@@ -413,7 +415,7 @@ def main(argv: list[str] | None = None) -> int:
     sub.add_parser("tick", help="one tick, or --loop; the chain's own entry", add_help=False)
     sub.add_parser(
         "init",
-        help="guided setup: write ~/.config/autoresearch/.env and the PAT file",
+        help="guided setup: write ~/.config/outerloop/.env and the PAT file",
         add_help=False,
     )
     argv = sys.argv[1:] if argv is None else list(argv)

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -48,6 +48,7 @@ from outerloop.orchestrator import (
     steward_out_of_scope,
 )
 from outerloop.orchestrator import improved as orch_improved
+from outerloop.paths import CONFIG_DIR
 from outerloop.progress import (
     PROGRESS_PATHS,
     fmt_metric,
@@ -1977,7 +1978,7 @@ def main() -> int:
         default=0,
         help="this job's Slurm walltime; arms the self-deadline (0 = off)",
     )
-    parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
+    parser.add_argument("--pat-file", default=str(CONFIG_DIR / "bot_pat"))
     parser.add_argument(
         "--github-app-file",
         default=os.environ.get("AUTORESEARCH_GITHUB_APP_FILE", ""),

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -1,7 +1,7 @@
 """`outerloop init` — the guided setup.
 
 Collects placement (Slurm or local), the target repo, and bot auth, then writes
-`~/.config/autoresearch/.env` (plus the credential files), so a new adopter never
+`~/.config/outerloop/.env` (plus the credential files), so a new adopter never
 hand-edits config or reasons about which `AUTORESEARCH_*` keys to set. Flags fill
 answers non-interactively; anything left out is prompted for (a secret via
 getpass, never echoed). Auth is the adopter's own GitHub App by default —

--- a/src/outerloop/paths.py
+++ b/src/outerloop/paths.py
@@ -1,0 +1,27 @@
+"""Where the operator's config lives.
+
+`~/.config/outerloop/` holds the `.env`, the bot's token or App file, and the
+role keys. `~/.config/autoresearch/` — the pre-rename name — is still honored:
+a machine set up before the rename keeps working untouched, and `outerloop init`
+on a fresh machine creates the new one. Resolution, once per process: the new
+dir if it exists, else the legacy dir if it exists, else the new dir.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+CONFIG_DIR_NAMES: tuple[str, ...] = ("outerloop", "autoresearch")  # new first
+
+
+def config_dir(home: Path | None = None) -> Path:
+    """The config dir for this machine (see the module docstring)."""
+    base = (home or Path.home()) / ".config"
+    for name in CONFIG_DIR_NAMES:
+        if (base / name).is_dir():
+            return base / name
+    return base / CONFIG_DIR_NAMES[0]
+
+
+CONFIG_DIR = config_dir()
+ENV_FILE = CONFIG_DIR / ".env"

--- a/src/outerloop/steward.py
+++ b/src/outerloop/steward.py
@@ -53,6 +53,7 @@ from outerloop.intake import (
 )
 from outerloop.markers import has_label, has_marker, marker
 from outerloop.orchestrator import draw_run_seed, steward_out_of_scope
+from outerloop.paths import CONFIG_DIR
 from outerloop.progress import (
     PROGRESS_PATHS,
     LeaderEntry,
@@ -773,7 +774,7 @@ def main() -> int:
     parser.add_argument("--session-minutes", type=int, default=60)
     parser.add_argument("--job-minutes", type=int, default=0)
     parser.add_argument("--deadline-margin-s", type=float, default=120.0)
-    parser.add_argument("--pat-file", default=os.path.expanduser("~/.config/autoresearch/bot_pat"))
+    parser.add_argument("--pat-file", default=str(CONFIG_DIR / "bot_pat"))
     parser.add_argument(
         "--github-app-file",
         default=os.environ.get("AUTORESEARCH_GITHUB_APP_FILE", ""),
@@ -782,7 +783,7 @@ def main() -> int:
     )
     parser.add_argument(
         "--key-file",
-        default=os.path.expanduser("~/.config/autoresearch/steward_key"),
+        default=str(CONFIG_DIR / "steward_key"),
         help="the STEWARD'S OWN key — never the solver harness key",
     )
     parser.add_argument("--issue", type=int, default=0)

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,29 @@
+"""The config dir: `~/.config/outerloop`, with the pre-rename dir still honored."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from outerloop.paths import CONFIG_DIR_NAMES, config_dir
+
+
+def test_fresh_machine_gets_the_new_dir(tmp_path: Path) -> None:
+    assert config_dir(tmp_path) == tmp_path / ".config" / "outerloop"
+    assert CONFIG_DIR_NAMES[0] == "outerloop"
+
+
+def test_legacy_dir_is_honored_when_it_is_the_only_one(tmp_path: Path) -> None:
+    (tmp_path / ".config" / "autoresearch").mkdir(parents=True)
+    assert config_dir(tmp_path) == tmp_path / ".config" / "autoresearch"
+
+
+def test_new_dir_wins_when_both_exist(tmp_path: Path) -> None:
+    (tmp_path / ".config" / "autoresearch").mkdir(parents=True)
+    (tmp_path / ".config" / "outerloop").mkdir(parents=True)
+    assert config_dir(tmp_path) == tmp_path / ".config" / "outerloop"
+
+
+def test_deploy_script_checks_both_dirs() -> None:
+    sh = (Path(__file__).resolve().parents[1] / "scripts" / "tick_deploy.sh").read_text()
+    assert 'ENV_FILE="$HOME/.config/outerloop/.env"' in sh
+    assert '[ -r "$ENV_FILE" ] || ENV_FILE="$HOME/.config/autoresearch/.env"' in sh


### PR DESCRIPTION
Third staged convention pass — **non-breaking**; the live fleet on Torch (legacy dir) is untouched.

**What changes:** the operator config dir is `~/.config/outerloop/` (`.env`, token/App file, role keys) in code, prose, and docs; `outerloop init` on a fresh machine creates it.

**How, safely:** new `paths.py` resolves the dir once per process — `~/.config/outerloop` if present, else the pre-rename `~/.config/autoresearch`, else the new one. `cli.ENV_FILE` re-exports it (init and tests keep their single source); the six credential-path defaults (`bot_pat`, `harness_key`, `codex_key`, `verifier_key`, `steward_key`) follow it; `tick_deploy.sh` does the same check-both in shell for its per-tick `.env` read. Moving Torch's dir is a separate runbook (note: the `github_app.*.json` files hold **absolute** PEM paths that must be updated when the dir moves).

**Tests:** new `test_paths.py` (fresh / legacy-only / both-present resolution; the deploy script's check-both). ruff/format/fresh-mypy clean; **full suite 1204 passed**, no fallout.

Next: env vars (`AUTORESEARCH_*`→`OUTERLOOP_*` with fallback), then the ABI-sensitive `.autoresearch/` channel last.