### PR TITLE
Version 0.1.0.dev1

### DIFF
--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0.dev1"
 
 
 def _bridge_legacy_env() -> None:


### PR DESCRIPTION
Per RELEASING.md step 1: bump only; `[Unreleased]` stays in place until the final release. Closes #284 once tagged. Since dev0 on PyPI: the local loop runs from a pip install (#288, #290), `init` writes the author key (#276), the App flow explains its steps and checks write access as the App (#297), the fleet queue rides in status.json (#278), the two follow-up stalls are fixed (#281, #282), and the PyPI description no longer mentions the lab.