### PR TITLE
Retire the pilot as the fallback target: AUTORESEARCH_TARGET is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,6 @@ Versions follow [SemVer](https://semver.org).
   with state, elapsed time, partition and submit time. Jobs on the account
   that are not the kernel's never appear. The strip republishes when a job
   appears, leaves, or changes state, not on elapsed drift.
-
-### Added
-
 - `outerloop init` asks for the author's model API key (hidden) and writes it to
   `~/.config/outerloop/<backend>_key` (0600), or takes `--author-key-file` for an
   existing file (checked to exist, stored absolute); the `.env` records it as
@@ -31,9 +28,10 @@ Versions follow [SemVer](https://semver.org).
   `~/.config/outerloop/claude_key` and the setting `OUTERLOOP_CLAUDE_KEY_FILE`.
   The pre-rename `harness_key` file and `*_HARNESS_KEY_FILE` setting are still
   read (the new name wins when both exist), so an existing setup keeps working.
-
-### Changed
-
+- `AUTORESEARCH_TARGET` is required for in-review servicing (follow-ups, wakes,
+  the board). The kernel no longer falls back to the retired
+  `agentic-learning-ai-lab/autoresearch-pilot` repo when it is unset; the tick
+  logs the missing setting like any other.
 - The test suite runs on all cores by default (pytest-xdist), about four times
   faster locally; `pytest --testmon` runs only the tests affected by your edits
   (pytest-testmon). Tier selection moved from `addopts` into `tests/conftest.py`

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -100,6 +100,9 @@ standing instruction they supersede — a resumed agent honors stale constraints
 
 ## Phase 5 — Benchmark-climb pilot
 
+Retired 2026-09-06: the fleet has climbed gpt-speedrun since 2026-08-31 and the
+pilot repo is archived. Kept for the record.
+
 Target: [autoresearch-pilot](https://github.com/agentic-learning-ai-lab/autoresearch-pilot)
 — a non-research-bearing proving ground (tsp / denoise / speedup; deterministic,
 CPU-only, contract and baselines already committed). Decouples this roadmap from

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -3003,7 +3003,8 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     # Local compute runs jobs as subprocesses: Slurm placement is meaningless
     # there, so account/partition are only required when a cluster is in play.
     placed = bool(account and partition) or local_mode()
-    if (pat_file or app_file) and placed and home and Path(image).is_file():
+    target = os.environ.get("AUTORESEARCH_TARGET", "")
+    if (pat_file or app_file) and placed and home and target and Path(image).is_file():
         from outerloop.appauth import resolve_bot_auth
         from outerloop.github import GitHubClient
 
@@ -3017,9 +3018,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
                 home=Path(home),
                 pat_file=pat_file,
                 github_app_file=app_file,
-                target=os.environ.get(
-                    "AUTORESEARCH_TARGET", "agentic-learning-ai-lab/autoresearch-pilot"
-                ),
+                target=target,
                 steward_key_file=os.environ.get("AUTORESEARCH_STEWARD_KEY_FILE", ""),
                 panel=os.environ.get("AUTORESEARCH_PANEL", "verify,review"),
                 panel_key_file=os.environ.get("AUTORESEARCH_PANEL_KEY_FILE", ""),
@@ -3039,6 +3038,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
             ("AUTORESEARCH_ACCOUNT", account or ("-" if local_mode() else "")),
             ("AUTORESEARCH_PARTITION", partition or ("-" if local_mode() else "")),
             ("AUTORESEARCH_HOME", home),
+            ("AUTORESEARCH_TARGET", target),
         ]
         if not value
     ]

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1848,6 +1848,7 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
         "AUTORESEARCH_PARTITION": "p",
         "AUTORESEARCH_IMAGE": str(image),
         "AUTORESEARCH_HOME": str(tmp_path),
+        "AUTORESEARCH_TARGET": "org/repo",
         "AUTORESEARCH_PANEL": "verify",
         "AUTORESEARCH_PANEL_KEY_FILE": "/keys/verifier",
     }
@@ -1856,7 +1857,13 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
     monkeypatch.setattr(tick_mod.os, "environ", env)
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None
+    assert spec.target == "org/repo"
     assert spec.panel == "verify" and spec.panel_key_file == "/keys/verifier"
+    # no target, no servicing: there is no fallback repo to write to
+    without = {k: v for k, v in env.items() if k != "AUTORESEARCH_TARGET"}
+    monkeypatch.setattr(tick_mod.os, "environ", without)
+    assert _followup_spec_from_env(tmp_path) == (None, None)
+    monkeypatch.setattr(tick_mod.os, "environ", env)
     env["AUTORESEARCH_PANEL"] = ""
     _github, off = _followup_spec_from_env(tmp_path)
     assert off is not None and off.panel == ""
@@ -3368,6 +3375,7 @@ def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -
         "AUTORESEARCH_PAT_FILE": str(pat),
         "AUTORESEARCH_IMAGE": str(image),
         "AUTORESEARCH_HOME": str(tmp_path),
+        "AUTORESEARCH_TARGET": "org/repo",
     }
     import outerloop.tick as tick_mod
 


### PR DESCRIPTION
The pilot proving ground (`agentic-learning-ai-lab/autoresearch-pilot`) is retired: the fleet has climbed gpt-speedrun since 2026-08-31, the pilot's board last published on 2026-08-30, and the repo is being archived. The kernel still named it as the fallback target when `AUTORESEARCH_TARGET` was unset, which would now point in-review servicing at a read-only repo.

- `_followup_spec_from_env`: the target is read once and required like the other settings; when it is missing, servicing is disabled and the tick logs `AUTORESEARCH_TARGET` in the missing list, instead of silently servicing the pilot.
- Test: the servicing test sets a target and checks that removing it turns servicing off.
- Roadmap: Phase 5 marked retired, kept for the record.
- CHANGELOG: entry under Changed; also folded the duplicated `### Added` / `### Changed` headings under Unreleased that the last two merges left behind.

No fleet impact: every deployment sets `AUTORESEARCH_TARGET` explicitly (`tick_deploy.sh` forwards it).
