### PR TITLE
A landed follow-up re-measure is finished even at the wake-attempt cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- A follow-up re-measurement that has landed is now finished even when the
+  run has spent its wake-attempt cap. The sessions that sync a stale PR onto
+  the moved base and dispatch the measurement each bill an attempt, so a
+  measurement could complete with nobody left to push its number; the run then
+  idled with "follow-up attempts without progress" every tick. The cap still
+  holds for follow-ups that have nothing landed to finish.
 - `outerloop init` no longer overwrites an existing `~/.config/autoresearch/.env`
   silently: interactively it asks; with `--yes` it refuses unless `--force` is
   passed. The check runs before any GitHub App is created.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,8 +88,10 @@ Versions follow [SemVer](https://semver.org).
   run has spent its wake-attempt cap. The sessions that sync a stale PR onto
   the moved base and dispatch the measurement each bill an attempt, so a
   measurement could complete with nobody left to push its number; the run then
-  idled with "follow-up attempts without progress" every tick. The cap still
-  holds for follow-ups that have nothing landed to finish.
+  idled with "follow-up attempts without progress" every tick. The finishing
+  follow-up has its own allowance of `MAX_WAKE_ATTEMPTS`, counted on the
+  stage, so a session that fails to finish is retried a bounded number of
+  times; the cap still holds for follow-ups that have nothing landed to finish.
 - `outerloop init` no longer overwrites an existing `~/.config/autoresearch/.env`
   silently: interactively it asks; with `--yes` it refuses unless `--force` is
   passed. The check runs before any GitHub App is created.

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -236,7 +236,8 @@ which wakes any run whose job reads terminal after the grace period —
 plus GONE past the deadline (vanished) and PENDING past the deadline
 (cancel, then wake as unschedulable); a still-RUNNING job is deliberately
 left alone, bounded by its own walltime; wakes that fire without producing
-progress -> `stuck` at MAX_WAKE_ATTEMPTS. A moved base during the wait is
+progress -> `stuck` at MAX_WAKE_ATTEMPTS (a landed re-measure is exempt: the
+follow-up that pushes its number always goes out). A moved base during the wait is
 review's to handle — the sealed candidate publishes as-is (research-loop.md:
 a stale PR is a re-wake, never an orchestrator auto-merge). Worktree cleanup has a named owner at every exit: the
 wake's own finally (primary, as in-job measures do today), the sweep's

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -236,8 +236,8 @@ which wakes any run whose job reads terminal after the grace period —
 plus GONE past the deadline (vanished) and PENDING past the deadline
 (cancel, then wake as unschedulable); a still-RUNNING job is deliberately
 left alone, bounded by its own walltime; wakes that fire without producing
-progress -> `stuck` at MAX_WAKE_ATTEMPTS (a landed re-measure is exempt: the
-follow-up that pushes its number always goes out). A moved base during the wait is
+progress -> `stuck` at MAX_WAKE_ATTEMPTS (a landed re-measure has its own
+allowance of MAX_WAKE_ATTEMPTS finishing follow-ups, counted on the stage). A moved base during the wait is
 review's to handle — the sealed candidate publishes as-is (research-loop.md:
 a stale PR is a re-wake, never an orchestrator auto-merge). Worktree cleanup has a named owner at every exit: the
 wake's own finally (primary, as in-job measures do today), the sweep's

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -683,12 +683,27 @@ def service_in_review(
                     continue  # unknown — do not stack another job
             # the wake-attempt counter caps follow-up retries too: a responder
             # that cannot advance its cursors must not burn a session per tick.
-            # A LANDED re-measure is exempt: the sessions that synced the base
-            # and dispatched it were progress, and the follow-up that pushes
-            # the sealed number is bounded by that GPU job, not by ticks —
-            # capping it here parks the result forever (speedrun agent-03,
-            # 2026-09-04: three syncs spent the cap, the measure completed,
-            # and the run idled for two days on this branch)
+            # A LANDED re-measure gets its own allowance: the sessions that
+            # synced the base and dispatched it were progress, and capping the
+            # follow-up that pushes the sealed number parks the result forever
+            # (speedrun agent-03, 2026-09-04: three syncs spent the cap, the
+            # measure completed, and the run idled for two days on this
+            # branch). The allowance is counted on the stage itself, so a
+            # finishing session that reverts and leaves the stage intact is
+            # retried MAX_WAKE_ATTEMPTS times, not once per tick; a stage that
+            # finishes is cleared, and with it the count.
+            finish_attempts = (
+                int(record.followup_stage.get("finish_attempts", 0) or 0)  # type: ignore[call-overload]
+                if measure_ready
+                else 0
+            )
+            if measure_ready and finish_attempts >= MAX_WAKE_ATTEMPTS:
+                log.warning(
+                    "run %s: %d follow-ups failed to finish the landed re-measure; parked",
+                    record.run_id,
+                    finish_attempts,
+                )
+                continue
             if record.wake_attempts >= MAX_WAKE_ATTEMPTS and not measure_ready:
                 log.warning(
                     "run %s: %d follow-up attempts without progress; not resubmitting",
@@ -783,11 +798,16 @@ def service_in_review(
             # read-modify-write on the FRESH record: the submitted job may
             # already be saving its own fields
             latest = load_record(root, record.run_id)
+            stage = latest.followup_stage
+            if measure_ready and stage:
+                # one finishing attempt billed against this landed measure
+                stage = {**stage, "finish_attempts": finish_attempts + 1}
             save_record(
                 root,
                 replace(
                     latest,
                     followup_job_id=job_id,
+                    followup_stage=stage,
                     wake_attempts=latest.wake_attempts + 1,
                 ),
                 now,

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -682,8 +682,14 @@ def service_in_review(
                 except SlurmQueryError:
                     continue  # unknown — do not stack another job
             # the wake-attempt counter caps follow-up retries too: a responder
-            # that cannot advance its cursors must not burn a session per tick
-            if record.wake_attempts >= MAX_WAKE_ATTEMPTS:
+            # that cannot advance its cursors must not burn a session per tick.
+            # A LANDED re-measure is exempt: the sessions that synced the base
+            # and dispatched it were progress, and the follow-up that pushes
+            # the sealed number is bounded by that GPU job, not by ticks —
+            # capping it here parks the result forever (speedrun agent-03,
+            # 2026-09-04: three syncs spent the cap, the measure completed,
+            # and the run idled for two days on this branch)
+            if record.wake_attempts >= MAX_WAKE_ATTEMPTS and not measure_ready:
                 log.warning(
                     "run %s: %d follow-up attempts without progress; not resubmitting",
                     record.run_id,

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -4032,7 +4032,7 @@ def test_a_landed_remeasure_is_finished_even_at_the_wake_cap(tmp_path: Path) -> 
     the sealed number must still go out — otherwise the result parks forever
     (speedrun agent-03, 2026-09-04). Without a landed measure the cap holds."""
     from outerloop.compute import CommandResult
-    from outerloop.runstate import IN_REVIEW, MAX_WAKE_ATTEMPTS, RunRecord, save_record
+    from outerloop.runstate import IN_REVIEW, MAX_WAKE_ATTEMPTS, RunRecord, load_record, save_record
     from outerloop.tick import FollowupSpec, service_in_review
 
     class G:
@@ -4055,8 +4055,8 @@ def test_a_landed_remeasure_is_finished_even_at_the_wake_cap(tmp_path: Path) -> 
         def list_pr_review_comments(self, repo, number, max_pages=10):
             return []
 
-    def run(stage: dict) -> list:
-        root = tmp_path / f"root-{len(stage)}"
+    def run(stage: dict) -> tuple[list, dict]:
+        root = tmp_path / f"root-{len(stage)}-{stage.get('finish_attempts', 0)}"
         root.mkdir()
         save_record(
             root,
@@ -4087,12 +4087,20 @@ def test_a_landed_remeasure_is_finished_even_at_the_wake_cap(tmp_path: Path) -> 
             home=Path("/home/x/autoresearch"),
         )
         _ended, submitted = service_in_review(root, G(), SlurmCompute(runner=runner), spec, NOW)
-        return submitted
+        return submitted, load_record(root, "r-rev").followup_stage
 
-    # landed measure: finished despite the cap
-    assert run({"job_ids": ["9001"], "candidate_sha": "c" * 40}) == [("r-rev", "77")]
+    landed = {"job_ids": ["9001"], "candidate_sha": "c" * 40}
+    # landed measure: finished despite the cap, and the attempt is counted on the stage
+    submitted, stage = run(landed)
+    assert submitted == [("r-rev", "77")] and stage["finish_attempts"] == 1
+    # a finishing session that reverted and left the stage intact is retried...
+    submitted, stage = run({**landed, "finish_attempts": MAX_WAKE_ATTEMPTS - 1})
+    assert submitted == [("r-rev", "77")] and stage["finish_attempts"] == MAX_WAKE_ATTEMPTS
+    # ...a bounded number of times, never once per tick
+    submitted, stage = run({**landed, "finish_attempts": MAX_WAKE_ATTEMPTS})
+    assert submitted == [] and stage["finish_attempts"] == MAX_WAKE_ATTEMPTS
     # new comments only: the cap still holds
-    assert run({}) == []
+    assert run({})[0] == []
 
 
 def test_a_blind_parked_remeasure_waits_its_floor_before_a_followup_is_sent(tmp_path: Path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -4026,6 +4026,75 @@ def test_a_parked_remeasure_is_polled_then_finished_by_a_followup(tmp_path: Path
     assert "--account acct" in wrap and "--partition cpu_short" in wrap
 
 
+def test_a_landed_remeasure_is_finished_even_at_the_wake_cap(tmp_path: Path) -> None:
+    """The sessions that synced the base and dispatched the re-measure can
+    spend the whole wake cap before the eval lands. The follow-up that pushes
+    the sealed number must still go out — otherwise the result parks forever
+    (speedrun agent-03, 2026-09-04). Without a landed measure the cap holds."""
+    from outerloop.compute import CommandResult
+    from outerloop.runstate import IN_REVIEW, MAX_WAKE_ATTEMPTS, RunRecord, save_record
+    from outerloop.tick import FollowupSpec, service_in_review
+
+    class G:
+        def get_pull_request(self, repo, number):
+            return {"state": "open", "merged": False, "head": {"sha": "a" * 40}}
+
+        def list_comments(self, repo, number, max_pages=20):
+            return [
+                {
+                    "id": 9,
+                    "body": "explain",
+                    "user": {"login": "renmengye"},
+                    "author_association": "MEMBER",
+                }
+            ]
+
+        def list_pr_reviews(self, repo, number, max_pages=10):
+            return []
+
+        def list_pr_review_comments(self, repo, number, max_pages=10):
+            return []
+
+    def run(stage: dict) -> list:
+        root = tmp_path / f"root-{len(stage)}"
+        root.mkdir()
+        save_record(
+            root,
+            RunRecord(
+                run_id="r-rev",
+                target="org/pilot",
+                task_title="t",
+                state=IN_REVIEW,
+                pr_url="https://github.com/org/pilot/pull/9",
+                wake_attempts=MAX_WAKE_ATTEMPTS,
+                followup_stage=stage,
+            ),
+            now=NOW,
+        )
+
+        def runner(argv, timeout_s):
+            if argv[0] == "sbatch":
+                return CommandResult(0, "77\n", "")
+            if argv[0] == "sacct":
+                return CommandResult(0, "COMPLETED\n", "")
+            raise AssertionError(argv)
+
+        spec = FollowupSpec(
+            account="acct",
+            partition="cpu_short",
+            run_root=root,
+            image="/img/a.sif",
+            home=Path("/home/x/autoresearch"),
+        )
+        _ended, submitted = service_in_review(root, G(), SlurmCompute(runner=runner), spec, NOW)
+        return submitted
+
+    # landed measure: finished despite the cap
+    assert run({"job_ids": ["9001"], "candidate_sha": "c" * 40}) == [("r-rev", "77")]
+    # new comments only: the cap still holds
+    assert run({}) == []
+
+
 def test_a_blind_parked_remeasure_waits_its_floor_before_a_followup_is_sent(tmp_path: Path) -> None:
     """No job ids to poll (the measurer could not read the queue): the eval
     walltime plus the queue slack is the floor — never a follow-up per tick."""


### PR DESCRIPTION
**What happened.** speedrun `agent-03` (PR agentic-learning-ai-lab/gpt-speedrun#9) went stale when main moved. Three follow-up sessions synced the PR onto the new base and dispatched the exact re-measurement; each was billed one wake attempt, spending the cap of three. The measurement completed (7936 against the 8192 main of the time) at 23:50 UTC on 2026-09-03. From the next tick on, `service_in_review` logged `3 follow-up attempts without progress; not resubmitting` every 30 minutes, because the cap check runs before the follow-up that finishes a landed measurement is submitted. The result was never pushed and the agent idled for two days while main moved on to 7808.

**Fix.** The cap exempts a landed re-measure (`measure_ready`). Those sessions were progress, and the finishing follow-up is bounded by the GPU job that produced the result, not by ticks: once it runs, `followup.py` either pushes the number and resets the counter, or reverts and leaves the count at the cap, where the existing rule takes over. Follow-ups with nothing landed to finish are still capped exactly as before.

**Test.** `test_a_landed_remeasure_is_finished_even_at_the_wake_cap`: at `wake_attempts == MAX_WAKE_ATTEMPTS`, a record with a completed stage job gets its follow-up submitted; the same record with no stage and only new comments does not.

**Fleet effect.** On deploy, the next tick submits agent-03's finishing follow-up. It will push the sealed 7936 to #9, find the base has moved again, and re-sync and re-measure on the current main; the panel decides from there. No record needs a hand edit.

Docs: dispatcher.md clause on the cap; CHANGELOG under Fixed.
