### PR TITLE
Resume a base-synced re-measure against the PR head at park, not the local merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- A base-synced re-measurement is finished instead of abandoned. The parked
+  stage recorded the session's local merge of the moved base as its parent,
+  a commit GitHub never saw, so the resume judged the PR head as "moved" on
+  every base-synced park and threw the landed result away. The stage now
+  records the PR head at park and the resume compares against that. An
+  abandon also releases the wake-attempt cap, so the "ask again" it invites
+  can be served.
 - A follow-up re-measurement that has landed is now finished even when the
   run has spent its wake-attempt cap. The sessions that sync a stale PR onto
   the moved base and dispatch the measurement each bill an attempt, so a

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -958,6 +958,7 @@ def _respond(
                         changed=changed,
                         conflict_head=conflict_head if conflict_wake else "",
                         base_synced=base_synced,
+                        pr_head=str((pr.get("head") or {}).get("sha", "")),
                         panel_wake=panel_wake,
                         now=now,
                         secrets=secrets,
@@ -1593,6 +1594,7 @@ def _park_remeasure(
     changed: list[str],
     conflict_head: str,
     base_synced: bool,
+    pr_head: str,
     panel_wake: bool,
     now: float,
     secrets: tuple[str, ...],
@@ -1606,6 +1608,11 @@ def _park_remeasure(
         "candidate_sha": snap.commit,
         "candidate_ref": snap.ref,
         "parent": ws.git("rev-parse", "HEAD").strip(),
+        # the PR's head on GitHub at park. After a base sync `parent` is the
+        # session's local merge, which GitHub never saw: the resume compares
+        # the live head against THIS, not against parent (speedrun agent-03,
+        # 2026-09-06: every base-synced re-measure was abandoned as "moved")
+        "pr_head": pr_head,
         "job_ids": list(pend.job_ids),
         "afterany": pend.afterany(),
         "seed": run_seed,
@@ -1729,7 +1736,13 @@ def _resume_measure(
             ws.git("clean", "-fdq")
         drop_snapshot(ws, snapshot)
         github.comment(record.target, number, f"{REPLY_MARKER}\n{note}")
-        save_record(run_root, replace(load_record(run_root, run_id), followup_stage={}), now)
+        # the thread was told and invited to ask again: that next ask needs a
+        # follow-up, so the landed measure counts as progress for the cap
+        save_record(
+            run_root,
+            replace(load_record(run_root, run_id), followup_stage={}, wake_attempts=0),
+            now,
+        )
         return FollowupOutcome(run_id, "replied", "dispatched re-measure abandoned")
 
     try:
@@ -1764,12 +1777,16 @@ def _resume_measure(
             )
         return FollowupOutcome(run_id, "replied", "dispatched re-measure already landed")
 
-    # the sealed commit is parented on the head the PR had at park: a push
-    # since (a maintainer's) makes it unpushable AND measured on a tree that
-    # is no longer the PR's — abandon honestly rather than force or rebuild
-    if head_now and parent and head_now != parent:
+    # the sealed commit descends from the head the PR had at park (directly,
+    # or through the session's local base-sync merge): a push since (a
+    # maintainer's) makes it unpushable AND measured on a tree that is no
+    # longer the PR's — abandon honestly rather than force or rebuild. Stages
+    # parked before `pr_head` was recorded fall back to conflict_head, then
+    # parent.
+    parked_head = str(stage.get("pr_head") or stage.get("conflict_head") or parent)
+    if head_now and parked_head and head_now != parked_head:
         return _abandon(
-            f"_(The PR's head moved while the re-measure ran (`{parent[:12]}` → "
+            f"_(The PR's head moved while the re-measure ran (`{parked_head[:12]}` → "
             f"`{head_now[:12]}`), so the measured change no longer applies to this "
             "branch and was not pushed. Ask again and it will be redone on the new head.)_"
         )

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2694,6 +2694,8 @@ def test_a_moved_pr_head_abandons_the_parked_change_honestly(review_run) -> None
         secrets=("sk-x",),
         dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
     )
+    # the syncs before this park spent the wake cap
+    save_record(root, replace(load_record(root, "tsp-r1"), wake_attempts=3), NOW)
     # a maintainer pushed to the PR while the GPU job ran
     github2 = AutoGitHub(pr={"state": "open", "merged": False, "head": {"sha": "e" * 40}})
     out = respond_once(
@@ -2712,7 +2714,65 @@ def test_a_moved_pr_head_abandons_the_parked_change_honestly(review_run) -> None
     assert not _origin_has_branch(bare)
     rec = load_record(root, "tsp-r1")
     assert rec.followup_stage == {}
+    assert rec.wake_attempts == 0  # "ask again" needs a follow-up: the cap is released
     assert _git(run_dir(root, "tsp-r1") / "ws", "for-each-ref", "refs/dispatch/").strip() == ""
+
+
+def test_a_base_synced_park_is_finished_when_the_pr_head_did_not_move(review_run) -> None:
+    """A behind wake merges the moved base locally and seals a change on top;
+    the stage's `parent` is that local merge, which GitHub never saw. The
+    resume must judge "did the head move" against the head the PR had at
+    park, not against parent — otherwise every base-synced re-measure is
+    abandoned as moved (speedrun agent-03, 2026-09-06: a landed improvement
+    thrown away with the PR head unchanged for three days)."""
+    root, bare = review_run
+    _gpu_run(root)
+    # main moves cleanly: an out-of-scope doc lands upstream
+    seed2 = root.parent / "seed2f"
+    _git(root.parent, "clone", "-q", str(bare), str(seed2))
+    (seed2 / "docs" / "news.md").write_text("from main\n")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(seed2, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "main moves")
+    _git(seed2, "push", "-q", "origin", "main")
+    pr_head = _ws_head(root)
+    ws = run_dir(root, "tsp-r1") / "ws"
+    _git(ws, "fetch", "-q", "origin", "main")
+    github = AutoGitHub(pr=_behind_pr(head=pr_head), comments=[member(901, "tweak")])
+    respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(merge_base=True, edits={"src/pilot/solvers/tsp.py": "v2 after sync\n"}),
+        QueueEvaluator(values=[]),
+        github,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
+    )
+    stage = load_record(root, "tsp-r1").followup_stage
+    assert stage["base_synced"] and stage["pr_head"] == pr_head
+    assert stage["parent"] != pr_head  # the local merge: GitHub never had this commit
+
+    # the measure lands; GitHub still reports the head the PR had at park
+    github2 = AutoGitHub(pr=_behind_pr(head=pr_head))
+    out = respond_once(
+        root,
+        "tsp-r1",
+        ResumingHarness(),
+        QueueEvaluator(values=[]),
+        github2,  # type: ignore[arg-type]
+        bot_login=BOT,
+        now=NOW + 1,
+        secrets=("sk-x",),
+        dispatch=FakeDispatch(FakeMeasurer(value=10.2)),  # type: ignore[arg-type]
+    )
+    assert out.action == "replied" and "applied" in out.note
+    assert "Re-measured after this change" in github2.posted[0]
+    head = _origin_head(bare)
+    assert _git(ws, "show", f"{head}:src/pilot/solvers/tsp.py") == "v2 after sync\n"
+    assert _git(ws, "show", f"{head}:docs/news.md") == "from main\n"  # the sync rode along
+    rec = load_record(root, "tsp-r1")
+    assert rec.followup_stage == {} and rec.wake_attempts == 0
 
 
 def test_a_resume_always_disarms_before_pushing(review_run) -> None:


### PR DESCRIPTION
**What happened.** After #281 deployed, speedrun `agent-03`'s finishing follow-up (job 17022667, 36 s) abandoned its landed re-measurement (7936) with "The PR's head moved while the re-measure ran (`ac4198c979dd` → `7bb04d6e0ac1`)". The PR's head had not moved: `7bb04d6` has been gpt-speedrun#9's only commit since 2026-09-03. `ac4198c` is the session's local merge of the moved base, which `_park_remeasure` recorded as the stage's `parent` (`ws.git rev-parse HEAD` at park) and which was never pushed. `_resume_measure` compared the live head against that, so every base-synced park is abandoned as moved.

**Fix.**
- `_park_remeasure` takes and records `pr_head`, the PR's head on GitHub at park (passed from the caller, which has the PR dict).
- `_resume_measure` compares the live head against `stage["pr_head"]`, falling back to `conflict_head`, then `parent`, for stages parked by older code.
- `_abandon` also resets `wake_attempts`: the abandon message invites the thread to ask again, and that ask needs a follow-up the cap would otherwise refuse (the same "landed measure is progress" rule as #281).

**Tests.** `test_a_base_synced_park_is_finished_when_the_pr_head_did_not_move`: main moves, a behind wake merges it locally and seals a change, the stage's parent differs from the PR head, the resume with an unchanged PR head pushes the sealed tree (the sync rides along) and clears the stage. The existing moved-head test now also checks the cap release.

**agent-03.** Its stage is already cleared and its count is at 4, so this fix does not resurrect that result (which main has since passed anyway); the PR needs closing or the count zeroing by hand.
