### PR TITLE
init: the App flow says what to click at each step, and asks for the organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,10 @@ Versions follow [SemVer](https://semver.org).
   tokens cannot answer, so it warned about a missing push permission on Apps
   that could push. It now checks the installation's repository list and its
   granted permissions.
+- `init --github-app` records the App's login (`<slug>[bot]`) as
+  `OUTERLOOP_BOT_LOGIN`. Without it the kernel fell back to a built-in
+  default that is not the adopter's identity and did not recognize its own
+  pull requests.
 - The local loop launches attempts without a container image. On a machine
   with no Apptainer image, `AUTORESEARCH_COMPUTE=local` now brings up
   servicing with an empty image, logs once that sessions run under the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- `outerloop init --github-app` says what to do at each step: which page
+  opens, which button to click, where the code appears, how to install the
+  App on the repository, and that the last step checks write access. It also
+  asks whether to create the App under your account or an organization,
+  which before needed the undocumented `--org` flag.
 - The local loop launches attempts without a container image. On a machine
   with no Apptainer image, `AUTORESEARCH_COMPUTE=local` now brings up
   servicing with an empty image, logs once that sessions run under the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ Versions follow [SemVer](https://semver.org).
   App on the repository, and that the last step checks write access. It also
   asks whether to create the App under your account or an organization,
   which before needed the undocumented `--org` flag.
+- The App flow's final write check asked GitHub a question installation
+  tokens cannot answer, so it warned about a missing push permission on Apps
+  that could push. It now checks the installation's repository list and its
+  granted permissions.
 - The local loop launches attempts without a container image. On a machine
   with no Apptainer image, `AUTORESEARCH_COMPUTE=local` now brings up
   servicing with an empty image, logs once that sessions run under the

--- a/src/outerloop/appmanifest.py
+++ b/src/outerloop/appmanifest.py
@@ -91,10 +91,14 @@ def request_manifest_code(
     state = secrets.token_urlsafe(16)
     manifest = build_manifest(name, homepage_url)
     url = build_setup_url(manifest, state, org)
-    print_fn("Create your GitHub App — open this URL in a browser (any machine):")
+    where = f"the {org} organization" if org else "your account"
+    print_fn("Step 1 of 3: create the GitHub App.")
+    print_fn("  Open this link in a browser where you are signed in to GitHub (any machine):")
     print_fn(f"\n  {url}\n")
-    print_fn("Click 'Create GitHub App', then copy the code the page shows.")
-    return input_fn("Paste the code here: ").strip()
+    print_fn(f"  GitHub shows a page titled 'Create GitHub App' under {where}. Click the")
+    print_fn("  green 'Create GitHub App' button. GitHub then sends you to")
+    print_fn("  setup.outerloop.science, which shows a one-time code.")
+    return input_fn("Paste that code here: ").strip()
 
 
 def _default_transport(request: urllib.request.Request) -> Any:

--- a/src/outerloop/appmanifest.py
+++ b/src/outerloop/appmanifest.py
@@ -25,6 +25,7 @@ import os
 import secrets
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Callable
 from pathlib import Path
@@ -96,8 +97,9 @@ def request_manifest_code(
     print_fn("  Open this link in a browser where you are signed in to GitHub (any machine):")
     print_fn(f"\n  {url}\n")
     print_fn(f"  GitHub shows a page titled 'Create GitHub App' under {where}. Click the")
+    host = urllib.parse.urlsplit(SETUP_URL).netloc or SETUP_URL
     print_fn("  green 'Create GitHub App' button. GitHub then sends you to")
-    print_fn("  setup.outerloop.science, which shows a one-time code.")
+    print_fn(f"  {host}, which shows a one-time code.")
     return input_fn("Paste that code here: ").strip()
 
 

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -150,16 +150,19 @@ def _check_app_access(provider: Any, target: str) -> str:
     headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
     try:
         token = provider.token()
+        # an installation token sees a repository only when the installation
+        # covers it, so one direct read answers "is it installed there"
+        # without paging through the installation's repository list
         req = urllib.request.Request(
-            f"{API}/installation/repositories",
-            headers={**headers, "Authorization": f"Bearer {token}"},
+            f"{API}/repos/{target}", headers={**headers, "Authorization": f"Bearer {token}"}
         )
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            repos = json.loads(resp.read()).get("repositories") or []
-        names = {str(r.get("full_name", "")).lower() for r in repos}
-        if target.lower() not in names:
-            listed = ", ".join(sorted(names)) or "no repositories"
-            return f"the App is installed on {listed}, not on {target}; install it there"
+        try:
+            with urllib.request.urlopen(req, timeout=15):
+                pass
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return f"the App is not installed on {target}; install it there"
+            raise
         jwt = build_app_jwt(provider.app_id, time.time(), provider._sign)
         req = urllib.request.Request(
             f"{API}/app/installations/{provider.installation_id}",

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -50,7 +50,9 @@ class InitAnswers:
     author_key_file: str = ""  # the author's model key file, when known
 
 
-def render_env(a: InitAnswers, pat_file: str = "", *, app_file: str = "") -> str:
+def render_env(
+    a: InitAnswers, pat_file: str = "", *, app_file: str = "", bot_login: str = ""
+) -> str:
     """The `.env` body for these answers — only the keys that have a value, so
     the file stays minimal and every line means something. Ordered placement →
     target → auth → author to read top-to-bottom like the setup itself. Auth is
@@ -66,6 +68,10 @@ def render_env(a: InitAnswers, pat_file: str = "", *, app_file: str = "") -> str
         lines.append(f"OUTERLOOP_GITHUB_APP_FILE={app_file}")
     elif pat_file:
         lines.append(f"OUTERLOOP_PAT_FILE={pat_file}")
+    if bot_login:
+        # every own-comment filter and own-PR scan keys on this login; without
+        # it the kernel assumes a default that is not this adopter's identity
+        lines.append(f"OUTERLOOP_BOT_LOGIN={bot_login}")
     if a.author_backend:
         lines.append(f"OUTERLOOP_AUTHOR_BACKEND={a.author_backend}")
     if a.author_model:
@@ -320,7 +326,10 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
             f"Settings > Installations), then run outerloop start."
         )
     env_path = CONFIG_DIR / ENV_FILE.name
-    write_private(env_path, render_env(answers, app_file=str(app_json)))
+    write_private(
+        env_path,
+        render_env(answers, app_file=str(app_json), bot_login=f"{conversion['slug']}[bot]"),
+    )
     print(f"wrote {env_path}")
     _author_key_hint(answers)
     print("next: outerloop start")

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -239,9 +239,23 @@ def _collect(args: argparse.Namespace, interactive: bool) -> tuple[InitAnswers, 
 
 
 ORG_PROMPT = (
-    "Create the App under your own account, or under an organization? "
-    "(organization name, or Enter for your account)"
+    "Create the App under which account? (the repository's owner is the only one "
+    "the App can then be installed on; Enter to accept)"
 )
+
+
+def _owner_is_user(owner: str) -> bool:
+    """Whether `owner` is a user account rather than an organization. GitHub
+    creates Apps at different pages for the two. Best effort: unknown means
+    organization, which is the common case for a shared target."""
+    req = urllib.request.Request(
+        f"{API}/users/{owner}", headers={"Accept": "application/vnd.github+json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return str(json.loads(resp.read()).get("type", "")) == "User"
+    except Exception:
+        return False
 
 
 def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
@@ -274,6 +288,16 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
     print()
     print(f"Step 3 of 3: checking that the App can write {answers.target}.")
     iid = appmanifest.capture_installation_id(int(conversion["id"]), pem_path, owner)
+    for _ in range(2):
+        if iid:
+            break
+        # not installed yet: a rerun of init would stop at the existing config,
+        # so ask again here rather than sending the adopter around the loop
+        print(
+            f"  no installation found yet. Install the App at {appmanifest.install_url(conversion)}"
+        )
+        input("Press Enter once GitHub shows the App as installed… ")
+        iid = appmanifest.capture_installation_id(int(conversion["id"]), pem_path, owner)
     if iid:
         appmanifest.set_installation_id(app_json, iid)
         print(f"  installation id {iid} recorded")
@@ -288,8 +312,9 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
         print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
     else:
         print(
-            f"  no installation found yet. Install the App on {answers.target} (the link above), "
-            f"then run init again, or set installation_id in {app_json} by hand."
+            f"  still no installation. When it is installed, put its id into {app_json} as "
+            f"installation_id (GitHub shows it in the URL of the App's page under "
+            f"Settings > Installations), then run outerloop start."
         )
     env_path = CONFIG_DIR / ENV_FILE.name
     write_private(env_path, render_env(answers, app_file=str(app_json)))
@@ -401,7 +426,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.github_app:
         org = args.org or ""
         if not org and interactive:
-            org = _ask(ORG_PROMPT, "").strip()
+            # a private App installs only on the account that created it, so
+            # the target's owner is the only default that can work
+            owner = answers.target.split("/")[0]
+            org = _ask(ORG_PROMPT, owner).strip()
+        if org and _owner_is_user(org):
+            org = ""  # a user account: GitHub's personal App page, not an org page
         return _github_app_setup(answers, args.app_name or "", org)
 
     token = ""

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -155,27 +155,28 @@ def _check_app_access(provider: Any, target: str) -> str:
 
     headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
     try:
-        token = provider.token()
-        # an installation token sees a repository only when the installation
-        # covers it, so one direct read answers "is it installed there"
-        # without paging through the installation's repository list
+        # Asked as the App itself: GitHub answers with the installation that
+        # covers this repository, permissions included, or 404. A public
+        # repository would answer a plain read for any token, and the
+        # installation's repository list paginates, so neither is asked.
+        jwt = build_app_jwt(provider.app_id, time.time(), provider._sign)
         req = urllib.request.Request(
-            f"{API}/repos/{target}", headers={**headers, "Authorization": f"Bearer {token}"}
+            f"{API}/repos/{target}/installation",
+            headers={**headers, "Authorization": f"Bearer {jwt}"},
         )
         try:
-            with urllib.request.urlopen(req, timeout=15):
-                pass
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                installation = json.loads(resp.read())
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 return f"the App is not installed on {target}; install it there"
             raise
-        jwt = build_app_jwt(provider.app_id, time.time(), provider._sign)
-        req = urllib.request.Request(
-            f"{API}/app/installations/{provider.installation_id}",
-            headers={**headers, "Authorization": f"Bearer {jwt}"},
-        )
-        with urllib.request.urlopen(req, timeout=15) as resp:
-            perms = json.loads(resp.read()).get("permissions") or {}
+        if int(installation.get("id", 0)) != int(provider.installation_id):
+            return (
+                f"the App is installed on {target} under installation "
+                f"{installation.get('id')}, but the App file records {provider.installation_id}"
+            )
+        perms = installation.get("permissions") or {}
         missing = [k for k in ("contents", "issues", "pull_requests") if perms.get(k) != "write"]
         if missing:
             return (

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -176,9 +176,12 @@ def _check_app_access(provider: Any, target: str) -> str:
         )
         with urllib.request.urlopen(req, timeout=15) as resp:
             perms = json.loads(resp.read()).get("permissions") or {}
-        missing = [k for k in ("contents", "pull_requests") if perms.get(k) != "write"]
+        missing = [k for k in ("contents", "issues", "pull_requests") if perms.get(k) != "write"]
         if missing:
-            return f"the App lacks write on {', '.join(missing)} (it pushes branches and opens PRs)"
+            return (
+                f"the App lacks write on {', '.join(missing)} "
+                "(it pushes branches, opens PRs, and files and closes issues)"
+            )
         return ""
     except urllib.error.HTTPError as exc:
         return f"GitHub returned {exc.code} while checking the App"
@@ -253,18 +256,18 @@ ORG_PROMPT = (
 )
 
 
-def _owner_is_user(owner: str) -> bool:
-    """Whether `owner` is a user account rather than an organization. GitHub
-    creates Apps at different pages for the two. Best effort: unknown means
-    organization, which is the common case for a shared target."""
+def _owner_type(owner: str) -> str:
+    """ "User" or "Organization" for a GitHub account, or "" when the lookup
+    fails. GitHub creates Apps at different pages for the two, and a wrong
+    guess sends the adopter to a page that cannot create the App."""
     req = urllib.request.Request(
         f"{API}/users/{owner}", headers={"Accept": "application/vnd.github+json"}
     )
     try:
         with urllib.request.urlopen(req, timeout=15) as resp:
-            return str(json.loads(resp.read()).get("type", "")) == "User"
+            return str(json.loads(resp.read()).get("type", ""))
     except Exception:
-        return False
+        return ""
 
 
 def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
@@ -442,8 +445,13 @@ def main(argv: list[str] | None = None) -> int:
             # the target's owner is the only default that can work
             owner = answers.target.split("/")[0]
             org = _ask(ORG_PROMPT, owner).strip()
-        if org and _owner_is_user(org):
-            org = ""  # a user account: GitHub's personal App page, not an org page
+        if org:
+            kind = _owner_type(org)
+            if not kind and interactive:
+                answer = _ask(f"Is '{org}' an organization or a user account? [org/user]", "org")
+                kind = "User" if answer.strip().lower().startswith("u") else "Organization"
+            if kind == "User":
+                org = ""  # a user account: GitHub's personal App page, not an org page
         return _github_app_setup(answers, args.app_name or "", org)
 
     token = ""

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -21,10 +21,12 @@ import getpass
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from outerloop.cli import ENV_FILE
 from outerloop.paths import write_private
@@ -135,6 +137,48 @@ def _check_repo_access(token: str, target: str) -> str:
         return f"could not reach GitHub: {exc.reason}"
 
 
+def _check_app_access(provider: Any, target: str) -> str:
+    """Can this App write the target repo? "" on success, else a short reason.
+
+    An installation token does not populate a repository's `permissions`
+    object, so the PAT check above reads all-false for an App that can push.
+    The App is asked the two questions that decide it: is the target among
+    the repositories its installation covers, and does the installation carry
+    write on contents and pull requests. Never raises."""
+    from outerloop.appauth import build_app_jwt
+
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    try:
+        token = provider.token()
+        req = urllib.request.Request(
+            f"{API}/installation/repositories",
+            headers={**headers, "Authorization": f"Bearer {token}"},
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            repos = json.loads(resp.read()).get("repositories") or []
+        names = {str(r.get("full_name", "")).lower() for r in repos}
+        if target.lower() not in names:
+            listed = ", ".join(sorted(names)) or "no repositories"
+            return f"the App is installed on {listed}, not on {target}; install it there"
+        jwt = build_app_jwt(provider.app_id, time.time(), provider._sign)
+        req = urllib.request.Request(
+            f"{API}/app/installations/{provider.installation_id}",
+            headers={**headers, "Authorization": f"Bearer {jwt}"},
+        )
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            perms = json.loads(resp.read()).get("permissions") or {}
+        missing = [k for k in ("contents", "pull_requests") if perms.get(k) != "write"]
+        if missing:
+            return f"the App lacks write on {', '.join(missing)} (it pushes branches and opens PRs)"
+        return ""
+    except urllib.error.HTTPError as exc:
+        return f"GitHub returned {exc.code} while checking the App"
+    except urllib.error.URLError as exc:
+        return f"could not reach GitHub: {exc.reason}"
+    except Exception as exc:  # a check failure is a warning, never fails setup
+        return f"could not check the App: {exc}"
+
+
 def validate_pat(pat_file: str, target: str) -> str:
     """Best-effort: can the PAT in `pat_file` write the target repo?"""
     try:
@@ -238,11 +282,10 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
         from outerloop.appauth import app_provider_from_file
 
         try:
-            token = app_provider_from_file(app_json).token()
-            problem = _check_repo_access(token, answers.target)
-            print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
+            problem = _check_app_access(app_provider_from_file(app_json), answers.target)
         except Exception as exc:  # a check failure is a warning, never fails setup
-            print(f"  auth check: WARNING — could not mint a token: {exc}")
+            problem = f"could not read the App credentials: {exc}"
+        print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
     else:
         print(
             f"  no installation found yet. Install the App on {answers.target} (the link above), "

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -194,6 +194,12 @@ def _collect(args: argparse.Namespace, interactive: bool) -> tuple[InitAnswers, 
     return answers, (args.pat_file or "")
 
 
+ORG_PROMPT = (
+    "Create the App under your own account, or under an organization? "
+    "(organization name, or Enter for your account)"
+)
+
+
 def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
     """The `--github-app` path: create the adopter's own App via the manifest
     flow, write its creds, help install it, then point the .env at the App file.
@@ -214,9 +220,15 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
         print(f"outerloop init: {exc}", file=sys.stderr)
         return 1
     pem_path, app_json = appmanifest.save_app_creds(conversion, CONFIG_DIR)
-    print(f"created App '{conversion['slug']}' — wrote {app_json} and {pem_path} (0600)")
-    print(f"install it on {answers.target}: {appmanifest.install_url(conversion)}")
-    input("press Enter once you've installed the App… ")
+    repo = answers.target.split("/", 1)[-1]
+    print(f"  created App '{conversion['slug']}'; credentials in {app_json} and {pem_path} (0600)")
+    print()
+    print(f"Step 2 of 3: install the App on {answers.target}.")
+    print(f"  Open {appmanifest.install_url(conversion)}")
+    print(f"  choose 'Only select repositories', pick '{repo}', and click 'Install'.")
+    input("Press Enter here once GitHub shows the App as installed… ")
+    print()
+    print(f"Step 3 of 3: checking that the App can write {answers.target}.")
     iid = appmanifest.capture_installation_id(int(conversion["id"]), pem_path, owner)
     if iid:
         appmanifest.set_installation_id(app_json, iid)
@@ -233,7 +245,8 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
             print(f"  auth check: WARNING — could not mint a token: {exc}")
     else:
         print(
-            f"  no installation found yet — install the App, then set installation_id in {app_json}"
+            f"  no installation found yet. Install the App on {answers.target} (the link above), "
+            f"then run init again, or set installation_id in {app_json} by hand."
         )
     env_path = CONFIG_DIR / ENV_FILE.name
     write_private(env_path, render_env(answers, app_file=str(app_json)))
@@ -343,7 +356,10 @@ def main(argv: list[str] | None = None) -> int:
         if choice.startswith("a"):
             args.github_app = True
     if args.github_app:
-        return _github_app_setup(answers, args.app_name or "", args.org or "")
+        org = args.org or ""
+        if not org and interactive:
+            org = _ask(ORG_PROMPT, "").strip()
+        return _github_app_setup(answers, args.app_name or "", org)
 
     token = ""
     if not pat_file and interactive:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -421,6 +421,7 @@ def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -
     repository list and its granted permissions instead."""
     import io
     import json as _json
+    import urllib.error
 
     class Provider:
         app_id = 1
@@ -433,7 +434,7 @@ def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -
             return "tok"
 
     answers = {
-        "installation/repositories": {"repositories": [{"full_name": "o/r"}]},
+        "repos/o/r": {"full_name": "o/r"},
         "app/installations/2": {"permissions": {"contents": "write", "pull_requests": "write"}},
     }
 
@@ -447,14 +448,16 @@ def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -
     def fake_urlopen(req, timeout=0):
         for suffix, body in answers.items():
             if req.full_url.endswith(suffix):
+                if body is None:  # the installation does not cover it: GitHub 404s
+                    raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, None)  # type: ignore[arg-type]
                 return Resp(_json.dumps(body).encode())
         raise AssertionError(req.full_url)
 
     monkeypatch.setattr(init.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr("outerloop.appauth.build_app_jwt", lambda *a, **k: "jwt")
     assert init._check_app_access(Provider(), "o/r") == ""
-    answers["installation/repositories"] = {"repositories": [{"full_name": "o/other"}]}
-    assert "not on o/r" in init._check_app_access(Provider(), "o/r")
-    answers["installation/repositories"] = {"repositories": [{"full_name": "o/r"}]}
+    answers["repos/o/r"] = None
+    assert "not installed on o/r" in init._check_app_access(Provider(), "o/r")
+    answers["repos/o/r"] = {"full_name": "o/r"}
     answers["app/installations/2"] = {"permissions": {"contents": "read", "pull_requests": "write"}}
     assert "lacks write on contents" in init._check_app_access(Provider(), "o/r")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -166,6 +166,8 @@ def test_github_app_run_asks_only_for_the_organization(tmp_path: Path, monkeypat
     monkeypatch.setattr(init, "_owner_is_user", lambda owner: False)
     monkeypatch.setattr("builtins.input", lambda *a: "")
     assert init.main(["--github-app", "--compute", "local", "--target", "o/r"]) == 0
+    written = (tmp_path / ".env").read_text()
+    assert "OUTERLOOP_BOT_LOGIN=s[bot]" in written  # the login it recognizes itself by
     # the organization question is the only prompt; nothing about the author
     assert asked == [init.ORG_PROMPT]
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -146,7 +146,7 @@ def test_main_yes_slurm_requires_root_and_account(tmp_path: Path, monkeypatch, c
     assert "Slurm needs --root and --account" in capsys.readouterr().err
 
 
-def test_github_app_run_asks_nothing_about_the_author(tmp_path: Path, monkeypatch) -> None:
+def test_github_app_run_asks_only_for_the_organization(tmp_path: Path, monkeypatch) -> None:
     """A focused --github-app run is about auth; it must not prompt for the author."""
     from outerloop import appmanifest
 
@@ -165,7 +165,8 @@ def test_github_app_run_asks_nothing_about_the_author(tmp_path: Path, monkeypatc
     monkeypatch.setattr(appmanifest, "capture_installation_id", lambda *a, **k: 0)
     monkeypatch.setattr("builtins.input", lambda *a: "")
     assert init.main(["--github-app", "--compute", "local", "--target", "o/r"]) == 0
-    assert asked == []  # no author (or any other) prompt on the way
+    # the organization question is the only prompt; nothing about the author
+    assert asked == [init.ORG_PROMPT]
 
 
 def test_main_yes_rejects_an_unknown_author_backend(tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -412,3 +412,48 @@ def test_author_key_file_flag_must_be_readable_and_is_stored_absolute(
     rc = init.main([*base, "--author-backend", "codex", "--author-key-file", "k/codex_key"])
     assert rc == 0
     assert f"OUTERLOOP_CODEX_KEY_FILE={key}" in (tmp_path / ".env").read_text()  # absolute
+
+
+def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -> None:
+    """An installation token leaves a repository's `permissions` object all
+    false even when the App can push, so the App check reads the installation's
+    repository list and its granted permissions instead."""
+    import io
+    import json as _json
+
+    class Provider:
+        app_id = 1
+        installation_id = 2
+
+        def _sign(self, data: bytes) -> bytes:
+            return b"sig"
+
+        def token(self) -> str:
+            return "tok"
+
+    answers = {
+        "installation/repositories": {"repositories": [{"full_name": "o/r"}]},
+        "app/installations/2": {"permissions": {"contents": "write", "pull_requests": "write"}},
+    }
+
+    class Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def fake_urlopen(req, timeout=0):
+        for suffix, body in answers.items():
+            if req.full_url.endswith(suffix):
+                return Resp(_json.dumps(body).encode())
+        raise AssertionError(req.full_url)
+
+    monkeypatch.setattr(init.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setattr("outerloop.appauth.build_app_jwt", lambda *a, **k: "jwt")
+    assert init._check_app_access(Provider(), "o/r") == ""
+    answers["installation/repositories"] = {"repositories": [{"full_name": "o/other"}]}
+    assert "not on o/r" in init._check_app_access(Provider(), "o/r")
+    answers["installation/repositories"] = {"repositories": [{"full_name": "o/r"}]}
+    answers["app/installations/2"] = {"permissions": {"contents": "read", "pull_requests": "write"}}
+    assert "lacks write on contents" in init._check_app_access(Provider(), "o/r")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -163,6 +163,7 @@ def test_github_app_run_asks_only_for_the_organization(tmp_path: Path, monkeypat
         appmanifest, "convert_manifest", lambda code, **k: {"id": 1, "slug": "s", "pem": "p"}
     )
     monkeypatch.setattr(appmanifest, "capture_installation_id", lambda *a, **k: 0)
+    monkeypatch.setattr(init, "_owner_is_user", lambda owner: False)
     monkeypatch.setattr("builtins.input", lambda *a: "")
     assert init.main(["--github-app", "--compute", "local", "--target", "o/r"]) == 0
     # the organization question is the only prompt; nothing about the author

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -163,7 +163,7 @@ def test_github_app_run_asks_only_for_the_organization(tmp_path: Path, monkeypat
         appmanifest, "convert_manifest", lambda code, **k: {"id": 1, "slug": "s", "pem": "p"}
     )
     monkeypatch.setattr(appmanifest, "capture_installation_id", lambda *a, **k: 0)
-    monkeypatch.setattr(init, "_owner_is_user", lambda owner: False)
+    monkeypatch.setattr(init, "_owner_type", lambda owner: "Organization")
     monkeypatch.setattr("builtins.input", lambda *a: "")
     assert init.main(["--github-app", "--compute", "local", "--target", "o/r"]) == 0
     written = (tmp_path / ".env").read_text()
@@ -437,7 +437,9 @@ def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -
 
     answers = {
         "repos/o/r": {"full_name": "o/r"},
-        "app/installations/2": {"permissions": {"contents": "write", "pull_requests": "write"}},
+        "app/installations/2": {
+            "permissions": {"contents": "write", "issues": "write", "pull_requests": "write"}
+        },
     }
 
     class Resp(io.BytesIO):
@@ -461,5 +463,7 @@ def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -
     answers["repos/o/r"] = None
     assert "not installed on o/r" in init._check_app_access(Provider(), "o/r")
     answers["repos/o/r"] = {"full_name": "o/r"}
-    answers["app/installations/2"] = {"permissions": {"contents": "read", "pull_requests": "write"}}
+    answers["app/installations/2"] = {
+        "permissions": {"contents": "read", "issues": "write", "pull_requests": "write"}
+    }
     assert "lacks write on contents" in init._check_app_access(Provider(), "o/r")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import stat
 from pathlib import Path
+from typing import Any
 
 from outerloop import init
 from outerloop.init import (
@@ -435,10 +436,10 @@ def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -
         def token(self) -> str:
             return "tok"
 
-    answers = {
-        "repos/o/r": {"full_name": "o/r"},
-        "app/installations/2": {
-            "permissions": {"contents": "write", "issues": "write", "pull_requests": "write"}
+    answers: dict[str, Any] = {
+        "repos/o/r/installation": {
+            "id": 2,
+            "permissions": {"contents": "write", "issues": "write", "pull_requests": "write"},
         },
     }
 
@@ -460,10 +461,12 @@ def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -
     monkeypatch.setattr(init.urllib.request, "urlopen", fake_urlopen)
     monkeypatch.setattr("outerloop.appauth.build_app_jwt", lambda *a, **k: "jwt")
     assert init._check_app_access(Provider(), "o/r") == ""
-    answers["repos/o/r"] = None
+    answers["repos/o/r/installation"] = None  # not installed there: GitHub 404s, public or not
     assert "not installed on o/r" in init._check_app_access(Provider(), "o/r")
-    answers["repos/o/r"] = {"full_name": "o/r"}
-    answers["app/installations/2"] = {
-        "permissions": {"contents": "read", "issues": "write", "pull_requests": "write"}
+    answers["repos/o/r/installation"] = {
+        "id": 2,
+        "permissions": {"contents": "read", "issues": "write", "pull_requests": "write"},
     }
     assert "lacks write on contents" in init._check_app_access(Provider(), "o/r")
+    answers["repos/o/r/installation"] = {"id": 9, "permissions": {"contents": "write"}}
+    assert "installation 9" in init._check_app_access(Provider(), "o/r")


### PR DESCRIPTION
Found by the PI running `init --github-app` for the first time today: at each step the wizard reported what it had done and not what to do next (`Paste the code here:` with no mention of where the code comes from; `install it on …: <url>` with no mention of what to choose on that page).

Three numbered steps now: (1) open the link, click the green Create GitHub App button, GitHub sends you to setup.outerloop.science which shows the code, paste it; (2) open the install link, choose Only select repositories, pick the repo, click Install, press Enter; (3) the wizard checks that the App can write the repo. The no-installation branch says to install and run init again. The wizard also asks whether to create the App under the account or an organization, which before needed the undocumented `--org` flag (noted by the advisory reviewer on #296). The test that pinned `--github-app` runs asking nothing now pins that the organization question is the only one. Full suite green.