### PR TITLE
Convention pass 4/5: config is OUTERLOOP_* (AUTORESEARCH_* still accepted — boundary bridge)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Configuration is now `OUTERLOOP_*` (`OUTERLOOP_TARGET`, `OUTERLOOP_ACCOUNT`, …):
+  `outerloop init` writes these names and the docs use them. The pre-rename
+  `AUTORESEARCH_*` names are still accepted everywhere: the `.env` reader and the
+  chain's deploy take either spelling, and both the Python package (on import)
+  and the chain scripts (at entry) bridge `OUTERLOOP_*` into the internal names.
+
+### Changed
+
 - The operator config dir is now **`~/.config/outerloop/`** (`.env`, token or App
   file, role keys). `~/.config/autoresearch/` is still honored: the code and the
   chain's deploy resolve the new dir if present, else the pre-rename one, so a

--- a/docs/design/onboarding.md
+++ b/docs/design/onboarding.md
@@ -35,7 +35,7 @@ non-interactive use):
   A pre-existing PAT path is accepted as the alternative for orgs that
   prefer it.
 - **Collect the author key.** One path prompt per configured backend
-  (`AUTORESEARCH_HARNESS_KEY_FILE` / codex equivalent), mode-600 enforced.
+  (`OUTERLOOP_HARNESS_KEY_FILE` / codex equivalent), mode-600 enforced.
 - **Write `~/.config/outerloop/.env`** — only keys the operator chose;
   the tick chain's allowlist is the contract for what matters.
 - **Doctor.** Re-run every check the tick already preflights, plus the
@@ -59,9 +59,9 @@ the tick preflights with, so the doctor and the tick cannot disagree
 The `Compute` protocol already has both implementations; onboarding adds
 **selection** and a **local chain**, nothing more.
 
-- `AUTORESEARCH_COMPUTE=slurm` (default) — unchanged: the self-resubmitting
+- `OUTERLOOP_COMPUTE=slurm` (default) — unchanged: the self-resubmitting
   sbatch chain, every role its own job.
-- `AUTORESEARCH_COMPUTE=local` — `LocalCompute` at the two construction
+- `OUTERLOOP_COMPUTE=local` — `LocalCompute` at the two construction
   sites (tick, attempt). Jobs run as subprocesses of the tick process,
   **synchronously**: `submit` returns with the job already terminal.
 
@@ -94,7 +94,7 @@ swapped, nothing else different.
 ## Stages
 
 1. **Kernel enablement** (this note's PR series, part 1):
-   `AUTORESEARCH_COMPUTE` selection at the two `SlurmCompute()` sites,
+   `OUTERLOOP_COMPUTE` selection at the two `SlurmCompute()` sites,
    `tick --loop`, local-mode wake-arming skip, per-mode required-env
    relaxation (no account/partition in local mode), and the one launch
    command `autoresearch start` (`src/autoresearch/cli.py`). Done.

--- a/docs/install.md
+++ b/docs/install.md
@@ -213,21 +213,22 @@ Experiments run wherever your `compute` backend says. Slurm is the first
 backend; the interface is small (submit a job, poll for completion), so a CI
 runner, a cloud backend, or a hardware rig plugs in the same way.
 
-The deployment is configured by environment. Placement and paths are set
-when the chain is started: `AUTORESEARCH_ACCOUNT`/`AUTORESEARCH_PARTITION`
-place the CPU jobs (ticks, author sessions), `AUTORESEARCH_HOME`/
-`AUTORESEARCH_ROOT` locate the checkout and the state, `AUTORESEARCH_IMAGE`
+The deployment is configured by environment (`OUTERLOOP_*`; the pre-rename
+`AUTORESEARCH_*` names are still accepted everywhere). Placement and paths are set
+when the chain is started: `OUTERLOOP_ACCOUNT`/`OUTERLOOP_PARTITION`
+place the CPU jobs (ticks, author sessions), `OUTERLOOP_HOME`/
+`OUTERLOOP_ROOT` locate the checkout and the state, `OUTERLOOP_IMAGE`
 the container. The rest is re-read from `~/.config/outerloop/.env` each
-tick, so changes take effect at the next cadence: `AUTORESEARCH_TARGET`
-names the repo being climbed; `AUTORESEARCH_GPU_PARTITION` (optionally
-`AUTORESEARCH_GPU_ACCOUNT`) is the lane for GPU evals and launches — a
+tick, so changes take effect at the next cadence: `OUTERLOOP_TARGET`
+names the repo being climbed; `OUTERLOOP_GPU_PARTITION` (optionally
+`OUTERLOOP_GPU_ACCOUNT`) is the lane for GPU evals and launches — a
 comma-separated partition list lets Slurm start each job wherever it fits
-first; `AUTORESEARCH_PANEL` names the verify/review lenses (with
-`AUTORESEARCH_PANEL_*_KEY_FILE` for their keys); the author backend is
-`AUTORESEARCH_AUTHOR_BACKEND`/`AUTORESEARCH_AUTHOR_MODEL`, its key file
-`AUTORESEARCH_HARNESS_KEY_FILE` (Claude) or `AUTORESEARCH_CODEX_KEY_FILE`
+first; `OUTERLOOP_PANEL` names the verify/review lenses (with
+`OUTERLOOP_PANEL_*_KEY_FILE` for their keys); the author backend is
+`OUTERLOOP_AUTHOR_BACKEND`/`OUTERLOOP_AUTHOR_MODEL`, its key file
+`OUTERLOOP_HARNESS_KEY_FILE` (Claude) or `OUTERLOOP_CODEX_KEY_FILE`
 (Codex). Evals run inside the
-Apptainer image at `AUTORESEARCH_IMAGE` (default
+Apptainer image at `OUTERLOOP_IMAGE` (default
 `~/autoresearch-images/agent-py312.sif`) in a jail that binds only the
 checked-out tree — an eval that needs data must fetch it into the tree, and
 GPU jobs are requested per node (`--gpus-per-node`).
@@ -241,9 +242,9 @@ backend) can run on Claude-in-Vertex instead of an Anthropic API key —
 useful when GCP credits are the budget. Config-driven, one env owner:
 
 ```bash
-AUTORESEARCH_VERTEX_PROJECT=your-gcp-project   # presence flips vertex ON
-AUTORESEARCH_VERTEX_REGION=global              # optional (default: global)
-AUTORESEARCH_VERTEX_ADC=~/.config/outerloop/vertex_adc.json  # ADC file
+OUTERLOOP_VERTEX_PROJECT=your-gcp-project   # presence flips vertex ON
+OUTERLOOP_VERTEX_REGION=global              # optional (default: global)
+OUTERLOOP_VERTEX_ADC=~/.config/outerloop/vertex_adc.json  # ADC file
 ```
 
 Enable the Claude models in the project's Model Garden, mint ADC

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -37,6 +37,13 @@
 # NO set -u before the top-up: a config mistake must fail loudly AFTER the
 # chain has secured its successors, not break the chain silently. Required
 # vars are checked by hand instead.
+# Accept the new OUTERLOOP_* names at the boundary: copy each into its
+# AUTORESEARCH_* twin (when the twin is unset) so the chain's internals, which
+# still read AUTORESEARCH_* during the rename, see one name. The Python side does
+# the same on import. Removed with the final internal flip.
+for _ov in $(env | sed -n 's/^OUTERLOOP_\([A-Z_][A-Z0-9_]*\)=.*/\1/p'); do
+    eval "[ -n \"\${AUTORESEARCH_${_ov}:-}\" ] || export AUTORESEARCH_${_ov}=\"\${OUTERLOOP_${_ov}}\""
+done
 CADENCE_MIN="${AUTORESEARCH_CADENCE_MIN:-30}"
 JOB_NAME="autoresearch-tick"
 RESIDENT_JOB_NAME="autoresearch-resident"

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -106,7 +106,8 @@ if [ -r "$ENV_FILE" ]; then
                   AUTORESEARCH_PANEL_CODEX_KEY_FILE \
                   AUTORESEARCH_PANEL_HERMES_KEY_FILE \
                   REVIEW_HERMES_REPO REVIEW_HERMES_PROVIDER; do
-            _line=$(grep -E "^${_k}=" "$ENV_FILE" 2>/dev/null | tail -1)
+            # either spelling: the canonical key or its public OUTERLOOP_ twin
+            _line=$(grep -E "^(${_k}|OUTERLOOP_${_k#AUTORESEARCH_})=" "$ENV_FILE" 2>/dev/null | tail -1)
             # PRESENCE-based, not value-based: a key set to "" in .env is a
             # live OFF-SWITCH (AUTORESEARCH_PANEL="" disables the panel,
             # VERTEX_PROJECT="" reverts to API-key billing) and must override

--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -1,3 +1,18 @@
 """Autonomous research agent that co-develops the lab's benchmark-bearing repos."""
 
+import os
+
 __version__ = "0.1.0.dev0"
+
+
+def _bridge_legacy_env() -> None:
+    """Accept the new `OUTERLOOP_*` names at the process boundary: copy each into
+    its `AUTORESEARCH_*` twin when the twin is unset, so the kernel's internals —
+    which still read `AUTORESEARCH_*` during the rename — see one name. The chain
+    scripts do the same in shell. Removed with the final internal flip."""
+    for key, value in list(os.environ.items()):
+        if key.startswith("OUTERLOOP_"):
+            os.environ.setdefault("AUTORESEARCH_" + key[len("OUTERLOOP_") :], value)
+
+
+_bridge_legacy_env()

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -94,6 +94,8 @@ def env_file_values(path: Path = ENV_FILE, keys: tuple[str, ...] = START_KEYS) -
             continue
         key, value = line.split("=", 1)
         key = key.strip()
+        if key.startswith("OUTERLOOP_"):  # the public name; `keys` are canonical
+            key = "AUTORESEARCH_" + key[len("OUTERLOOP_") :]
         if key not in keys:
             continue
         value = value.strip()

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -2,7 +2,7 @@
 
 Collects placement (Slurm or local), the target repo, and bot auth, then writes
 `~/.config/outerloop/.env` (plus the credential files), so a new adopter never
-hand-edits config or reasons about which `AUTORESEARCH_*` keys to set. Flags fill
+hand-edits config or reasons about which `OUTERLOOP_*` keys to set. Flags fill
 answers non-interactively; anything left out is prompted for (a secret via
 getpass, never echoed). Auth is the adopter's own GitHub App by default —
 `--github-app`, one click via the manifest flow in `appmanifest.py` — with a PAT
@@ -49,21 +49,21 @@ def render_env(a: InitAnswers, pat_file: str = "", *, app_file: str = "") -> str
     the file stays minimal and every line means something. Ordered placement →
     target → auth → author to read top-to-bottom like the setup itself. Auth is
     an App file (`--github-app`) or a PAT file, never both."""
-    lines = [f"AUTORESEARCH_COMPUTE={a.compute}"]
+    lines = [f"OUTERLOOP_COMPUTE={a.compute}"]
     if a.compute == "slurm":
-        lines.append(f"AUTORESEARCH_ROOT={a.root}")
-        lines.append(f"AUTORESEARCH_ACCOUNT={a.account}")
+        lines.append(f"OUTERLOOP_ROOT={a.root}")
+        lines.append(f"OUTERLOOP_ACCOUNT={a.account}")
         if a.partition:  # optional: unset lets Slurm pick its default partition
-            lines.append(f"AUTORESEARCH_PARTITION={a.partition}")
-    lines.append(f"AUTORESEARCH_TARGET={a.target}")
+            lines.append(f"OUTERLOOP_PARTITION={a.partition}")
+    lines.append(f"OUTERLOOP_TARGET={a.target}")
     if app_file:
-        lines.append(f"AUTORESEARCH_GITHUB_APP_FILE={app_file}")
+        lines.append(f"OUTERLOOP_GITHUB_APP_FILE={app_file}")
     elif pat_file:
-        lines.append(f"AUTORESEARCH_PAT_FILE={pat_file}")
+        lines.append(f"OUTERLOOP_PAT_FILE={pat_file}")
     if a.author_backend:
-        lines.append(f"AUTORESEARCH_AUTHOR_BACKEND={a.author_backend}")
+        lines.append(f"OUTERLOOP_AUTHOR_BACKEND={a.author_backend}")
     if a.author_model:
-        lines.append(f"AUTORESEARCH_AUTHOR_MODEL={a.author_model}")
+        lines.append(f"OUTERLOOP_AUTHOR_MODEL={a.author_model}")
     return "\n".join(lines) + "\n"
 
 
@@ -308,6 +308,6 @@ def main(argv: list[str] | None = None) -> int:
         problem = validate_pat(effective_pat, answers.target)
         print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
     else:
-        print("  no PAT set — add AUTORESEARCH_PAT_FILE before the agents can open PRs")
+        print("  no PAT set — add OUTERLOOP_PAT_FILE before the agents can open PRs")
     print("next: outerloop start")
     return 0

--- a/tests/test_env_bridge.py
+++ b/tests/test_env_bridge.py
@@ -1,0 +1,61 @@
+"""OUTERLOOP_* is the public name; AUTORESEARCH_* still works — bridged at every boundary."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+import outerloop
+from outerloop.cli import START_KEYS, env_file_values
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+
+
+def test_python_bridge_copies_new_into_legacy_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("AUTORESEARCH_ZZ_TEST", raising=False)
+    monkeypatch.setenv("OUTERLOOP_ZZ_TEST", "from-new")
+    outerloop._bridge_legacy_env()
+    assert os.environ["AUTORESEARCH_ZZ_TEST"] == "from-new"
+    # an explicitly set legacy twin wins (setdefault semantics)
+    monkeypatch.setenv("AUTORESEARCH_ZZ_TEST", "explicit")
+    monkeypatch.setenv("OUTERLOOP_ZZ_TEST", "ignored")
+    outerloop._bridge_legacy_env()
+    assert os.environ["AUTORESEARCH_ZZ_TEST"] == "explicit"
+
+
+def test_env_file_reads_the_public_names_canonically(tmp_path: Path) -> None:
+    env = tmp_path / ".env"
+    env.write_text("OUTERLOOP_ROOT=/scratch/x\nAUTORESEARCH_ACCOUNT=acct\n")
+    env.chmod(0o600)
+    got = env_file_values(env, START_KEYS)
+    assert got == {"AUTORESEARCH_ROOT": "/scratch/x", "AUTORESEARCH_ACCOUNT": "acct"}
+
+
+def _bridge_block() -> str:
+    text = (SCRIPTS / "tick_chain.sbatch").read_text()
+    m = re.search(r"^for _ov in .*?^done\n", text, re.S | re.M)
+    assert m, "the shell bridge loop must be present at the chain's entry"
+    return m.group(0)
+
+
+def test_shell_bridge_exports_legacy_twin_and_respects_an_explicit_one() -> None:
+    block = _bridge_block()
+    run = lambda env: (
+        subprocess.run(
+            ["bash", "-c", block + '\nprintf "%s" "${AUTORESEARCH_ZZ_TEST:-unset}"'],
+            env={**{"PATH": os.environ["PATH"]}, **env},
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    )
+    assert run({"OUTERLOOP_ZZ_TEST": "from-new"}) == "from-new"
+    assert run({"OUTERLOOP_ZZ_TEST": "new", "AUTORESEARCH_ZZ_TEST": "keep"}) == "keep"
+    assert run({}) == "unset"
+
+
+def test_deploy_allowlist_takes_either_spelling() -> None:
+    sh = (SCRIPTS / "tick_deploy.sh").read_text()
+    assert 'grep -E "^(${_k}|OUTERLOOP_${_k#AUTORESEARCH_})="' in sh

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -21,26 +21,26 @@ def test_render_env_slurm_full() -> None:
         author_model="opus",
     )
     env = render_env(a, "/home/me/.config/autoresearch/bot_pat")
-    assert "AUTORESEARCH_COMPUTE=slurm" in env
-    assert "AUTORESEARCH_ROOT=/scratch/r" in env
-    assert "AUTORESEARCH_ACCOUNT=acct" in env
-    assert "AUTORESEARCH_PARTITION=cpu,gpu" in env  # comma-list preserved verbatim
-    assert "AUTORESEARCH_TARGET=o/r" in env
-    assert "AUTORESEARCH_PAT_FILE=/home/me/.config/autoresearch/bot_pat" in env
-    assert "AUTORESEARCH_AUTHOR_BACKEND=claude" in env
+    assert "OUTERLOOP_COMPUTE=slurm" in env
+    assert "OUTERLOOP_ROOT=/scratch/r" in env
+    assert "OUTERLOOP_ACCOUNT=acct" in env
+    assert "OUTERLOOP_PARTITION=cpu,gpu" in env  # comma-list preserved verbatim
+    assert "OUTERLOOP_TARGET=o/r" in env
+    assert "OUTERLOOP_PAT_FILE=/home/me/.config/autoresearch/bot_pat" in env
+    assert "OUTERLOOP_AUTHOR_BACKEND=claude" in env
 
 
 def test_render_env_omits_the_optional_keys() -> None:
     env = render_env(InitAnswers(compute="slurm", target="o/r", root="/r", account="a"), "")
-    assert "AUTORESEARCH_PARTITION" not in env  # optional -> Slurm default
-    assert "AUTORESEARCH_PAT_FILE" not in env
-    assert "AUTORESEARCH_AUTHOR_BACKEND" not in env
+    assert "OUTERLOOP_PARTITION" not in env  # optional -> Slurm default
+    assert "OUTERLOOP_PAT_FILE" not in env
+    assert "OUTERLOOP_AUTHOR_BACKEND" not in env
 
 
 def test_render_env_local_has_no_slurm_placement() -> None:
     env = render_env(InitAnswers(compute="local", target="o/r"), "")
-    assert "AUTORESEARCH_COMPUTE=local" in env
-    assert "AUTORESEARCH_ROOT" not in env and "AUTORESEARCH_ACCOUNT" not in env
+    assert "OUTERLOOP_COMPUTE=local" in env
+    assert "OUTERLOOP_ROOT" not in env and "OUTERLOOP_ACCOUNT" not in env
 
 
 def test_write_config_writes_env_and_pat_0600(tmp_path: Path) -> None:
@@ -51,7 +51,7 @@ def test_write_config_writes_env_and_pat_0600(tmp_path: Path) -> None:
     assert pat_path.read_text() == "ghp_secrettoken"  # no trailing newline
     assert stat.S_IMODE(env_path.stat().st_mode) == 0o600
     assert stat.S_IMODE(pat_path.stat().st_mode) == 0o600
-    assert f"AUTORESEARCH_PAT_FILE={pat_path}" in env_path.read_text()
+    assert f"OUTERLOOP_PAT_FILE={pat_path}" in env_path.read_text()
 
 
 def test_write_config_no_token_keeps_the_given_pat_file(tmp_path: Path) -> None:
@@ -59,7 +59,7 @@ def test_write_config_no_token_keeps_the_given_pat_file(tmp_path: Path) -> None:
         InitAnswers(compute="local", target="o/r"), "", "/existing/pat", config_dir=tmp_path
     )
     assert pat_path is None
-    assert "AUTORESEARCH_PAT_FILE=/existing/pat" in env_path.read_text()
+    assert "OUTERLOOP_PAT_FILE=/existing/pat" in env_path.read_text()
 
 
 def test_validate_pat_read_errors(tmp_path: Path) -> None:
@@ -122,9 +122,9 @@ def test_main_yes_writes_config(tmp_path: Path, monkeypatch, capsys) -> None:
     )
     assert rc == 0
     env = (tmp_path / ".env").read_text()
-    assert "AUTORESEARCH_TARGET=o/r" in env
-    assert "AUTORESEARCH_PARTITION=cpu,gpu" in env  # comma-list survives the wizard
-    assert "AUTORESEARCH_PAT_FILE=/some/pat" in env
+    assert "OUTERLOOP_TARGET=o/r" in env
+    assert "OUTERLOOP_PARTITION=cpu,gpu" in env  # comma-list survives the wizard
+    assert "OUTERLOOP_PAT_FILE=/some/pat" in env
 
 
 def test_main_yes_requires_target(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -172,8 +172,8 @@ def test_render_env_app_file_wins_over_pat() -> None:
     env = render_env(
         InitAnswers(compute="local", target="o/r"), "some-pat", app_file="/c/github_app.x.json"
     )
-    assert "AUTORESEARCH_GITHUB_APP_FILE=/c/github_app.x.json" in env
-    assert "AUTORESEARCH_PAT_FILE" not in env
+    assert "OUTERLOOP_GITHUB_APP_FILE=/c/github_app.x.json" in env
+    assert "OUTERLOOP_PAT_FILE" not in env
 
 
 def test_main_github_app_writes_app_env(tmp_path: Path, monkeypatch, capsys) -> None:
@@ -190,11 +190,11 @@ def test_main_github_app_writes_app_env(tmp_path: Path, monkeypatch, capsys) -> 
     app_json = tmp_path / "github_app.sl.json"
     assert json.loads(app_json.read_text())["installation_id"] == 999
     env = (tmp_path / ".env").read_text()
-    assert f"AUTORESEARCH_GITHUB_APP_FILE={app_json}" in env
-    assert "AUTORESEARCH_PAT_FILE" not in env
+    assert f"OUTERLOOP_GITHUB_APP_FILE={app_json}" in env
+    assert "OUTERLOOP_PAT_FILE" not in env
 
 
-KEEP = "AUTORESEARCH_TARGET=keep/me\n"
+KEEP = "OUTERLOOP_TARGET=keep/me\n"
 
 
 def test_init_refuses_to_overwrite_an_existing_env_non_interactively(
@@ -216,7 +216,7 @@ def test_init_force_overwrites_an_existing_env(tmp_path: Path, monkeypatch) -> N
         ["--yes", "--force", "--compute", "local", "--target", "o/r", "--pat-file", "/p"]
     )
     assert rc == 0
-    assert "AUTORESEARCH_TARGET=o/r" in (tmp_path / ".env").read_text()
+    assert "OUTERLOOP_TARGET=o/r" in (tmp_path / ".env").read_text()
 
 
 def test_init_interactive_declined_overwrite_keeps_the_config(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
Fourth staged convention pass, **approach A (boundary bridge)** as agreed — the fleet-launch scripts get a tiny additive block, not 51 rewrites.

**Public surface → `OUTERLOOP_*`:** `outerloop init` writes the new names; `install.md`/onboarding use them (with a legacy note).

**Every boundary accepts both spellings:**
- `.env` reader (`env_file_values`): `OUTERLOOP_X=` canonicalizes to the internal key.
- Deploy allowlist (`tick_deploy.sh`): greps `^(AUTORESEARCH_X|OUTERLOOP_X)=`.
- Python package (`outerloop/__init__.py`): on import, copies each `OUTERLOOP_X` into an unset `AUTORESEARCH_X` twin.
- Chain scripts (`tick_chain.sbatch` entry): one loop does the same in shell, before the first env read.

**Internals unchanged for now:** the 54 Python and 51 shell `AUTORESEARCH_*` reads stay — they're implementation, adopters never see them — and flip in a final cleanup after Torch's `.env` migrates. Torch today (all `AUTORESEARCH_*`) is unaffected: the bridge is a no-op with no `OUTERLOOP_*` set, and the dual grep still matches the legacy keys.

**Tests:** new `test_env_bridge.py` — the Python bridge (incl. setdefault semantics), `.env` canonicalization, and a **functional** shell test that runs the actual bridge loop under bash (new→legacy export; explicit twin wins; unset stays unset); `test_init` asserts the new written names. Both scripts pass `bash -n`. ruff/format/fresh-mypy clean; **full suite 1208 passed**.

Next: stage 5, the `.autoresearch/` syscall channel (an ABI for in-flight author sessions) — timed for a quiet point on the fleet.