### PR TITLE
start: the local loop needs no source checkout (#287)

### DIFF
--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -166,19 +166,23 @@ def _setting(key: str, flag: str, environ: dict[str, str], from_file: dict[str, 
     return from_file.get(key, "")
 
 
-def _home(environ: dict[str, str], cwd: Path) -> Path:
-    """The checkout the loop runs from: AUTORESEARCH_HOME, else the current
-    directory when it is one. Both modes need it; the tick's launch lanes
-    and GitHub servicing switch off without it."""
-    home = (
-        Path(environ["AUTORESEARCH_HOME"]).expanduser() if environ.get("AUTORESEARCH_HOME") else cwd
+def _home(environ: dict[str, str], cwd: Path, *, local: bool, root: Path) -> Path:
+    """The directory the loop runs from. On Slurm it must be a source
+    checkout (AUTORESEARCH_HOME, else the current directory): the chain
+    deploys from it and every job runs from a flight snapshot of its HEAD.
+    The local loop has no deploy step and runs the installed package, so it
+    uses a checkout when one is at hand and otherwise a `home` directory
+    under the state root, where flights and logs land."""
+    named = environ.get("AUTORESEARCH_HOME")
+    home = Path(named).expanduser() if named else cwd
+    if (home / "scripts" / "tick_chain.sbatch").is_file():
+        return home
+    if local and not named:
+        return root / "home"
+    raise StartError(
+        f"{home} is not a source checkout (no scripts/tick_chain.sbatch); "
+        "run start from a clone of the kernel, or set OUTERLOOP_HOME to one"
     )
-    if not (home / "scripts" / "tick_chain.sbatch").is_file():
-        raise StartError(
-            f"{home} is not an autoresearch checkout (no scripts/tick_chain.sbatch); "
-            "run start from the checkout the chain should deploy from, or set AUTORESEARCH_HOME"
-        )
-    return home
 
 
 def plan_start(
@@ -208,13 +212,15 @@ def plan_start(
                 f"AUTORESEARCH_CADENCE_MIN must be a positive number of minutes, got {cadence!r}"
             )
     pat = _setting("AUTORESEARCH_PAT_FILE", "", environ, from_file)
-    # both modes run from a checkout: the tick's launch lanes and GitHub
-    # servicing switch off without AUTORESEARCH_HOME
-    home = _home(environ, cwd)
+    # Slurm runs from a checkout; the local loop runs the installed package
+    # and needs only a directory (the launch lanes and GitHub servicing
+    # switch off without AUTORESEARCH_HOME, so one is always set)
+    local_root = Path(root_s).expanduser() if root_s else DEFAULT_LOCAL_ROOT
+    home = _home(environ, cwd, local=(mode == "local"), root=local_root)
     if mode == "local":
         return StartPlan(
             mode="local",
-            root=Path(root_s).expanduser() if root_s else DEFAULT_LOCAL_ROOT,
+            root=local_root,
             home=home,
             cadence_min=cadence,
             pat_file=pat,

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -173,7 +173,7 @@ def _home(environ: dict[str, str], cwd: Path, *, local: bool, root: Path) -> Pat
     The local loop has no deploy step and runs the installed package, so it
     uses a checkout when one is at hand and otherwise a `home` directory
     under the state root, where flights and logs land."""
-    named = environ.get("AUTORESEARCH_HOME")
+    named = environ.get("OUTERLOOP_HOME") or environ.get("AUTORESEARCH_HOME")
     home = Path(named).expanduser() if named else cwd
     if (home / "scripts" / "tick_chain.sbatch").is_file():
         return home

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -340,6 +340,7 @@ def start(args: argparse.Namespace) -> int:
         env["AUTORESEARCH_COMPUTE"] = "local"
         env["AUTORESEARCH_ROOT"] = str(plan.root)
         env["AUTORESEARCH_HOME"] = str(plan.home)
+        plan.home.mkdir(parents=True, exist_ok=True)  # <root>/home when there is no checkout
         if plan.cadence_min:
             env["AUTORESEARCH_CADENCE_MIN"] = plan.cadence_min
         if plan.pat_file:

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -234,6 +234,11 @@ def flight_checkout(home: Path, name: str, now: float) -> Path:
     uncommitted hand-edits in the shared checkout do not fly — only
     deployed code does. Failures fall back to the shared checkout — a
     snapshot must never ground the fleet."""
+    if not (home / ".git").exists():
+        # not a checkout (the local loop on an installed package): nothing to
+        # pin, the job runs from the home directory itself
+        home.mkdir(parents=True, exist_ok=True)
+        return home
     flights = home.parent / "flights"
     try:
         flights.mkdir(parents=True, exist_ok=True)

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -21,6 +21,7 @@ import os
 import re
 import socket
 import subprocess
+import sys
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
@@ -288,6 +289,16 @@ def _gpu_lane_error(contract: Any, benchmark: str, spec: FollowupSpec) -> str:
             "configured (set AUTORESEARCH_GPU_PARTITION)"
         )
     return ""
+
+
+def _interpreter(home: Path) -> list[str]:
+    """How a job runs Python. From a source checkout, `uv run python` resolves
+    the project's own environment, as the cluster's flights do. From a plain
+    home directory (the local loop on an installed package) the job runs the
+    interpreter this tick runs under, which is where the package is."""
+    if (home / "pyproject.toml").is_file():
+        return ["uv", "run", "python"]
+    return [sys.executable]
 
 
 def _flight_command(home: Path, job_name: str, now: float, argv: list[str]) -> str:
@@ -750,9 +761,7 @@ def service_in_review(
             if panel_argv:
                 panel_argv = [*panel_argv, "--panel-minutes", str(job_minutes - author_minutes)]
             argv = [
-                "uv",
-                "run",
-                "python",
+                *_interpreter(spec.home),
                 "-m",
                 "outerloop.followup",
                 "--run-root",
@@ -2475,9 +2484,7 @@ def service_self_initiated(
             return (benchmark, "dry-run")
         job_minutes = _attempt_job_minutes(spec, limits)
         argv = [
-            "uv",
-            "run",
-            "python",
+            *_interpreter(spec.home),
             "-m",
             "outerloop.attempt",
             "--target",
@@ -2604,9 +2611,7 @@ def service_steward(
 
         work_order_b64 = _b64.b64encode(issue_hypothesis(task).encode()).decode()
         argv = [
-            "uv",
-            "run",
-            "python",
+            *_interpreter(spec.home),
             "-m",
             "outerloop.steward",
             "--target",
@@ -2746,9 +2751,7 @@ def service_intake(
 
         hypothesis_b64 = _b64.b64encode(issue_hypothesis(task).encode()).decode()
         argv = [
-            "uv",
-            "run",
-            "python",
+            *_interpreter(spec.home),
             "-m",
             "outerloop.attempt",
             "--target",
@@ -2830,9 +2833,7 @@ class JobWakeDispatcher:
 
     def dispatch(self, record: RunRecord, reason: str) -> str:
         argv = [
-            "uv",
-            "run",
-            "python",
+            *_interpreter(self.spec.home),
             "-m",
             "outerloop.attempt",
             "--resume",

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -237,7 +237,6 @@ def flight_checkout(home: Path, name: str, now: float) -> Path:
     if not (home / ".git").exists():
         # not a checkout (the local loop on an installed package): nothing to
         # pin, the job runs from the home directory itself
-        home.mkdir(parents=True, exist_ok=True)
         return home
     flights = home.parent / "flights"
     try:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -351,6 +351,13 @@ def test_local_start_needs_no_checkout(clean_env: Path, monkeypatch: pytest.Monk
     env = seen["env"]
     assert isinstance(env, dict)
     assert env["AUTORESEARCH_HOME"] == str(clean_env / "state" / "home")
+    assert (clean_env / "state" / "home").is_dir()  # jobs cd into it
+
+
+def test_outerloop_home_is_read_from_the_environment(clean_env: Path) -> None:
+    home = checkout(clean_env)
+    p = plan(clean_env, cwd=clean_env, local=True, root="/r", environ={"OUTERLOOP_HOME": str(home)})
+    assert p.home == home
 
 
 def test_slurm_start_still_needs_a_checkout(

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -190,16 +190,20 @@ def test_precedence_is_flag_then_environment_then_file(tmp_path: Path) -> None:
     assert (str(p.root), p.account, p.partition) == ("/env/root", "envacct", "flagged")
 
 
-def test_home_from_env_or_cwd_and_must_be_a_checkout_in_both_modes(tmp_path: Path) -> None:
+def test_home_is_a_checkout_on_slurm_and_optional_for_the_local_loop(tmp_path: Path) -> None:
     home = checkout(tmp_path)
     base = {"AUTORESEARCH_ROOT": "/r", "AUTORESEARCH_ACCOUNT": "a", "AUTORESEARCH_PARTITION": "p"}
     with_home = {**base, "AUTORESEARCH_HOME": str(home)}
     assert plan(tmp_path, cwd=tmp_path, environ=with_home).home == home
     assert plan(tmp_path, cwd=tmp_path, local=True, environ=with_home).home == home
-    with pytest.raises(StartError, match="not an autoresearch checkout"):
+    # Slurm deploys from the checkout: none at hand is an error
+    with pytest.raises(StartError, match="source checkout"):
         plan(tmp_path, cwd=tmp_path, environ=base)
-    with pytest.raises(StartError, match="not an autoresearch checkout"):
-        plan(tmp_path, cwd=tmp_path, local=True)
+    # the local loop runs the installed package: home falls back under the root
+    assert plan(tmp_path, cwd=tmp_path, local=True, root="/r").home == Path("/r/home")
+    # a NAMED home that is not a checkout is still an error, in either mode
+    with pytest.raises(StartError, match="source checkout"):
+        plan(tmp_path, cwd=tmp_path, local=True, environ={"AUTORESEARCH_HOME": str(tmp_path)})
 
 
 def test_slurm_requires_root_and_account_but_partition_is_optional(tmp_path: Path) -> None:
@@ -325,6 +329,39 @@ def test_local_start_execs_the_loop_with_env_knobs(
     assert env["AUTORESEARCH_PANEL"] == ""  # an off-switch in the file still lands
     assert env["AUTORESEARCH_CADENCE_MIN"] == "15"  # the loop's cadence comes from .env too
     assert env["AUTORESEARCH_PAT_FILE"] == "/home/me/pat"
+
+
+def test_local_start_needs_no_checkout(clean_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A pip-installed adopter has no source checkout. The local loop runs the
+    installed package, so start must not demand one: home becomes a directory
+    under the state root, where flights and logs land (#287)."""
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli, "ENV_FILE", env_file(clean_env, "AUTORESEARCH_TARGET=o/r\n"))
+    seen: dict[str, object] = {}
+
+    def fake_exec(cmd: list[str], env: dict[str, str]) -> int:
+        seen["env"] = env
+        return 0
+
+    monkeypatch.setattr(cli, "_exec", fake_exec)
+    plain = clean_env / "somewhere"
+    plain.mkdir()
+    monkeypatch.chdir(plain)
+    assert main(["start", "--root", str(clean_env / "state")]) == 0
+    env = seen["env"]
+    assert isinstance(env, dict)
+    assert env["AUTORESEARCH_HOME"] == str(clean_env / "state" / "home")
+
+
+def test_slurm_start_still_needs_a_checkout(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/sbatch")
+    plain = clean_env / "somewhere"
+    plain.mkdir()
+    monkeypatch.chdir(plain)
+    assert main(["start", "--root", str(clean_env / "state"), "--account", "a"]) == 2
+    assert "source checkout" in capsys.readouterr().err
 
 
 def test_slurm_start_submits_once_and_reports(

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -4161,3 +4161,16 @@ def test_a_blind_parked_remeasure_waits_its_floor_before_a_followup_is_sent(tmp_
     assert run(NOW - (30 + BLIND_PARK_SLACK_MIN) * 60 - 1) == [
         ("r-rev", "78")
     ]  # floor passed: look
+
+
+def test_jobs_run_the_installed_interpreter_outside_a_checkout(tmp_path: Path) -> None:
+    """From a source checkout a job runs `uv run python`, which resolves the
+    project's environment. From the local loop's plain home there is no
+    project, so the job runs this interpreter, where the package is (#288)."""
+    import sys
+
+    from outerloop.tick import _interpreter
+
+    assert _interpreter(tmp_path) == [sys.executable]
+    (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
+    assert _interpreter(tmp_path) == ["uv", "run", "python"]


### PR DESCRIPTION
Fixes #287, the first blocker on the pip-install path.

**What happened.** In a fresh venv with an isolated HOME, the README's three commands stop at the third: `outerloop start` (and `start --local`) refuses to run without a source checkout, because `_home()` required `scripts/tick_chain.sbatch` in both modes. The requirement exists for flights: every submitted job runs from a detached git worktree of the checkout's HEAD, which pins the deployed commit against the Slurm deploy's `reset --hard`. The local loop has no deploy step and runs the installed package, so it has nothing to pin and no source to snapshot.

**Fix.**
- `_home()` requires a checkout only on Slurm. In local mode, with no checkout at hand and no `OUTERLOOP_HOME` named, home is `<root>/home`, which `start` creates. A named home that is not a checkout is still an error in either mode.
- `flight_checkout()` returns the home directory itself when it is not a git checkout, so the launch lanes run `argv` from there without a worktree.
- The Slurm error now says "source checkout" and names `OUTERLOOP_HOME`.

**Tests.** The both-modes test becomes "checkout on Slurm, optional for the local loop": local without a checkout resolves to `<root>/home`, Slurm without one errors, a named non-checkout errors in either mode. Two new `main()` tests exercise the pip-only case end to end and the Slurm refusal. Full suite green after an earlier push in this branch went out with seven in-review servicing tests failing (the fallback tried to `mkdir` a fake home); that is fixed in the second commit.

**Not in this PR.** The container image is the next blocker on a laptop: `_followup_spec_from_env` disables in-review servicing without `OUTERLOOP_IMAGE` on disk, and the panel always runs contained. Filing separately after measuring it on the same path.
