### PR TITLE
Local loop: launch attempts without a container image (#289)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,8 +93,9 @@ Versions follow [SemVer](https://semver.org).
   with no Apptainer image, `AUTORESEARCH_COMPUTE=local` now brings up
   servicing with an empty image, logs once that sessions run under the
   harness's own sandbox and evaluations run bare on that machine, and passes
-  `--uncontained` to its jobs. The panel says the same when it runs that way.
-  Slurm still requires the image (#289).
+  `--uncontained` to its jobs. The panel is off in that mode unless
+  `OUTERLOOP_PANEL_UNCONTAINED=1` opts in, and says so when it runs. Slurm
+  still requires the image, and so does a Codex author in every mode (#289).
 - The PyPI description no longer refers to the lab.
 - A base-synced re-measurement is finished instead of abandoned. The parked
   stage recorded the session's local merge of the moved base as its parent,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- The local loop launches attempts without a container image. On a machine
+  with no Apptainer image, `AUTORESEARCH_COMPUTE=local` now brings up
+  servicing with an empty image, logs once that sessions run under the
+  harness's own sandbox and evaluations run bare on that machine, and passes
+  `--uncontained` to its jobs. The panel says the same when it runs that way.
+  Slurm still requires the image (#289).
+- The PyPI description no longer refers to the lab.
 - A base-synced re-measurement is finished instead of abandoned. The parked
   stage recorded the session's local merge of the moved base as its parent,
   a commit GitHub never saw, so the resume judged the PR head as "moved" on

--- a/docs/install.md
+++ b/docs/install.md
@@ -230,11 +230,21 @@ first; `OUTERLOOP_PANEL` names the verify/review lenses (with
 `OUTERLOOP_CODEX_KEY_FILE`; `init` writes the key to
 `~/.config/outerloop/<backend>_key`, 0600, and a pre-rename `harness_key` is
 still read). A Codex author always runs contained, so it also needs the image
-(`OUTERLOOP_IMAGE`) and a Codex model in `OUTERLOOP_AUTHOR_MODEL`. Evals run inside the
-Apptainer image at `OUTERLOOP_IMAGE` (default
+(`OUTERLOOP_IMAGE`) and a Codex model in `OUTERLOOP_AUTHOR_MODEL`. On a
+cluster, evals run inside the Apptainer image at `OUTERLOOP_IMAGE` (default
 `~/autoresearch-images/agent-py312.sif`) in a jail that binds only the
 checked-out tree — an eval that needs data must fetch it into the tree, and
 GPU jobs are requested per node (`--gpus-per-node`).
+
+**Local mode without an image.** On a machine with no Apptainer image,
+`OUTERLOOP_COMPUTE=local` still runs. Sessions run under the harness's own
+sandbox, evaluations run bare in a throwaway tree under an allowlisted
+environment, both on your machine with your keys, and the loop says so once
+at start. The verification panel is off in this mode unless you set
+`OUTERLOOP_PANEL_UNCONTAINED=1`, because an uncontained judge holds a shell
+next to its own key file; a pull request opened without a panel says so. A
+Codex author needs the image in every mode. Contained local mode, the
+default on Linux once the image is published, needs Apptainer and the image.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "outerloop-science"
 dynamic = ["version"]
-description = "Autonomous research agent that co-develops the lab's benchmark-bearing repos"
+description = "Autonomous research agents that improve the benchmark you point them at, one verified pull request at a time"
 readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -2195,6 +2195,12 @@ def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str
         else:
             lens_key = panel_key
         try:
+            if not args.image:
+                log.warning(
+                    "panel lens %s runs uncontained (local mode, no image): the judge "
+                    "shares this machine with the operator's keys",
+                    backend,
+                )
             judge = build_harness(
                 lens_key,
                 reviewer_spec(),

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -291,6 +291,12 @@ def _gpu_lane_error(contract: Any, benchmark: str, spec: FollowupSpec) -> str:
     return ""
 
 
+def _containment(image: str) -> list[str]:
+    """The job's containment flags: the image when there is one, else the
+    explicit uncontained flag every entry point requires in its absence."""
+    return ["--image", image] if image else ["--uncontained"]
+
+
 def _interpreter(home: Path) -> list[str]:
     """How a job runs Python. From a source checkout, `uv run python` resolves
     the project's own environment, as the cluster's flights do. From a plain
@@ -768,8 +774,7 @@ def service_in_review(
                 str(spec.run_root),
                 "--run-id",
                 record.run_id,
-                "--image",
-                spec.image,
+                *_containment(spec.image),
                 "--bot-login",
                 spec.bot_login,
                 "--job-minutes",
@@ -2493,8 +2498,7 @@ def service_self_initiated(
             benchmark,
             "--run-root",
             str(spec.run_root),
-            "--image",
-            spec.image,
+            *_containment(spec.image),
             "--agent-id",
             slot_agent,
             *_climb_limit_argv(limits, job_minutes),
@@ -2620,8 +2624,7 @@ def service_steward(
             task.benchmark,
             "--run-root",
             str(spec.run_root),
-            "--image",
-            spec.image,
+            *_containment(spec.image),
             "--issue",
             str(task.number),
             "--work-order-b64",
@@ -2760,8 +2763,7 @@ def service_intake(
             task.benchmark,
             "--run-root",
             str(spec.run_root),
-            "--image",
-            spec.image,
+            *_containment(spec.image),
             "--issue",
             str(task.number),
             "--hypothesis-b64",
@@ -2840,8 +2842,7 @@ class JobWakeDispatcher:
             record.run_id,
             "--run-root",
             str(self.spec.run_root),
-            "--image",
-            self.spec.image,
+            *_containment(self.spec.image),
             "--account",
             self.spec.account,
             "--partition",
@@ -3035,7 +3036,19 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     # there, so account/partition are only required when a cluster is in play.
     placed = bool(account and partition) or local_mode()
     target = os.environ.get("AUTORESEARCH_TARGET", "")
-    if (pat_file or app_file) and placed and home and target and Path(image).is_file():
+    image_ok = Path(image).is_file()
+    if not image_ok and local_mode():
+        # The local loop on a machine with no container: sessions run under
+        # the harness's own sandbox and evaluations run bare, on the
+        # operator's own machine with the operator's own keys. Said once,
+        # loudly. Contained local mode needs apptainer and the image.
+        log.warning(
+            "local mode: no container image at %s; sessions run under the harness "
+            "sandbox and evaluations run bare on this machine (docs/install.md)",
+            image,
+        )
+        image, image_ok = "", True
+    if (pat_file or app_file) and placed and home and target and image_ok:
         from outerloop.appauth import resolve_bot_auth
         from outerloop.github import GitHubClient
 
@@ -3073,7 +3086,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         ]
         if not value
     ]
-    if not Path(image).is_file():
+    if not image_ok:
         absent.append(f"image:{image}")
     log.info("in-review servicing disabled (missing: %s)", ", ".join(absent))
     return None, None

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -291,6 +291,9 @@ def _gpu_lane_error(contract: Any, benchmark: str, spec: FollowupSpec) -> str:
     return ""
 
 
+_UNCONTAINED_WARNED = False  # the local-mode warning is said once per process
+
+
 def _containment(image: str) -> list[str]:
     """The job's containment flags: the image when there is one, else the
     explicit uncontained flag every entry point requires in its absence."""
@@ -3037,16 +3040,30 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     placed = bool(account and partition) or local_mode()
     target = os.environ.get("AUTORESEARCH_TARGET", "")
     image_ok = Path(image).is_file()
+    panel = os.environ.get("AUTORESEARCH_PANEL", "verify,review")
     if not image_ok and local_mode():
         # The local loop on a machine with no container: sessions run under
         # the harness's own sandbox and evaluations run bare, on the
-        # operator's own machine with the operator's own keys. Said once,
-        # loudly. Contained local mode needs apptainer and the image.
-        log.warning(
-            "local mode: no container image at %s; sessions run under the harness "
-            "sandbox and evaluations run bare on this machine (docs/install.md)",
-            image,
-        )
+        # operator's own machine with the operator's own keys. The panel is
+        # off unless the operator opts in, because an uncontained judge holds
+        # a shell next to its own key file. Said once per process. Contained
+        # local mode needs apptainer and the image (docs/install.md).
+        global _UNCONTAINED_WARNED
+        if not _UNCONTAINED_WARNED:
+            _UNCONTAINED_WARNED = True
+            log.warning(
+                "local mode: no container image at %s; sessions run under the harness "
+                "sandbox and evaluations run bare on this machine; the panel is %s; a "
+                "codex author needs the image (docs/install.md, local mode)",
+                image,
+                "on by AUTORESEARCH_PANEL_UNCONTAINED=1"
+                if os.environ.get("AUTORESEARCH_PANEL_UNCONTAINED") == "1"
+                else "off (AUTORESEARCH_PANEL_UNCONTAINED=1 turns it on)",
+            )
+        if os.environ.get("AUTORESEARCH_PANEL_UNCONTAINED") != "1":
+            panel = ""
+        # the jobs must not inherit a path to an image that is not there
+        os.environ.pop("AUTORESEARCH_IMAGE", None)
         image, image_ok = "", True
     if (pat_file or app_file) and placed and home and target and image_ok:
         from outerloop.appauth import resolve_bot_auth
@@ -3064,7 +3081,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
                 github_app_file=app_file,
                 target=target,
                 steward_key_file=os.environ.get("AUTORESEARCH_STEWARD_KEY_FILE", ""),
-                panel=os.environ.get("AUTORESEARCH_PANEL", "verify,review"),
+                panel=panel,
                 panel_key_file=os.environ.get("AUTORESEARCH_PANEL_KEY_FILE", ""),
                 job_partition=os.environ.get("AUTORESEARCH_JOB_PARTITION", ""),
                 gpu_partition=os.environ.get("AUTORESEARCH_GPU_PARTITION", ""),

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -4174,3 +4174,30 @@ def test_jobs_run_the_installed_interpreter_outside_a_checkout(tmp_path: Path) -
     assert _interpreter(tmp_path) == [sys.executable]
     (tmp_path / "pyproject.toml").write_text("[project]\nname = 'x'\n")
     assert _interpreter(tmp_path) == ["uv", "run", "python"]
+
+
+def test_local_mode_runs_uncontained_without_an_image(monkeypatch: Any, tmp_path: Path) -> None:
+    """A laptop has no Apptainer image. Under AUTORESEARCH_COMPUTE=local the
+    servicing spec still comes up, with an empty image, and the job argv says
+    --uncontained; Slurm mode without the image stays disabled (#289)."""
+    from outerloop.tick import _containment, _followup_spec_from_env
+
+    pat = tmp_path / "pat"
+    pat.write_text("t")
+    env = {
+        "AUTORESEARCH_PAT_FILE": str(pat),
+        "AUTORESEARCH_IMAGE": str(tmp_path / "missing.sif"),
+        "AUTORESEARCH_HOME": str(tmp_path),
+        "AUTORESEARCH_TARGET": "org/repo",
+        "AUTORESEARCH_ACCOUNT": "a",
+        "AUTORESEARCH_PARTITION": "p",
+    }
+    import outerloop.tick as tick_mod
+
+    monkeypatch.setattr(tick_mod.os, "environ", env)
+    assert _followup_spec_from_env(tmp_path) == (None, None)  # slurm: image required
+    env["AUTORESEARCH_COMPUTE"] = "local"
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is not None and spec.image == ""
+    assert _containment(spec.image) == ["--uncontained"]
+    assert _containment("/img/a.sif") == ["--image", "/img/a.sif"]

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -4199,5 +4199,10 @@ def test_local_mode_runs_uncontained_without_an_image(monkeypatch: Any, tmp_path
     env["AUTORESEARCH_COMPUTE"] = "local"
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None and spec.image == ""
+    assert spec.panel == ""  # an uncontained judge is opt-in
+    assert "AUTORESEARCH_IMAGE" not in env  # the jobs do not inherit a missing image
     assert _containment(spec.image) == ["--uncontained"]
     assert _containment("/img/a.sif") == ["--image", "/img/a.sif"]
+    env["AUTORESEARCH_PANEL_UNCONTAINED"] = "1"
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is not None and spec.panel == "verify,review"


### PR DESCRIPTION
Fixes #289, the second blocker on the pip-install path, and the PyPI description line from #286.

**What happened.** After #288 the local loop starts on a laptop and ticks, but `_followup_spec_from_env` requires the Apptainer image on disk in every mode, and every launch lane hangs off that spec, so the loop logged `in-review servicing disabled (missing: image: ...)` and never launched anything.

**Design.** One containment mode per platform, decided at start, never detected per job. Slurm requires the image, as before. Local mode without an image runs uncontained: sessions under the harness's own sandbox (Codex under Seatbelt or Landlock, Claude Code's permission sandbox), evaluations bare in a throwaway tree under an allowlisted environment (the `env -i` path that already exists in `dispatch.py`), on the operator's own machine with the operator's own keys. The kernel says so once at start and the panel says so when it runs. This is the interim for machines that cannot run Apptainer; a follow-up issue covers publishing the image so Linux workstations run contained.

**Changes.**
- `_followup_spec_from_env`: in local mode a missing image becomes an empty image with one warning; the spec comes up. Slurm mode is unchanged.
- `_containment(image)` returns `--image <path>` or `--uncontained`; all five job argv sites use it. The entry points already require one or the other.
- `attempt.py`: the panel logs that it runs uncontained when there is no image.
- `pyproject.toml`: description rewritten for the public.

**Test.** `test_local_mode_runs_uncontained_without_an_image`: Slurm mode without the image yields no spec; local mode yields a spec with an empty image; `_containment` maps both cases.

**Not verified here.** An end-to-end attempt on a laptop needs a model key and a GitHub identity; that walk-through is next, on cluster0, and its findings will be filed like #284 to #289.
