### PR TITLE
README in plain language; contract and compute detail move to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,18 @@ themselves.
 
 ## Get started
 
-Four commands and one file. You need a repo with a benchmark command, a model
-API key, and a Slurm cluster or one machine with a GPU.
+Three commands and two files: your model key and the contract. You need a repo
+with a benchmark command, a model API key (Anthropic by default), and a Slurm
+cluster or one machine with a GPU.
 
 ```bash
 pip install outerloop-science
-outerloop init     # asks for your model key and compute, sets up your GitHub bot, writes the config
+outerloop init     # where the loop runs, which repo, your GitHub bot; writes the config
 ```
 
-Then add one file, `.outerloop.yaml`, to the repo you want improved:
+Put your Anthropic API key in `~/.config/outerloop/harness_key`: one line,
+readable only by you (`chmod 600`). Then add one file, `.outerloop.yaml`, to
+the repo you want improved:
 
 ```yaml
 benchmarks:
@@ -55,16 +58,20 @@ benchmarks:
     direction: max
 budgets:
   gpu_hours_per_run: 8
+  runs_per_week: 10
 scope:
   allowed: [src/]        # the only paths an agent may change
+roadmap: docs/roadmap.md # what the agents read for direction; never written
 ```
 
 ```bash
 outerloop start    # on a Slurm login node this submits the loop; without Slurm it runs in the foreground
 ```
 
-Step by step: [docs/install.md](https://github.com/outerloop-science/outerloop/blob/main/docs/install.md). Everything the contract can
-say: [docs/contract.md](https://github.com/outerloop-science/outerloop/blob/main/docs/contract.md).
+Step by step, other model backends included:
+[docs/install.md](https://github.com/outerloop-science/outerloop/blob/main/docs/install.md).
+Everything the contract can say:
+[docs/contract.md](https://github.com/outerloop-science/outerloop/blob/main/docs/contract.md).
 
 ## Only want pull request reviews?
 

--- a/README.md
+++ b/README.md
@@ -7,72 +7,45 @@
 
 [![ci](https://github.com/outerloop-science/outerloop/actions/workflows/ci.yml/badge.svg)](https://github.com/outerloop-science/outerloop/actions/workflows/ci.yml)
 
-An autonomous research agent you point at your own repos. It reviews pull
-requests, implements ideas, runs experiments on your compute, and opens a PR
-when a benchmark actually improves — with a readable research report, not just
-numbers. How much it may do on its own is a per-repo dial: PRs wait for a human
-by default, or merge themselves when the gate and the review panel are clean.
+**Autoresearch agents that improve your benchmark.**
 
-Built and dogfooded by the [Agentic Learning AI Lab](https://agenticlearning.ai)
-at NYU, where it co-develops our research codebases. Designed from the start to
-be **self-hosted by anyone**: your credentials, your compute, your repos.
-Nothing reports back to us.
+Outerloop runs AI agents on your own research code. An agent proposes a change,
+runs the experiment on your cluster, and opens a pull request only when your
+benchmark actually improves. Every attempt is written up, including the ones
+that failed.
 
-> Currently private while we harden it in production on our own lab. All
-> history is written to be public.
+You run it yourself: your keys, your compute, your repos. Nothing reports back
+to us. It is built and used every day by the
+[Agentic Learning AI Lab](https://agenticlearning.ai) at NYU, where it
+co-develops our research codebases.
 
-## What it does
+## How it works
 
-- **Advisory PR reviews** — comments on pull requests with concrete findings.
-  It never approves, never blocks, and never fails your CI. Five minutes to
-  set up.
-- **Benchmark climbing** — given a contract (`.outerloop.yaml`) declaring
-  what "better" means and where the agent may write, authors propose changes
-  and the orchestrator measures them itself: the base tree and the candidate
-  are evaluated on your cluster (under one fresh shared seed when the
-  benchmark declares `seed_env`), a calibrated
-  significance floor decides whether the movement is real, a verify/review
-  panel reads the claim, and only then does a PR open. Several authors can
-  climb one benchmark abreast (the width dial); each author can run its own
-  experiments outside the sandbox and sleep until they finish (the depth
-  dial). Claims stay re-verifiable by your own CI because benchmark commands
-  are deterministic.
-- **Research reports** — every attempt ends with a report (hypothesis,
-  change, outcome, takeaway, next step), including the negatives. Reports
-  are archived on a `research-log` branch of the target and pointed to from
-  a rolling issue; credited improvements update the target's ledger
-  (`BENCHMARKS.md`, `results/leader.json`).
+1. **Propose.** An agent picks a hypothesis and writes the code change.
+2. **Experiment.** It runs the training on your cluster and reads the results.
+3. **Measure.** Outerloop scores the change against the base tree at the same
+   seed. Noise does not count as an improvement.
+4. **Review.** Reviewers read the change and the claim. If both hold up, a
+   pull request opens.
+5. **Record.** Every attempt gets a short report: hypothesis, change, outcome,
+   next step. Negative results included.
 
-## Where it runs
+Agents cannot touch the benchmark, the budgets, or your CI. Your branch
+protection and required checks apply to them as to any contributor. By default
+a pull request waits for a human; a repo can also let clean ones merge
+themselves.
 
-It is built for your own compute, and the first-class home is a **Slurm
-cluster**:
+## Get started
 
-- **No daemon.** The whole system is a chain of short Slurm jobs on a cadence
-  you set, each resubmitting the next. Nothing listens and nothing needs
-  inbound SSH, so a cluster that requires 2FA is fine.
-- **Every role is a job.** Author sessions, gate evals, experiment launches
-  and sweeps, and wakes are each their own job, placed where you say: CPU
-  roles on your CPU partition, evals and experiments on the GPU lanes you
-  name.
-- **Waiting costs nothing.** A run that is waiting on jobs parks with no
-  process alive; its wake is queued behind those jobs and runs when they
-  finish. Preemption and lost jobs heal on the next tick.
-- **Jobs are jailed and metered.** Evals and launches run inside your
-  Apptainer image, seeing only the checked-out tree and job-local scratch,
-  with no credentials; GPU-hours are metered per attempt against the
-  contract's budget.
+Four commands and one file. You need a repo with a benchmark command, a model
+API key, and a Slurm cluster or one machine with a GPU.
 
-You do not need a cluster to start. Level 1 (advisory PR reviews) is one
-workflow file in your repo's CI. The climber's compute interface is small,
-and the local backend runs the same job scripts as subprocesses on **one
-machine**, so a workstation with a GPU can climb a cheap benchmark before you
-point the loop at a cluster. Another backend — a cloud queue, a CI runner, a
-hardware rig — plugs in by implementing that interface.
+```bash
+pip install git+https://github.com/outerloop-science/outerloop   # on PyPI as outerloop-science from the first release
+outerloop init     # asks for your model key and compute, sets up your GitHub bot, writes the config
+```
 
-## The contract
-
-One file in the target repo. The minimum:
+Then add one file, `.outerloop.yaml`, to the repo you want improved:
 
 ```yaml
 benchmarks:
@@ -82,67 +55,46 @@ benchmarks:
     direction: max
 budgets:
   gpu_hours_per_run: 8
-  runs_per_week: 10
 scope:
-  allowed: [src/]                                # the ONLY paths the agent may write
-roadmap: docs/roadmap.md
+  allowed: [src/]        # the only paths an agent may change
 ```
-
-The knobs that shape a climb, all optional:
-
-| Knob | What it decides |
-| --- | --- |
-| `seed_env`, `min_delta` / `min_delta_rel` | Paired seeding for resampled evals, and the significance floor a delta must clear — calibrate it from seed variance, the gate enforces it |
-| `eval_minutes`, `gpus` | Evals that need their own job (and GPUs) are dispatched to the cluster rather than run in the author's job |
-| `baseline: paired \| cached` | Re-measure the base tree beside every candidate, or measure it once per base and run only candidates |
-| `depth_k`, `sleep_k` | How many experiments an author may launch and how many times it may sleep for results |
-| `max_active_attempts`, `attempt_cooldown_minutes` | Width: authors abreast on one target; pacing between attempts (0 for a hot loop) |
-| `steward.allowed` | Paths a separate stewardship lane may maintain (the ruler, the harness) — never the solver |
-| `merge: manual \| auto` | Whether a gate-and-panel-clean PR waits for a human or merges itself |
-
-For GPU benchmarks `gpu_hours_per_run` is a real budget. An author's
-experiment launches and its gate evals (baseline and candidate when paired)
-draw on it, and the author sets how long its final eval may run
-(`submit --minutes`). Compute is charged to the author that spends it; it
-is never the metric. CPU benchmarks are not metered.
 
 ```bash
-uv run python -m outerloop.contract_cli .outerloop.yaml   # validate before you push
+outerloop start    # on a Slurm login node this submits the loop; without Slurm it runs in the foreground
 ```
 
-## Getting started
+Step by step: [docs/install.md](docs/install.md). Everything the contract can
+say: [docs/contract.md](docs/contract.md).
 
-See **[docs/install.md](docs/install.md)**. Level 1 (advisory reviews) needs
-only an LLM API key and one workflow file — **[docs/reviewer.md](docs/reviewer.md)**
-walks through it in three steps. Level 2 (the climber) adds a bot account, a
-contract, and a Slurm cluster with Apptainer.
+## Only want pull request reviews?
 
-## Design principles
+The reviewer works on its own. One workflow file and an API key, about five
+minutes, no bot account and no cluster. It comments on pull requests with
+concrete findings and never approves, blocks, or fails your build. See
+[docs/reviewer.md](docs/reviewer.md).
 
-- **Opt-in and contract-bound.** A repo participates by granting the bot access
+## Where it runs
+
+The first-class home is a Slurm cluster. There is no daemon: the loop is a
+chain of short jobs that resubmit themselves, so nothing listens and no inbound
+SSH is needed. Experiments and evaluations run inside your container image with
+no credentials, and GPU-hours are metered against the contract's budget. A
+single machine with a GPU works too, for cheap benchmarks. Details:
+[docs/compute.md](docs/compute.md).
+
+## Safety by design
+
+- **Opt-in and contract-bound.** A repo takes part by granting the bot access
   and committing a contract. The contract, your roadmap, and `.github/` are
-  never writable by the agent, whatever the contract says.
-- **Your gates apply.** The agent is an ordinary contributor: branch
-  protection, required checks, and code owners bind it like anyone else. In
-  `merge: auto` mode your required CI (with strict up-to-date checks) decides,
-  and GitHub itself refuses a merge against a stale base.
-- **Untrusted by default.** PR text, diffs, issue text, and job output are
-  data, never instructions. Authors run without credentials in their
-  environment; evals run in a jail that sees only the checked-out tree.
-  Budgets — launches, sleeps, GPU-hours, weekly runs — are enforced in code.
-  Every role can search and read the web (literature, documentation); what
-  it reads there is data too.
-- **Nothing is taken on trust.** The orchestrator measures every claim
-  itself, on committed trees, and re-verifies credited candidates before a
-  PR exists.
-- **Nothing leaves your infrastructure.** Experiments run where you say
-  (Slurm is the first backend; the compute interface is small and pluggable).
-- **No resident process.** The system is a chain of short Slurm jobs
-  ("ticks") that resubmit themselves; all state lives in records on the
-  shared filesystem, and every role is its own job. If any job dies, the
-  next tick records the run as ended and moves on.
-- **No model lock-in.** Every model call goes through the harness layer, so
-  backends are swappable — Claude Code, Codex, and hermes-agent are wired today.
+  never writable by an agent.
+- **Nothing on trust.** Outerloop measures every claim itself, on committed
+  trees, and re-verifies before a pull request exists.
+- **Untrusted input.** Pull request text, diffs, issues, web pages, and job
+  output are data, never instructions. Agents run without credentials.
+- **Budgets in code.** Launches, GPU-hours, and runs per week are enforced by
+  the kernel, not left to the agent.
+- **No model lock-in.** Claude Code, Codex, and hermes-agent are wired today;
+  backends are swappable.
 
 Full design: [docs/design/architecture.md](docs/design/architecture.md) ·
 Roadmap: [docs/roadmap.md](docs/roadmap.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <picture>
-  <source media="(prefers-color-scheme: dark)" srcset="docs/assets/icon-dark.svg">
-  <img alt="Outerloop" src="docs/assets/icon-light.svg" width="132">
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/outerloop-science/outerloop/main/docs/assets/icon-dark.svg">
+  <img alt="Outerloop" src="https://raw.githubusercontent.com/outerloop-science/outerloop/main/docs/assets/icon-light.svg" width="132">
 </picture>
 
 # Outerloop
@@ -41,7 +41,7 @@ Four commands and one file. You need a repo with a benchmark command, a model
 API key, and a Slurm cluster or one machine with a GPU.
 
 ```bash
-pip install git+https://github.com/outerloop-science/outerloop   # on PyPI as outerloop-science from the first release
+pip install outerloop-science
 outerloop init     # asks for your model key and compute, sets up your GitHub bot, writes the config
 ```
 
@@ -63,15 +63,15 @@ scope:
 outerloop start    # on a Slurm login node this submits the loop; without Slurm it runs in the foreground
 ```
 
-Step by step: [docs/install.md](docs/install.md). Everything the contract can
-say: [docs/contract.md](docs/contract.md).
+Step by step: [docs/install.md](https://github.com/outerloop-science/outerloop/blob/main/docs/install.md). Everything the contract can
+say: [docs/contract.md](https://github.com/outerloop-science/outerloop/blob/main/docs/contract.md).
 
 ## Only want pull request reviews?
 
 The reviewer works on its own. One workflow file and an API key, about five
 minutes, no bot account and no cluster. It comments on pull requests with
 concrete findings and never approves, blocks, or fails your build. See
-[docs/reviewer.md](docs/reviewer.md).
+[docs/reviewer.md](https://github.com/outerloop-science/outerloop/blob/main/docs/reviewer.md).
 
 ## Where it runs
 
@@ -80,7 +80,7 @@ chain of short jobs that resubmit themselves, so nothing listens and no inbound
 SSH is needed. Experiments and evaluations run inside your container image with
 no credentials, and GPU-hours are metered against the contract's budget. A
 single machine with a GPU works too, for cheap benchmarks. Details:
-[docs/compute.md](docs/compute.md).
+[docs/compute.md](https://github.com/outerloop-science/outerloop/blob/main/docs/compute.md).
 
 ## Safety by design
 
@@ -96,8 +96,8 @@ single machine with a GPU works too, for cheap benchmarks. Details:
 - **No model lock-in.** Claude Code, Codex, and hermes-agent are wired today;
   backends are swappable.
 
-Full design: [docs/design/architecture.md](docs/design/architecture.md) ·
-Roadmap: [docs/roadmap.md](docs/roadmap.md)
+Full design: [docs/design/architecture.md](https://github.com/outerloop-science/outerloop/blob/main/docs/design/architecture.md) ·
+Roadmap: [docs/roadmap.md](https://github.com/outerloop-science/outerloop/blob/main/docs/roadmap.md)
 
 ## Developing
 
@@ -116,4 +116,4 @@ uv run pytest
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE) and [NOTICE](NOTICE).
+Apache License 2.0 — see [LICENSE](https://github.com/outerloop-science/outerloop/blob/main/LICENSE) and [NOTICE](https://github.com/outerloop-science/outerloop/blob/main/NOTICE).

--- a/docs/compute.md
+++ b/docs/compute.md
@@ -1,0 +1,26 @@
+# Where it runs
+
+It is built for your own compute, and the first-class home is a **Slurm
+cluster**:
+
+- **No daemon.** The whole system is a chain of short Slurm jobs on a cadence
+  you set, each resubmitting the next. Nothing listens and nothing needs
+  inbound SSH, so a cluster that requires 2FA is fine.
+- **Every role is a job.** Author sessions, gate evals, experiment launches
+  and sweeps, and wakes are each their own job, placed where you say: CPU
+  roles on your CPU partition, evals and experiments on the GPU lanes you
+  name.
+- **Waiting costs nothing.** A run that is waiting on jobs parks with no
+  process alive; its wake is queued behind those jobs and runs when they
+  finish. Preemption and lost jobs heal on the next tick.
+- **Jobs are jailed and metered.** Evals and launches run inside your
+  Apptainer image, seeing only the checked-out tree and job-local scratch,
+  with no credentials; GPU-hours are metered per attempt against the
+  contract's budget.
+
+You do not need a cluster to start. Level 1 (advisory PR reviews) is one
+workflow file in your repo's CI. The climber's compute interface is small,
+and the local backend runs the same job scripts as subprocesses on **one
+machine**, so a workstation with a GPU can climb a cheap benchmark before you
+point the loop at a cluster. Another backend — a cloud queue, a CI runner, a
+hardware rig — plugs in by implementing that interface.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -1,0 +1,39 @@
+# The contract
+
+One file in the target repo. The minimum:
+
+```yaml
+benchmarks:
+  - name: my-benchmark
+    command: uv run python -m mypkg.eval --json   # prints {"success_rate": 0.42}
+    metric: success_rate
+    direction: max
+budgets:
+  gpu_hours_per_run: 8
+  runs_per_week: 10
+scope:
+  allowed: [src/]                                # the ONLY paths the agent may write
+roadmap: docs/roadmap.md
+```
+
+The knobs that shape a climb, all optional:
+
+| Knob | What it decides |
+| --- | --- |
+| `seed_env`, `min_delta` / `min_delta_rel` | Paired seeding for resampled evals, and the significance floor a delta must clear — calibrate it from seed variance, the gate enforces it |
+| `eval_minutes`, `gpus` | Evals that need their own job (and GPUs) are dispatched to the cluster rather than run in the author's job |
+| `baseline: paired \| cached` | Re-measure the base tree beside every candidate, or measure it once per base and run only candidates |
+| `depth_k`, `sleep_k` | How many experiments an author may launch and how many times it may sleep for results |
+| `max_active_attempts`, `attempt_cooldown_minutes` | Width: authors abreast on one target; pacing between attempts (0 for a hot loop) |
+| `steward.allowed` | Paths a separate stewardship lane may maintain (the ruler, the harness) — never the solver |
+| `merge: manual \| auto` | Whether a gate-and-panel-clean PR waits for a human or merges itself |
+
+For GPU benchmarks `gpu_hours_per_run` is a real budget. An author's
+experiment launches and its gate evals (baseline and candidate when paired)
+draw on it, and the author sets how long its final eval may run
+(`submit --minutes`). Compute is charged to the author that spends it; it
+is never the metric. CPU benchmarks are not metered.
+
+```bash
+uv run python -m outerloop.contract_cli .outerloop.yaml   # validate before you push
+```

--- a/docs/install.md
+++ b/docs/install.md
@@ -139,7 +139,7 @@ The optional knobs — paired seeding and the significance floor
 (`eval_minutes`, `gpus`), `baseline: paired|cached`, the depth budgets
 (`depth_k`, `sleep_k`), width and pacing (`max_active_attempts`,
 `attempt_cooldown_minutes`), a stewardship scope, and `merge: manual|auto` —
-are listed in the README's contract table; the schema's own docstrings
+are listed in [docs/contract.md](contract.md); the schema's own docstrings
 (`src/outerloop/contract.py`) are the reference. A GPU benchmark needs a
 dispatched eval (`eval_minutes` above the in-job threshold) and a cached
 baseline needs a positive floor — the validator says so — and for GPU

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Install
 
-autoresearch is **self-hosted**. You run it, with your keys, on your compute,
+Outerloop is **self-hosted**. You run it, with your keys, on your compute,
 against your repos. Nothing reports back to us and there is no service to sign
 up for.
 


### PR DESCRIPTION
A plain-language pass on the README now that the repo is public, matched to the landing page's framing.

**What changed**
- Opens with what Outerloop is in three sentences and who runs it, then the five steps of the loop in one sentence each.
- "Get started" is four commands and one file (install, `outerloop init`, the contract, `outerloop start`). The install line uses the git URL until the first PyPI release lands; swap it to `pip install outerloop-science` then.
- The reviewer-only path gets its own short section, since it is the five-minute on-ramp.
- Principles condensed to five plain bullets under "Safety by design".
- Removed the "currently private" note.

**Nothing is deleted, only moved:** the contract reference (minimum file, knob table, budget note, validate command) is now `docs/contract.md`, and the Slurm/where-it-runs detail is `docs/compute.md`, both verbatim. `docs/install.md` still called the project autoresearch in its first line; fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
