### PR TITLE
Slurm account and partition optional; only the image gates dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,10 +128,12 @@ Versions follow [SemVer](https://semver.org).
 - `outerloop init` no longer overwrites an existing `~/.config/autoresearch/.env`
   silently: interactively it asks; with `--yes` it refuses unless `--force` is
   passed. The check runs before any GitHub App is created.
-- The partition is optional everywhere, as `outerloop start` already allowed:
+- Slurm account and partition are both optional (#300). `outerloop start`
+  no longer requires an account, `outerloop init` no longer insists on one,
   the tick's in-review servicing and the attempt's resume and dispatch gates
-  need only the account on Slurm, and every sbatch the kernel builds passes
-  `--partition` only when one is set, so Slurm chooses (#300).
+  need only the image, and every sbatch the kernel builds passes `--account`
+  and `--partition` only when set, so Slurm bills the caller's default
+  association and picks its default partition.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,10 @@ Versions follow [SemVer](https://semver.org).
 - `outerloop init` no longer overwrites an existing `~/.config/autoresearch/.env`
   silently: interactively it asks; with `--yes` it refuses unless `--force` is
   passed. The check runs before any GitHub App is created.
+- The partition is optional everywhere, as `outerloop start` already allowed:
+  the tick's in-review servicing and the attempt's resume and dispatch gates
+  need only the account on Slurm, and every sbatch the kernel builds passes
+  `--partition` only when one is set, so Slurm chooses (#300).
 
 ### Added
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -216,8 +216,9 @@ runner, a cloud backend, or a hardware rig plugs in the same way.
 The deployment is configured by environment (`OUTERLOOP_*`; the pre-rename
 `AUTORESEARCH_*` names are still accepted everywhere). Placement and paths are set
 when the chain is started: `OUTERLOOP_ACCOUNT`/`OUTERLOOP_PARTITION`
-place the CPU jobs (ticks, author sessions; the partition is optional, unset
-lets Slurm choose), `OUTERLOOP_HOME`/
+place the CPU jobs (ticks, author sessions; both are optional, unset lets
+Slurm bill the default association and pick the default partition),
+`OUTERLOOP_HOME`/
 `OUTERLOOP_ROOT` locate the checkout and the state, `OUTERLOOP_IMAGE`
 the container. The rest is re-read from `~/.config/outerloop/.env` each
 tick, so changes take effect at the next cadence: `OUTERLOOP_TARGET`

--- a/docs/install.md
+++ b/docs/install.md
@@ -216,7 +216,8 @@ runner, a cloud backend, or a hardware rig plugs in the same way.
 The deployment is configured by environment (`OUTERLOOP_*`; the pre-rename
 `AUTORESEARCH_*` names are still accepted everywhere). Placement and paths are set
 when the chain is started: `OUTERLOOP_ACCOUNT`/`OUTERLOOP_PARTITION`
-place the CPU jobs (ticks, author sessions), `OUTERLOOP_HOME`/
+place the CPU jobs (ticks, author sessions; the partition is optional, unset
+lets Slurm choose), `OUTERLOOP_HOME`/
 `OUTERLOOP_ROOT` locate the checkout and the state, `OUTERLOOP_IMAGE`
 the container. The rest is re-read from `~/.config/outerloop/.env` each
 tick, so changes take effect at the next cadence: `OUTERLOOP_TARGET`

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -48,12 +48,15 @@ CADENCE_MIN="${AUTORESEARCH_CADENCE_MIN:-30}"
 JOB_NAME="autoresearch-tick"
 RESIDENT_JOB_NAME="autoresearch-resident"
 missing=""
-for var in AUTORESEARCH_HOME AUTORESEARCH_ROOT AUTORESEARCH_ACCOUNT; do
+for var in AUTORESEARCH_HOME AUTORESEARCH_ROOT; do
     eval "val=\${$var:-}"
     [ -z "$val" ] && missing="$missing $var"
 done
-# Partition is optional: unset lets Slurm place the job on its default
-# partition. When set (including a comma-list like "a,b"), pass it through.
+# Account and partition are optional: unset, Slurm bills the default
+# association and places the job on its default partition. When set (a
+# partition may be a comma-list like "a,b"), pass them through.
+acct_arg=""
+[ -n "${AUTORESEARCH_ACCOUNT:-}" ] && acct_arg="--account=${AUTORESEARCH_ACCOUNT}"
 part_arg=""
 [ -n "${AUTORESEARCH_PARTITION:-}" ] && part_arg="--partition=${AUTORESEARCH_PARTITION}"
 
@@ -106,7 +109,7 @@ while [ "$i" -le "$need" ]; do
             || date -r "$begin_epoch" +%Y-%m-%dT%H:%M:%S)
     for attempt in 1 2 3; do
         if sbatch --dependency=singleton --begin="$begin" \
-                  --account="${AUTORESEARCH_ACCOUNT:-}" ${part_arg:+"$part_arg"} \
+                  ${acct_arg:+"$acct_arg"} ${part_arg:+"$part_arg"} \
                   "${AUTORESEARCH_HOME:-}/scripts/tick_chain.sbatch"; then
             break
         fi

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -11,7 +11,8 @@
 # `sbatch --export=...` when starting the chain; successors inherit):
 #   AUTORESEARCH_HOME  checkout to run from        (required)
 #   AUTORESEARCH_ROOT  state root on the shared FS (required)
-#   AUTORESEARCH_ACCOUNT / AUTORESEARCH_PARTITION  slurm placement (required)
+#   AUTORESEARCH_ACCOUNT / AUTORESEARCH_PARTITION  slurm placement (optional;
+#                             unset uses Slurm's default association/partition)
 #   AUTORESEARCH_CADENCE_MIN  tick cadence, default 30
 #   AUTORESEARCH_PAT_FILE     bot PAT for the deploy pull (optional; no file
 #                             means run whatever code is already deployed)

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -41,14 +41,17 @@ submit_successor() {
     # singleton keeps two residents from ever running together
     local dep="singleton"
     [ -n "$self" ] && dep="afterany:${self},singleton"
-    # Partition is optional (unset -> Slurm's default); pass it only when set.
+    # Account and partition are optional (unset -> Slurm's defaults); pass
+    # them only when set.
+    local acct_arg=""
+    [ -n "${AUTORESEARCH_ACCOUNT:-}" ] && acct_arg="--account=${AUTORESEARCH_ACCOUNT}"
     local part_arg=""
     [ -n "${AUTORESEARCH_PARTITION:-}" ] && part_arg="--partition=${AUTORESEARCH_PARTITION}"
     local out="" attempt
     for attempt in 1 2 3; do
         if out=$(sbatch --parsable --dependency="$dep" --time="$resident_minutes" \
                     --job-name="$RESIDENT_JOB_NAME" --export=ALL \
-                    --account="${AUTORESEARCH_ACCOUNT:-}" ${part_arg:+"$part_arg"} \
+                    ${acct_arg:+"$acct_arg"} ${part_arg:+"$part_arg"} \
                     "$shim" 2>/dev/null); then
             printf '%s' "${out%%;*}"
             return 0

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -3262,12 +3262,12 @@ def main() -> int:
     # and re-enter the decision. The wake job the WakeDispatcher submits runs
     # exactly this.
     if args.resume:
-        placed = bool(args.account and args.partition) or local_mode()
+        placed = bool(args.account) or local_mode()
         if not (placed and args.image and Path(args.image).is_file()):
             parser.error(
-                "--resume needs the cluster triple (--account/--partition/--image) "
-                "to rebuild the dispatched measurer (local compute waives the "
-                "account/partition pair, never the image)"
+                "--resume needs --account and --image to rebuild the dispatched "
+                "measurer (local compute waives the account, never the image; "
+                "an empty --partition leaves the choice to Slurm)"
             )
         from outerloop.runstate import load_record
 
@@ -3432,13 +3432,12 @@ def main() -> int:
     except ValueError as exc:
         parser.error(str(exc))
 
-    # Dispatched measurement needs the full cluster triple AND a real image
-    # file to bind against; missing any, the climb measures inline (the tick
-    # sets these on the climb job's env, a bare CLI run leaves them empty).
+    # Dispatched measurement needs an account (or local compute) AND a real
+    # image file to bind against; missing either, the climb measures inline
+    # (the tick sets these on the climb job's env, a bare CLI run leaves them
+    # empty). The partition is optional: empty lets Slurm choose.
     dispatch: DispatchSettings | None = None
-    if (bool(args.account and args.partition) or local_mode()) and (
-        args.image and Path(args.image).is_file()
-    ):
+    if (bool(args.account) or local_mode()) and (args.image and Path(args.image).is_file()):
         dispatch = _dispatch_settings(args)
     try:
         try:

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -3144,9 +3144,10 @@ def main() -> int:
     parser.add_argument("--base-branch", default="main")
     # All three default from the chain env the tick sets on the climb job, so
     # a contained run with AUTORESEARCH_{IMAGE,ACCOUNT,PARTITION} set selects
-    # dispatched measurement without extra flags. The image also containers the
-    # session + inline eval; absent any of the three, measurement stays inline
-    # regardless of the benchmark's eval hint.
+    # dispatched measurement without extra flags. Dispatched measurement needs
+    # the image and the account; an empty partition lets Slurm choose. The
+    # image also contains the session + inline eval; without it or the
+    # account, measurement stays inline regardless of the benchmark's eval hint.
     parser.add_argument(
         "--image",
         default=os.environ.get("AUTORESEARCH_IMAGE", ""),

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -27,7 +27,7 @@ from typing import Any, cast
 
 from outerloop.appauth import resolve_bot_auth
 from outerloop.brief import BudgetState, distill_lessons
-from outerloop.compute import LocalCompute, local_mode
+from outerloop.compute import LocalCompute
 from outerloop.contract import Benchmark, Contract, contract_text_in_tree, load_contract
 from outerloop.dispatch import (
     Snapshot,
@@ -3144,10 +3144,10 @@ def main() -> int:
     parser.add_argument("--base-branch", default="main")
     # All three default from the chain env the tick sets on the climb job, so
     # a contained run with AUTORESEARCH_{IMAGE,ACCOUNT,PARTITION} set selects
-    # dispatched measurement without extra flags. Dispatched measurement needs
-    # the image and the account; an empty partition lets Slurm choose. The
-    # image also contains the session + inline eval; without it or the
-    # account, measurement stays inline regardless of the benchmark's eval hint.
+    # dispatched measurement without extra flags. Only the image is required
+    # for dispatch (it also contains the session + inline eval); without it,
+    # measurement stays inline regardless of the benchmark's eval hint. Empty
+    # account/partition use Slurm's defaults.
     parser.add_argument(
         "--image",
         default=os.environ.get("AUTORESEARCH_IMAGE", ""),
@@ -3263,12 +3263,11 @@ def main() -> int:
     # and re-enter the decision. The wake job the WakeDispatcher submits runs
     # exactly this.
     if args.resume:
-        placed = bool(args.account) or local_mode()
-        if not (placed and args.image and Path(args.image).is_file()):
+        if not (args.image and Path(args.image).is_file()):
             parser.error(
-                "--resume needs --account and --image to rebuild the dispatched "
-                "measurer (local compute waives the account, never the image; "
-                "an empty --partition leaves the choice to Slurm)"
+                "--resume needs --image to rebuild the dispatched measurer "
+                "(account and partition are optional: empty ones use Slurm's "
+                "defaults, and local compute has no placement)"
             )
         from outerloop.runstate import load_record
 
@@ -3433,12 +3432,12 @@ def main() -> int:
     except ValueError as exc:
         parser.error(str(exc))
 
-    # Dispatched measurement needs an account (or local compute) AND a real
-    # image file to bind against; missing either, the climb measures inline
-    # (the tick sets these on the climb job's env, a bare CLI run leaves them
-    # empty). The partition is optional: empty lets Slurm choose.
+    # Dispatched measurement needs a real image file to bind against; without
+    # one the climb measures inline. Account and partition are optional: empty
+    # ones use Slurm's defaults (the tick sets them on the climb job's env from
+    # the chain's), and local compute has no placement.
     dispatch: DispatchSettings | None = None
-    if (bool(args.account) or local_mode()) and (args.image and Path(args.image).is_file()):
+    if args.image and Path(args.image).is_file():
         dispatch = _dispatch_settings(args)
     try:
         try:

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -127,9 +127,10 @@ class StartPlan:
             "AUTORESEARCH_RESIDENT": "1",
             "AUTORESEARCH_HOME": str(self.home),
             "AUTORESEARCH_ROOT": str(self.root),
-            "AUTORESEARCH_ACCOUNT": self.account,
             "AUTORESEARCH_RESIDENT_MINUTES": str(self.resident_minutes),  # successors reuse it
         }
+        if self.account:
+            env["AUTORESEARCH_ACCOUNT"] = self.account
         if self.partition:
             env["AUTORESEARCH_PARTITION"] = self.partition
         if self.cadence_min:
@@ -147,8 +148,9 @@ class StartPlan:
             "--dependency=singleton",  # two starts can both submit; only one ever runs
             f"--time={self.resident_minutes}",
             f"--job-name={RESIDENT_JOB_NAME}",
-            f"--account={self.account}",
         ]
+        if self.account:  # unset bills the caller's default Slurm association
+            argv.append(f"--account={self.account}")
         if self.partition:  # unset lets Slurm choose its default partition
             argv.append(f"--partition={self.partition}")
         # --export=ALL carries export_env() from the inherited environment; a
@@ -232,10 +234,8 @@ def plan_start(
         )
     acc = _setting("AUTORESEARCH_ACCOUNT", account, environ, from_file)
     part = _setting("AUTORESEARCH_PARTITION", partition, environ, from_file)
-    # Partition is optional: left unset, Slurm places the job on its default
-    # partition. Account stays required (clusters bill by it).
-    if not acc:
-        raise StartError("Slurm mode needs --account / AUTORESEARCH_ACCOUNT")
+    # Account and partition are both optional: left unset, Slurm bills the
+    # caller's default association and places the job on its default partition.
     minutes_s = _setting("AUTORESEARCH_RESIDENT_MINUTES", "", environ, from_file)
     try:
         minutes = int(minutes_s) if minutes_s else DEFAULT_RESIDENT_MINUTES

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -416,8 +416,13 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument(
         "--root", help="state root (shared filesystem on Slurm; default ~/.autoresearch locally)"
     )
-    p.add_argument("--account", help="Slurm account")
-    p.add_argument("--partition", help="Slurm partition for the tick")
+    p.add_argument(
+        "--account", help="Slurm account (optional; unset bills your default association)"
+    )
+    p.add_argument(
+        "--partition",
+        help="Slurm partition for the tick (optional; unset lets Slurm choose; a,b = list)",
+    )
     p.add_argument(
         "--local", action="store_true", help="run the local loop even where sbatch exists"
     )

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -104,12 +104,13 @@ class JobSpec:
             "sbatch",
             "--parsable",
             f"--job-name={self.job_name}",
-            f"--account={self.account}",
             f"--time={self.time_minutes}",
             f"--cpus-per-task={self.cpus}",
             f"--mem={self.mem}",
             f"--output={self.output}",
         ]
+        if self.account:  # unset bills the caller's default Slurm association
+            argv.append(f"--account={self.account}")
         if self.partition:  # unset lets Slurm pick its default partition
             argv.append(f"--partition={self.partition}")
         if self.gpus:

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -2043,11 +2043,10 @@ def main() -> int:
     )
     from outerloop.panel import panel_read_minutes
 
-    # cluster coordinates (the climb's own resolver): a GPU benchmark's
-    # re-measure is dispatched to the GPU lane; with none, evals run inline
-    dispatch = (
-        _dispatch_settings(args) if (args.account or args.partition or args.gpu_partition) else None
-    )
+    # cluster coordinates (the climb's own resolver, the climb's own rule):
+    # a real image dispatches evals, a GPU benchmark's to the GPU lane; with
+    # no image, evals run inline. Account and partition are optional (#300).
+    dispatch = _dispatch_settings(args) if (args.image and Path(args.image).is_file()) else None
 
     # a follow-up services ONE run: reproduce THAT run's author (the persisted
     # (backend, model) PAIR), not the current fleet default, so a codex-authored

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -350,7 +350,9 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--compute", choices=["slurm", "local"], help="where the loop runs")
     parser.add_argument("--target", help="the repo the agents work on, owner/repo")
     parser.add_argument("--root", help="Slurm state root on the shared filesystem")
-    parser.add_argument("--account", help="Slurm account")
+    parser.add_argument(
+        "--account", help="Slurm account (optional; unset bills your default association)"
+    )
     parser.add_argument(
         "--partition", help="Slurm partition (optional; blank = default; a,b = list)"
     )

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -385,8 +385,9 @@ def main(argv: list[str] | None = None) -> int:
     if not answers.target:
         print("outerloop init: a target repo is required (--target owner/repo)", file=sys.stderr)
         return 2
-    if answers.compute == "slurm" and not (answers.root and answers.account):
-        print("outerloop init: Slurm needs --root and --account", file=sys.stderr)
+    if answers.compute == "slurm" and not answers.root:
+        # the account and the partition are optional: Slurm's defaults apply
+        print("outerloop init: Slurm needs --root", file=sys.stderr)
         return 2
     if answers.author_backend and answers.author_backend not in AUTHOR_BACKENDS:
         print(

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -43,7 +43,7 @@ class InitAnswers:
     compute: str  # "slurm" | "local"
     target: str  # "owner/repo"
     root: str = ""  # Slurm state root on the shared filesystem
-    account: str = ""  # Slurm account (required for Slurm)
+    account: str = ""  # Slurm account (optional; unset -> the default association)
     partition: str = ""  # Slurm partition (optional; unset -> Slurm default)
     author_backend: str = ""  # optional: the climbing author's harness
     author_model: str = ""  # optional
@@ -60,7 +60,8 @@ def render_env(
     lines = [f"OUTERLOOP_COMPUTE={a.compute}"]
     if a.compute == "slurm":
         lines.append(f"OUTERLOOP_ROOT={a.root}")
-        lines.append(f"OUTERLOOP_ACCOUNT={a.account}")
+        if a.account:  # optional: unset bills the caller's default association
+            lines.append(f"OUTERLOOP_ACCOUNT={a.account}")
         if a.partition:  # optional: unset lets Slurm pick its default partition
             lines.append(f"OUTERLOOP_PARTITION={a.partition}")
     lines.append(f"OUTERLOOP_TARGET={a.target}")
@@ -226,7 +227,9 @@ def _collect(args: argparse.Namespace, interactive: bool) -> tuple[InitAnswers, 
         root = args.root or (
             _ask("Slurm state root (shared filesystem)", required=True) if interactive else ""
         )
-        account = args.account or (_ask("Slurm account", required=True) if interactive else "")
+        account = args.account or (
+            _ask("Slurm account (blank = your default association)") if interactive else ""
+        )
         partition = args.partition or (
             _ask("Slurm partition (blank = Slurm default; a,b for a list)") if interactive else ""
         )

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -3035,9 +3035,10 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         os.path.expanduser("~/autoresearch-images/agent-py312.sif"),
     )
     home = os.environ.get("AUTORESEARCH_HOME", "")
-    # Local compute runs jobs as subprocesses: Slurm placement is meaningless
-    # there, so account/partition are only required when a cluster is in play.
-    placed = bool(account and partition) or local_mode()
+    # Local compute runs jobs as subprocesses, so the account is only required
+    # when a cluster is in play. The partition is optional everywhere: empty
+    # leaves the choice to Slurm, as `start` already does for the resident.
+    placed = bool(account) or local_mode()
     target = os.environ.get("AUTORESEARCH_TARGET", "")
     image_ok = Path(image).is_file()
     panel = os.environ.get("AUTORESEARCH_PANEL", "verify,review")
@@ -3097,7 +3098,6 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         for name, value in [
             ("AUTORESEARCH_PAT_FILE or _GITHUB_APP_FILE", pat_file or app_file),
             ("AUTORESEARCH_ACCOUNT", account or ("-" if local_mode() else "")),
-            ("AUTORESEARCH_PARTITION", partition or ("-" if local_mode() else "")),
             ("AUTORESEARCH_HOME", home),
             ("AUTORESEARCH_TARGET", target),
         ]

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -3035,10 +3035,9 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         os.path.expanduser("~/autoresearch-images/agent-py312.sif"),
     )
     home = os.environ.get("AUTORESEARCH_HOME", "")
-    # Local compute runs jobs as subprocesses, so the account is only required
-    # when a cluster is in play. The partition is optional everywhere: empty
-    # leaves the choice to Slurm, as `start` already does for the resident.
-    placed = bool(account) or local_mode()
+    # Account and partition are optional on Slurm: empty ones leave the billing
+    # association and the partition to Slurm's defaults, as `start` already
+    # does for the resident. Local compute has no placement at all.
     target = os.environ.get("AUTORESEARCH_TARGET", "")
     image_ok = Path(image).is_file()
     panel = os.environ.get("AUTORESEARCH_PANEL", "verify,review")
@@ -3066,7 +3065,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         # the jobs must not inherit a path to an image that is not there
         os.environ.pop("AUTORESEARCH_IMAGE", None)
         image, image_ok = "", True
-    if (pat_file or app_file) and placed and home and target and image_ok:
+    if (pat_file or app_file) and home and target and image_ok:
         from outerloop.appauth import resolve_bot_auth
         from outerloop.github import GitHubClient
 
@@ -3097,7 +3096,6 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         name
         for name, value in [
             ("AUTORESEARCH_PAT_FILE or _GITHUB_APP_FILE", pat_file or app_file),
-            ("AUTORESEARCH_ACCOUNT", account or ("-" if local_mode() else "")),
             ("AUTORESEARCH_HOME", home),
             ("AUTORESEARCH_TARGET", target),
         ]

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -46,11 +46,13 @@ def test_submit_parses_job_id() -> None:
     assert "--wrap=echo hi" in argv
 
 
-def test_partition_is_optional_in_the_argv() -> None:
-    with_part = JobSpec(job_name="j", account="a", partition="cpu,gpu", time_minutes=1, command="x")
-    assert "--partition=cpu,gpu" in with_part.to_argv()  # comma-list passes through
-    without = JobSpec(job_name="j", account="a", partition="", time_minutes=1, command="x")
-    assert not any(a.startswith("--partition") for a in without.to_argv())
+def test_account_and_partition_are_optional_in_the_argv() -> None:
+    with_both = JobSpec(job_name="j", account="a", partition="cpu,gpu", time_minutes=1, command="x")
+    assert "--account=a" in with_both.to_argv()
+    assert "--partition=cpu,gpu" in with_both.to_argv()  # comma-list passes through
+    # unset: Slurm bills the default association and picks the default partition
+    bare = JobSpec(job_name="j", account="", partition="", time_minutes=1, command="x")
+    assert not any(a.startswith(("--account", "--partition")) for a in bare.to_argv())
 
 
 def test_submit_parses_cluster_suffixed_id() -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -141,10 +141,19 @@ def test_main_yes_requires_target(tmp_path: Path, monkeypatch, capsys) -> None:
     assert "target repo is required" in capsys.readouterr().err
 
 
-def test_main_yes_slurm_requires_root_and_account(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_main_yes_slurm_requires_root_only(tmp_path: Path, monkeypatch, capsys) -> None:
+    """The state root is the one Slurm setting init insists on; account and
+    partition are optional (#300) and an accountless config is written
+    without either line, so Slurm's defaults apply."""
     monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
     assert init.main(["--yes", "--compute", "slurm", "--target", "o/r"]) == 2
-    assert "Slurm needs --root and --account" in capsys.readouterr().err
+    assert "Slurm needs --root" in capsys.readouterr().err
+    monkeypatch.setattr(init, "validate_pat", lambda pf, t: "")
+    argv = ["--yes", "--compute", "slurm", "--target", "o/r", "--root", "/r"]
+    assert init.main([*argv, "--pat-file", "/some/pat"]) == 0
+    env = (tmp_path / ".env").read_text()
+    assert "OUTERLOOP_ROOT=/r" in env
+    assert "OUTERLOOP_ACCOUNT" not in env and "OUTERLOOP_PARTITION" not in env
 
 
 def test_github_app_run_asks_only_for_the_organization(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -206,17 +206,20 @@ def test_home_is_a_checkout_on_slurm_and_optional_for_the_local_loop(tmp_path: P
         plan(tmp_path, cwd=tmp_path, local=True, environ={"AUTORESEARCH_HOME": str(tmp_path)})
 
 
-def test_slurm_requires_root_and_account_but_partition_is_optional(tmp_path: Path) -> None:
+def test_slurm_requires_root_but_account_and_partition_are_optional(tmp_path: Path) -> None:
     with pytest.raises(StartError, match="state root"):
         plan(tmp_path)
-    with pytest.raises(StartError, match="--account / AUTORESEARCH_ACCOUNT"):
-        plan(tmp_path, root="/r")
-    # partition unset is fine: Slurm places on its default, and neither the
-    # sbatch command nor export_env carries an AUTORESEARCH_PARTITION.
-    p = plan(tmp_path, root="/r", account="a")
-    assert p.partition == ""
-    assert not any(a.startswith("--partition=") for a in p.command())
+    # account and partition unset are fine (#300): Slurm bills the default
+    # association and places on its default partition, and the sbatch command
+    # carries neither flag.
+    p = plan(tmp_path, root="/r")
+    assert p.account == "" and p.partition == ""
+    assert not any(a.startswith(("--account=", "--partition=")) for a in p.command())
+    assert "AUTORESEARCH_ACCOUNT" not in p.export_env()
     assert "AUTORESEARCH_PARTITION" not in p.export_env()
+    p = plan(tmp_path, root="/r", account="a")
+    assert "--account=a" in p.command()
+    assert not any(a.startswith("--partition=") for a in p.command())
 
 
 def test_slurm_accepts_a_comma_list_partition(tmp_path: Path) -> None:

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3448,6 +3448,78 @@ def test_local_mode_waives_placement_at_the_attempt_gates(
     assert "needs --account" not in capsys.readouterr().err
 
 
+def test_fresh_climb_dispatches_with_an_account_and_no_partition(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """The fresh climb's dispatch gate needs the account and the image, not
+    the partition (#300): with --account and no --partition the measurer is
+    dispatched (Slurm picks the partition); without an account off local mode
+    the climb measures inline (dispatch=None). main() is halted right past
+    the gate with a BaseException, which the run's `except Exception`
+    containment does not swallow."""
+    import sys
+
+    import pytest
+
+    import outerloop.attempt as attempt_mod
+
+    class _Stop(BaseException):
+        pass
+
+    image = tmp_path / "agent.sif"
+    image.write_text("")
+    for name in ("pat", "key"):
+        f = tmp_path / name
+        f.write_text("t")
+        f.chmod(0o600)
+    argv = [
+        "attempt",
+        "--target",
+        "org/repo",
+        "--benchmark",
+        "b",
+        "--run-root",
+        str(tmp_path),
+        "--image",
+        str(image),
+        "--pat-file",
+        str(tmp_path / "pat"),
+        "--key-file",
+        str(tmp_path / "key"),
+        "--min-free-gb",
+        "0",
+    ]
+    for name in ("AUTORESEARCH_COMPUTE", "AUTORESEARCH_ACCOUNT", "AUTORESEARCH_PARTITION"):
+        monkeypatch.delenv(name, raising=False)
+    seen: dict[str, Any] = {}
+
+    def fake_dispatch_settings(args: Any) -> Any:
+        seen["dispatch_args"] = (args.account, args.partition)
+        raise _Stop
+
+    def fake_live_attempt(**kwargs: Any) -> Any:
+        seen["live_dispatch"] = kwargs["dispatch"]
+        raise _Stop
+
+    monkeypatch.setattr(attempt_mod, "_dispatch_settings", fake_dispatch_settings)
+    monkeypatch.setattr(attempt_mod, "live_attempt", fake_live_attempt)
+    monkeypatch.setattr(attempt_mod, "build_harness", lambda *a, **k: None)
+
+    # account, no partition: the gate passes and the settings carry the empty
+    # partition through (JobSpec then omits --partition, Slurm chooses)
+    monkeypatch.setattr(sys, "argv", [*argv, "--account", "acct"])
+    with pytest.raises(_Stop):
+        attempt_mod.main()
+    assert seen.pop("dispatch_args") == ("acct", "")
+    assert "live_dispatch" not in seen
+
+    # no account on Slurm: measured inline
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(_Stop):
+        attempt_mod.main()
+    assert seen == {"live_dispatch": None}
+
+
 def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> None:
     """LocalCompute's job-env scrub passes AUTORESEARCH_*/REVIEW_HERMES_*
     through as a prefix rule — a locally submitted wake must arrive still in

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3361,11 +3361,11 @@ def test_service_syncs_fetches_for_live_sessions(tmp_path: Path, monkeypatch) ->
     assert _g(ws, "show", "origin/main:docs/b.md").strip() == "new"
 
 
-def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -> None:
-    """Under AUTORESEARCH_COMPUTE=local the followup service comes up without
-    account/partition (subprocess jobs have no placement). Slurm mode still
-    requires the account, and only the account: an empty partition leaves
-    the choice to Slurm, as `start` already allows (#300)."""
+def test_followup_spec_needs_no_account_or_partition(monkeypatch: Any, tmp_path: Path) -> None:
+    """The followup service comes up without account/partition in both modes
+    (#300): on Slurm, empty ones use the cluster's default association and
+    partition, as `start` already allows; under AUTORESEARCH_COMPUTE=local
+    subprocess jobs have no placement at all. Set, the account passes through."""
     from outerloop.tick import _followup_spec_from_env
 
     image = tmp_path / "agent.sif"
@@ -3382,10 +3382,11 @@ def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -
 
     monkeypatch.setattr(tick_mod.os, "environ", env)
     _github, spec = _followup_spec_from_env(tmp_path)
-    assert spec is None  # slurm mode: the account is required
+    assert spec is not None  # slurm mode, no account, no partition
+    assert spec.account == "" and spec.partition == ""
     env["AUTORESEARCH_ACCOUNT"] = "acct"
     _github, spec = _followup_spec_from_env(tmp_path)
-    assert spec is not None  # ... and the partition is not
+    assert spec is not None
     assert spec.account == "acct" and spec.partition == ""
     del env["AUTORESEARCH_ACCOUNT"]
     env["AUTORESEARCH_COMPUTE"] = "local"
@@ -3394,15 +3395,13 @@ def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -
     assert spec.account == "" and spec.partition == ""
 
 
-def test_local_mode_waives_placement_at_the_attempt_gates(
-    monkeypatch: Any, tmp_path: Path, capsys: Any
-) -> None:
+def test_resume_gate_needs_only_the_image(monkeypatch: Any, tmp_path: Path, capsys: Any) -> None:
     """The resume gate accepts empty account/partition under
     AUTORESEARCH_COMPUTE=local (terra #223: locally dispatched wakes died at
-    the parser), and an account with no partition on Slurm (#300: Slurm
-    picks the partition). Proof of admission: the CLI proceeds far enough to
-    complain about the missing parked run, not about the placement — and
-    without local mode or an account the same argv still trips the gate."""
+    the parser) and on Slurm (#300: the cluster's defaults apply). Proof of
+    admission: the CLI proceeds far enough to complain about the missing
+    parked run, not about the placement. Only the image is required: without
+    it the same argv trips the gate."""
     import sys
 
     import pytest
@@ -3434,28 +3433,33 @@ def test_local_mode_waives_placement_at_the_attempt_gates(
     # fails THERE (no parked run in this tmp root) — proof of admission
     with pytest.raises(FileNotFoundError, match=r"state\.json"):
         attempt_mod.main()
-    assert "needs --account" not in capsys.readouterr().err
+    assert "needs --image" not in capsys.readouterr().err
 
+    # Slurm mode, no account, no partition: admitted the same way
     monkeypatch.delenv("AUTORESEARCH_COMPUTE", raising=False)
-    with pytest.raises(SystemExit):
-        attempt_mod.main()
-    assert "needs --account" in capsys.readouterr().err
-
-    # Slurm mode with an account and no partition: admitted the same way
-    monkeypatch.setattr(sys, "argv", [*argv, "--account", "acct"])
     with pytest.raises(FileNotFoundError, match=r"state\.json"):
         attempt_mod.main()
-    assert "needs --account" not in capsys.readouterr().err
+    assert "needs --image" not in capsys.readouterr().err
+
+    # the image is the one thing the gate needs
+    # a path that is not a file: past the parser's own --image check, but not
+    # the gate
+    missing = str(tmp_path / "missing.sif")
+    monkeypatch.setattr(sys, "argv", [(missing if a == str(image) else a) for a in argv])
+    with pytest.raises(SystemExit):
+        attempt_mod.main()
+    assert "needs --image" in capsys.readouterr().err
 
 
-def test_fresh_climb_dispatches_with_an_account_and_no_partition(
+def test_fresh_climb_dispatches_without_account_or_partition(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    """The fresh climb's dispatch gate needs the account and the image, not
-    the partition (#300): with --account and no --partition the measurer is
-    dispatched (Slurm picks the partition); without an account off local mode
-    the climb measures inline (dispatch=None). main() is halted right past
-    the gate with a BaseException, which the run's `except Exception`
+    """The fresh climb's dispatch gate needs only the image (#300): with no
+    --account and no --partition the measurer is still dispatched and the
+    settings carry the empty placement (JobSpec then omits both flags, Slurm
+    applies its defaults); a set account passes through; without an image the
+    climb measures inline (dispatch=None). main() is halted right past the
+    gate with a BaseException, which the run's `except Exception`
     containment does not swallow."""
     import sys
 
@@ -3505,16 +3509,24 @@ def test_fresh_climb_dispatches_with_an_account_and_no_partition(
     monkeypatch.setattr(attempt_mod, "live_attempt", fake_live_attempt)
     monkeypatch.setattr(attempt_mod, "build_harness", lambda *a, **k: None)
 
-    # account, no partition: the gate passes and the settings carry the empty
-    # partition through (JobSpec then omits --partition, Slurm chooses)
+    # no account, no partition: dispatched with the empty placement
+    monkeypatch.setattr(sys, "argv", argv)
+    with pytest.raises(_Stop):
+        attempt_mod.main()
+    assert seen.pop("dispatch_args") == ("", "")
+    assert "live_dispatch" not in seen
+
+    # a set account passes through
     monkeypatch.setattr(sys, "argv", [*argv, "--account", "acct"])
     with pytest.raises(_Stop):
         attempt_mod.main()
     assert seen.pop("dispatch_args") == ("acct", "")
-    assert "live_dispatch" not in seen
 
-    # no account on Slurm: measured inline
-    monkeypatch.setattr(sys, "argv", argv)
+    # no image: measured inline
+    # a path that is not a file: past the parser's own --image check, but not
+    # the gate
+    missing = str(tmp_path / "missing.sif")
+    monkeypatch.setattr(sys, "argv", [(missing if a == str(image) else a) for a in argv])
     with pytest.raises(_Stop):
         attempt_mod.main()
     assert seen == {"live_dispatch": None}

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3363,8 +3363,9 @@ def test_service_syncs_fetches_for_live_sessions(tmp_path: Path, monkeypatch) ->
 
 def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -> None:
     """Under AUTORESEARCH_COMPUTE=local the followup service comes up without
-    account/partition (subprocess jobs have no placement); Slurm mode still
-    requires them."""
+    account/partition (subprocess jobs have no placement). Slurm mode still
+    requires the account, and only the account: an empty partition leaves
+    the choice to Slurm, as `start` already allows (#300)."""
     from outerloop.tick import _followup_spec_from_env
 
     image = tmp_path / "agent.sif"
@@ -3381,7 +3382,12 @@ def test_local_mode_needs_no_slurm_placement(monkeypatch: Any, tmp_path: Path) -
 
     monkeypatch.setattr(tick_mod.os, "environ", env)
     _github, spec = _followup_spec_from_env(tmp_path)
-    assert spec is None  # slurm mode: placement required
+    assert spec is None  # slurm mode: the account is required
+    env["AUTORESEARCH_ACCOUNT"] = "acct"
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is not None  # ... and the partition is not
+    assert spec.account == "acct" and spec.partition == ""
+    del env["AUTORESEARCH_ACCOUNT"]
     env["AUTORESEARCH_COMPUTE"] = "local"
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None
@@ -3393,9 +3399,10 @@ def test_local_mode_waives_placement_at_the_attempt_gates(
 ) -> None:
     """The resume gate accepts empty account/partition under
     AUTORESEARCH_COMPUTE=local (terra #223: locally dispatched wakes died at
-    the parser). Proof of admission: the CLI proceeds far enough to complain
-    about the missing parked run, not about the cluster triple — and without
-    local mode the same argv still trips the triple."""
+    the parser), and an account with no partition on Slurm (#300: Slurm
+    picks the partition). Proof of admission: the CLI proceeds far enough to
+    complain about the missing parked run, not about the placement — and
+    without local mode or an account the same argv still trips the gate."""
     import sys
 
     import pytest
@@ -3427,12 +3434,18 @@ def test_local_mode_waives_placement_at_the_attempt_gates(
     # fails THERE (no parked run in this tmp root) — proof of admission
     with pytest.raises(FileNotFoundError, match=r"state\.json"):
         attempt_mod.main()
-    assert "cluster triple" not in capsys.readouterr().err
+    assert "needs --account" not in capsys.readouterr().err
 
     monkeypatch.delenv("AUTORESEARCH_COMPUTE", raising=False)
     with pytest.raises(SystemExit):
         attempt_mod.main()
-    assert "cluster triple" in capsys.readouterr().err
+    assert "needs --account" in capsys.readouterr().err
+
+    # Slurm mode with an account and no partition: admitted the same way
+    monkeypatch.setattr(sys, "argv", [*argv, "--account", "acct"])
+    with pytest.raises(FileNotFoundError, match=r"state\.json"):
+        attempt_mod.main()
+    assert "needs --account" not in capsys.readouterr().err
 
 
 def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
Fixes #300 (reported by an adopter: `outerloop start` allows an empty partition, but the tick and the attempt gates still required one). Extended after the PI's review: the account is optional as well.

## What changed

- **Slurm account and partition are both optional.** `outerloop start` no longer raises without an account. `outerloop init` asks for the account without requiring it and writes `OUTERLOOP_ACCOUNT` only when given.
- **Every sbatch the kernel builds passes `--account` and `--partition` only when set**: `JobSpec.to_argv`, the resident submit in `cli.py`, `scripts/tick_chain.sbatch`, `scripts/tick_resident.sh`. Unset, Slurm bills the caller's default association and places the job on its default partition. The chain script no longer lists the account as a required variable.
- **Only the image gates dispatched measurement.** The tick's in-review servicing needs pat/app, home, target and the image. The attempt's `--resume` gate and fresh-climb gate, and followup's dispatch decision, dispatch when `--image` is a real file. The account used to double as the "a cluster is in play" signal; the compute mode (`AUTORESEARCH_COMPUTE`) already carries that, so local mode and an uncontained local run (no image) behave as before: no placement, inline evals.
- CHANGELOG under Unreleased, `docs/install.md` wording.

## Behaviour note

A bare `outerloop attempt --image x.sif` on a machine with no Slurm and no `AUTORESEARCH_COMPUTE=local` used to measure inline (no account set); it now dispatches through sbatch and fails there. Local mode is the documented setting for that machine.

## Tests

- `test_account_and_partition_are_optional_in_the_argv` (compute): both flags present when set, both absent when empty.
- `test_slurm_requires_root_but_account_and_partition_are_optional` (start): no `StartError` without an account; neither flag in the command nor either variable in `export_env`; a set account passes through.
- `test_followup_spec_needs_no_account_or_partition` (tick): the spec comes up on Slurm with neither, carries a set account, and comes up in local mode.
- `test_resume_gate_needs_only_the_image` and `test_fresh_climb_dispatches_without_account_or_partition` (attempt): dispatched with the empty placement, a set account passes through, a missing image measures inline / trips the resume gate.

Gate: ruff check, ruff format --check, mypy, pytest (1227 passed), pre-commit on the scripts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
