### PR TITLE
The fleet's queue rides in status.json, attributed to agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `climb/status.json` carries the fleet's queue: the kernel's own Slurm jobs
+  (tick chain, sessions, wakes, evals, launches), each attributed to an agent,
+  with state, elapsed time, partition and submit time. Jobs on the account
+  that are not the kernel's never appear. The strip republishes when a job
+  appears, leaves, or changes state, not on elapsed drift.
+
+### Added
+
 - `outerloop init` asks for the author's model API key (hidden) and writes it to
   `~/.config/outerloop/<backend>_key` (0600), or takes `--author-key-file` for an
   existing file (checked to exist, stored absolute); the `.env` records it as

--- a/src/outerloop/climbboard.py
+++ b/src/outerloop/climbboard.py
@@ -784,22 +784,28 @@ def render_html(
 
 
 STATUS_PATH = "climb/status.json"
-# The queue view shows the kernel's own jobs only: the tick chain, sessions,
-# wakes, evals, and launches. Anything else on the account is the operator's.
-KERNEL_JOB_PREFIXES = (
-    "autoresearch-",
-    "outerloop-",
-    "climb-",
-    "followup-",
-    "wake-",
-    "steward-",
-    "eval-",
+# The queue view shows the kernel's own jobs only. Every kernel job has one of
+# these exact name shapes (see tick.py / attempt.py / scripts/); an eval's name
+# is a liveness hash and is claimed only through its run's marker. Anything
+# else on the account is the operator's and never leaves the cluster.
+_RUN = r"[\w.]+-\d{8}-\d{6}-agent-\d+"  # a run id: <benchmark>-<stamp>-<agent>
+KERNEL_JOB_PATTERNS = tuple(
+    re.compile(p)
+    for p in (
+        r"^(autoresearch|outerloop)-(resident|tick)$",
+        r"^climb-[\w.]+-agent-\d+$",
+        rf"^(followup|wake)-{_RUN}$",
+        rf"^{_RUN}-launch-",
+        r"^(steward|climb)-issue-\d+$",
+    )
 )
 _AGENT_RE = re.compile(r"agent-\d+")
 
 
 def is_kernel_job(name: str) -> bool:
-    return name.startswith(KERNEL_JOB_PREFIXES) or "-launch-" in name
+    """A job the kernel submitted, by its exact name shape (evals excluded:
+    they are claimed by marker in queue_rows)."""
+    return any(p.match(name) for p in KERNEL_JOB_PATTERNS)
 
 
 def eval_job_owners(root: Path, target: str) -> dict[str, tuple[str, str]]:
@@ -829,12 +835,14 @@ def queue_rows(root: Path, target: str, snapshot: list[dict[str, str]]) -> list[
     rows: list[dict[str, str]] = []
     for job in snapshot:
         name = str(job.get("name", ""))
-        if not is_kernel_job(name):
-            continue
-        run_id, agent = owners.get(str(job.get("id", "")), ("", ""))
-        if not agent:
+        job_id = str(job.get("id", ""))
+        if job_id in owners:  # an eval of one of this target's live runs
+            run_id, agent = owners[job_id]
+        elif is_kernel_job(name):
             found = _AGENT_RE.search(name)
-            agent = found.group(0) if found else ""
+            run_id, agent = "", (found.group(0) if found else "")
+        else:
+            continue  # an eval whose marker is not written yet, or the operator's own job
         rows.append(
             {
                 "id": str(job.get("id", "")),
@@ -1002,9 +1010,13 @@ def service_status(
                 "sleep_k",
             )
             shape = lambda runs: [{k: r.get(k) for k in keys} for r in runs]
-            # the queue's shape is which jobs exist and their state; elapsed
-            # time drifts every tick and the page shows it from `submitted`
-            qshape = lambda q: [(j.get("id"), j.get("state")) for j in (q or [])]
+            # the queue's shape is which jobs exist, their state, partition and
+            # attribution (an eval claimed by its marker one tick later must
+            # republish); elapsed time drifts every tick and is left out
+            qshape = lambda q: [
+                (j.get("id"), j.get("state"), j.get("partition"), j.get("agent"), j.get("run_id"))
+                for j in (q or [])
+            ]
             if (
                 isinstance(existing, dict)
                 and isinstance(existing.get("runs"), list)

--- a/src/outerloop/climbboard.py
+++ b/src/outerloop/climbboard.py
@@ -796,28 +796,43 @@ def render_html(
 
 
 STATUS_PATH = "climb/status.json"
-# The queue view shows the kernel's own jobs only. Every kernel job has one of
-# these exact name shapes (see tick.py / attempt.py / scripts/); an eval's name
-# is a liveness hash and is claimed only through its run's marker. Anything
-# else on the account is the operator's and never leaves the cluster.
-_RUN = r"[\w.]+-\d{8}-\d{6}-agent-\d+"  # a run id: <benchmark>-<stamp>-<agent>
-KERNEL_JOB_PATTERNS = tuple(
+# The queue view shows the kernel's own jobs only. Fixed-name jobs (the tick
+# chain, issue sessions, climb sessions) are matched by shape; per-run jobs
+# (wake, followup, launch) are matched against the names the kernel itself
+# derives from this target's run ids, with the same 60-character cut Slurm
+# forces on them; an eval's name is a liveness hash and is claimed only
+# through its run's marker. Anything else on the account is the operator's
+# and never leaves the cluster.
+JOB_NAME_LIMIT = 60
+FIXED_JOB_PATTERNS = tuple(
     re.compile(p)
     for p in (
         r"^(autoresearch|outerloop)-(resident|tick)$",
-        r"^climb-[\w.]+-agent-\d+$",
-        rf"^(followup|wake)-{_RUN}$",
-        rf"^{_RUN}-launch-",
+        r"^climb-[\w.-]+-agent-\d+$",
         r"^(steward|climb)-issue-\d+$",
     )
 )
 _AGENT_RE = re.compile(r"agent-\d+")
 
 
-def is_kernel_job(name: str) -> bool:
-    """A job the kernel submitted, by its exact name shape (evals excluded:
-    they are claimed by marker in queue_rows)."""
-    return any(p.match(name) for p in KERNEL_JOB_PATTERNS)
+def is_fixed_kernel_job(name: str) -> bool:
+    return any(p.match(name) for p in FIXED_JOB_PATTERNS)
+
+
+def run_job_names(root: Path, target: str) -> dict[str, tuple[str, str, bool]]:
+    """Expected per-run job names for `target`: name -> (run_id, agent,
+    is_prefix). Exact for wake and followup; a prefix for launches, whose
+    names end in the experiment's own label. Every run of the target counts,
+    ended ones too: a finishing job can outlive its record's state."""
+    out: dict[str, tuple[str, str, bool]] = {}
+    for record in list_runs(root):
+        if record.target != target:
+            continue
+        rid, agent = record.run_id, record.agent_id
+        for exact in (f"wake-{rid}", f"followup-{rid}"):
+            out[exact[:JOB_NAME_LIMIT]] = (rid, agent, False)
+        out[f"{rid}-launch-"[:JOB_NAME_LIMIT]] = (rid, agent, True)
+    return out
 
 
 def eval_job_owners(root: Path, target: str) -> dict[str, tuple[str, str]]:
@@ -844,15 +859,21 @@ def queue_rows(root: Path, target: str, snapshot: list[dict[str, str]]) -> list[
     each attributed to an agent (by eval marker, else by the agent id every
     other kernel job carries in its name)."""
     owners = eval_job_owners(root, target)
+    expected = run_job_names(root, target)
     rows: list[dict[str, str]] = []
     for job in snapshot:
         name = str(job.get("name", ""))
         job_id = str(job.get("id", ""))
+        run_id = agent = ""
         if job_id in owners:  # an eval of one of this target's live runs
             run_id, agent = owners[job_id]
-        elif is_kernel_job(name):
+        elif name in expected and not expected[name][2]:  # wake / followup, exact
+            run_id, agent = expected[name][:2]
+        elif any(name.startswith(k) for k, v in expected.items() if v[2]):  # a launch
+            run_id, agent = next(v[:2] for k, v in expected.items() if v[2] and name.startswith(k))
+        elif is_fixed_kernel_job(name):
             found = _AGENT_RE.search(name)
-            run_id, agent = "", (found.group(0) if found else "")
+            agent = found.group(0) if found else ""
         else:
             continue  # an eval whose marker is not written yet, or the operator's own job
         rows.append(

--- a/src/outerloop/climbboard.py
+++ b/src/outerloop/climbboard.py
@@ -784,6 +784,72 @@ def render_html(
 
 
 STATUS_PATH = "climb/status.json"
+# The queue view shows the kernel's own jobs only: the tick chain, sessions,
+# wakes, evals, and launches. Anything else on the account is the operator's.
+KERNEL_JOB_PREFIXES = (
+    "autoresearch-",
+    "outerloop-",
+    "climb-",
+    "followup-",
+    "wake-",
+    "steward-",
+    "eval-",
+)
+_AGENT_RE = re.compile(r"agent-\d+")
+
+
+def is_kernel_job(name: str) -> bool:
+    return name.startswith(KERNEL_JOB_PREFIXES) or "-launch-" in name
+
+
+def eval_job_owners(root: Path, target: str) -> dict[str, tuple[str, str]]:
+    """Slurm job id -> (run_id, agent) for every eval a live run of `target`
+    has dispatched: the measurer leaves the id in eval-*/submitted. Eval job
+    names are liveness hashes with no agent in them, so this is how the queue
+    view knows whose eval is whose."""
+    out: dict[str, tuple[str, str]] = {}
+    for record in list_runs(root):
+        if record.target != target or record.state == ENDED:
+            continue
+        for submitted in run_dir(root, record.run_id).glob("eval-*/submitted"):
+            try:
+                job_id = submitted.read_text().strip()
+            except OSError:
+                continue
+            if job_id:
+                out[job_id] = (record.run_id, record.agent_id)
+    return out
+
+
+def queue_rows(root: Path, target: str, snapshot: list[dict[str, str]]) -> list[dict[str, str]]:
+    """The published queue: kernel jobs from a `Compute.queue_snapshot()`,
+    each attributed to an agent (by eval marker, else by the agent id every
+    other kernel job carries in its name)."""
+    owners = eval_job_owners(root, target)
+    rows: list[dict[str, str]] = []
+    for job in snapshot:
+        name = str(job.get("name", ""))
+        if not is_kernel_job(name):
+            continue
+        run_id, agent = owners.get(str(job.get("id", "")), ("", ""))
+        if not agent:
+            found = _AGENT_RE.search(name)
+            agent = found.group(0) if found else ""
+        rows.append(
+            {
+                "id": str(job.get("id", "")),
+                "name": name,
+                "state": str(job.get("state", "")),
+                "elapsed": str(job.get("elapsed", "")),
+                "partition": str(job.get("partition", "")),
+                "submitted": str(job.get("submitted", "")),
+                "agent": agent,
+                "run_id": run_id,
+            }
+        )
+    return rows
+
+
 _LIVE_STATES = ("implementing", "waiting", "in-review", "concluding")
 
 
@@ -823,7 +889,13 @@ def _experiment_progress(root: Path, record: Any) -> tuple[int, int, int]:
     return (done, len(names), minutes)
 
 
-def collect_status(root: Path, target: str, now: float, contract: Any = None) -> dict[str, Any]:
+def collect_status(
+    root: Path,
+    target: str,
+    now: float,
+    contract: Any = None,
+    queue: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
     """The fleet's live picture for `target`: one entry per non-terminal run.
     Timestamps, not durations — the page computes elapsed time client-side,
     so the strip feels live between pushes."""
@@ -878,15 +950,25 @@ def collect_status(root: Path, target: str, now: float, contract: Any = None) ->
             }
         )
     runs.sort(key=lambda r: str(r.get("run_id")))
-    return {"target": target, "published": now, "runs": runs}
+    status: dict[str, Any] = {"target": target, "published": now, "runs": runs}
+    if queue is not None:  # a snapshot was taken (Slurm); the local loop has no queue
+        status["queue"] = queue_rows(root, target, queue)
+    return status
 
 
-def service_status(root: Path, github: Any, target: str, now: float, contract: Any = None) -> bool:
+def service_status(
+    root: Path,
+    github: Any,
+    target: str,
+    now: float,
+    contract: Any = None,
+    queue: list[dict[str, str]] | None = None,
+) -> bool:
     """Publish the strip when the fleet's SHAPE changed — a run appearing,
     leaving, or changing state/phase — never on every tick: the page shows
     elapsed time client-side, so timestamp-only drift is not worth a commit.
     Advisory like the board; True when a write happened."""
-    status = collect_status(root, target, now, contract)
+    status = collect_status(root, target, now, contract, queue)
     try:
         existing_raw: str | None = github.get_file(target, STATUS_PATH, BOARD_BRANCH)
     except Exception as exc:
@@ -920,10 +1002,14 @@ def service_status(root: Path, github: Any, target: str, now: float, contract: A
                 "sleep_k",
             )
             shape = lambda runs: [{k: r.get(k) for k in keys} for r in runs]
+            # the queue's shape is which jobs exist and their state; elapsed
+            # time drifts every tick and the page shows it from `submitted`
+            qshape = lambda q: [(j.get("id"), j.get("state")) for j in (q or [])]
             if (
                 isinstance(existing, dict)
                 and isinstance(existing.get("runs"), list)
                 and shape(existing["runs"]) == shape(status["runs"])
+                and qshape(existing.get("queue")) == qshape(status.get("queue"))
             ):
                 return False
         except (ValueError, TypeError, AttributeError):

--- a/src/outerloop/climbboard.py
+++ b/src/outerloop/climbboard.py
@@ -829,9 +829,18 @@ def run_job_names(root: Path, target: str) -> dict[str, tuple[str, str, bool]]:
         if record.target != target:
             continue
         rid, agent = record.run_id, record.agent_id
-        for exact in (f"wake-{rid}", f"followup-{rid}"):
-            out[exact[:JOB_NAME_LIMIT]] = (rid, agent, False)
-        out[f"{rid}-launch-"[:JOB_NAME_LIMIT]] = (rid, agent, True)
+        for name, prefix in (
+            (f"wake-{rid}", False),
+            (f"followup-{rid}", False),
+            (f"{rid}-launch-", True),
+        ):
+            key = name[:JOB_NAME_LIMIT]
+            if key in out and out[key][0] != rid:
+                # two runs whose names collide under the cut: the job is still
+                # the kernel's, but nobody can say whose, so it is claimed by none
+                out[key] = ("", "", prefix)
+            else:
+                out[key] = (rid, agent, prefix)
     return out
 
 

--- a/src/outerloop/climbboard.py
+++ b/src/outerloop/climbboard.py
@@ -773,6 +773,18 @@ def render_html(
         "    now.append(card);\n"
         "  }\n"
         "  if (!strip.runs.length) now.textContent = 'no active runs';\n"
+        "  // the kernel's own Slurm jobs, as squeue would list them (when published)\n"
+        "  if (Array.isArray(strip.queue) && strip.queue.length) {\n"
+        "    const ST = {RUNNING: 'R', PENDING: 'PD', COMPLETING: 'CG', CONFIGURING: 'CF'};\n"
+        "    const pad = (s, n) => String(s ?? '').padEnd(n).slice(0, n);\n"
+        "    const q = document.createElement('pre'); q.className = 'queue';\n"
+        "    const head = pad('JOBID', 10) + pad('NAME', 28)\n"
+        "      + pad('ST', 4) + pad('TIME', 11) + 'AGENT';\n"
+        "    const row = j => pad(j.id, 10) + pad(j.name, 28) + pad(ST[j.state] || j.state, 4)\n"
+        "      + pad(j.elapsed, 11) + (j.agent || '');\n"
+        "    q.textContent = [head, ...strip.queue.map(row)].join('\\n');\n"
+        "    now.append(q);\n"
+        "  }\n"
         "};\n"
         "refresh();\n"
         "// the strip re-FETCHES every few minutes (new/left/changed runs) and\n"
@@ -1013,10 +1025,22 @@ def service_status(
             # the queue's shape is which jobs exist, their state, partition and
             # attribution (an eval claimed by its marker one tick later must
             # republish); elapsed time drifts every tick and is left out
-            qshape = lambda q: [
-                (j.get("id"), j.get("state"), j.get("partition"), j.get("agent"), j.get("run_id"))
-                for j in (q or [])
-            ]
+            # an absent queue (no snapshot) and an empty one (nothing running)
+            # are different shapes: recovering from a blind tick must publish
+            qshape = lambda q: (
+                None
+                if q is None
+                else [
+                    (
+                        j.get("id"),
+                        j.get("state"),
+                        j.get("partition"),
+                        j.get("agent"),
+                        j.get("run_id"),
+                    )
+                    for j in q
+                ]
+            )
             if (
                 isinstance(existing, dict)
                 and isinstance(existing.get("runs"), list)

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -133,6 +133,9 @@ class JobSpec:
         return argv
 
 
+QUEUE_FIELDS = ("id", "name", "state", "elapsed", "partition", "submitted")
+
+
 class Compute(Protocol):
     """The verbs every compute backend implements. Callers (the measurer, the
     launcher, the wake dispatcher) depend on this, never on a backend."""
@@ -142,6 +145,7 @@ class Compute(Protocol):
     def pending_reason(self, job_id: str) -> str: ...
     def job_partition(self, job_id: str) -> str: ...
     def active_job_names(self) -> list[str]: ...
+    def queue_snapshot(self) -> list[dict[str, str]]: ...
     def job_id_for_name(self, name: str) -> str: ...
     def cancel(self, job_id: str) -> None: ...
 
@@ -256,6 +260,26 @@ class SlurmCompute:
         if result.returncode != 0:
             raise SlurmQueryError(f"squeue failed ({result.returncode}): {result.stderr.strip()}")
         return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+    def queue_snapshot(self) -> list[dict[str, str]]:
+        """This user's PENDING and RUNNING jobs as rows of QUEUE_FIELDS — what
+        a queue view needs, nothing a caller acts on. Raises SlurmQueryError
+        on failure, like active_job_names."""
+        try:
+            result = self.runner(
+                ["squeue", "--me", "--noheader", "-o", "%i|%j|%T|%M|%P|%V"],
+                self.command_timeout_s,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SlurmQueryError(f"squeue did not run: {exc}") from exc
+        if result.returncode != 0:
+            raise SlurmQueryError(f"squeue failed ({result.returncode}): {result.stderr.strip()}")
+        rows: list[dict[str, str]] = []
+        for line in result.stdout.splitlines():
+            parts = line.strip().split("|")
+            if len(parts) == len(QUEUE_FIELDS) and parts[0]:
+                rows.append(dict(zip(QUEUE_FIELDS, parts, strict=True)))
+        return rows
 
     def job_id_for_name(self, name: str) -> str:
         """The id of this user's PENDING/RUNNING job with exactly `name`, or
@@ -435,6 +459,9 @@ class LocalCompute:
 
     def active_job_names(self) -> list[str]:
         return []  # synchronous: nothing is ever pending or running
+
+    def queue_snapshot(self) -> list[dict[str, str]]:
+        return []
 
     def job_id_for_name(self, name: str) -> str:
         return ""

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -1790,7 +1790,7 @@ def tick(
                 log.warning("self-initiated selection failed: %s", exc)
         # AFTER the launch block: a run started this tick is on the strip
         # this tick, not the next one
-        service_boards(root, github, spec.target, contract, now)
+        service_boards(root, github, spec.target, contract, now, compute)
         report = replace_report(
             report,
             ended,
@@ -1844,10 +1844,13 @@ def service_syncs(root: Path, spec: Any, now: float) -> None:
             log.warning("sync failed for %s: %s", record.run_id, exc)
 
 
-def service_boards(root: Path, github: Any, target: str, contract: Any, now: float) -> None:
+def service_boards(
+    root: Path, github: Any, target: str, contract: Any, now: float, compute: Any = None
+) -> None:
     """The climb board and the live strip, together and advisory: the views
     publish from the first tick (before any run ends), and a failure never
-    stops the tick."""
+    stops the tick. With a compute backend, the strip also carries the
+    kernel's queue (its own Slurm jobs, attributed to agents)."""
     try:
         from outerloop.climbboard import contract_directions, service_climb_board
 
@@ -1857,7 +1860,13 @@ def service_boards(root: Path, github: Any, target: str, contract: Any, now: flo
     try:
         from outerloop.climbboard import service_status
 
-        service_status(root, github, target, now, contract)
+        queue = None
+        if compute is not None:
+            try:
+                queue = compute.queue_snapshot()
+            except Exception as exc:  # blind this tick: the strip publishes without a queue
+                log.warning("queue snapshot failed: %s", exc)
+        service_status(root, github, target, now, contract, queue=queue)
     except Exception as exc:  # each is advisory ALONE: one failing never mutes the other
         log.warning("status strip service failed: %s", exc)
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -624,6 +624,9 @@ class QueueCompute:
     def active_job_names(self) -> list:
         return []
 
+    def queue_snapshot(self) -> list[dict[str, str]]:
+        return []
+
     def job_id_for_name(self, name: str) -> str:
         return ""
 

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -1149,15 +1149,33 @@ def test_status_carries_the_kernel_queue_attributed_to_agents(tmp_path: Path) ->
         job("778", "speedrun-20260905-063328-agent-01-launch-sweep", "PENDING", "0:00", "gpu"),
         job("779", "my-own-notebook", "RUNNING", "5:00", "cpu"),
         job("780", "autoresearch-resident", "RUNNING", "4:00:00", "cpu"),
+        job(
+            "781", "eval-my-model-please-ignore", "RUNNING", "0:01", "gpu"
+        ),  # the operator's, not ours
+        job(
+            "782", "rocket-launch-sim", "RUNNING", "0:01", "cpu"
+        ),  # -launch- alone is not a kernel job
+        job("783", "wake-speedrun-20260905-063328-agent-04", "PENDING", "0:00", "cpu"),
     ]
     body = collect_status(tmp_path, "org/repo", 3.0, queue=snap)
     q = {j["id"]: j for j in body["queue"]}
-    assert set(q) == {"777", "778", "780"}
+    assert set(q) == {"777", "778", "780", "783"}
     assert q["777"]["agent"] == "agent-01" and q["777"]["run_id"] == record.run_id
     assert q["778"]["agent"] == "agent-01" and q["778"]["run_id"] == ""
-    assert q["780"]["agent"] == ""
+    assert q["780"]["agent"] == "" and q["783"]["agent"] == "agent-04"
     assert "queue" not in collect_status(tmp_path, "org/repo", 3.0)  # no snapshot: no key
     assert service_status(tmp_path, gh, "org/repo", 4.0, queue=snap) is True
     drift = [dict(j, elapsed="9:59") for j in snap]
     assert service_status(tmp_path, gh, "org/repo", 5.0, queue=drift) is False
+    # a job finishing, a partition move, and an eval claimed by a marker written later all republish
     assert service_status(tmp_path, gh, "org/repo", 6.0, queue=snap[1:]) is True
+    moved = [dict(j, partition="gpu_prem") if j["id"] == "778" else j for j in snap[1:]]
+    assert service_status(tmp_path, gh, "org/repo", 7.0, queue=moved) is True
+    late = run_dir(tmp_path, record.run_id) / "eval-late" / "submitted"
+    late.parent.mkdir()
+    late.write_text("790\n")
+    with_eval = [*moved, job("790", "eval-speedrun-2-base-ff00", "RUNNING", "0:02", "gpu")]
+    assert service_status(tmp_path, gh, "org/repo", 8.0, queue=with_eval) is True
+    assert {j["id"]: j["agent"] for j in json.loads(gh.files["climb/status.json"])["queue"]}[
+        "790"
+    ] == "agent-01"

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -1147,12 +1147,15 @@ def test_status_carries_the_kernel_queue_attributed_to_agents(tmp_path: Path) ->
         }
 
     # a second run: a hyphenated benchmark whose derived names hit Slurm's 60-char cut
-    long_id = "my-long-benchmark-name-here-20260905-070000-agent-04"
+    long_id = "my-very-long-benchmark-name-that-keeps-going-20260905-070000-agent-04"
     other = dc_replace(
-        record, run_id=long_id, agent_id="agent-04", benchmark="my-long-benchmark-name-here"
+        record,
+        run_id=long_id,
+        agent_id="agent-04",
+        benchmark="my-very-long-benchmark-name-that-keeps-going",
     )
     save_record(tmp_path, other, 2.5)
-    assert len(f"wake-{long_id}") > 56  # the cut bites the derived names
+    assert len(f"wake-{long_id}") > 60  # the cut bites the derived names
     snap = [
         job("777", "eval-speedrun-2-cand-ab12", "RUNNING", "0:10", "gpu"),
         job("778", "speedrun-20260905-063328-agent-01-launch-sweep", "PENDING", "0:00", "gpu"),
@@ -1162,7 +1165,13 @@ def test_status_carries_the_kernel_queue_attributed_to_agents(tmp_path: Path) ->
         job("782", "rocket-launch-sim", "RUNNING", "0:01", "cpu"),  # -launch- alone is nobody's
         job("783", f"wake-{long_id}"[:60], "PENDING", "0:00", "cpu"),  # cut as the kernel cuts
         job("784", f"{long_id}-launch-lr-sweep"[:60], "RUNNING", "0:30", "gpu"),
-        job("785", "climb-my-long-benchmark-name-here-agent-04", "RUNNING", "0:05", "cpu"),
+        job(
+            "785",
+            "climb-my-very-long-benchmark-name-that-keeps-going-agent-04",
+            "RUNNING",
+            "0:05",
+            "cpu",
+        ),
         job("786", "wake-speedrun-20260905-063328-agent-09", "PENDING", "0:00", "cpu"),  # not ours
     ]
     body = collect_status(tmp_path, "org/repo", 3.0, queue=snap)
@@ -1172,6 +1181,14 @@ def test_status_carries_the_kernel_queue_attributed_to_agents(tmp_path: Path) ->
     assert q["778"]["agent"] == "agent-01" and q["778"]["run_id"] == record.run_id
     assert q["780"]["agent"] == "" and q["785"]["agent"] == "agent-04"
     assert q["783"]["run_id"] == long_id and q["784"]["run_id"] == long_id
+    # two runs whose derived names collide under the cut: the job stays, attributed to no one
+    from outerloop.climbboard import run_job_names
+
+    twin = dc_replace(other, run_id=long_id[:-1] + "9", agent_id="agent-09")
+    save_record(tmp_path, twin, 2.6)
+    names = run_job_names(tmp_path, "org/repo")
+    assert names[f"wake-{long_id}"[:60]] == ("", "", False)
+    assert names[f"wake-{record.run_id}"] == (record.run_id, "agent-01", False)
     assert "queue" not in collect_status(tmp_path, "org/repo", 3.0)  # no snapshot: no key
     assert service_status(tmp_path, gh, "org/repo", 4.0, queue=snap) is True
     drift = [dict(j, elapsed="9:59") for j in snap]

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -475,6 +475,8 @@ def test_html_carries_the_live_strip() -> None:
     assert "setInterval(refresh, 180000)" in html and "setInterval(render, 30000)" in html
     # a 404 page or malformed body never poisons the strip's render loop
     assert "r.ok ? r.json() : null" in html and "Array.isArray(s.runs)" in html
+    # the page lists the kernel's Slurm jobs when the strip carries them
+    assert "Array.isArray(strip.queue)" in html and "'JOBID'" in html
 
 
 def test_service_boards_publishes_strip_and_views_before_any_terminal_run(tmp_path: Path) -> None:
@@ -1179,3 +1181,8 @@ def test_status_carries_the_kernel_queue_attributed_to_agents(tmp_path: Path) ->
     assert {j["id"]: j["agent"] for j in json.loads(gh.files["climb/status.json"])["queue"]}[
         "790"
     ] == "agent-01"
+    # a blind tick publishes without the key; the next good, empty snapshot must publish
+    assert service_status(tmp_path, gh, "org/repo", 9.0, queue=None) is True
+    assert "queue" not in json.loads(gh.files["climb/status.json"])
+    assert service_status(tmp_path, gh, "org/repo", 10.0, queue=[]) is True
+    assert json.loads(gh.files["climb/status.json"])["queue"] == []

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -1107,3 +1107,57 @@ def test_run_base_renders_as_markers_not_a_line() -> None:
     block = html[html.index("'run base'") :][:400]
     assert "showLine: false" in block and "crossRot" in block
     assert "borderColor: css('--base')" in block  # the legend swatch color
+
+
+def test_status_carries_the_kernel_queue_attributed_to_agents(tmp_path: Path) -> None:
+    """The strip publishes the kernel's own Slurm jobs: an eval is attributed
+    to its run through the measurer's marker, other kernel jobs through the
+    agent id in their name, and the operator's unrelated jobs never appear.
+    Job appearing/finishing is a shape change; elapsed drift is not."""
+    from outerloop.climbboard import collect_status, service_status
+    from outerloop.runstate import run_dir
+
+    gh = _BoardGitHub()
+    record = RunRecord(
+        run_id="speedrun-20260905-063328-agent-01",
+        target="org/repo",
+        task_title="t",
+        state="waiting",
+        benchmark="speedrun",
+        agent_id="agent-01",
+        created=1.0,
+        updated=2.0,
+        stage={},
+    )
+    save_record(tmp_path, record, 2.0)
+    marker = run_dir(tmp_path, record.run_id) / "eval-slot" / "submitted"
+    marker.parent.mkdir(parents=True)
+    marker.write_text("777\n")
+
+    def job(id_: str, name: str, state: str, elapsed: str, partition: str) -> dict[str, str]:
+        return {
+            "id": id_,
+            "name": name,
+            "state": state,
+            "elapsed": elapsed,
+            "partition": partition,
+            "submitted": "s",
+        }
+
+    snap = [
+        job("777", "eval-speedrun-2-cand-ab12", "RUNNING", "0:10", "gpu"),
+        job("778", "speedrun-20260905-063328-agent-01-launch-sweep", "PENDING", "0:00", "gpu"),
+        job("779", "my-own-notebook", "RUNNING", "5:00", "cpu"),
+        job("780", "autoresearch-resident", "RUNNING", "4:00:00", "cpu"),
+    ]
+    body = collect_status(tmp_path, "org/repo", 3.0, queue=snap)
+    q = {j["id"]: j for j in body["queue"]}
+    assert set(q) == {"777", "778", "780"}
+    assert q["777"]["agent"] == "agent-01" and q["777"]["run_id"] == record.run_id
+    assert q["778"]["agent"] == "agent-01" and q["778"]["run_id"] == ""
+    assert q["780"]["agent"] == ""
+    assert "queue" not in collect_status(tmp_path, "org/repo", 3.0)  # no snapshot: no key
+    assert service_status(tmp_path, gh, "org/repo", 4.0, queue=snap) is True
+    drift = [dict(j, elapsed="9:59") for j in snap]
+    assert service_status(tmp_path, gh, "org/repo", 5.0, queue=drift) is False
+    assert service_status(tmp_path, gh, "org/repo", 6.0, queue=snap[1:]) is True

--- a/tests/test_climbboard.py
+++ b/tests/test_climbboard.py
@@ -1146,25 +1146,32 @@ def test_status_carries_the_kernel_queue_attributed_to_agents(tmp_path: Path) ->
             "submitted": "s",
         }
 
+    # a second run: a hyphenated benchmark whose derived names hit Slurm's 60-char cut
+    long_id = "my-long-benchmark-name-here-20260905-070000-agent-04"
+    other = dc_replace(
+        record, run_id=long_id, agent_id="agent-04", benchmark="my-long-benchmark-name-here"
+    )
+    save_record(tmp_path, other, 2.5)
+    assert len(f"wake-{long_id}") > 56  # the cut bites the derived names
     snap = [
         job("777", "eval-speedrun-2-cand-ab12", "RUNNING", "0:10", "gpu"),
         job("778", "speedrun-20260905-063328-agent-01-launch-sweep", "PENDING", "0:00", "gpu"),
         job("779", "my-own-notebook", "RUNNING", "5:00", "cpu"),
         job("780", "autoresearch-resident", "RUNNING", "4:00:00", "cpu"),
-        job(
-            "781", "eval-my-model-please-ignore", "RUNNING", "0:01", "gpu"
-        ),  # the operator's, not ours
-        job(
-            "782", "rocket-launch-sim", "RUNNING", "0:01", "cpu"
-        ),  # -launch- alone is not a kernel job
-        job("783", "wake-speedrun-20260905-063328-agent-04", "PENDING", "0:00", "cpu"),
+        job("781", "eval-my-model-please-ignore", "RUNNING", "0:01", "gpu"),  # the operator's
+        job("782", "rocket-launch-sim", "RUNNING", "0:01", "cpu"),  # -launch- alone is nobody's
+        job("783", f"wake-{long_id}"[:60], "PENDING", "0:00", "cpu"),  # cut as the kernel cuts
+        job("784", f"{long_id}-launch-lr-sweep"[:60], "RUNNING", "0:30", "gpu"),
+        job("785", "climb-my-long-benchmark-name-here-agent-04", "RUNNING", "0:05", "cpu"),
+        job("786", "wake-speedrun-20260905-063328-agent-09", "PENDING", "0:00", "cpu"),  # not ours
     ]
     body = collect_status(tmp_path, "org/repo", 3.0, queue=snap)
     q = {j["id"]: j for j in body["queue"]}
-    assert set(q) == {"777", "778", "780", "783"}
+    assert set(q) == {"777", "778", "780", "783", "784", "785"}
     assert q["777"]["agent"] == "agent-01" and q["777"]["run_id"] == record.run_id
-    assert q["778"]["agent"] == "agent-01" and q["778"]["run_id"] == ""
-    assert q["780"]["agent"] == "" and q["783"]["agent"] == "agent-04"
+    assert q["778"]["agent"] == "agent-01" and q["778"]["run_id"] == record.run_id
+    assert q["780"]["agent"] == "" and q["785"]["agent"] == "agent-04"
+    assert q["783"]["run_id"] == long_id and q["784"]["run_id"] == long_id
     assert "queue" not in collect_status(tmp_path, "org/repo", 3.0)  # no snapshot: no key
     assert service_status(tmp_path, gh, "org/repo", 4.0, queue=snap) is True
     drift = [dict(j, elapsed="9:59") for j in snap]

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -147,3 +147,27 @@ def test_compute_from_env_selects_the_backend(monkeypatch) -> None:
     assert isinstance(compute_from_env(), LocalCompute)
     monkeypatch.setenv("AUTORESEARCH_COMPUTE", "lokal")
     assert isinstance(compute_from_env(), SlurmCompute)
+
+
+def test_queue_snapshot_parses_rows_and_fails_loud() -> None:
+    from outerloop.compute import LocalCompute
+
+    out = (
+        "101|eval-speedrun-2-cand-ab12|RUNNING|1:02:03|gpu|2026-09-05T20:00:00\n"
+        "102|wake-run|PENDING|0:00|cpu|2026-09-05T20:01:00\n"
+    )
+    runner = FakeRunner([CommandResult(0, out, "")])
+    rows = SlurmCompute(runner=runner).queue_snapshot()
+    assert runner.seen[0][:3] == ["squeue", "--me", "--noheader"]
+    assert rows[0] == {
+        "id": "101",
+        "name": "eval-speedrun-2-cand-ab12",
+        "state": "RUNNING",
+        "elapsed": "1:02:03",
+        "partition": "gpu",
+        "submitted": "2026-09-05T20:00:00",
+    }
+    assert rows[1]["state"] == "PENDING" and len(rows) == 2
+    with pytest.raises(SlurmQueryError):
+        SlurmCompute(runner=FakeRunner([CommandResult(1, "", "slurmctld down")])).queue_snapshot()
+    assert LocalCompute.queue_snapshot(None) == []  # type: ignore[arg-type]  # no queue in the monolith

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -197,6 +197,9 @@ def test_job_terminal_without_a_result_fails_instead_of_parking(tmp_path: Path) 
         def active_job_names(self) -> list:
             return []
 
+        def queue_snapshot(self) -> list[dict[str, str]]:
+            return []
+
         def job_id_for_name(self, name: str) -> str:
             return ""
 


### PR DESCRIPTION
The landing page's right pane should be a real `squeue` view, and that needs the kernel to publish its own Slurm jobs. This adds them to the existing public strip rather than a new file.

**What changes**
- `Compute.queue_snapshot()`: on Slurm, `squeue --me --noheader -o '%i|%j|%T|%M|%P|%V'` parsed into rows (id, name, state, elapsed, partition, submitted); raises `SlurmQueryError` like `active_job_names`. The local backend returns `[]`.
- `climbboard`: `queue_rows()` keeps only kernel-owned jobs (prefixes `autoresearch- outerloop- climb- followup- wake- steward- eval-`, or `-launch-` in the name) and attributes each to an agent: evals through the `eval-*/submitted` marker of this target's live runs (their names are liveness hashes with no agent in them), everything else through the `agent-NN` in its name. `collect_status` adds `queue` when a snapshot was taken; `service_status` treats job ids and states as part of the shape, so elapsed drift alone never commits.
- `tick.service_boards` takes the compute backend and passes the snapshot; a failed `squeue` logs and publishes the strip without a queue.

**Deliberately not done:** renaming eval jobs to carry the agent. The kernel re-derives an eval's job name to ask Slurm whether it is alive, so a rename would orphan in-flight evals at the deploy boundary. Attribution by marker gives the queue view the same information with no fleet risk.

**Verified:** ruff, ruff format, mypy (clean cache), 1218 tests in parallel + 9 serial, pre-commit. Tests cover parsing, failure, the local backend, filtering, both attribution paths, and the shape rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
