### PR TITLE
Kernel reads OUTERLOOP_* everywhere; AUTORESEARCH_* bridged for one release; CLI help pass

### DIFF
--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -261,7 +261,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_REPO: ${{ github.repository }}
           REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
-          AUTORESEARCH_BOT_ALIASES: ${{ inputs.bot_aliases }}
+          OUTERLOOP_BOT_ALIASES: ${{ inputs.bot_aliases }}
           REVIEW_CHECKOUT: ${{ github.workspace }}/pr-head
           REVIEW_LENS: ${{ inputs.lens }}
           REVIEW_EMIT_FILE: ${{ runner.temp }}/findings.json
@@ -342,7 +342,7 @@ jobs:
           PR_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
           REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
-          AUTORESEARCH_BOT_ALIASES: ${{ inputs.bot_aliases }}
+          OUTERLOOP_BOT_ALIASES: ${{ inputs.bot_aliases }}
           REVIEW_EMIT_FILE: ${{ runner.temp }}/findings.json
           REVIEW_OPINION_LABEL: ${{ inputs.opinion_label }}
         run: uv run python -m outerloop.review_post_cli

--- a/.github/workflows/advisory-review-summarize.yml
+++ b/.github/workflows/advisory-review-summarize.yml
@@ -249,7 +249,7 @@ jobs:
           PR_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ env.PR_NUMBER }}
           REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
-          AUTORESEARCH_BOT_ALIASES: ${{ inputs.bot_aliases }}
+          OUTERLOOP_BOT_ALIASES: ${{ inputs.bot_aliases }}
           REVIEW_EMIT_FILE: ${{ runner.temp }}/findings.json
           REVIEW_OPINION_LABEL: ${{ inputs.opinion_label }}
         run: uv run python -m outerloop.review_post_cli

--- a/.github/workflows/verify-agent.yml
+++ b/.github/workflows/verify-agent.yml
@@ -159,7 +159,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_REPO: ${{ github.repository }}
           REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
-          AUTORESEARCH_BOT_ALIASES: ${{ inputs.bot_aliases }}
+          OUTERLOOP_BOT_ALIASES: ${{ inputs.bot_aliases }}
           VERIFY_MODEL: ${{ inputs.model }}
           # The parent of the two checkouts (pr-head/ and base/).
           VERIFY_CHECKOUT: ${{ github.workspace }}
@@ -238,6 +238,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_REPO: ${{ github.repository }}
           REVIEW_BOT_LOGIN: ${{ inputs.bot_login }}
-          AUTORESEARCH_BOT_ALIASES: ${{ inputs.bot_aliases }}
+          OUTERLOOP_BOT_ALIASES: ${{ inputs.bot_aliases }}
           VERIFY_EMIT_FILE: ${{ runner.temp }}/verdict.json
         run: uv run python -m outerloop.verify_post_cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ Versions follow [SemVer](https://semver.org).
   (a `-m` in `addopts` disables testmon), and a `serial` tier holds the tests
   that inspect the process table: skipped while workers run, and `pytest -m
   serial` turns workers off, so the tier always runs alone (CI's second step).
+- The kernel reads `OUTERLOOP_*` everywhere: every internal read, log line,
+  chain script and test now uses the public names. The pre-rename
+  `AUTORESEARCH_*` names are still accepted for one release, bridged at the
+  process boundary, the `.env` file and the chain scripts, and will be
+  dropped in the release after 0.1. The review footer names `outerloop`, and
+  `outerloop --version` exists; `start`, `tick` and `init` describe themselves
+  and every flag in `--help`.
 
 ### Changed
 

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -66,7 +66,7 @@ orchestrator chooses per eval site, not per repo.
 launches alike: the JobSpec requests `--gpus=N`, and the jail adds `--nv` so
 the allocation is visible inside the container; nothing else about the
 containment changes. GPU jobs need their own lane, so the deployment names
-one — `AUTORESEARCH_GPU_PARTITION`, optionally `AUTORESEARCH_GPU_ACCOUNT`
+one — `OUTERLOOP_GPU_PARTITION`, optionally `OUTERLOOP_GPU_ACCOUNT`
 (default: the CPU account) — and a benchmark with `gpus > 0` on a deployment
 without a lane is REFUSED at launch (both attempt lanes), never queued into
 evals that can never run. GPUs exist only on DISPATCHED jobs: the contract
@@ -287,7 +287,7 @@ GPU benchmarks and portfolio climbs both multiply eval load; both were
 designed against this seam. Portfolio's N concurrent climbs become N
 waiting records with independent wakes — the serialization question stays
 in the picker, not the dispatcher. The tick's job-partition knobs
-(`AUTORESEARCH_JOB_PARTITION`) already route work jobs; per-benchmark
+(`OUTERLOOP_JOB_PARTITION`) already route work jobs; per-benchmark
 partition/GPU allocation fields are a phase-3 contract-schema change
 (`Benchmark` rejects unknown fields today, deliberately), validated and
 clamped by operator ceilings like every other budget.

--- a/docs/design/github-app-auth.md
+++ b/docs/design/github-app-auth.md
@@ -108,7 +108,7 @@ Swapping the live fleet's identity mid-campaign is an ops event:
 
 ## The flag
 
-`AUTORESEARCH_GITHUB_APP_FILE` names a JSON config —
+`OUTERLOOP_GITHUB_APP_FILE` names a JSON config —
 
 ```json
 {"app_id": 1234, "installation_id": 5678,
@@ -117,13 +117,13 @@ Swapping the live fleet's identity mid-campaign is an ops event:
 
 — and rides the rails the PAT already rides: role CLIs default their
 `--github-app-file` from it (jobs inherit the tick's environment, the same
-way `AUTORESEARCH_AUTHOR_*` reaches them), and every bot-auth construction
+way `OUTERLOOP_AUTHOR_*` reaches them), and every bot-auth construction
 goes through one factory, `appauth.resolve_bot_auth(pat_file, app_file)`:
 App provider when the config is set, PAT otherwise. Revert = unset the env
 var. The ids are not secrets; the key path inside keeps PAT-file custody
 (600, never committed).
 
-The identity flips WITH the credential: `AUTORESEARCH_BOT_LOGIN` names the
+The identity flips WITH the credential: `OUTERLOOP_BOT_LOGIN` names the
 login the kernel now posts as (`<app-slug>[bot]`, e.g.
 `outerloop-autoresearch[bot]`), read by every role through one
 `github.bot_login_from_env()` default. Every own-comment filter, alarm-issue
@@ -135,10 +135,10 @@ Everything the kernel created BEFORE the flip carries the old login — the
 research-log issue, contract alarms, intake claims, its PRs. Recognition is
 keyed on login on purpose (the markers are public strings anyone can paste),
 so a flip must widen the set of our logins, not loosen the check:
-`AUTORESEARCH_BOT_ALIASES=agentic-learning-bot` names the former identity,
+`OUTERLOOP_BOT_ALIASES=agentic-learning-bot` names the former identity,
 and every "is this ours" gate goes through `github.is_own_login`. The
 reusable review and verify workflows take the same value as a `bot_aliases`
-input (exported as `AUTORESEARCH_BOT_ALIASES`; the verifier's author gate
+input (exported as `OUTERLOOP_BOT_ALIASES`; the verifier's author gate
 accepts an alias too), so a target repo passes `bot_login` = the App login and
 `bot_aliases` = the former account. Live lesson: without it, the first tick
 under the App claimed the kernel's own research-log issue as a research order.

--- a/docs/design/headline.md
+++ b/docs/design/headline.md
@@ -61,7 +61,7 @@ monitoring agent + ~100 interventions; AIDE: in-process tree search). Ours is
 **decentralized on Slurm**: no resident daemon — a self-perpetuating chain of
 ~16 s stateless ticks; all state in typed records on the shared FS; every
 role (author session, eval, panel judge, wake) its own Slurm job — wake
-dispatch sits behind an operator flag (`AUTORESEARCH_DISPATCH_WAKE`, on in
+dispatch sits behind an operator flag (`OUTERLOOP_DISPATCH_WAKE`, on in
 our deployment since 2026-08-20; retiring the dark-launch flag to
 default-on is a listed cleanup); crash or preemption anywhere heals
 through the sweep into honest endings.

--- a/docs/design/resident-tick.md
+++ b/docs/design/resident-tick.md
@@ -1,7 +1,7 @@
 # The resident tick
 
 *Design note, 2026-09-02. Status: built as the opt-in mode
-(`AUTORESEARCH_RESIDENT=1`, `scripts/tick_resident.sh`); the chain restarts of
+(`OUTERLOOP_RESIDENT=1`, `scripts/tick_resident.sh`); the chain restarts of
 2026-09-02 are the evidence.*
 
 ## The problem
@@ -91,7 +91,7 @@ covers it.
 
 ## Rollout
 
-1. Opt-in mode in `scripts/tick_chain.sbatch`: `AUTORESEARCH_RESIDENT=1` in
+1. Opt-in mode in `scripts/tick_chain.sbatch`: `OUTERLOOP_RESIDENT=1` in
    the chain's environment selects the loop; unset keeps the per-cadence
    chain. The walltime is fixed by Slurm before the script runs, so the
    resident chain is STARTED with an explicit walltime and its own job name:
@@ -99,8 +99,8 @@ covers it.
    ```
    sbatch --time=360 --job-name=autoresearch-resident --dependency=singleton \
      --account=… --partition=cpu_short \
-     --export=ALL,AUTORESEARCH_RESIDENT=1,AUTORESEARCH_HOME=…,AUTORESEARCH_ROOT=…,\
-   AUTORESEARCH_ACCOUNT=…,AUTORESEARCH_PARTITION=cpu_short,AUTORESEARCH_PAT_FILE=… \
+     --export=ALL,OUTERLOOP_RESIDENT=1,OUTERLOOP_HOME=…,OUTERLOOP_ROOT=…,\
+   OUTERLOOP_ACCOUNT=…,OUTERLOOP_PARTITION=cpu_short,OUTERLOOP_PAT_FILE=… \
      scripts/tick_chain.sbatch
    ```
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -214,7 +214,7 @@ backend; the interface is small (submit a job, poll for completion), so a CI
 runner, a cloud backend, or a hardware rig plugs in the same way.
 
 The deployment is configured by environment (`OUTERLOOP_*`; the pre-rename
-`AUTORESEARCH_*` names are still accepted everywhere). Placement and paths are set
+`AUTORESEARCH_*` names are still accepted for one release). Placement and paths are set
 when the chain is started: `OUTERLOOP_ACCOUNT`/`OUTERLOOP_PARTITION`
 place the CPU jobs (ticks, author sessions; both are optional, unset lets
 Slurm bill the default association and pick the default partition),

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -238,7 +238,7 @@ Research findings sync through GitHub; job state never leaves its cluster.
       re-measured and re-gated); capped-out blocking opens a DRAFT PR and
       never arms auto-merge; the transcript rides in the PR body. DEPLOYED
       in code: the tick passes --panel verify,review to every climb job by
-      default (off-switch AUTORESEARCH_PANEL=""). Cluster prerequisite: the
+      default (off-switch OUTERLOOP_PANEL=""). Cluster prerequisite: the
       verifier key file at ~/.config/outerloop/verifier_key on the tick
       account — a missing key fails climbs LOUDLY by design. GitHub-side
       verify.yml thins per target after the pilot runs clean

--- a/docs/validation/author-syscalls.md
+++ b/docs/validation/author-syscalls.md
@@ -4,7 +4,7 @@
 > milestones green — the codex author launched + slept unprompted, the same
 > session resumed with its launch's post-hibernation results, and the run
 > reached an honest negative terminal. The `--author-syscalls` /
-> `AUTORESEARCH_AUTHOR_SYSCALLS` arming described by the original runbook has
+> `OUTERLOOP_AUTHOR_SYSCALLS` arming described by the original runbook has
 > since RETIRED: enablement is contract-driven (dispatch coords + a resumable
 > backend + `depth_k > 0`; `depth_k: 0` is a benchmark's opt-out). The steps
 > below are kept for re-validation after substrate changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ outerloop = "outerloop.cli:main"
 
 [project.optional-dependencies]
 # GitHub App auth: RS256 signing for App JWTs (docs/design/github-app-auth.md).
-# Install where AUTORESEARCH_GITHUB_APP_FILE is set; the PAT path needs nothing.
+# Install where OUTERLOOP_GITHUB_APP_FILE is set; the PAT path needs nothing.
 app-auth = ["cryptography>=42"]
 
 [dependency-groups]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@ runs the local loop elsewhere, reading placement from `~/.config/outerloop/.env`
 | Script | Purpose |
 | --- | --- |
 | `setup_branch_protection.sh` | Apply/refresh branch protection on `main`. Solo-phase default: 0 approvals, checks required, admins enforced. Re-run with `1` once a second code owner joins. |
-| `tick_chain.sbatch` | The Slurm tick entry: per-cadence chain (deploy, one tick, schedule the next) or, with `AUTORESEARCH_RESIDENT=1`, the resident loop (`docs/design/resident-tick.md`). |
+| `tick_chain.sbatch` | The Slurm tick entry: per-cadence chain (deploy, one tick, schedule the next) or, with `OUTERLOOP_RESIDENT=1`, the resident loop (`docs/design/resident-tick.md`). |
 | `tick_deploy.sh` | The deploy step both modes source: stale-lock sweep, pull `main`, sync deps, read the operator's `.env` knobs, install backends. |
 | `tick_resident.sh` | The resident loop: deploy → one tick under a timeout → sleep to the slot, one `afterany:self` successor, pause exits clean, shim changes resubmit the successor. |
 | `requeue_moved_successors.sh` | Cancel pending same-name jobs that are no longer on the requested partition. The tick chain runs this before adding successors. |

--- a/scripts/install_codex.sh
+++ b/scripts/install_codex.sh
@@ -9,7 +9,7 @@
 #
 # Usage: install_codex.sh [target_path]
 #   target_path  where to place the binary
-#                (default: $AUTORESEARCH_CODEX_BIN, else ~/.local/bin/codex)
+#                (default: $OUTERLOOP_CODEX_BIN, else ~/.local/bin/codex)
 set -euo pipefail
 
 # Pinned: 0.130.0 is harness-verified — it needs neither the code-mode-host helper
@@ -20,7 +20,7 @@ WANT="0.130.0"
 # release asset can never execute on the host (integrity, not self-reported
 # version). To bump WANT: fetch the new asset and `sha256sum` it, then update both.
 WANT_SHA256="16779e7b7857508a768a36d7d4e084eec336ec23946ed70a9b09489b8f861190"
-TARGET="${1:-${AUTORESEARCH_CODEX_BIN:-$HOME/.local/bin/codex}}"
+TARGET="${1:-${OUTERLOOP_CODEX_BIN:-$HOME/.local/bin/codex}}"
 
 have="$("$TARGET" --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
 if [ "$have" = "$WANT" ]; then

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -9,24 +9,24 @@
 #
 # Deploy/config knobs come from the environment (set once via
 # `sbatch --export=...` when starting the chain; successors inherit):
-#   AUTORESEARCH_HOME  checkout to run from        (required)
-#   AUTORESEARCH_ROOT  state root on the shared FS (required)
-#   AUTORESEARCH_ACCOUNT / AUTORESEARCH_PARTITION  slurm placement (optional;
+#   OUTERLOOP_HOME  checkout to run from        (required)
+#   OUTERLOOP_ROOT  state root on the shared FS (required)
+#   OUTERLOOP_ACCOUNT / OUTERLOOP_PARTITION  slurm placement (optional;
 #                             unset uses Slurm's default association/partition)
-#   AUTORESEARCH_CADENCE_MIN  tick cadence, default 30
-#   AUTORESEARCH_PAT_FILE     bot PAT for the deploy pull (optional; no file
+#   OUTERLOOP_CADENCE_MIN  tick cadence, default 30
+#   OUTERLOOP_PAT_FILE     bot PAT for the deploy pull (optional; no file
 #                             means run whatever code is already deployed)
-#   AUTORESEARCH_RESIDENT=1   run as the RESIDENT tick (design/resident-tick.md):
+#   OUTERLOOP_RESIDENT=1   run as the RESIDENT tick (design/resident-tick.md):
 #                             one long-lived job that loops deploy -> tick ->
 #                             sleep, with a single afterany:self successor.
 #                             `outerloop start` submits it (walltime,
 #                             name, and exports filled in); by hand:
 #                             `sbatch --time=360 --job-name=autoresearch-resident
-#                             --export=ALL,AUTORESEARCH_RESIDENT=1,...`. The
+#                             --export=ALL,OUTERLOOP_RESIDENT=1,...`. The
 #                             per-cadence chain drains itself once a resident
 #                             job exists. Unset = the per-cadence chain below.
 # Further config also loads from ~/.config/outerloop/.env (0600) each tick, so
-# a live config change (e.g. AUTORESEARCH_AUTHOR_BACKEND=codex + its key file)
+# a live config change (e.g. OUTERLOOP_AUTHOR_BACKEND=codex + its key file)
 # needs no chain restart — just an edit to that file.
 #
 #SBATCH --job-name=autoresearch-tick
@@ -38,18 +38,18 @@
 # NO set -u before the top-up: a config mistake must fail loudly AFTER the
 # chain has secured its successors, not break the chain silently. Required
 # vars are checked by hand instead.
-# Accept the new OUTERLOOP_* names at the boundary: copy each into its
-# AUTORESEARCH_* twin (when the twin is unset) so the chain's internals, which
-# still read AUTORESEARCH_* during the rename, see one name. The Python side does
-# the same on import. Removed with the final internal flip.
-for _ov in $(env | sed -n 's/^OUTERLOOP_\([A-Z_][A-Z0-9_]*\)=.*/\1/p'); do
-    eval "[ -n \"\${AUTORESEARCH_${_ov}:-}\" ] || export AUTORESEARCH_${_ov}=\"\${OUTERLOOP_${_ov}}\""
+# Accept the pre-rename AUTORESEARCH_* names at the boundary for one release:
+# copy each into its OUTERLOOP_* twin (when the twin is unset) so the chain
+# reads one name. The Python side does the same on import. Removed in the
+# release after 0.1.
+for _ov in $(env | sed -n 's/^AUTORESEARCH_\([A-Z_][A-Z0-9_]*\)=.*/\1/p'); do
+    eval "[ -n \"\${OUTERLOOP_${_ov}:-}\" ] || export OUTERLOOP_${_ov}=\"\${AUTORESEARCH_${_ov}}\""
 done
-CADENCE_MIN="${AUTORESEARCH_CADENCE_MIN:-30}"
+CADENCE_MIN="${OUTERLOOP_CADENCE_MIN:-30}"
 JOB_NAME="autoresearch-tick"
 RESIDENT_JOB_NAME="autoresearch-resident"
 missing=""
-for var in AUTORESEARCH_HOME AUTORESEARCH_ROOT; do
+for var in OUTERLOOP_HOME OUTERLOOP_ROOT; do
     eval "val=\${$var:-}"
     [ -z "$val" ] && missing="$missing $var"
 done
@@ -57,20 +57,20 @@ done
 # association and places the job on its default partition. When set (a
 # partition may be a comma-list like "a,b"), pass them through.
 acct_arg=""
-[ -n "${AUTORESEARCH_ACCOUNT:-}" ] && acct_arg="--account=${AUTORESEARCH_ACCOUNT}"
+[ -n "${OUTERLOOP_ACCOUNT:-}" ] && acct_arg="--account=${OUTERLOOP_ACCOUNT}"
 part_arg=""
-[ -n "${AUTORESEARCH_PARTITION:-}" ] && part_arg="--partition=${AUTORESEARCH_PARTITION}"
+[ -n "${OUTERLOOP_PARTITION:-}" ] && part_arg="--partition=${OUTERLOOP_PARTITION}"
 
 # --- 0. the resident tick: hand the whole job to the loop ---
 # A resident job has no queued successor to protect yet, so a misconfigured
 # start fails LOUDLY here (the per-cadence chain below checks after its
 # top-up on purpose: its successors are already queued and must stay so).
-if [ "${AUTORESEARCH_RESIDENT:-}" = "1" ]; then
+if [ "${OUTERLOOP_RESIDENT:-}" = "1" ]; then
     if [ -n "$missing" ]; then
         echo "resident tick misconfigured; missing:$missing" >&2
         exit 1
     fi
-    . "${AUTORESEARCH_HOME:-.}/scripts/tick_resident.sh"
+    . "${OUTERLOOP_HOME:-.}/scripts/tick_resident.sh"
     exit $?
 fi
 
@@ -84,7 +84,7 @@ if squeue -u "$USER" --name="$RESIDENT_JOB_NAME" -h 2>/dev/null | grep -q '[0-9]
 else
 # A successor the SITE moved off our partition starves there and blocks its
 # twin through singleton; cancel it first so the top-up below requeues it.
-bash "${AUTORESEARCH_HOME:-.}/scripts/requeue_moved_successors.sh" "$JOB_NAME" "${AUTORESEARCH_PARTITION:-}" || true
+bash "${OUTERLOOP_HOME:-.}/scripts/requeue_moved_successors.sh" "$JOB_NAME" "${OUTERLOOP_PARTITION:-}" || true
 # Successors land on slots AFTER the ones already-queued jobs occupy —
 # otherwise every top-up doubles the tick rate on the next slot.
 if squeue_out=$(squeue -u "$USER" --name="$JOB_NAME" -h -t PENDING 2>/dev/null); then
@@ -111,7 +111,7 @@ while [ "$i" -le "$need" ]; do
     for attempt in 1 2 3; do
         if sbatch --dependency=singleton --begin="$begin" \
                   ${acct_arg:+"$acct_arg"} ${part_arg:+"$part_arg"} \
-                  "${AUTORESEARCH_HOME:-}/scripts/tick_chain.sbatch"; then
+                  "${OUTERLOOP_HOME:-}/scripts/tick_chain.sbatch"; then
             break
         fi
         echo "sbatch retry $attempt failed; backing off"
@@ -126,7 +126,7 @@ if [ -n "$missing" ]; then
     echo "tick misconfigured; missing:$missing" >&2
     exit 1
 fi
-LOG_DIR="$AUTORESEARCH_ROOT/logs"
+LOG_DIR="$OUTERLOOP_ROOT/logs"
 mkdir -p "$LOG_DIR" || true
 if [ -w "$LOG_DIR" ]; then
     exec >>"$LOG_DIR/tick-$(date +%Y%m%d).log" 2>&1
@@ -135,12 +135,12 @@ echo "=== tick $(date -Is) on $(hostname -s) job=${SLURM_JOB_ID:-none}"
 
 # --- 2. deploy: pull main, sync deps, read the operator's knobs (best-effort;
 #        scripts/tick_deploy.sh, sourced so its exports reach the tick) ---
-. "$AUTORESEARCH_HOME/scripts/tick_deploy.sh"
+. "$OUTERLOOP_HOME/scripts/tick_deploy.sh"
 
 # --- 3. the tick itself (scrubbed of the PAT path; sessions are scrubbed
 #        further down in the harness) ---
-cd "$AUTORESEARCH_HOME"
-# The tick keeps AUTORESEARCH_PAT_FILE: it reads GitHub (PR states, review
+cd "$OUTERLOOP_HOME"
+# The tick keeps OUTERLOOP_PAT_FILE: it reads GitHub (PR states, review
 # comments) and submits follow-up jobs. Agent sessions remain scrubbed by the
 # harness env allowlist regardless.
 # --no-sync: the deploy step above already synced (or logged its failure);
@@ -148,8 +148,8 @@ cd "$AUTORESEARCH_HOME"
 # 2026-09-03: every tick from 13:30Z died here for two hours — the tick never
 # starts. Running the venv as it stands is the "continue on the previous
 # code" the deploy promises.
-if [ "${AUTORESEARCH_DEPLOY_BROKEN:-}" = "1" ]; then
+if [ "${OUTERLOOP_DEPLOY_BROKEN:-}" = "1" ]; then
     echo "tick skipped: checkout and environment inconsistent after a failed deploy"
     exit 0  # successors are already queued; the next deploy retries
 fi
-exec uv run --no-sync python -m outerloop.tick --root "$AUTORESEARCH_ROOT"
+exec uv run --no-sync python -m outerloop.tick --root "$OUTERLOOP_ROOT"

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -39,11 +39,11 @@
 # chain has secured its successors, not break the chain silently. Required
 # vars are checked by hand instead.
 # Accept the pre-rename AUTORESEARCH_* names at the boundary for one release:
-# copy each into its OUTERLOOP_* twin (when the twin is unset) so the chain
-# reads one name. The Python side does the same on import. Removed in the
-# release after 0.1.
+# copy each into its OUTERLOOP_* twin when the twin is UNSET (an explicitly
+# empty twin is an off-switch and stays empty) so the chain reads one name.
+# The Python side does the same on import. Removed in the release after 0.1.
 for _ov in $(env | sed -n 's/^AUTORESEARCH_\([A-Z_][A-Z0-9_]*\)=.*/\1/p'); do
-    eval "[ -n \"\${OUTERLOOP_${_ov}:-}\" ] || export OUTERLOOP_${_ov}=\"\${AUTORESEARCH_${_ov}}\""
+    eval "[ -n \"\${OUTERLOOP_${_ov}+set}\" ] || export OUTERLOOP_${_ov}=\"\${AUTORESEARCH_${_ov}}\""
 done
 CADENCE_MIN="${OUTERLOOP_CADENCE_MIN:-30}"
 JOB_NAME="autoresearch-tick"

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -106,8 +106,10 @@ if [ -r "$ENV_FILE" ]; then
                   OUTERLOOP_PANEL_CODEX_KEY_FILE \
                   OUTERLOOP_PANEL_HERMES_KEY_FILE \
                   REVIEW_HERMES_REPO REVIEW_HERMES_PROVIDER; do
-            # either spelling: the canonical key or its pre-rename AUTORESEARCH_ twin
-            _line=$(grep -E "^(${_k}|AUTORESEARCH_${_k#OUTERLOOP_})=" "$ENV_FILE" 2>/dev/null | tail -1)
+            # either spelling, the canonical key first: a pre-rename AUTORESEARCH_
+            # twin counts only when the OUTERLOOP_ key is absent, whatever the order
+            _line=$(grep -E "^${_k}=" "$ENV_FILE" 2>/dev/null | tail -1)
+            [ -n "$_line" ] || _line=$(grep -E "^AUTORESEARCH_${_k#OUTERLOOP_}=" "$ENV_FILE" 2>/dev/null | tail -1)
             # PRESENCE-based, not value-based: a key set to "" in .env is a
             # live OFF-SWITCH (OUTERLOOP_PANEL="" disables the panel,
             # VERTEX_PROJECT="" reverts to API-key billing) and must override

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -6,22 +6,22 @@
 # crashes the tick, never the chain. Shared by the per-cadence chain (once per
 # job) and the resident loop (once per iteration).
 #
-# Expects: AUTORESEARCH_HOME, AUTORESEARCH_ROOT; optional AUTORESEARCH_PAT_FILE.
+# Expects: OUTERLOOP_HOME, OUTERLOOP_ROOT; optional OUTERLOOP_PAT_FILE.
 
 # --- 2. deploy: pull main with the bot PAT, sync deps (best-effort) ---
 # A tick killed mid-fetch leaves .git/*.lock files that make every later
 # deploy fail and the chain run stale code; sweep locks older than a few
 # minutes (a live git op holds one for seconds) before touching the checkout.
-bash "$AUTORESEARCH_HOME/scripts/sweep_git_locks.sh" "$AUTORESEARCH_HOME" 10 || true
+bash "$OUTERLOOP_HOME/scripts/sweep_git_locks.sh" "$OUTERLOOP_HOME" 10 || true
 # The PAT never appears in argv (argv is world-readable via /proc on shared
 # nodes): git asks for it through GIT_ASKPASS instead.
-if [ -n "${AUTORESEARCH_PAT_FILE:-}" ] && [ -r "$AUTORESEARCH_PAT_FILE" ]; then
+if [ -n "${OUTERLOOP_PAT_FILE:-}" ] && [ -r "$OUTERLOOP_PAT_FILE" ]; then
     ASKPASS=$(mktemp 2>/dev/null || echo "") && [ -n "$ASKPASS" ] && chmod 700 "$ASKPASS"
-    printf '#!/bin/sh\ncat "%s"\n' "$AUTORESEARCH_PAT_FILE" > "$ASKPASS"
-    DEPLOY_PREV=$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD 2>/dev/null || echo "")
-    if GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 git -C "$AUTORESEARCH_HOME" fetch --quiet \
+    printf '#!/bin/sh\ncat "%s"\n' "$OUTERLOOP_PAT_FILE" > "$ASKPASS"
+    DEPLOY_PREV=$(git -C "$OUTERLOOP_HOME" rev-parse HEAD 2>/dev/null || echo "")
+    if GIT_ASKPASS="$ASKPASS" GIT_TERMINAL_PROMPT=0 git -C "$OUTERLOOP_HOME" fetch --quiet \
         "https://x-access-token@github.com/outerloop-science/outerloop.git" main; then
-        git -C "$AUTORESEARCH_HOME" reset --hard --quiet FETCH_HEAD || echo "deploy: reset failed"
+        git -C "$OUTERLOOP_HOME" reset --hard --quiet FETCH_HEAD || echo "deploy: reset failed"
     else
         echo "deploy: fetch failed; running previous code"
     fi
@@ -31,8 +31,8 @@ fi
 # clusters and invisible until EDQUOT (verified on Torch — a full home took
 # down a live run). Default them under the state root (scratch-class
 # storage); explicit env wins. Submitted jobs inherit these via sbatch.
-export UV_CACHE_DIR="${UV_CACHE_DIR:-$AUTORESEARCH_ROOT/cache/uv}"
-export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-$AUTORESEARCH_ROOT/cache/apptainer}"
+export UV_CACHE_DIR="${UV_CACHE_DIR:-$OUTERLOOP_ROOT/cache/uv}"
+export APPTAINER_CACHEDIR="${APPTAINER_CACHEDIR:-$OUTERLOOP_ROOT/cache/apptainer}"
 mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
 
 # Code and environment move together or not at all. The tick runs with
@@ -40,19 +40,19 @@ mkdir -p "$UV_CACHE_DIR" "$APPTAINER_CACHEDIR" || true
 # checkout goes BACK to the commit whose environment is installed: new code
 # never runs against an old venv (a merge that adds a dependency would fail
 # at import), and the tick keeps running on the previous, consistent pair.
-# AUTORESEARCH_DEPLOY_BROKEN=1 tells the caller NOT to run the tick this
+# OUTERLOOP_DEPLOY_BROKEN=1 tells the caller NOT to run the tick this
 # iteration: the checkout and the installed environment do not match and
 # could not be made to (the rollback itself failed). Cleared on every deploy.
-AUTORESEARCH_DEPLOY_BROKEN=""
-if ! (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
-    NEW_HEAD=$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD 2>/dev/null || echo "")
+OUTERLOOP_DEPLOY_BROKEN=""
+if ! (cd "$OUTERLOOP_HOME" && uv sync --locked --quiet); then
+    NEW_HEAD=$(git -C "$OUTERLOOP_HOME" rev-parse HEAD 2>/dev/null || echo "")
     if [ -z "${DEPLOY_PREV:-}" ] || [ "$NEW_HEAD" = "$DEPLOY_PREV" ]; then
         # nothing was fetched: the environment is whatever the last good
         # deploy installed, and the checkout still matches it
         echo "deploy: uv sync failed; environment unchanged"
     elif [ -n "$NEW_HEAD" ] \
-        && [ "$(git -C "$AUTORESEARCH_HOME" rev-parse "$DEPLOY_PREV":uv.lock 2>/dev/null)" \
-           = "$(git -C "$AUTORESEARCH_HOME" rev-parse HEAD:uv.lock 2>/dev/null)" ]; then
+        && [ "$(git -C "$OUTERLOOP_HOME" rev-parse "$DEPLOY_PREV":uv.lock 2>/dev/null)" \
+           = "$(git -C "$OUTERLOOP_HOME" rev-parse HEAD:uv.lock 2>/dev/null)" ]; then
         # the lockfile did not change between the old and new commit, so the
         # installed environment already satisfies the new code: run it. This
         # is the common case under quota exhaustion — an ordinary merge does
@@ -65,20 +65,20 @@ if ! (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
         # and reinstall ITS environment. If that also fails (the quota is
         # still full), the pair cannot be made consistent — skip the tick
         # until a deploy succeeds rather than run on a half-synced venv.
-        if git -C "$AUTORESEARCH_HOME" reset --hard --quiet "$DEPLOY_PREV" \
-           && (cd "$AUTORESEARCH_HOME" && uv sync --locked --quiet); then
+        if git -C "$OUTERLOOP_HOME" reset --hard --quiet "$DEPLOY_PREV" \
+           && (cd "$OUTERLOOP_HOME" && uv sync --locked --quiet); then
             echo "deploy: uv sync failed; back on $DEPLOY_PREV with its environment"
         else
             echo "deploy: uv sync failed and the environment could not be made consistent; tick skipped until a deploy succeeds"
-            AUTORESEARCH_DEPLOY_BROKEN=1
+            OUTERLOOP_DEPLOY_BROKEN=1
         fi
     fi
 fi
-export AUTORESEARCH_DEPLOY_BROKEN
+export OUTERLOOP_DEPLOY_BROKEN
 
 # --- config knobs: read the config-driven AUTHOR knobs from the operator .env so
 # live config changes need no chain restart. These are where
-# AUTORESEARCH_AUTHOR_BACKEND/_MODEL and the per-backend key files live; the
+# OUTERLOOP_AUTHOR_BACKEND/_MODEL and the per-backend key files live; the
 # config-driven climb/followup default from them and the tick preflights them.
 #
 # We do NOT source .env: sourcing would execute it and let it set ANY variable
@@ -94,22 +94,22 @@ if [ -r "$ENV_FILE" ]; then
     perms=$(stat -c "%a" "$ENV_FILE" 2>/dev/null || echo 777)
     owner=$(stat -c "%u" "$ENV_FILE" 2>/dev/null || echo -1)
     if [ "$owner" = "$(id -u)" ] && [ $((8#$perms & 8#022)) -eq 0 ]; then
-        for _k in AUTORESEARCH_AUTHOR_BACKEND AUTORESEARCH_AUTHOR_MODEL \
-                  AUTORESEARCH_CODEX_BIN AUTORESEARCH_CODEX_KEY_FILE \
-                  AUTORESEARCH_CLAUDE_KEY_FILE AUTORESEARCH_HARNESS_KEY_FILE \
-                  AUTORESEARCH_VERTEX_PROJECT AUTORESEARCH_VERTEX_REGION \
-                  AUTORESEARCH_VERTEX_ADC \
-                  AUTORESEARCH_TARGET \
-                  AUTORESEARCH_GITHUB_APP_FILE AUTORESEARCH_BOT_LOGIN AUTORESEARCH_BOT_ALIASES \
-                  AUTORESEARCH_GPU_PARTITION AUTORESEARCH_GPU_ACCOUNT \
-                  AUTORESEARCH_PANEL AUTORESEARCH_PANEL_KEY_FILE \
-                  AUTORESEARCH_PANEL_CODEX_KEY_FILE \
-                  AUTORESEARCH_PANEL_HERMES_KEY_FILE \
+        for _k in OUTERLOOP_AUTHOR_BACKEND OUTERLOOP_AUTHOR_MODEL \
+                  OUTERLOOP_CODEX_BIN OUTERLOOP_CODEX_KEY_FILE \
+                  OUTERLOOP_CLAUDE_KEY_FILE OUTERLOOP_HARNESS_KEY_FILE \
+                  OUTERLOOP_VERTEX_PROJECT OUTERLOOP_VERTEX_REGION \
+                  OUTERLOOP_VERTEX_ADC \
+                  OUTERLOOP_TARGET \
+                  OUTERLOOP_GITHUB_APP_FILE OUTERLOOP_BOT_LOGIN OUTERLOOP_BOT_ALIASES \
+                  OUTERLOOP_GPU_PARTITION OUTERLOOP_GPU_ACCOUNT \
+                  OUTERLOOP_PANEL OUTERLOOP_PANEL_KEY_FILE \
+                  OUTERLOOP_PANEL_CODEX_KEY_FILE \
+                  OUTERLOOP_PANEL_HERMES_KEY_FILE \
                   REVIEW_HERMES_REPO REVIEW_HERMES_PROVIDER; do
-            # either spelling: the canonical key or its public OUTERLOOP_ twin
-            _line=$(grep -E "^(${_k}|OUTERLOOP_${_k#AUTORESEARCH_})=" "$ENV_FILE" 2>/dev/null | tail -1)
+            # either spelling: the canonical key or its pre-rename AUTORESEARCH_ twin
+            _line=$(grep -E "^(${_k}|AUTORESEARCH_${_k#OUTERLOOP_})=" "$ENV_FILE" 2>/dev/null | tail -1)
             # PRESENCE-based, not value-based: a key set to "" in .env is a
-            # live OFF-SWITCH (AUTORESEARCH_PANEL="" disables the panel,
+            # live OFF-SWITCH (OUTERLOOP_PANEL="" disables the panel,
             # VERTEX_PROJECT="" reverts to API-key billing) and must override
             # an inherited chain value; an ABSENT key changes nothing.
             if [ -n "$_line" ]; then
@@ -131,18 +131,18 @@ fi
 # bind-mounts the binary into every judge container). Best-effort: a failure
 # here must never break the chain — the climb will report a missing codex
 # clearly if it comes to that.
-case "${AUTORESEARCH_AUTHOR_BACKEND:-}:${AUTORESEARCH_PANEL:-}" in
+case "${OUTERLOOP_AUTHOR_BACKEND:-}:${OUTERLOOP_PANEL:-}" in
     codex:*|*:*codex*)
-        bash "$AUTORESEARCH_HOME/scripts/install_codex.sh" || echo "deploy: codex install failed"
+        bash "$OUTERLOOP_HOME/scripts/install_codex.sh" || echo "deploy: codex install failed"
         ;;
 esac
-case "${AUTORESEARCH_PANEL:-}" in
+case "${OUTERLOOP_PANEL:-}" in
     *hermes*)
         # the default install location IS the default config: exporting it
         # here connects the provisioned clone to the preflight/climb without
         # requiring the operator to name a path they didn't choose
         export REVIEW_HERMES_REPO="${REVIEW_HERMES_REPO:-$HOME/hermes-agent}"
-        bash "$AUTORESEARCH_HOME/scripts/install_hermes.sh" "$REVIEW_HERMES_REPO" \
+        bash "$OUTERLOOP_HOME/scripts/install_hermes.sh" "$REVIEW_HERMES_REPO" \
             || echo "deploy: hermes install failed"
         ;;
 esac

--- a/scripts/tick_resident.sh
+++ b/scripts/tick_resident.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # The resident tick (docs/design/resident-tick.md), SOURCED by tick_chain.sbatch
-# when AUTORESEARCH_RESIDENT=1: one long-lived job that loops
+# when OUTERLOOP_RESIDENT=1: one long-lived job that loops
 #   deploy -> one tick as a child under a hard timeout -> sleep to the next slot
 # and keeps exactly ONE successor queued, dependent on its own end
 # (afterany:self + singleton), so the chain needs a handful of scheduling
@@ -10,20 +10,20 @@
 # batch scripts at submission). The tick itself is unchanged: records,
 # leases, markers and the coalescing guard make a late or repeated tick safe.
 #
-# Knobs (chain environment): AUTORESEARCH_RESIDENT_MINUTES (walltime the job
-# was started with; default 360 = cpu_short's maximum), AUTORESEARCH_CADENCE_MIN,
-# AUTORESEARCH_TICK_TIMEOUT (default 15m), AUTORESEARCH_RESIDENT_MARGIN_S
+# Knobs (chain environment): OUTERLOOP_RESIDENT_MINUTES (walltime the job
+# was started with; default 360 = cpu_short's maximum), OUTERLOOP_CADENCE_MIN,
+# OUTERLOOP_TICK_TIMEOUT (default 15m), OUTERLOOP_RESIDENT_MARGIN_S
 # (stop this many seconds before walltime; default 1200),
-# AUTORESEARCH_RESIDENT_CADENCE_S (tests: override the cadence in seconds).
+# OUTERLOOP_RESIDENT_CADENCE_S (tests: override the cadence in seconds).
 
-resident_minutes="${AUTORESEARCH_RESIDENT_MINUTES:-360}"
-cadence_s="${AUTORESEARCH_RESIDENT_CADENCE_S:-$((${AUTORESEARCH_CADENCE_MIN:-30} * 60))}"
-tick_timeout="${AUTORESEARCH_TICK_TIMEOUT:-15m}"
-margin_s="${AUTORESEARCH_RESIDENT_MARGIN_S:-1200}"
-retry_s="${AUTORESEARCH_RESIDENT_RETRY_S:-20}"  # backoff unit for submit retries (tests: 0)
+resident_minutes="${OUTERLOOP_RESIDENT_MINUTES:-360}"
+cadence_s="${OUTERLOOP_RESIDENT_CADENCE_S:-$((${OUTERLOOP_CADENCE_MIN:-30} * 60))}"
+tick_timeout="${OUTERLOOP_TICK_TIMEOUT:-15m}"
+margin_s="${OUTERLOOP_RESIDENT_MARGIN_S:-1200}"
+retry_s="${OUTERLOOP_RESIDENT_RETRY_S:-20}"  # backoff unit for submit retries (tests: 0)
 self="${SLURM_JOB_ID:-}"
-shim="$AUTORESEARCH_HOME/scripts/tick_chain.sbatch"
-sentinel="$AUTORESEARCH_ROOT/PAUSE"
+shim="$OUTERLOOP_HOME/scripts/tick_chain.sbatch"
+sentinel="$OUTERLOOP_ROOT/PAUSE"
 
 epoch_of() { date -d "$1" +%s 2>/dev/null || date -j -f %Y-%m-%dT%H:%M:%S "$1" +%s 2>/dev/null || echo ""; }
 
@@ -44,9 +44,9 @@ submit_successor() {
     # Account and partition are optional (unset -> Slurm's defaults); pass
     # them only when set.
     local acct_arg=""
-    [ -n "${AUTORESEARCH_ACCOUNT:-}" ] && acct_arg="--account=${AUTORESEARCH_ACCOUNT}"
+    [ -n "${OUTERLOOP_ACCOUNT:-}" ] && acct_arg="--account=${OUTERLOOP_ACCOUNT}"
     local part_arg=""
-    [ -n "${AUTORESEARCH_PARTITION:-}" ] && part_arg="--partition=${AUTORESEARCH_PARTITION}"
+    [ -n "${OUTERLOOP_PARTITION:-}" ] && part_arg="--partition=${OUTERLOOP_PARTITION}"
     local out="" attempt
     for attempt in 1 2 3; do
         if out=$(sbatch --parsable --dependency="$dep" --time="$resident_minutes" \
@@ -74,7 +74,7 @@ shim_checksum() { cksum "$shim" 2>/dev/null | cut -d' ' -f1; }
 
 successor=""
 successor_sum=""  # the shim checksum the queued successor was submitted under
-LOG_DIR="$AUTORESEARCH_ROOT/logs"
+LOG_DIR="$OUTERLOOP_ROOT/logs"
 mkdir -p "$LOG_DIR" || true
 while :; do
     # the log file rolls daily: reopen it every iteration
@@ -118,7 +118,7 @@ while :; do
         fi
     fi
     # deploy + operator knobs, fresh every iteration (exports reach the tick)
-    . "$AUTORESEARCH_HOME/scripts/tick_deploy.sh"
+    . "$OUTERLOOP_HOME/scripts/tick_deploy.sh"
     new_sum=$(shim_checksum)
     if [ -n "$successor" ] && [ "$new_sum" != "$successor_sum" ]; then
         # Slurm spooled the successor's script at submission: resubmit so
@@ -141,11 +141,11 @@ while :; do
         fi
     fi
     echo "=== tick $(date -Is) on $(hostname -s) job=${self:-none} (resident)"
-    if [ "${AUTORESEARCH_DEPLOY_BROKEN:-}" = "1" ]; then
+    if [ "${OUTERLOOP_DEPLOY_BROKEN:-}" = "1" ]; then
         echo "$(date -u +%FT%TZ) tick skipped: checkout and environment inconsistent after a failed deploy (resident)"
     else
-    (cd "$AUTORESEARCH_HOME" && timeout --kill-after=60s "$tick_timeout" \
-        uv run --no-sync python -m outerloop.tick --root "$AUTORESEARCH_ROOT")
+    (cd "$OUTERLOOP_HOME" && timeout --kill-after=60s "$tick_timeout" \
+        uv run --no-sync python -m outerloop.tick --root "$OUTERLOOP_ROOT")
     fi
     rc=$?
     [ "$rc" -ne 0 ] && echo "resident: tick exited $rc; the loop continues"

--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -6,13 +6,13 @@ __version__ = "0.1.0.dev1"
 
 
 def _bridge_legacy_env() -> None:
-    """Accept the new `OUTERLOOP_*` names at the process boundary: copy each into
-    its `AUTORESEARCH_*` twin when the twin is unset, so the kernel's internals —
-    which still read `AUTORESEARCH_*` during the rename — see one name. The chain
-    scripts do the same in shell. Removed with the final internal flip."""
+    """Accept the pre-rename `AUTORESEARCH_*` names at the process boundary for
+    one release: copy each into its `OUTERLOOP_*` twin when the twin is unset,
+    so the kernel reads one name. The chain scripts do the same in shell.
+    Removed in the release after 0.1."""
     for key, value in list(os.environ.items()):
-        if key.startswith("OUTERLOOP_"):
-            os.environ.setdefault("AUTORESEARCH_" + key[len("OUTERLOOP_") :], value)
+        if key.startswith("AUTORESEARCH_"):
+            os.environ.setdefault("OUTERLOOP_" + key[len("AUTORESEARCH_") :], value)
 
 
 _bridge_legacy_env()

--- a/src/outerloop/appauth.py
+++ b/src/outerloop/appauth.py
@@ -3,7 +3,7 @@
 `AppInstallationTokenProvider` satisfies the `TokenProvider` protocol used
 throughout `github.py`. Role CLIs construct bot auth through
 `resolve_bot_auth`, which selects this provider when an App config file is
-given (`--github-app-file` / `AUTORESEARCH_GITHUB_APP_FILE`) and falls back
+given (`--github-app-file` / `OUTERLOOP_GITHUB_APP_FILE`) and falls back
 to the PAT file otherwise — the cutover flag, revertible by unsetting the
 env. Each `token()` mints a short-lived JWT (RS256, signed by the App
 private key), exchanges it for a ~1h installation token scoped to the

--- a/src/outerloop/appmanifest.py
+++ b/src/outerloop/appmanifest.py
@@ -14,7 +14,7 @@ and GitHub redirects back to that page with a one-time code the page displays.
 The adopter pastes the code here; we exchange it for the app id + key, write
 `github_app.<slug>.json` + the PEM (both 0600), help install the App, and capture
 the installation id. The written files are what `resolve_bot_auth` reads via
-`AUTORESEARCH_GITHUB_APP_FILE`, the same path `outerloop start` uses.
+`OUTERLOOP_GITHUB_APP_FILE`, the same path `outerloop start` uses.
 """
 
 from __future__ import annotations

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -110,18 +110,19 @@ def resolve_author_key_file(backend: str, explicit: str = "") -> str:
     config choice, not a key swap, and an in-flight run of either backend can
     still be woken/serviced after a fleet flip. An explicit path always wins;
     otherwise the per-backend env var, then the default path. For claude the
-    legacy spellings (`AUTORESEARCH_HARNESS_KEY_FILE`, `harness_key`) are still
+    legacy spellings (`AUTORESEARCH_HARNESS_KEY_FILE`, read through its bridged
+    `OUTERLOOP_` twin, and `harness_key`) are still
     honored, so a machine set up before the rename keeps working; the new name
     wins when both exist. The result is always ~-expanded, so every caller gets
     a real path (an env value like "~/.config/..." must not reach the token
     provider verbatim)."""
     if not explicit:
         if backend == "codex":
-            explicit = os.environ.get("AUTORESEARCH_CODEX_KEY_FILE") or CODEX_KEY_DEFAULT
+            explicit = os.environ.get("OUTERLOOP_CODEX_KEY_FILE") or CODEX_KEY_DEFAULT
         else:
             explicit = (
-                os.environ.get("AUTORESEARCH_CLAUDE_KEY_FILE")
-                or os.environ.get("AUTORESEARCH_HARNESS_KEY_FILE")
+                os.environ.get("OUTERLOOP_CLAUDE_KEY_FILE")
+                or os.environ.get("OUTERLOOP_HARNESS_KEY_FILE")
                 or ""
             )
             if not explicit:
@@ -140,14 +141,14 @@ def codex_author_config_error(backend: str, model: str, image: str) -> str:
     a unit and never a fleet backend against a run's model. codex writes+executes,
     so it must be contained (--image) and needs a non-claude model."""
     if backend not in ("claude", "codex"):
-        # a typo'd AUTORESEARCH_AUTHOR_BACKEND passes the env DEFAULT silently
+        # a typo'd OUTERLOOP_AUTHOR_BACKEND passes the env DEFAULT silently
         # (argparse validates the flag, not its default) and the climb rejects it
         # at build_harness — catch it on the tick host so a claimed intake
         # issue never strands on it
         return f"unknown author backend {backend!r} (expected 'claude' or 'codex')"
     if backend == "claude":
         # symmetric to the codex check: a claude harness 404s on a non-claude
-        # model (e.g. AUTORESEARCH_AUTHOR_MODEL left on a codex id while the
+        # model (e.g. OUTERLOOP_AUTHOR_MODEL left on a codex id while the
         # backend is claude) — catch that misconfig before spend
         if model and not model.startswith("claude"):
             return f"author-backend claude needs a claude model (got {model!r})"
@@ -2171,7 +2172,7 @@ def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str
         if backend == "codex":
             lens_key = _judge_lens_key(
                 backend="codex",
-                key_file_env="AUTORESEARCH_PANEL_CODEX_KEY_FILE",
+                key_file_env="OUTERLOOP_PANEL_CODEX_KEY_FILE",
                 author_backend="codex",
                 claude_panel_path=claude_panel_path,
                 image=args.image,
@@ -2185,7 +2186,7 @@ def _panel_lenses_from_args(args: Any) -> tuple[tuple[PanelLens, ...], tuple[str
             # separate against the codex author key.
             lens_key = _judge_lens_key(
                 backend="hermes",
-                key_file_env="AUTORESEARCH_PANEL_HERMES_KEY_FILE",
+                key_file_env="OUTERLOOP_PANEL_HERMES_KEY_FILE",
                 author_backend="codex",
                 claude_panel_path=claude_panel_path,
                 image=args.image,
@@ -3143,22 +3144,22 @@ def main() -> int:
     )
     parser.add_argument("--base-branch", default="main")
     # All three default from the chain env the tick sets on the climb job, so
-    # a contained run with AUTORESEARCH_{IMAGE,ACCOUNT,PARTITION} set selects
+    # a contained run with OUTERLOOP_{IMAGE,ACCOUNT,PARTITION} set selects
     # dispatched measurement without extra flags. Only the image is required
     # for dispatch (it also contains the session + inline eval); without it,
     # measurement stays inline regardless of the benchmark's eval hint. Empty
     # account/partition use Slurm's defaults.
     parser.add_argument(
         "--image",
-        default=os.environ.get("AUTORESEARCH_IMAGE", ""),
+        default=os.environ.get("OUTERLOOP_IMAGE", ""),
         help="apptainer image for session+eval",
     )
-    parser.add_argument("--account", default=os.environ.get("AUTORESEARCH_ACCOUNT", ""))
-    parser.add_argument("--partition", default=os.environ.get("AUTORESEARCH_PARTITION", ""))
+    parser.add_argument("--account", default=os.environ.get("OUTERLOOP_ACCOUNT", ""))
+    parser.add_argument("--partition", default=os.environ.get("OUTERLOOP_PARTITION", ""))
     # the GPU lane for benchmarks with `gpus > 0` (evals + author launches);
     # empty = this deployment cannot place GPU jobs
-    parser.add_argument("--gpu-partition", default=os.environ.get("AUTORESEARCH_GPU_PARTITION", ""))
-    parser.add_argument("--gpu-account", default=os.environ.get("AUTORESEARCH_GPU_ACCOUNT", ""))
+    parser.add_argument("--gpu-partition", default=os.environ.get("OUTERLOOP_GPU_PARTITION", ""))
+    parser.add_argument("--gpu-account", default=os.environ.get("OUTERLOOP_GPU_ACCOUNT", ""))
     parser.add_argument(
         "--uncontained",
         action="store_true",
@@ -3168,21 +3169,19 @@ def main() -> int:
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument(
         "--codex-bin",
-        default=os.path.expanduser(
-            os.environ.get("AUTORESEARCH_CODEX_BIN") or "~/.local/bin/codex"
-        ),
+        default=os.path.expanduser(os.environ.get("OUTERLOOP_CODEX_BIN") or "~/.local/bin/codex"),
         help="host codex binary for the codex author; bind-mounted into apptainer "
         "(must be an absolute path).",
     )
     parser.add_argument(
-        "--model", default=os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5"
+        "--model", default=os.environ.get("OUTERLOOP_AUTHOR_MODEL") or "claude-opus-5"
     )
     parser.add_argument(
         "--author-backend",
         choices=("claude", "codex"),
-        default=os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude",
+        default=os.environ.get("OUTERLOOP_AUTHOR_BACKEND") or "claude",
         help="agent backend for the author/editor role (config-driven: default "
-        "from AUTORESEARCH_AUTHOR_BACKEND). codex runs contained (apptainer + "
+        "from OUTERLOOP_AUTHOR_BACKEND). codex runs contained (apptainer + "
         "--sandbox danger-full-access) and REQUIRES --image and a codex/openai "
         "--model (e.g. gpt-5.6-terra).",
     )
@@ -3226,7 +3225,7 @@ def main() -> int:
     parser.add_argument("--pat-file", default=str(CONFIG_DIR / "bot_pat"))
     parser.add_argument(
         "--github-app-file",
-        default=os.environ.get("AUTORESEARCH_GITHUB_APP_FILE", ""),
+        default=os.environ.get("OUTERLOOP_GITHUB_APP_FILE", ""),
         help="GitHub App config (JSON: app_id, installation_id, private_key); "
         "when set, installation tokens replace the PAT",
     )
@@ -3234,7 +3233,7 @@ def main() -> int:
         "--key-file",
         default="",
         help="author key file; default resolves per backend (config-driven): "
-        "AUTORESEARCH_CLAUDE_KEY_FILE for claude, AUTORESEARCH_CODEX_KEY_FILE for codex",
+        "OUTERLOOP_CLAUDE_KEY_FILE for claude, OUTERLOOP_CODEX_KEY_FILE for codex",
     )
     parser.add_argument("--issue", type=int, default=0)
     parser.add_argument(

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -89,20 +89,26 @@ def env_file_values(path: Path = ENV_FILE, keys: tuple[str, ...] = START_KEYS) -
     except OSError as e:
         raise StartError(f"cannot read {path}: {e}") from None
     out: dict[str, str] = {}
+    canonical: set[str] = set()  # keys set by their OUTERLOOP_ spelling
     for raw in text.splitlines():
         line = raw.rstrip("\r").strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
         key, value = line.split("=", 1)
         key = key.strip()
-        if key.startswith("AUTORESEARCH_"):  # the pre-rename name, accepted for one release
+        legacy = key.startswith("AUTORESEARCH_")  # the pre-rename name, one more release
+        if legacy:
             key = "OUTERLOOP_" + key[len("AUTORESEARCH_") :]
         if key not in keys:
             continue
+        if legacy and key in canonical:
+            continue  # the OUTERLOOP_ spelling wins whatever the file order
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
             value = value[1:-1]
         out[key] = value
+        if not legacy:
+            canonical.add(key)
     return out
 
 

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -2,7 +2,7 @@
 
 With `sbatch` on PATH it submits the resident tick
 (docs/design/resident-tick.md) and returns; without it, or with
-AUTORESEARCH_COMPUTE=local, it runs the local loop in the foreground.
+OUTERLOOP_COMPUTE=local, it runs the local loop in the foreground.
 Settings come from flags, then the process environment, then
 ~/.config/outerloop/.env, read once here at launch. The running chain
 never takes identity or placement from that file (tick_deploy.sh reads an
@@ -30,37 +30,37 @@ ENV_FILE = paths.ENV_FILE  # ~/.config/outerloop/.env, or the pre-rename dir (se
 
 # What start itself decides from: mode, placement, root, cadence, walltime.
 START_KEYS = (
-    "AUTORESEARCH_COMPUTE",
-    "AUTORESEARCH_ROOT",
-    "AUTORESEARCH_ACCOUNT",
-    "AUTORESEARCH_PARTITION",
-    "AUTORESEARCH_CADENCE_MIN",
-    "AUTORESEARCH_RESIDENT_MINUTES",
-    "AUTORESEARCH_PAT_FILE",
+    "OUTERLOOP_COMPUTE",
+    "OUTERLOOP_ROOT",
+    "OUTERLOOP_ACCOUNT",
+    "OUTERLOOP_PARTITION",
+    "OUTERLOOP_CADENCE_MIN",
+    "OUTERLOOP_RESIDENT_MINUTES",
+    "OUTERLOOP_PAT_FILE",
 )
 # The author knobs the chain's deploy step exports from .env every tick. The
 # local loop has no deploy step, so start exports them once at launch; a test
 # keeps this list identical to tick_deploy.sh's.
 TICK_ENV_KEYS = (
-    "AUTORESEARCH_AUTHOR_BACKEND",
-    "AUTORESEARCH_AUTHOR_MODEL",
-    "AUTORESEARCH_CODEX_BIN",
-    "AUTORESEARCH_CODEX_KEY_FILE",
-    "AUTORESEARCH_CLAUDE_KEY_FILE",
-    "AUTORESEARCH_HARNESS_KEY_FILE",
-    "AUTORESEARCH_VERTEX_PROJECT",
-    "AUTORESEARCH_VERTEX_REGION",
-    "AUTORESEARCH_VERTEX_ADC",
-    "AUTORESEARCH_TARGET",
-    "AUTORESEARCH_GITHUB_APP_FILE",
-    "AUTORESEARCH_BOT_LOGIN",
-    "AUTORESEARCH_BOT_ALIASES",
-    "AUTORESEARCH_GPU_PARTITION",
-    "AUTORESEARCH_GPU_ACCOUNT",
-    "AUTORESEARCH_PANEL",
-    "AUTORESEARCH_PANEL_KEY_FILE",
-    "AUTORESEARCH_PANEL_CODEX_KEY_FILE",
-    "AUTORESEARCH_PANEL_HERMES_KEY_FILE",
+    "OUTERLOOP_AUTHOR_BACKEND",
+    "OUTERLOOP_AUTHOR_MODEL",
+    "OUTERLOOP_CODEX_BIN",
+    "OUTERLOOP_CODEX_KEY_FILE",
+    "OUTERLOOP_CLAUDE_KEY_FILE",
+    "OUTERLOOP_HARNESS_KEY_FILE",
+    "OUTERLOOP_VERTEX_PROJECT",
+    "OUTERLOOP_VERTEX_REGION",
+    "OUTERLOOP_VERTEX_ADC",
+    "OUTERLOOP_TARGET",
+    "OUTERLOOP_GITHUB_APP_FILE",
+    "OUTERLOOP_BOT_LOGIN",
+    "OUTERLOOP_BOT_ALIASES",
+    "OUTERLOOP_GPU_PARTITION",
+    "OUTERLOOP_GPU_ACCOUNT",
+    "OUTERLOOP_PANEL",
+    "OUTERLOOP_PANEL_KEY_FILE",
+    "OUTERLOOP_PANEL_CODEX_KEY_FILE",
+    "OUTERLOOP_PANEL_HERMES_KEY_FILE",
     "REVIEW_HERMES_REPO",
     "REVIEW_HERMES_PROVIDER",
 )
@@ -95,8 +95,8 @@ def env_file_values(path: Path = ENV_FILE, keys: tuple[str, ...] = START_KEYS) -
             continue
         key, value = line.split("=", 1)
         key = key.strip()
-        if key.startswith("OUTERLOOP_"):  # the public name; `keys` are canonical
-            key = "AUTORESEARCH_" + key[len("OUTERLOOP_") :]
+        if key.startswith("AUTORESEARCH_"):  # the pre-rename name, accepted for one release
+            key = "OUTERLOOP_" + key[len("AUTORESEARCH_") :]
         if key not in keys:
             continue
         value = value.strip()
@@ -124,19 +124,19 @@ class StartPlan:
         reads as "whichever frees up first") without corrupting the export
         delimiter. start() merges these into the environment it hands sbatch."""
         env = {
-            "AUTORESEARCH_RESIDENT": "1",
-            "AUTORESEARCH_HOME": str(self.home),
-            "AUTORESEARCH_ROOT": str(self.root),
-            "AUTORESEARCH_RESIDENT_MINUTES": str(self.resident_minutes),  # successors reuse it
+            "OUTERLOOP_RESIDENT": "1",
+            "OUTERLOOP_HOME": str(self.home),
+            "OUTERLOOP_ROOT": str(self.root),
+            "OUTERLOOP_RESIDENT_MINUTES": str(self.resident_minutes),  # successors reuse it
         }
         if self.account:
-            env["AUTORESEARCH_ACCOUNT"] = self.account
+            env["OUTERLOOP_ACCOUNT"] = self.account
         if self.partition:
-            env["AUTORESEARCH_PARTITION"] = self.partition
+            env["OUTERLOOP_PARTITION"] = self.partition
         if self.cadence_min:
-            env["AUTORESEARCH_CADENCE_MIN"] = self.cadence_min
+            env["OUTERLOOP_CADENCE_MIN"] = self.cadence_min
         if self.pat_file:
-            env["AUTORESEARCH_PAT_FILE"] = self.pat_file
+            env["OUTERLOOP_PAT_FILE"] = self.pat_file
         return env
 
     def command(self) -> list[str]:
@@ -170,7 +170,7 @@ def _setting(key: str, flag: str, environ: dict[str, str], from_file: dict[str, 
 
 def _home(environ: dict[str, str], cwd: Path, *, local: bool, root: Path) -> Path:
     """The directory the loop runs from. On Slurm it must be a source
-    checkout (AUTORESEARCH_HOME, else the current directory): the chain
+    checkout (OUTERLOOP_HOME, else the current directory): the chain
     deploys from it and every job runs from a flight snapshot of its HEAD.
     The local loop has no deploy step and runs the installed package, so it
     uses a checkout when one is at hand and otherwise a `home` directory
@@ -198,10 +198,10 @@ def plan_start(
     sbatch_on_path: bool,
     cwd: Path,
 ) -> StartPlan:
-    compute = _setting("AUTORESEARCH_COMPUTE", "local" if local else "", environ, from_file)
+    compute = _setting("OUTERLOOP_COMPUTE", "local" if local else "", environ, from_file)
     mode = "local" if compute.strip().lower() == "local" or not sbatch_on_path else "slurm"
-    root_s = _setting("AUTORESEARCH_ROOT", root, environ, from_file)
-    cadence = _setting("AUTORESEARCH_CADENCE_MIN", "", environ, from_file)
+    root_s = _setting("OUTERLOOP_ROOT", root, environ, from_file)
+    cadence = _setting("OUTERLOOP_CADENCE_MIN", "", environ, from_file)
     if cadence:
         # the chain divides by it and the loop sleeps on it: a bad value would
         # only surface after the job started
@@ -211,12 +211,12 @@ def plan_start(
             cadence_ok = False
         if not cadence_ok:
             raise StartError(
-                f"AUTORESEARCH_CADENCE_MIN must be a positive number of minutes, got {cadence!r}"
+                f"OUTERLOOP_CADENCE_MIN must be a positive number of minutes, got {cadence!r}"
             )
-    pat = _setting("AUTORESEARCH_PAT_FILE", "", environ, from_file)
+    pat = _setting("OUTERLOOP_PAT_FILE", "", environ, from_file)
     # Slurm runs from a checkout; the local loop runs the installed package
     # and needs only a directory (the launch lanes and GitHub servicing
-    # switch off without AUTORESEARCH_HOME, so one is always set)
+    # switch off without OUTERLOOP_HOME, so one is always set)
     local_root = Path(root_s).expanduser() if root_s else DEFAULT_LOCAL_ROOT
     home = _home(environ, cwd, local=(mode == "local"), root=local_root)
     if mode == "local":
@@ -230,21 +230,22 @@ def plan_start(
     if not root_s:
         raise StartError(
             "Slurm mode needs the state root on the shared filesystem: "
-            "--root, AUTORESEARCH_ROOT, or AUTORESEARCH_ROOT= in ~/.config/outerloop/.env"
+            "--root, OUTERLOOP_ROOT in the environment, or OUTERLOOP_ROOT= in "
+            "~/.config/outerloop/.env"
         )
-    acc = _setting("AUTORESEARCH_ACCOUNT", account, environ, from_file)
-    part = _setting("AUTORESEARCH_PARTITION", partition, environ, from_file)
+    acc = _setting("OUTERLOOP_ACCOUNT", account, environ, from_file)
+    part = _setting("OUTERLOOP_PARTITION", partition, environ, from_file)
     # Account and partition are both optional: left unset, Slurm bills the
     # caller's default association and places the job on its default partition.
-    minutes_s = _setting("AUTORESEARCH_RESIDENT_MINUTES", "", environ, from_file)
+    minutes_s = _setting("OUTERLOOP_RESIDENT_MINUTES", "", environ, from_file)
     try:
         minutes = int(minutes_s) if minutes_s else DEFAULT_RESIDENT_MINUTES
     except ValueError:
         raise StartError(
-            f"AUTORESEARCH_RESIDENT_MINUTES must be a whole number of minutes, got {minutes_s!r}"
+            f"OUTERLOOP_RESIDENT_MINUTES must be a whole number of minutes, got {minutes_s!r}"
         ) from None
     if minutes <= 0:
-        raise StartError("AUTORESEARCH_RESIDENT_MINUTES must be positive")
+        raise StartError("OUTERLOOP_RESIDENT_MINUTES must be positive")
     # These ride the inherited environment (sbatch --export=ALL), so a comma is
     # safe now (a multi-partition `a,b` is valid) — only a newline would corrupt
     # the environment or the sbatch argv.
@@ -337,14 +338,14 @@ def start(args: argparse.Namespace) -> int:
         for key, value in values.items():
             if key in TICK_ENV_KEYS:
                 env.setdefault(key, value)
-        env["AUTORESEARCH_COMPUTE"] = "local"
-        env["AUTORESEARCH_ROOT"] = str(plan.root)
-        env["AUTORESEARCH_HOME"] = str(plan.home)
+        env["OUTERLOOP_COMPUTE"] = "local"
+        env["OUTERLOOP_ROOT"] = str(plan.root)
+        env["OUTERLOOP_HOME"] = str(plan.home)
         plan.home.mkdir(parents=True, exist_ok=True)  # <root>/home when there is no checkout
         if plan.cadence_min:
-            env["AUTORESEARCH_CADENCE_MIN"] = plan.cadence_min
+            env["OUTERLOOP_CADENCE_MIN"] = plan.cadence_min
         if plan.pat_file:
-            env["AUTORESEARCH_PAT_FILE"] = plan.pat_file
+            env["OUTERLOOP_PAT_FILE"] = plan.pat_file
         print(
             f"local loop: state in {plan.root}; Ctrl-C stops it, the records resume it",
             file=sys.stderr,
@@ -406,12 +407,22 @@ def start(args: argparse.Namespace) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
+    from outerloop import __version__
+
     parser = argparse.ArgumentParser(
-        prog="outerloop", description="autonomous research agents in an outer loop"
+        prog="outerloop",
+        description="autonomous research agents in an outer loop",
+        epilog="Run `outerloop init` once, then `outerloop start`. Settings live in "
+        "~/.config/outerloop/.env; the install guide is docs/install.md.",
     )
+    parser.add_argument("--version", action="version", version=f"outerloop {__version__}")
     sub = parser.add_subparsers(dest="command", required=True)
     p = sub.add_parser(
-        "start", help="start the loop: the resident tick on Slurm, the local loop elsewhere"
+        "start",
+        help="start the loop: the resident tick on Slurm, the local loop elsewhere",
+        description="Submit the resident tick to Slurm, or run the local loop in the "
+        "foreground where there is no sbatch. Every flag defaults from "
+        "~/.config/outerloop/.env, written by `outerloop init`.",
     )
     p.add_argument(
         "--root", help="state root (shared filesystem on Slurm; default ~/.autoresearch locally)"

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -152,12 +152,12 @@ class Compute(Protocol):
 
 
 def local_mode() -> bool:
-    """AUTORESEARCH_COMPUTE=local selects the monolith: every job a
+    """OUTERLOOP_COMPUTE=local selects the monolith: every job a
     synchronous subprocess of the caller (docs/design/onboarding.md) — the
     zero-cluster on-ramp and the paper's serialized-baseline ablation. Any
     other value (or none) is Slurm. This helper is the only reader of the
     env var, so mode checks cannot drift."""
-    return os.environ.get("AUTORESEARCH_COMPUTE", "").strip().lower() == "local"
+    return os.environ.get("OUTERLOOP_COMPUTE", "").strip().lower() == "local"
 
 
 def compute_from_env() -> SlurmCompute | LocalCompute:
@@ -319,7 +319,7 @@ def _local_state_dir() -> Path | None:
     attempts it spawns each hold their own LocalCompute): under the state
     root when the deployment names one, else nowhere (memory-only — tests).
     Local jobs are synchronous, so only TERMINAL states ever need sharing."""
-    root = os.environ.get("AUTORESEARCH_ROOT", "").strip()
+    root = os.environ.get("OUTERLOOP_ROOT", "").strip()
     return Path(root) / "local_jobs" if root else None
 
 
@@ -355,7 +355,7 @@ class LocalCompute:
         # the submitting process holds live keys (and any inherited
         # APPTAINERENV_* would cross --cleanenv into the container), so the
         # job script starts from a minimal environment and sets its own.
-        # AUTORESEARCH_* / REVIEW_HERMES_* pass through as a PREFIX rule:
+        # OUTERLOOP_* / REVIEW_HERMES_* pass through as a PREFIX rule:
         # Slurm jobs inherit the tick's whole environment, and local jobs
         # need the same config surface (compute mode, author backend, panel,
         # key-file PATHS). Enumerating allowed names is how a mode flag dies
@@ -369,7 +369,7 @@ class LocalCompute:
             k: v
             for k, v in os.environ.items()
             if k in ("PATH", "HOME", "LANG", "TMPDIR", "SLURM_TMPDIR", "USER", "LOGNAME")
-            or (k.startswith(("AUTORESEARCH_", "REVIEW_HERMES_")) and not _secret_name(k))
+            or (k.startswith(("OUTERLOOP_", "REVIEW_HERMES_")) and not _secret_name(k))
         }
         try:
             # the job runs in its OWN session (= process group), so the

--- a/src/outerloop/contract.py
+++ b/src/outerloop/contract.py
@@ -126,8 +126,8 @@ class Benchmark(_StrictModel):
     eval_minutes: int | None = Field(default=None, ge=1)
     # GPUs for every dispatched job of this benchmark — gate measures and
     # author launches alike. 0 (default) = CPU. A GPU benchmark needs the
-    # deployment to name a GPU lane (AUTORESEARCH_GPU_PARTITION, optionally
-    # AUTORESEARCH_GPU_ACCOUNT); without one the tick refuses to launch
+    # deployment to name a GPU lane (OUTERLOOP_GPU_PARTITION, optionally
+    # OUTERLOOP_GPU_ACCOUNT); without one the tick refuses to launch
     # attempts on it rather than queue evals that can never run. Bounded at
     # one node's worth: multi-node evals are not a shape the jail supports.
     gpus: int = Field(default=0, ge=0, le=8)

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -1966,13 +1966,11 @@ def main() -> int:
     parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
     parser.add_argument(
         "--codex-bin",
-        default=os.path.expanduser(
-            os.environ.get("AUTORESEARCH_CODEX_BIN") or "~/.local/bin/codex"
-        ),
+        default=os.path.expanduser(os.environ.get("OUTERLOOP_CODEX_BIN") or "~/.local/bin/codex"),
     )
     parser.add_argument(
         "--model",
-        default=os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5",
+        default=os.environ.get("OUTERLOOP_AUTHOR_MODEL") or "claude-opus-5",
         help="fallback model only; a run's OWN (backend, model) from its record wins",
     )
     # No --author-backend: a follow-up services ONE run, whose backend+model are
@@ -1998,7 +1996,7 @@ def main() -> int:
     parser.add_argument("--pat-file", default=str(CONFIG_DIR / "bot_pat"))
     parser.add_argument(
         "--github-app-file",
-        default=os.environ.get("AUTORESEARCH_GITHUB_APP_FILE", ""),
+        default=os.environ.get("OUTERLOOP_GITHUB_APP_FILE", ""),
         help="GitHub App config (JSON: app_id, installation_id, private_key); "
         "when set, installation tokens replace the PAT",
     )
@@ -2006,7 +2004,7 @@ def main() -> int:
         "--key-file",
         default="",
         help="author key file; default resolves per backend (config-driven): "
-        "AUTORESEARCH_CLAUDE_KEY_FILE for claude, AUTORESEARCH_CODEX_KEY_FILE for codex",
+        "OUTERLOOP_CLAUDE_KEY_FILE for claude, OUTERLOOP_CODEX_KEY_FILE for codex",
     )
     parser.add_argument(
         "--panel",
@@ -2015,10 +2013,10 @@ def main() -> int:
         "re-read a pushed code change; '' = no re-read, a changed PR stays human-merged",
     )
     parser.add_argument("--panel-key-file", default="", help="the claude panel lenses' key file")
-    parser.add_argument("--account", default=os.environ.get("AUTORESEARCH_ACCOUNT", ""))
-    parser.add_argument("--partition", default=os.environ.get("AUTORESEARCH_PARTITION", ""))
-    parser.add_argument("--gpu-partition", default=os.environ.get("AUTORESEARCH_GPU_PARTITION", ""))
-    parser.add_argument("--gpu-account", default=os.environ.get("AUTORESEARCH_GPU_ACCOUNT", ""))
+    parser.add_argument("--account", default=os.environ.get("OUTERLOOP_ACCOUNT", ""))
+    parser.add_argument("--partition", default=os.environ.get("OUTERLOOP_PARTITION", ""))
+    parser.add_argument("--gpu-partition", default=os.environ.get("OUTERLOOP_GPU_PARTITION", ""))
+    parser.add_argument("--gpu-account", default=os.environ.get("OUTERLOOP_GPU_ACCOUNT", ""))
     parser.add_argument(
         "--panel-minutes",
         type=int,

--- a/src/outerloop/github.py
+++ b/src/outerloop/github.py
@@ -43,21 +43,21 @@ DEFAULT_BOT_LOGIN = "agentic-learning-bot"
 def bot_login_from_env(default: str = DEFAULT_BOT_LOGIN) -> str:
     """The login the kernel posts and pushes as — the bot ACCOUNT under a PAT,
     the App's `<slug>[bot]` under App auth (docs/design/github-app-auth.md).
-    `AUTORESEARCH_BOT_LOGIN` sets it for every role at once (the tick exports
+    `OUTERLOOP_BOT_LOGIN` sets it for every role at once (the tick exports
     it, jobs inherit it); every own-comment filter, alarm-issue lookup and
     intake-claim scan keys on this string, so it must follow the credential."""
-    return os.environ.get("AUTORESEARCH_BOT_LOGIN", "").strip() or default
+    return os.environ.get("OUTERLOOP_BOT_LOGIN", "").strip() or default
 
 
 def bot_aliases_from_env() -> tuple[str, ...]:
     """Former logins the kernel posted as (comma-separated
-    `AUTORESEARCH_BOT_ALIASES`). Every issue, claim, alarm and PR created
+    `OUTERLOOP_BOT_ALIASES`). Every issue, claim, alarm and PR created
     before an identity flip carries the OLD login; recognition stays keyed on
     login — never on the public markers, which anyone can paste — so the set
     of our logins is what a flip must widen (live: after the App flip the
     intake lane claimed the kernel's own research-log issue, authored by the
     PAT account)."""
-    raw = os.environ.get("AUTORESEARCH_BOT_ALIASES", "")
+    raw = os.environ.get("OUTERLOOP_BOT_ALIASES", "")
     return tuple(dict.fromkeys(a.strip() for a in raw.split(",") if a.strip()))
 
 

--- a/src/outerloop/harness.py
+++ b/src/outerloop/harness.py
@@ -142,7 +142,7 @@ def _rmtree_at(dir_fd: int, name: str) -> None:
 class VertexConfig:
     """Claude-on-Vertex auth (ADC): set to bill Anthropic sessions to a GCP
     project instead of an Anthropic API key. The single owner of the
-    AUTORESEARCH_VERTEX_* env contract is `vertex_from_env`."""
+    OUTERLOOP_VERTEX_* env contract is `vertex_from_env`."""
 
     project: str
     region: str = "global"
@@ -166,12 +166,12 @@ class VertexConfig:
 
 def vertex_from_env() -> VertexConfig | None:
     """The deployment's Vertex coordinates, or None (Anthropic-direct). A live
-    flip needs only the env: set AUTORESEARCH_VERTEX_PROJECT to route every
+    flip needs only the env: set OUTERLOOP_VERTEX_PROJECT to route every
     claude session through Vertex; unset it to fall back to the API key."""
-    project = os.environ.get("AUTORESEARCH_VERTEX_PROJECT", "").strip()
+    project = os.environ.get("OUTERLOOP_VERTEX_PROJECT", "").strip()
     if not project:
         return None
-    adc = os.path.expanduser(os.environ.get("AUTORESEARCH_VERTEX_ADC", "").strip())
+    adc = os.path.expanduser(os.environ.get("OUTERLOOP_VERTEX_ADC", "").strip())
     if not adc:
         # resolve the gcloud default NOW, under the real HOME — the session's
         # HOME is a scrubbed per-run directory where ambient discovery would
@@ -181,7 +181,7 @@ def vertex_from_env() -> VertexConfig | None:
             adc = default
     return VertexConfig(
         project=project,
-        region=os.environ.get("AUTORESEARCH_VERTEX_REGION", "global").strip() or "global",
+        region=os.environ.get("OUTERLOOP_VERTEX_REGION", "global").strip() or "global",
         adc_file=adc,
     )
 

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -345,7 +345,9 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(
-        prog="outerloop init", description="guided setup for outerloop"
+        prog="outerloop init",
+        description="Guided setup: asks for anything not given as a flag, checks the "
+        "credentials, and writes ~/.config/outerloop/.env.",
     )
     parser.add_argument("--compute", choices=["slurm", "local"], help="where the loop runs")
     parser.add_argument("--target", help="the repo the agents work on, owner/repo")
@@ -367,7 +369,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--app-name", dest="app_name", help="name for the created GitHub App")
     parser.add_argument("--org", help="create the App under this org (default: your account)")
-    parser.add_argument("--author-backend", dest="author_backend", help="climbing author's backend")
+    parser.add_argument(
+        "--author-backend",
+        dest="author_backend",
+        help=f"climbing author's backend ({' or '.join(AUTHOR_BACKENDS)}; default claude)",
+    )
     parser.add_argument("--author-model", dest="author_model", help="climbing author's model")
     parser.add_argument(
         "--author-key-file",

--- a/src/outerloop/limits.py
+++ b/src/outerloop/limits.py
@@ -26,7 +26,7 @@ from typing import Any
 # work — session budgets sized for solver tweaks starve construction work.
 # floor = session floor + overhead + self-deadline margin: even at the
 # floors, a session must fit inside its job with the ending's runway.
-# Public: the tick's AUTORESEARCH_MAX_JOB_MINUTES knob floors here too.
+# Public: the tick's OUTERLOOP_MAX_JOB_MINUTES knob floors here too.
 ATTEMPT_JOB_MINUTES_FLOOR = 40
 
 # Public: the tick shrinks a capped job's session with the same floor the

--- a/src/outerloop/measure.py
+++ b/src/outerloop/measure.py
@@ -278,7 +278,7 @@ class DispatchedMeasurer:
         if not self.gpu_partition:
             raise ValueError(
                 f"measure {m.name} needs {m.gpus} GPU(s) but no GPU lane is configured "
-                "(set AUTORESEARCH_GPU_PARTITION)"
+                "(set OUTERLOOP_GPU_PARTITION)"
             )
         return self.gpu_account or self.account, self.gpu_partition
 
@@ -494,7 +494,7 @@ class DispatchSettings:
         if not self.gpu_partition:
             raise ValueError(
                 f"benchmark needs {gpus} GPU(s) but no GPU lane is configured "
-                "(set AUTORESEARCH_GPU_PARTITION)"
+                "(set OUTERLOOP_GPU_PARTITION)"
             )
         return self.gpu_account or self.account, self.gpu_partition
 

--- a/src/outerloop/review.py
+++ b/src/outerloop/review.py
@@ -34,7 +34,7 @@ OPT_OUT_LABEL = label_name("no-review")
 # One calm line: the mechanical defense against forged endorsements is the
 # approval-language redaction in sanitize(), not header volume.
 ADVISORY_HEADER = (
-    "*Advisory findings from `autoresearch` — the code owner decides. "
+    "*Advisory findings from `outerloop` — the code owner decides. "
     f"Reply to disagree; the `{OPT_OUT_LABEL}` label opts this PR out.*"
 )
 MAX_DIFF_CHARS = 200_000

--- a/src/outerloop/steward.py
+++ b/src/outerloop/steward.py
@@ -777,7 +777,7 @@ def main() -> int:
     parser.add_argument("--pat-file", default=str(CONFIG_DIR / "bot_pat"))
     parser.add_argument(
         "--github-app-file",
-        default=os.environ.get("AUTORESEARCH_GITHUB_APP_FILE", ""),
+        default=os.environ.get("OUTERLOOP_GITHUB_APP_FILE", ""),
         help="GitHub App config (JSON: app_id, installation_id, private_key); "
         "when set, installation tokens replace the PAT",
     )

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -74,7 +74,7 @@ log = logging.getLogger(__name__)
 PAUSE_SENTINEL = "PAUSE"
 # Operator on-switch for dispatched-wake, mirroring PAUSE: a root-relative
 # sentinel an operator arms/disarms with a touch/rm — no chain restart, no
-# env-var surgery on a live tick. The AUTORESEARCH_DISPATCH_WAKE env var still
+# env-var surgery on a live tick. The OUTERLOOP_DISPATCH_WAKE env var still
 # works too (either arms it); the sentinel is the reversible, restart-free path.
 DISPATCH_WAKE_SENTINEL = "DISPATCH_WAKE"
 HEARTBEAT_NAME = "heartbeat.json"
@@ -95,7 +95,7 @@ DEFAULT_LEASE_TTL_S = 3600 + 15 * 60
 # (serialized by the singleton dependency), so they would run back-to-back and
 # redundantly re-sweep. The chain schedules ticks a full cadence apart by
 # begin-time, so only late-bunched pile-ups fall inside this window; keep it
-# well BELOW the cadence (default 30 min). 0 disables. Env: AUTORESEARCH_MIN_TICK_MINUTES.
+# well BELOW the cadence (default 30 min). 0 disables. Env: OUTERLOOP_MIN_TICK_MINUTES.
 DEFAULT_MIN_TICK_S = 10 * 60
 # Ceiling for the coalesce window: a value above this is almost certainly a typo
 # (a window near/over the cadence would coalesce every on-cadence tick and stall
@@ -154,8 +154,8 @@ class TickReport:
 # The submitted walltime must never exceed the job partition's MaxTime —
 # sbatch REJECTS a longer request outright, which would ground every climb.
 # The DEFAULT matches cpu_short (6 h); an operator moving work jobs to a
-# longer partition (AUTORESEARCH_JOB_PARTITION=cpu48) raises the cap with
-# AUTORESEARCH_MAX_JOB_MINUTES. Code-side ceiling: the cap must stay under
+# longer partition (OUTERLOOP_JOB_PARTITION=cpu48) raises the cap with
+# OUTERLOOP_MAX_JOB_MINUTES. Code-side ceiling: the cap must stay under
 # STRANDED_IMPLEMENTING_S or the picker declares live runs stranded — jobs
 # longer than 10 h need that window made spec-aware first (named gap). The
 # self-deadline arms at the CLAMPED value, so a job that wanted more time
@@ -181,12 +181,12 @@ class FollowupSpec:
     partition: str
     run_root: Path
     image: str
-    home: Path  # AUTORESEARCH_HOME: cwd for the submitted job
+    home: Path  # OUTERLOOP_HOME: cwd for the submitted job
     bot_login: str = field(default_factory=_bot_login_default)
     time_minutes: int = 90  # min()'d with the contract's followup_job_minutes
     max_turns: int = DEFAULT_MAX_TURNS  # session turn budget for follow-up jobs
     pat_file: str = ""  # forwarded to the job; "" = the followup CLI default
-    # GitHub App config path; jobs inherit AUTORESEARCH_GITHUB_APP_FILE from
+    # GitHub App config path; jobs inherit OUTERLOOP_GITHUB_APP_FILE from
     # the tick environment, so it is never threaded through argv
     github_app_file: str = ""
     target: str = ""  # the repo the intake pass scans for requested-lane issues
@@ -194,7 +194,7 @@ class FollowupSpec:
     # until the operator provisions it
     steward_key_file: str = ""
     # Pre-PR verification panel for climb jobs (docs/design/orchestrator-verify.md).
-    # DEFAULT ON — the flip is code, the off-switch is AUTORESEARCH_PANEL="".
+    # DEFAULT ON — the flip is code, the off-switch is OUTERLOOP_PANEL="".
     # The climb CLI fails LOUDLY on a bad panel config (a configured gate must
     # never silently vanish); the tick preflights the same rules — lens
     # grammar AND key file — before claiming or submitting so nothing is
@@ -286,7 +286,7 @@ def _gpu_lane_error(contract: Any, benchmark: str, spec: FollowupSpec) -> str:
     if gpu_benches:
         return (
             f"contract has GPU benchmarks ({', '.join(gpu_benches)}) but no GPU lane is "
-            "configured (set AUTORESEARCH_GPU_PARTITION)"
+            "configured (set OUTERLOOP_GPU_PARTITION)"
         )
     return ""
 
@@ -961,7 +961,7 @@ def dispatch_wake_armed(root: Path) -> bool:
     sentinel file (touch/rm, no chain restart). Read by the tick and by every
     park, so a disarm takes effect at once."""
     return (
-        bool(os.environ.get("AUTORESEARCH_DISPATCH_WAKE", "").strip())
+        bool(os.environ.get("OUTERLOOP_DISPATCH_WAKE", "").strip())
         or (root / DISPATCH_WAKE_SENTINEL).exists()
     )
 
@@ -2171,13 +2171,13 @@ def _climb_panel_argv(spec: FollowupSpec) -> list[str]:
 def _author_config_error(spec: FollowupSpec) -> str:
     """Why the config-driven author would die at the climb's startup ("" when it
     won't), checked on the tick host BEFORE a claim/submit so a codex misconfig
-    (e.g. AUTORESEARCH_AUTHOR_BACKEND=codex with no non-claude model) never
+    (e.g. OUTERLOOP_AUTHOR_BACKEND=codex with no non-claude model) never
     strands a claimed intake issue. Reads the fleet author config from env — the
     same source the climb defaults from — and the image the tick already knows."""
     from outerloop.attempt import codex_author_config_error
 
-    backend = os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude"
-    model = os.environ.get("AUTORESEARCH_AUTHOR_MODEL") or "claude-opus-5"
+    backend = os.environ.get("OUTERLOOP_AUTHOR_BACKEND") or "claude"
+    model = os.environ.get("OUTERLOOP_AUTHOR_MODEL") or "claude-opus-5"
     return codex_author_config_error(backend, model, spec.image)
 
 
@@ -2208,8 +2208,8 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
         # neither the author's nor the claude panel key + readable), and for
         # hermes its pinned clone.
         shelled = {
-            "codex": "AUTORESEARCH_PANEL_CODEX_KEY_FILE",
-            "hermes": "AUTORESEARCH_PANEL_HERMES_KEY_FILE",
+            "codex": "OUTERLOOP_PANEL_CODEX_KEY_FILE",
+            "hermes": "OUTERLOOP_PANEL_HERMES_KEY_FILE",
         }
         for lens_backend, key_env in shelled.items():
             if not any(backend == lens_backend for _, backend, _ in lenses):
@@ -2217,7 +2217,7 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
             if not spec.image or not Path(spec.image).is_file():
                 return (
                     f"a {lens_backend} panel lens requires a real container image "
-                    f"(AUTORESEARCH_IMAGE={spec.image!r})"
+                    f"(OUTERLOOP_IMAGE={spec.image!r})"
                 )
             key_raw = os.environ.get(key_env, "").strip()
             if not key_raw:
@@ -2273,7 +2273,7 @@ def _panel_preflight_error(spec: FollowupSpec) -> str:
         # (claude vs codex keys coexist), config-driven like the climb itself — so
         # the role-separation check compares the panel key against the RIGHT author
         # key, and a codex run is never judged by a stray Claude key.
-        fleet_backend = os.environ.get("AUTORESEARCH_AUTHOR_BACKEND") or "claude"
+        fleet_backend = os.environ.get("OUTERLOOP_AUTHOR_BACKEND") or "claude"
         author = Path(resolve_author_key_file(fleet_backend))
         if not author.is_absolute():
             # same rule as the panel key: the climb resolves paths from a
@@ -2462,7 +2462,7 @@ def service_self_initiated(
             # that would publish panel-less self-merging PRs (terra #171)
             log.error(
                 "attempt on %s not launched: contract sets merge:auto but "
-                "no panel is configured (set AUTORESEARCH_PANEL, or the "
+                "no panel is configured (set OUTERLOOP_PANEL, or the "
                 "contract back to merge:manual)",
                 benchmark,
             )
@@ -2474,7 +2474,7 @@ def service_self_initiated(
         if author_error:
             log.error(
                 "climb on %s not launched: author misconfigured — %s "
-                "(fix AUTORESEARCH_AUTHOR_BACKEND/_MODEL)",
+                "(fix OUTERLOOP_AUTHOR_BACKEND/_MODEL)",
                 benchmark,
                 author_error,
             )
@@ -2483,7 +2483,7 @@ def service_self_initiated(
         if panel_error:
             log.error(
                 "climb on %s not launched: panel misconfigured — %s "
-                "(fix it, or set AUTORESEARCH_PANEL='' to disable the panel)",
+                "(fix it, or set OUTERLOOP_PANEL='' to disable the panel)",
                 benchmark,
                 panel_error,
             )
@@ -2510,7 +2510,7 @@ def service_self_initiated(
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
         # config-driven author: climb resolves the author backend/model/key from
-        # AUTORESEARCH_AUTHOR_* env (inherited by the job), so the tick threads
+        # OUTERLOOP_AUTHOR_* env (inherited by the job), so the tick threads
         # neither the backend nor its key — a new backend needs zero tick change.
         job_id = compute.submit(
             JobSpec(
@@ -2714,7 +2714,7 @@ def service_intake(
             # that would publish panel-less self-merging PRs (terra #171)
             log.error(
                 "attempt on %s not launched: contract sets merge:auto but "
-                "no panel is configured (set AUTORESEARCH_PANEL, or the "
+                "no panel is configured (set OUTERLOOP_PANEL, or the "
                 "contract back to merge:manual)",
                 task.benchmark,
             )
@@ -2726,7 +2726,7 @@ def service_intake(
         if author_error:
             log.error(
                 "issue #%d not claimed: author misconfigured — %s "
-                "(fix AUTORESEARCH_AUTHOR_BACKEND/_MODEL)",
+                "(fix OUTERLOOP_AUTHOR_BACKEND/_MODEL)",
                 task.number,
                 author_error,
             )
@@ -2735,7 +2735,7 @@ def service_intake(
         if panel_error:
             log.error(
                 "issue #%d not claimed: panel misconfigured — %s "
-                "(fix it, or set AUTORESEARCH_PANEL='' to disable the panel)",
+                "(fix it, or set OUTERLOOP_PANEL='' to disable the panel)",
                 task.number,
                 panel_error,
             )
@@ -2777,7 +2777,7 @@ def service_intake(
         if spec.pat_file:
             argv += ["--pat-file", spec.pat_file]
         # config-driven author: climb resolves the author key from the
-        # AUTORESEARCH_AUTHOR_* env by backend; the tick does not thread it.
+        # OUTERLOOP_AUTHOR_* env by backend; the tick does not thread it.
         try:
             job_id = compute.submit(
                 JobSpec(
@@ -2921,7 +2921,7 @@ def _wake_dispatcher_from_env(
     """The wake delivery for this tick, behind an EXPLICIT on-switch so the
     dispatched-wake path lands DARK. Returns `(dispatcher, live)`:
 
-    * armed (the `AUTORESEARCH_DISPATCH_WAKE` env var OR a `<root>/DISPATCH_WAKE`
+    * armed (the `OUTERLOOP_DISPATCH_WAKE` env var OR a `<root>/DISPATCH_WAKE`
       sentinel file) AND the chain env carries what a wake job needs -> the real
       `JobWakeDispatcher` and a LIVE sweep;
     * otherwise -> the `LoggingDispatcher` and a DRY sweep.
@@ -2940,7 +2940,7 @@ def _wake_dispatcher_from_env(
 
 
 def _max_job_minutes_from_env() -> int:
-    """AUTORESEARCH_MAX_JOB_MINUTES, clamped into what the code can honor:
+    """OUTERLOOP_MAX_JOB_MINUTES, clamped into what the code can honor:
     at least the climb-job floor (an operator on a short-MaxTime partition
     must be able to LOWER the cap below cpu_short's 6h, or every submit is
     rejected), at most the ceiling the stranded window allows. A clamped
@@ -2948,24 +2948,24 @@ def _max_job_minutes_from_env() -> int:
     rejecting jobs for no reason."""
     from outerloop.limits import ATTEMPT_JOB_MINUTES_FLOOR
 
-    raw = os.environ.get("AUTORESEARCH_MAX_JOB_MINUTES", "").strip()
+    raw = os.environ.get("OUTERLOOP_MAX_JOB_MINUTES", "").strip()
     if not raw:
         return MAX_ATTEMPT_JOB_MINUTES
     try:
         value = int(raw)
     except ValueError:
-        log.warning("AUTORESEARCH_MAX_JOB_MINUTES=%r is not an integer; using default", raw)
+        log.warning("OUTERLOOP_MAX_JOB_MINUTES=%r is not an integer; using default", raw)
         return MAX_ATTEMPT_JOB_MINUTES
     clamped = max(ATTEMPT_JOB_MINUTES_FLOOR, min(value, MAX_JOB_MINUTES_CEILING))
     if clamped != value:
-        log.warning("AUTORESEARCH_MAX_JOB_MINUTES=%d clamped to %d", value, clamped)
+        log.warning("OUTERLOOP_MAX_JOB_MINUTES=%d clamped to %d", value, clamped)
     return clamped
 
 
 def _cadence_s() -> float:
-    """The chain's tick cadence in seconds (AUTORESEARCH_CADENCE_MIN, the same
+    """The chain's tick cadence in seconds (OUTERLOOP_CADENCE_MIN, the same
     knob tick_chain.sbatch uses), defaulting to 30 min when unset/invalid."""
-    raw = os.environ.get("AUTORESEARCH_CADENCE_MIN", "").strip()
+    raw = os.environ.get("OUTERLOOP_CADENCE_MIN", "").strip()
     try:
         cadence_s = float(raw) * 60 if raw else 30 * 60
     except ValueError:
@@ -2975,7 +2975,7 @@ def _cadence_s() -> float:
 
 def _coalesce_ceiling_s() -> float:
     """The largest SAFE coalesce window, bounding both the default and an
-    explicit AUTORESEARCH_MIN_TICK_MINUTES: half the cadence (so an on-cadence
+    explicit OUTERLOOP_MIN_TICK_MINUTES: half the cadence (so an on-cadence
     tick is never coalesced even when the previous one ran a little late), and
     never above the absolute MAX_MIN_TICK_S. A window at/above the cadence would
     swallow every normal tick and stall the loop — this is what forbids it."""
@@ -2991,29 +2991,29 @@ def _default_min_tick_s() -> float:
 
 
 def _min_tick_s_from_env() -> float:
-    """AUTORESEARCH_MIN_TICK_MINUTES -> the coalesce window in seconds. Unset
+    """OUTERLOOP_MIN_TICK_MINUTES -> the coalesce window in seconds. Unset
     derives a cadence-aware default; non-numeric/non-finite also fall back to it;
     negative clamps to 0 (coalesce disabled); a value at/above the safe ceiling
     (half the cadence, capped at MAX_MIN_TICK_S) clamps down so it cannot stall
     the loop."""
-    raw = os.environ.get("AUTORESEARCH_MIN_TICK_MINUTES", "").strip()
+    raw = os.environ.get("OUTERLOOP_MIN_TICK_MINUTES", "").strip()
     if not raw:
         return _default_min_tick_s()
     try:
         minutes = float(raw)
     except ValueError:
-        log.warning("AUTORESEARCH_MIN_TICK_MINUTES=%r is not a number; using default", raw)
+        log.warning("OUTERLOOP_MIN_TICK_MINUTES=%r is not a number; using default", raw)
         return _default_min_tick_s()
     # reject inf/nan: an infinite window would coalesce every future tick and
     # freeze the loop (a finite elapsed time is always < inf)
     if not math.isfinite(minutes):
-        log.warning("AUTORESEARCH_MIN_TICK_MINUTES=%r is not finite; using default", raw)
+        log.warning("OUTERLOOP_MIN_TICK_MINUTES=%r is not finite; using default", raw)
         return _default_min_tick_s()
     seconds = max(0.0, minutes * 60)
     ceiling = _coalesce_ceiling_s()
     if seconds > ceiling:
         log.warning(
-            "AUTORESEARCH_MIN_TICK_MINUTES=%s exceeds the safe ceiling "
+            "OUTERLOOP_MIN_TICK_MINUTES=%s exceeds the safe ceiling "
             "(%.0f min, ~half the cadence); clamping so normal ticks are not coalesced",
             raw,
             ceiling / 60,
@@ -3026,21 +3026,21 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     """GitHub client + FollowupSpec from the chain environment, or Nones when
     the environment is incomplete (the tick then runs without in-review
     servicing, and logs what is absent)."""
-    pat_file = os.environ.get("AUTORESEARCH_PAT_FILE", "")
-    app_file = os.environ.get("AUTORESEARCH_GITHUB_APP_FILE", "")
-    account = os.environ.get("AUTORESEARCH_ACCOUNT", "")
-    partition = os.environ.get("AUTORESEARCH_PARTITION", "")
+    pat_file = os.environ.get("OUTERLOOP_PAT_FILE", "")
+    app_file = os.environ.get("OUTERLOOP_GITHUB_APP_FILE", "")
+    account = os.environ.get("OUTERLOOP_ACCOUNT", "")
+    partition = os.environ.get("OUTERLOOP_PARTITION", "")
     image = os.environ.get(
-        "AUTORESEARCH_IMAGE",
+        "OUTERLOOP_IMAGE",
         os.path.expanduser("~/autoresearch-images/agent-py312.sif"),
     )
-    home = os.environ.get("AUTORESEARCH_HOME", "")
+    home = os.environ.get("OUTERLOOP_HOME", "")
     # Account and partition are optional on Slurm: empty ones leave the billing
     # association and the partition to Slurm's defaults, as `start` already
     # does for the resident. Local compute has no placement at all.
-    target = os.environ.get("AUTORESEARCH_TARGET", "")
+    target = os.environ.get("OUTERLOOP_TARGET", "")
     image_ok = Path(image).is_file()
-    panel = os.environ.get("AUTORESEARCH_PANEL", "verify,review")
+    panel = os.environ.get("OUTERLOOP_PANEL", "verify,review")
     if not image_ok and local_mode():
         # The local loop on a machine with no container: sessions run under
         # the harness's own sandbox and evaluations run bare, on the
@@ -3056,14 +3056,14 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
                 "sandbox and evaluations run bare on this machine; the panel is %s; a "
                 "codex author needs the image (docs/install.md, local mode)",
                 image,
-                "on by AUTORESEARCH_PANEL_UNCONTAINED=1"
-                if os.environ.get("AUTORESEARCH_PANEL_UNCONTAINED") == "1"
-                else "off (AUTORESEARCH_PANEL_UNCONTAINED=1 turns it on)",
+                "on by OUTERLOOP_PANEL_UNCONTAINED=1"
+                if os.environ.get("OUTERLOOP_PANEL_UNCONTAINED") == "1"
+                else "off (OUTERLOOP_PANEL_UNCONTAINED=1 turns it on)",
             )
-        if os.environ.get("AUTORESEARCH_PANEL_UNCONTAINED") != "1":
+        if os.environ.get("OUTERLOOP_PANEL_UNCONTAINED") != "1":
             panel = ""
         # the jobs must not inherit a path to an image that is not there
-        os.environ.pop("AUTORESEARCH_IMAGE", None)
+        os.environ.pop("OUTERLOOP_IMAGE", None)
         image, image_ok = "", True
     if (pat_file or app_file) and home and target and image_ok:
         from outerloop.appauth import resolve_bot_auth
@@ -3080,12 +3080,12 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
                 pat_file=pat_file,
                 github_app_file=app_file,
                 target=target,
-                steward_key_file=os.environ.get("AUTORESEARCH_STEWARD_KEY_FILE", ""),
+                steward_key_file=os.environ.get("OUTERLOOP_STEWARD_KEY_FILE", ""),
                 panel=panel,
-                panel_key_file=os.environ.get("AUTORESEARCH_PANEL_KEY_FILE", ""),
-                job_partition=os.environ.get("AUTORESEARCH_JOB_PARTITION", ""),
-                gpu_partition=os.environ.get("AUTORESEARCH_GPU_PARTITION", ""),
-                gpu_account=os.environ.get("AUTORESEARCH_GPU_ACCOUNT", ""),
+                panel_key_file=os.environ.get("OUTERLOOP_PANEL_KEY_FILE", ""),
+                job_partition=os.environ.get("OUTERLOOP_JOB_PARTITION", ""),
+                gpu_partition=os.environ.get("OUTERLOOP_GPU_PARTITION", ""),
+                gpu_account=os.environ.get("OUTERLOOP_GPU_ACCOUNT", ""),
                 max_job_minutes=_max_job_minutes_from_env(),
             )
             return github, followup_spec
@@ -3095,9 +3095,9 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     absent = [
         name
         for name, value in [
-            ("AUTORESEARCH_PAT_FILE or _GITHUB_APP_FILE", pat_file or app_file),
-            ("AUTORESEARCH_HOME", home),
-            ("AUTORESEARCH_TARGET", target),
+            ("OUTERLOOP_PAT_FILE or _GITHUB_APP_FILE", pat_file or app_file),
+            ("OUTERLOOP_HOME", home),
+            ("OUTERLOOP_TARGET", target),
         ]
         if not value
     ]
@@ -3110,7 +3110,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
 def _loop_cadence_s(cadence_min: float) -> float:
     """The --loop sleep, clamped to [60s, 24h]: argparse accepts inf (which
     would OverflowError out of time.sleep) and sub-minute values would spin.
-    A non-positive argument defers to AUTORESEARCH_CADENCE_MIN."""
+    A non-positive argument defers to OUTERLOOP_CADENCE_MIN."""
     return min(24 * 3600.0, max(60.0, cadence_min * 60 if cadence_min > 0 else _cadence_s()))
 
 
@@ -3118,15 +3118,30 @@ def main() -> int:
     import argparse
     import time
 
-    parser = argparse.ArgumentParser(description="One tick of the autoresearch loop.")
+    parser = argparse.ArgumentParser(
+        prog="outerloop tick",
+        description="One tick of the loop: service the open runs, launch new work, wake "
+        "parked runs. The chain runs this every cadence; --loop does the same in the "
+        "foreground.",
+    )
     parser.add_argument("--root", required=True, type=Path, help="state root on the shared FS")
-    parser.add_argument("--grace-s", type=float, default=DEFAULT_GRACE_S)
-    parser.add_argument("--lease-ttl-s", type=float, default=DEFAULT_LEASE_TTL_S)
+    parser.add_argument(
+        "--grace-s",
+        type=float,
+        default=DEFAULT_GRACE_S,
+        help="seconds a finished experiment's delivery job gets before the sweep steps in",
+    )
+    parser.add_argument(
+        "--lease-ttl-s",
+        type=float,
+        default=DEFAULT_LEASE_TTL_S,
+        help="seconds after which a held run lease counts as stale",
+    )
     parser.add_argument(
         "--min-free-gb",
         type=float,
         default=DEFAULT_MIN_FREE_BYTES / 1024**3,
-        help="skip launching new work when the state filesystem has less free",
+        help="skip launching new work when the state filesystem has less than this many GB free",
     )
     parser.add_argument(
         "--loop",
@@ -3139,23 +3154,23 @@ def main() -> int:
         type=float,
         default=0.0,
         help="minutes between --loop ticks; unset defers to "
-        "AUTORESEARCH_CADENCE_MIN via the chain's own parser (default 30)",
+        "OUTERLOOP_CADENCE_MIN via the chain's own parser (default 30)",
     )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
 
     args.root.mkdir(parents=True, exist_ok=True)
     # The tick's --root is the authority; children (and this process's own
-    # LocalCompute) read AUTORESEARCH_ROOT, so a bare `tick --loop --root X`
+    # LocalCompute) read OUTERLOOP_ROOT, so a bare `tick --loop --root X`
     # must not split-brain them: local job states would land nowhere and
     # every finished job would read GONE until the park deadline.
     # RESOLVED: local jobs cd into flight checkouts, so a relative root
     # would scatter their state dirs across working directories
-    if os.environ.get("AUTORESEARCH_ROOT", "") != str(args.root.resolve()):
-        os.environ["AUTORESEARCH_ROOT"] = str(args.root.resolve())
+    if os.environ.get("OUTERLOOP_ROOT", "") != str(args.root.resolve()):
+        os.environ["OUTERLOOP_ROOT"] = str(args.root.resolve())
     # In-review servicing is LIVE when credentials + image are available in the
     # chain environment. The waiting-run sweep delivers real wakes only when the
-    # operator arms it — the AUTORESEARCH_DISPATCH_WAKE env var or a
+    # operator arms it — the OUTERLOOP_DISPATCH_WAKE env var or a
     # <root>/DISPATCH_WAKE sentinel — and the env is complete; by default it
     # stays dry with the LoggingDispatcher — dispatched climbing lands DARK.
     # ONE compute for the process: LocalCompute remembers its jobs' states

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -121,7 +121,7 @@ def test_park_arms_its_own_wake_when_the_tick_published_the_recipe(tmp_path, mon
             tmp_path, record, parked, "refs/dispatch/tok", None, 1000.0, dispatch=_fake_dispatch()
         )
 
-    monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_DISPATCH_WAKE", raising=False)
     park("tsp-quiet")
     assert read_lease(tmp_path, "tsp-quiet") is None
     assert load_record(tmp_path, "tsp-quiet").wake_attempts == 0
@@ -806,8 +806,8 @@ def test_resume_author_reproduces_the_run_not_the_fleet(monkeypatch) -> None:
 
     from outerloop.attempt import resume_author
 
-    monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", "/h")
-    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", "/c")
+    monkeypatch.setenv("OUTERLOOP_HARNESS_KEY_FILE", "/h")
+    monkeypatch.setenv("OUTERLOOP_CODEX_KEY_FILE", "/c")
 
     legacy = SimpleNamespace(author_backend="", author_model="", author_key_file="")
     assert resume_author(legacy, fleet_model="gpt-5.6-terra") == ("claude", "claude-opus-5", "/h")
@@ -858,9 +858,9 @@ def test_resolve_author_key_file(monkeypatch, tmp_path) -> None:
     from outerloop import attempt
     from outerloop.attempt import CODEX_KEY_DEFAULT, resolve_author_key_file
 
-    for var in ("AUTORESEARCH_CLAUDE_KEY_FILE", "AUTORESEARCH_HARNESS_KEY_FILE"):
+    for var in ("OUTERLOOP_CLAUDE_KEY_FILE", "OUTERLOOP_HARNESS_KEY_FILE"):
         monkeypatch.delenv(var, raising=False)
-    monkeypatch.delenv("AUTORESEARCH_CODEX_KEY_FILE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_CODEX_KEY_FILE", raising=False)
     new, legacy = tmp_path / "claude_key", tmp_path / "harness_key"
     monkeypatch.setattr(attempt, "CLAUDE_KEY_DEFAULT", str(new))
     monkeypatch.setattr(attempt, "HARNESS_KEY_DEFAULT", str(legacy))
@@ -872,11 +872,11 @@ def test_resolve_author_key_file(monkeypatch, tmp_path) -> None:
     assert resolve_author_key_file("claude") == str(legacy)  # pre-rename machine
     new.write_text("k")
     assert resolve_author_key_file("claude") == str(new)  # both: new wins
-    monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", "/h-key")
+    monkeypatch.setenv("OUTERLOOP_HARNESS_KEY_FILE", "/h-key")
     assert resolve_author_key_file("claude") == "/h-key"  # legacy env still honored
-    monkeypatch.setenv("AUTORESEARCH_CLAUDE_KEY_FILE", "/c-key")
+    monkeypatch.setenv("OUTERLOOP_CLAUDE_KEY_FILE", "/c-key")
     assert resolve_author_key_file("claude") == "/c-key"  # new env wins over legacy
-    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", "/x-key")
+    monkeypatch.setenv("OUTERLOOP_CODEX_KEY_FILE", "/x-key")
     assert resolve_author_key_file("codex") == "/x-key"
 
 
@@ -3254,7 +3254,7 @@ def test_codex_panel_lens_requires_the_judges_own_key(monkeypatch) -> None:
 
     from outerloop.attempt import _panel_lenses_from_args
 
-    monkeypatch.delenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_PANEL_CODEX_KEY_FILE", raising=False)
     args = argparse.Namespace(
         panel="review:codex:gpt-5.6-terra",
         panel_key_file="/dev/null",
@@ -3263,7 +3263,7 @@ def test_codex_panel_lens_requires_the_judges_own_key(monkeypatch) -> None:
         image="/img.sif",
     )
     monkeypatch.setattr("outerloop.attempt.role_key", lambda *a, **k: "k")
-    with pytest.raises(ValueError, match="AUTORESEARCH_PANEL_CODEX_KEY_FILE"):
+    with pytest.raises(ValueError, match="OUTERLOOP_PANEL_CODEX_KEY_FILE"):
         _panel_lenses_from_args(args)
 
 
@@ -3276,7 +3276,7 @@ def test_codex_only_panel_never_reads_the_claude_key(monkeypatch, tmp_path) -> N
     codex_key = tmp_path / "panel_codex_key"
     codex_key.write_text("sk-judge")
     codex_key.chmod(0o600)
-    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(codex_key))
+    monkeypatch.setenv("OUTERLOOP_PANEL_CODEX_KEY_FILE", str(codex_key))
     args = argparse.Namespace(
         panel="review:codex:gpt-5.6-terra",
         panel_key_file=str(tmp_path / "no-such-anthropic-key"),  # absent, must not matter
@@ -3301,8 +3301,8 @@ def test_codex_panel_key_must_not_be_the_author_key(monkeypatch, tmp_path) -> No
     author_key = tmp_path / "codex_key"
     author_key.write_text("sk-author")
     author_key.chmod(0o600)
-    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", str(author_key))
-    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(author_key))
+    monkeypatch.setenv("OUTERLOOP_CODEX_KEY_FILE", str(author_key))
+    monkeypatch.setenv("OUTERLOOP_PANEL_CODEX_KEY_FILE", str(author_key))
     args = argparse.Namespace(
         panel="review:codex:gpt-5.6-terra",
         panel_key_file="/dev/null",
@@ -3326,7 +3326,7 @@ def test_codex_panel_key_must_not_be_the_claude_panel_key(monkeypatch, tmp_path)
     shared = tmp_path / "verifier_key"
     shared.write_text("sk-ant")
     shared.chmod(0o600)
-    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(shared))
+    monkeypatch.setenv("OUTERLOOP_PANEL_CODEX_KEY_FILE", str(shared))
     args = argparse.Namespace(
         panel="review:codex:gpt-5.6-terra",
         panel_key_file=str(shared),
@@ -3350,7 +3350,7 @@ def test_codex_panel_lens_refuses_to_run_uncontained(monkeypatch, tmp_path) -> N
     judge_key = tmp_path / "panel_codex_key"
     judge_key.write_text("sk-judge")
     judge_key.chmod(0o600)
-    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(judge_key))
+    monkeypatch.setenv("OUTERLOOP_PANEL_CODEX_KEY_FILE", str(judge_key))
     args = argparse.Namespace(
         panel="review:codex:gpt-5.6-terra",
         panel_key_file="/dev/null",
@@ -3380,20 +3380,20 @@ def test_hermes_panel_lens_shares_the_judge_key_rules(monkeypatch, tmp_path) -> 
             image=image,
         )
 
-    monkeypatch.delenv("AUTORESEARCH_PANEL_HERMES_KEY_FILE", raising=False)
-    with pytest.raises(ValueError, match="AUTORESEARCH_PANEL_HERMES_KEY_FILE"):
+    monkeypatch.delenv("OUTERLOOP_PANEL_HERMES_KEY_FILE", raising=False)
+    with pytest.raises(ValueError, match="OUTERLOOP_PANEL_HERMES_KEY_FILE"):
         _panel_lenses_from_args(args())
     judge = tmp_path / "panel_hermes_key"
     judge.write_text("sk-judge")
     judge.chmod(0o600)
-    monkeypatch.setenv("AUTORESEARCH_PANEL_HERMES_KEY_FILE", str(judge))
+    monkeypatch.setenv("OUTERLOOP_PANEL_HERMES_KEY_FILE", str(judge))
     with pytest.raises(ValueError, match="requires --image"):
         _panel_lenses_from_args(args(image=""))
     # author-key reuse refused (the codex author key is the OpenAI author key)
-    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", str(judge))
+    monkeypatch.setenv("OUTERLOOP_CODEX_KEY_FILE", str(judge))
     with pytest.raises(ValueError, match="role separation"):
         _panel_lenses_from_args(args())
-    monkeypatch.delenv("AUTORESEARCH_CODEX_KEY_FILE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_CODEX_KEY_FILE", raising=False)
     # a properly separated key builds the contained hermes judge
     repo = tmp_path / "hermes-agent"
     repo.mkdir()

--- a/tests/test_bot_aliases.py
+++ b/tests/test_bot_aliases.py
@@ -7,12 +7,12 @@ from outerloop.github import bot_aliases_from_env, is_own_login
 
 
 def test_aliases_parse_and_own_login_matches_any_identity(monkeypatch) -> None:
-    monkeypatch.delenv("AUTORESEARCH_BOT_ALIASES", raising=False)
+    monkeypatch.delenv("OUTERLOOP_BOT_ALIASES", raising=False)
     assert bot_aliases_from_env() == ()
     assert is_own_login("outerloop-autoresearch[bot]", "outerloop-autoresearch[bot]")
     assert not is_own_login("agentic-learning-bot", "outerloop-autoresearch[bot]")
     monkeypatch.setenv(
-        "AUTORESEARCH_BOT_ALIASES", " agentic-learning-bot, old-bot ,agentic-learning-bot"
+        "OUTERLOOP_BOT_ALIASES", " agentic-learning-bot, old-bot ,agentic-learning-bot"
     )
     assert bot_aliases_from_env() == ("agentic-learning-bot", "old-bot")
     assert is_own_login("Agentic-Learning-Bot", "outerloop-autoresearch[bot]")
@@ -38,9 +38,9 @@ def test_the_kernels_old_research_log_issue_is_never_an_order(monkeypatch) -> No
         "user": {"login": "agentic-learning-bot"},
         "author_association": "MEMBER",
     }
-    monkeypatch.delenv("AUTORESEARCH_BOT_ALIASES", raising=False)
+    monkeypatch.delenv("OUTERLOOP_BOT_ALIASES", raising=False)
     assert qualifying_issue(issue, "outerloop-autoresearch[bot]")  # the hole
-    monkeypatch.setenv("AUTORESEARCH_BOT_ALIASES", "agentic-learning-bot")
+    monkeypatch.setenv("OUTERLOOP_BOT_ALIASES", "agentic-learning-bot")
     assert not qualifying_issue(issue, "outerloop-autoresearch[bot]")
     # a maintainer's issue still qualifies
     theirs = {**issue, "user": {"login": "renmengye"}, "body": "try a wider model"}
@@ -51,7 +51,7 @@ def test_old_claims_alarms_and_comments_are_still_ours(monkeypatch) -> None:
     from outerloop.followup import qualifying_comments
     from outerloop.tick import CONTRACT_ALARM_MARKER, _find_alarm_issue
 
-    monkeypatch.setenv("AUTORESEARCH_BOT_ALIASES", "agentic-learning-bot")
+    monkeypatch.setenv("OUTERLOOP_BOT_ALIASES", "agentic-learning-bot")
     bot = "outerloop-autoresearch[bot]"
     # a comment the old account posted is the kernel's, not a maintainer's
     old = {
@@ -84,7 +84,7 @@ def test_old_claims_alarms_and_comments_are_still_ours(monkeypatch) -> None:
             ]
 
     assert _find_alarm_issue(G(), "org/repo", bot) == 7
-    monkeypatch.delenv("AUTORESEARCH_BOT_ALIASES")
+    monkeypatch.delenv("OUTERLOOP_BOT_ALIASES")
     assert _find_alarm_issue(G(), "org/repo", bot) == 0  # without the alias: not ours
 
 
@@ -110,7 +110,7 @@ def test_the_reusable_workflows_carry_the_aliases() -> None:
             for step in job.get("steps", []):
                 env = step.get("env") or {}
                 if "REVIEW_BOT_LOGIN" in env:
-                    assert env.get("AUTORESEARCH_BOT_ALIASES") == "${{ inputs.bot_aliases }}", (
+                    assert env.get("OUTERLOOP_BOT_ALIASES") == "${{ inputs.bot_aliases }}", (
                         name,
                         step.get("name"),
                     )

--- a/tests/test_bot_login.py
+++ b/tests/test_bot_login.py
@@ -6,11 +6,11 @@ from outerloop.github import DEFAULT_BOT_LOGIN, bot_login_from_env
 
 
 def test_bot_login_defaults_to_the_account_and_follows_the_knob(monkeypatch) -> None:
-    monkeypatch.delenv("AUTORESEARCH_BOT_LOGIN", raising=False)
+    monkeypatch.delenv("OUTERLOOP_BOT_LOGIN", raising=False)
     assert bot_login_from_env() == DEFAULT_BOT_LOGIN
-    monkeypatch.setenv("AUTORESEARCH_BOT_LOGIN", "   ")
+    monkeypatch.setenv("OUTERLOOP_BOT_LOGIN", "   ")
     assert bot_login_from_env() == DEFAULT_BOT_LOGIN  # blank is unset
-    monkeypatch.setenv("AUTORESEARCH_BOT_LOGIN", "outerloop-autoresearch[bot]")
+    monkeypatch.setenv("OUTERLOOP_BOT_LOGIN", "outerloop-autoresearch[bot]")
     assert bot_login_from_env() == "outerloop-autoresearch[bot]"
 
 
@@ -21,11 +21,11 @@ def test_every_role_config_reads_the_login_at_construction(monkeypatch, tmp_path
     from outerloop.steward import StewardConfig
     from outerloop.tick import FollowupSpec
 
-    monkeypatch.setenv("AUTORESEARCH_BOT_LOGIN", "outerloop-autoresearch[bot]")
+    monkeypatch.setenv("OUTERLOOP_BOT_LOGIN", "outerloop-autoresearch[bot]")
     spec = FollowupSpec(account="a", partition="p", run_root=tmp_path, image="", home=tmp_path)
     assert spec.bot_login == "outerloop-autoresearch[bot]"
     assert RunConfig(target="o/r", benchmark="b").bot_login == "outerloop-autoresearch[bot]"
     assert StewardConfig(target="o/r", benchmark="b").bot_login == "outerloop-autoresearch[bot]"
     assert RunConfig(target="o/r", benchmark="b", bot_login="x").bot_login == "x"
-    monkeypatch.delenv("AUTORESEARCH_BOT_LOGIN")
+    monkeypatch.delenv("OUTERLOOP_BOT_LOGIN")
     assert RunConfig(target="o/r", benchmark="b").bot_login == DEFAULT_BOT_LOGIN

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -136,18 +136,18 @@ def test_quote_command_shell_safety() -> None:
 
 
 def test_compute_from_env_selects_the_backend(monkeypatch) -> None:
-    """AUTORESEARCH_COMPUTE=local is the monolith switch; anything else —
+    """OUTERLOOP_COMPUTE=local is the monolith switch; anything else —
     unset, empty, or a typo — stays Slurm (fail toward the real scheduler,
     never silently toward subprocesses)."""
     from outerloop.compute import LocalCompute, SlurmCompute, compute_from_env, local_mode
 
-    monkeypatch.delenv("AUTORESEARCH_COMPUTE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_COMPUTE", raising=False)
     assert isinstance(compute_from_env(), SlurmCompute) and not local_mode()
-    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
     assert isinstance(compute_from_env(), LocalCompute) and local_mode()
-    monkeypatch.setenv("AUTORESEARCH_COMPUTE", " Local ")
+    monkeypatch.setenv("OUTERLOOP_COMPUTE", " Local ")
     assert isinstance(compute_from_env(), LocalCompute)
-    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "lokal")
+    monkeypatch.setenv("OUTERLOOP_COMPUTE", "lokal")
     assert isinstance(compute_from_env(), SlurmCompute)
 
 

--- a/tests/test_env_bridge.py
+++ b/tests/test_env_bridge.py
@@ -1,4 +1,5 @@
-"""OUTERLOOP_* is the public name; AUTORESEARCH_* still works — bridged at every boundary."""
+"""OUTERLOOP_* is the name; the pre-rename AUTORESEARCH_* still works for one
+release, bridged at every boundary (process env, .env file, chain scripts)."""
 
 from __future__ import annotations
 
@@ -13,24 +14,24 @@ from outerloop.cli import START_KEYS, env_file_values
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 
 
-def test_python_bridge_copies_new_into_legacy_when_unset(monkeypatch) -> None:
-    monkeypatch.delenv("AUTORESEARCH_ZZ_TEST", raising=False)
-    monkeypatch.setenv("OUTERLOOP_ZZ_TEST", "from-new")
+def test_python_bridge_copies_legacy_into_new_when_unset(monkeypatch) -> None:
+    monkeypatch.delenv("OUTERLOOP_ZZ_TEST", raising=False)
+    monkeypatch.setenv("AUTORESEARCH_ZZ_TEST", "from-legacy")
     outerloop._bridge_legacy_env()
-    assert os.environ["AUTORESEARCH_ZZ_TEST"] == "from-new"
-    # an explicitly set legacy twin wins (setdefault semantics)
-    monkeypatch.setenv("AUTORESEARCH_ZZ_TEST", "explicit")
-    monkeypatch.setenv("OUTERLOOP_ZZ_TEST", "ignored")
+    assert os.environ["OUTERLOOP_ZZ_TEST"] == "from-legacy"
+    # an explicitly set new name wins (setdefault semantics)
+    monkeypatch.setenv("OUTERLOOP_ZZ_TEST", "explicit")
+    monkeypatch.setenv("AUTORESEARCH_ZZ_TEST", "ignored")
     outerloop._bridge_legacy_env()
-    assert os.environ["AUTORESEARCH_ZZ_TEST"] == "explicit"
+    assert os.environ["OUTERLOOP_ZZ_TEST"] == "explicit"
 
 
-def test_env_file_reads_the_public_names_canonically(tmp_path: Path) -> None:
+def test_env_file_reads_either_spelling_canonically(tmp_path: Path) -> None:
     env = tmp_path / ".env"
     env.write_text("OUTERLOOP_ROOT=/scratch/x\nAUTORESEARCH_ACCOUNT=acct\n")
     env.chmod(0o600)
     got = env_file_values(env, START_KEYS)
-    assert got == {"AUTORESEARCH_ROOT": "/scratch/x", "AUTORESEARCH_ACCOUNT": "acct"}
+    assert got == {"OUTERLOOP_ROOT": "/scratch/x", "OUTERLOOP_ACCOUNT": "acct"}
 
 
 def _bridge_block() -> str:
@@ -40,22 +41,22 @@ def _bridge_block() -> str:
     return m.group(0)
 
 
-def test_shell_bridge_exports_legacy_twin_and_respects_an_explicit_one() -> None:
+def test_shell_bridge_exports_new_twin_and_respects_an_explicit_one() -> None:
     block = _bridge_block()
     run = lambda env: (
         subprocess.run(
-            ["bash", "-c", block + '\nprintf "%s" "${AUTORESEARCH_ZZ_TEST:-unset}"'],
+            ["bash", "-c", block + '\nprintf "%s" "${OUTERLOOP_ZZ_TEST:-unset}"'],
             env={**{"PATH": os.environ["PATH"]}, **env},
             capture_output=True,
             text=True,
             check=True,
         ).stdout
     )
-    assert run({"OUTERLOOP_ZZ_TEST": "from-new"}) == "from-new"
-    assert run({"OUTERLOOP_ZZ_TEST": "new", "AUTORESEARCH_ZZ_TEST": "keep"}) == "keep"
+    assert run({"AUTORESEARCH_ZZ_TEST": "from-legacy"}) == "from-legacy"
+    assert run({"AUTORESEARCH_ZZ_TEST": "old", "OUTERLOOP_ZZ_TEST": "keep"}) == "keep"
     assert run({}) == "unset"
 
 
 def test_deploy_allowlist_takes_either_spelling() -> None:
     sh = (SCRIPTS / "tick_deploy.sh").read_text()
-    assert 'grep -E "^(${_k}|OUTERLOOP_${_k#AUTORESEARCH_})="' in sh
+    assert 'grep -E "^(${_k}|AUTORESEARCH_${_k#OUTERLOOP_})="' in sh

--- a/tests/test_env_bridge.py
+++ b/tests/test_env_bridge.py
@@ -34,6 +34,23 @@ def test_env_file_reads_either_spelling_canonically(tmp_path: Path) -> None:
     assert got == {"OUTERLOOP_ROOT": "/scratch/x", "OUTERLOOP_ACCOUNT": "acct"}
 
 
+def test_env_file_prefers_the_new_spelling_whatever_the_order(tmp_path: Path) -> None:
+    """A file edited across the rename can hold both spellings; the OUTERLOOP_
+    line wins even when the legacy line comes later (terra, #302). Among
+    lines of one spelling the last still wins."""
+    env = tmp_path / ".env"
+    env.write_text(
+        "OUTERLOOP_ROOT=/new\nAUTORESEARCH_ROOT=/old\n"
+        "AUTORESEARCH_ACCOUNT=old\nOUTERLOOP_ACCOUNT=new1\nOUTERLOOP_ACCOUNT=new2\n"
+        "AUTORESEARCH_PARTITION=p1\nAUTORESEARCH_PARTITION=p2\n"
+    )
+    env.chmod(0o600)
+    got = env_file_values(env, START_KEYS)
+    assert got["OUTERLOOP_ROOT"] == "/new"
+    assert got["OUTERLOOP_ACCOUNT"] == "new2"
+    assert got["OUTERLOOP_PARTITION"] == "p2"
+
+
 def _bridge_block() -> str:
     text = (SCRIPTS / "tick_chain.sbatch").read_text()
     m = re.search(r"^for _ov in .*?^done\n", text, re.S | re.M)
@@ -57,6 +74,10 @@ def test_shell_bridge_exports_new_twin_and_respects_an_explicit_one() -> None:
     assert run({}) == "unset"
 
 
-def test_deploy_allowlist_takes_either_spelling() -> None:
+def test_deploy_allowlist_takes_either_spelling_new_first() -> None:
     sh = (SCRIPTS / "tick_deploy.sh").read_text()
-    assert 'grep -E "^(${_k}|AUTORESEARCH_${_k#OUTERLOOP_})="' in sh
+    new = sh.index('_line=$(grep -E "^${_k}=" "$ENV_FILE"')
+    old = sh.index(
+        '[ -n "$_line" ] || _line=$(grep -E "^AUTORESEARCH_${_k#OUTERLOOP_}=" "$ENV_FILE"'
+    )
+    assert new < old  # the legacy grep only fills an absent canonical key

--- a/tests/test_env_bridge.py
+++ b/tests/test_env_bridge.py
@@ -59,10 +59,12 @@ def _bridge_block() -> str:
 
 
 def test_shell_bridge_exports_new_twin_and_respects_an_explicit_one() -> None:
+    """An explicitly EMPTY new twin is an off-switch (OUTERLOOP_PANEL= disables
+    the panel) and must survive a non-empty legacy value (terra, #302)."""
     block = _bridge_block()
     run = lambda env: (
         subprocess.run(
-            ["bash", "-c", block + '\nprintf "%s" "${OUTERLOOP_ZZ_TEST:-unset}"'],
+            ["bash", "-c", block + '\nprintf "%s" "${OUTERLOOP_ZZ_TEST-unset}"'],
             env={**{"PATH": os.environ["PATH"]}, **env},
             capture_output=True,
             text=True,
@@ -71,6 +73,7 @@ def test_shell_bridge_exports_new_twin_and_respects_an_explicit_one() -> None:
     )
     assert run({"AUTORESEARCH_ZZ_TEST": "from-legacy"}) == "from-legacy"
     assert run({"AUTORESEARCH_ZZ_TEST": "old", "OUTERLOOP_ZZ_TEST": "keep"}) == "keep"
+    assert run({"AUTORESEARCH_ZZ_TEST": "verify", "OUTERLOOP_ZZ_TEST": ""}) == ""
     assert run({}) == "unset"
 
 

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -63,7 +63,7 @@ def test_successful_session_parses_everything(tmp_path: Path) -> None:
 
 def test_session_env_is_scrubbed(tmp_path: Path, monkeypatch) -> None:
     """The threat model's credential-theft guard: no PAT, no stray secrets."""
-    monkeypatch.setenv("AUTORESEARCH_BOT_PAT", "github_pat_SECRET")
+    monkeypatch.setenv("OUTERLOOP_BOT_PAT", "github_pat_SECRET")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "aws_SECRET")
     binary = fake_claude(tmp_path, json.dumps(CANNED))
     ws = tmp_path / "ws"
@@ -807,10 +807,10 @@ def test_vertex_contained_session_binds_the_adc_file(tmp_path: Path, monkeypatch
 def test_vertex_from_env_is_the_single_owner(monkeypatch) -> None:
     from outerloop.harness import vertex_from_env
 
-    monkeypatch.delenv("AUTORESEARCH_VERTEX_PROJECT", raising=False)
+    monkeypatch.delenv("OUTERLOOP_VERTEX_PROJECT", raising=False)
     assert vertex_from_env() is None
-    monkeypatch.setenv("AUTORESEARCH_VERTEX_PROJECT", "p-9")
-    monkeypatch.setenv("AUTORESEARCH_VERTEX_ADC", "~/adc.json")
+    monkeypatch.setenv("OUTERLOOP_VERTEX_PROJECT", "p-9")
+    monkeypatch.setenv("OUTERLOOP_VERTEX_ADC", "~/adc.json")
     cfg = vertex_from_env()
     assert cfg is not None and cfg.project == "p-9" and cfg.region == "global"
     assert cfg.adc_file.endswith("/adc.json") and not cfg.adc_file.startswith("~")
@@ -825,8 +825,8 @@ def test_vertex_from_env_resolves_ambient_adc_under_the_real_home(tmp_path, monk
     default.parent.mkdir(parents=True)
     default.write_text("{}")
     monkeypatch.setenv("HOME", str(tmp_path))
-    monkeypatch.setenv("AUTORESEARCH_VERTEX_PROJECT", "p-9")
-    monkeypatch.delenv("AUTORESEARCH_VERTEX_ADC", raising=False)
+    monkeypatch.setenv("OUTERLOOP_VERTEX_PROJECT", "p-9")
+    monkeypatch.delenv("OUTERLOOP_VERTEX_ADC", raising=False)
     cfg = vertex_from_env()
     assert cfg is not None and cfg.adc_file == str(default)
 
@@ -835,10 +835,10 @@ def test_role_key_tolerates_a_missing_file_only_under_vertex(tmp_path, monkeypat
     from outerloop.role_runner import role_key
 
     missing = tmp_path / "no-such-key"
-    monkeypatch.delenv("AUTORESEARCH_VERTEX_PROJECT", raising=False)
+    monkeypatch.delenv("OUTERLOOP_VERTEX_PROJECT", raising=False)
     with pytest.raises(ValueError):
         role_key(missing)  # no vertex: loud, as ever
-    monkeypatch.setenv("AUTORESEARCH_VERTEX_PROJECT", "p-9")
+    monkeypatch.setenv("OUTERLOOP_VERTEX_PROJECT", "p-9")
     assert role_key(missing) == ""  # ADC-only claude deployment
     with pytest.raises(ValueError):
         role_key(missing, "codex")  # vertex never excuses a non-claude backend

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -259,20 +259,20 @@ def test_terminal_states_survive_across_instances(tmp_path, monkeypatch) -> None
     memory-only behavior is unchanged."""
     from outerloop.compute import GONE, JobSpec, LocalCompute
 
-    monkeypatch.setenv("AUTORESEARCH_ROOT", str(tmp_path))
+    monkeypatch.setenv("OUTERLOOP_ROOT", str(tmp_path))
     submitter = LocalCompute()
     job_id = submitter.submit(
         JobSpec(job_name="probe", account="", partition="", time_minutes=1, command="true")
     )
     poller = LocalCompute()  # a different process in real life
     assert poller.status(job_id) == "COMPLETED"
-    monkeypatch.delenv("AUTORESEARCH_ROOT")
+    monkeypatch.delenv("OUTERLOOP_ROOT")
     assert poller.status(job_id) == GONE  # no root -> memory-only, as before
 
 
 def test_gpu_contracts_pass_the_lane_check_under_local_mode(monkeypatch) -> None:
     """Local compute has no lanes: a contract with GPU benchmarks must not be
-    rejected for a missing AUTORESEARCH_GPU_PARTITION (terra #223)."""
+    rejected for a missing OUTERLOOP_GPU_PARTITION (terra #223)."""
     from types import SimpleNamespace
 
     from outerloop.tick import FollowupSpec, _gpu_lane_error
@@ -282,7 +282,7 @@ def test_gpu_contracts_pass_the_lane_check_under_local_mode(monkeypatch) -> None
     )
     contract = SimpleNamespace(benchmarks=[SimpleNamespace(name="speedrun", gpus=1)])
     assert "no GPU lane" in _gpu_lane_error(contract, "speedrun", spec)
-    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
     assert _gpu_lane_error(contract, "speedrun", spec) == ""
 
 
@@ -296,9 +296,9 @@ def test_local_mode_places_gpu_measures_without_a_lane(monkeypatch) -> None:
     settings = DispatchSettings(
         compute=LocalCompute(), image="", account="", partition="", gpu_partition=""
     )
-    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
     assert settings.placement(1) == ("", "")
-    monkeypatch.delenv("AUTORESEARCH_COMPUTE")
+    monkeypatch.delenv("OUTERLOOP_COMPUTE")
     import pytest
 
     with pytest.raises(ValueError, match="no GPU lane"):

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -376,7 +376,7 @@ def test_dispatch_settings_place_gpu_jobs_on_the_gpu_lane(tmp_path):
         partition="cpu",
     )
     assert cpu_only.placement(0) == ("acct", "cpu")
-    with pytest.raises(ValueError, match="AUTORESEARCH_GPU_PARTITION"):
+    with pytest.raises(ValueError, match="OUTERLOOP_GPU_PARTITION"):
         cpu_only.placement(1)
     with_lane = DispatchSettings(
         compute=cpu_only.compute,

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -49,18 +49,18 @@ def env_file(tmp_path: Path, text: str, mode: int = 0o600) -> Path:
 def test_env_file_values_reads_only_start_keys_last_wins_and_unquotes(tmp_path: Path) -> None:
     path = env_file(
         tmp_path,
-        "# comment\nAUTORESEARCH_ROOT=/old\nAUTORESEARCH_ROOT='/scratch/me/ar'\r\n"
-        'AUTORESEARCH_ACCOUNT="acct"\nAUTORESEARCH_PANEL=\nOTHER=x\n'
-        "AUTORESEARCH_CADENCE_MIN = 20\n",
+        "# comment\nAUTORESEARCH_ROOT=/old\nOUTERLOOP_ROOT='/scratch/me/ar'\r\n"
+        'OUTERLOOP_ACCOUNT="acct"\nOUTERLOOP_PANEL=\nOTHER=x\n'
+        "OUTERLOOP_CADENCE_MIN = 20\n",
     )
     got = env_file_values(path)
     assert got == {
-        "AUTORESEARCH_ROOT": "/scratch/me/ar",
-        "AUTORESEARCH_ACCOUNT": "acct",
-        "AUTORESEARCH_CADENCE_MIN": "20",
+        "OUTERLOOP_ROOT": "/scratch/me/ar",
+        "OUTERLOOP_ACCOUNT": "acct",
+        "OUTERLOOP_CADENCE_MIN": "20",
     }
     # the author-knob view of the same file: an empty value is PRESENT
-    assert env_file_values(path, TICK_ENV_KEYS) == {"AUTORESEARCH_PANEL": ""}
+    assert env_file_values(path, TICK_ENV_KEYS) == {"OUTERLOOP_PANEL": ""}
 
 
 def test_env_file_values_missing_file_is_empty(tmp_path: Path) -> None:
@@ -75,7 +75,7 @@ def test_env_file_values_unreadable_is_a_start_error(tmp_path: Path) -> None:
 
 @pytest.mark.parametrize("mode", [0o620, 0o602, 0o666])
 def test_env_file_values_refuses_a_writable_file(tmp_path: Path, mode: int) -> None:
-    path = env_file(tmp_path, "AUTORESEARCH_ROOT=/x\n", mode)
+    path = env_file(tmp_path, "OUTERLOOP_ROOT=/x\n", mode)
     if not path.stat().st_mode & (stat.S_IWGRP | stat.S_IWOTH):
         pytest.skip("filesystem drops group/other write bits")
     with pytest.raises(StartError, match="refusing to read"):
@@ -128,8 +128,8 @@ def test_local_without_sbatch_defaults_the_root(tmp_path: Path) -> None:
 
 def test_local_by_flag_or_env_or_file_even_with_sbatch(tmp_path: Path) -> None:
     assert plan(tmp_path, local=True).mode == "local"
-    assert plan(tmp_path, environ={"AUTORESEARCH_COMPUTE": "Local"}).mode == "local"
-    assert plan(tmp_path, from_file={"AUTORESEARCH_COMPUTE": "local"}).mode == "local"
+    assert plan(tmp_path, environ={"OUTERLOOP_COMPUTE": "Local"}).mode == "local"
+    assert plan(tmp_path, from_file={"OUTERLOOP_COMPUTE": "local"}).mode == "local"
     p = plan(tmp_path, local=True, root="~/state")
     assert p.root == Path("~/state").expanduser()
 
@@ -140,11 +140,11 @@ def test_slurm_composes_the_resident_submit(tmp_path: Path) -> None:
         tmp_path,
         cwd=home,
         from_file={
-            "AUTORESEARCH_ROOT": "/scratch/me/ar",
-            "AUTORESEARCH_ACCOUNT": "pr_1_general",
-            "AUTORESEARCH_PARTITION": "cpu_short",
-            "AUTORESEARCH_CADENCE_MIN": "20",
-            "AUTORESEARCH_PAT_FILE": "/home/me/.config/autoresearch/bot_pat",
+            "OUTERLOOP_ROOT": "/scratch/me/ar",
+            "OUTERLOOP_ACCOUNT": "pr_1_general",
+            "OUTERLOOP_PARTITION": "cpu_short",
+            "OUTERLOOP_CADENCE_MIN": "20",
+            "OUTERLOOP_PAT_FILE": "/home/me/.config/autoresearch/bot_pat",
         },
     )
     assert p.mode == "slurm"
@@ -161,14 +161,14 @@ def test_slurm_composes_the_resident_submit(tmp_path: Path) -> None:
     ]
     # The knobs ride the inherited environment, not a comma-joined --export list.
     assert p.export_env() == {
-        "AUTORESEARCH_RESIDENT": "1",
-        "AUTORESEARCH_HOME": str(home),
-        "AUTORESEARCH_ROOT": "/scratch/me/ar",
-        "AUTORESEARCH_ACCOUNT": "pr_1_general",
-        "AUTORESEARCH_RESIDENT_MINUTES": str(DEFAULT_RESIDENT_MINUTES),
-        "AUTORESEARCH_PARTITION": "cpu_short",
-        "AUTORESEARCH_CADENCE_MIN": "20",
-        "AUTORESEARCH_PAT_FILE": "/home/me/.config/autoresearch/bot_pat",
+        "OUTERLOOP_RESIDENT": "1",
+        "OUTERLOOP_HOME": str(home),
+        "OUTERLOOP_ROOT": "/scratch/me/ar",
+        "OUTERLOOP_ACCOUNT": "pr_1_general",
+        "OUTERLOOP_RESIDENT_MINUTES": str(DEFAULT_RESIDENT_MINUTES),
+        "OUTERLOOP_PARTITION": "cpu_short",
+        "OUTERLOOP_CADENCE_MIN": "20",
+        "OUTERLOOP_PAT_FILE": "/home/me/.config/autoresearch/bot_pat",
     }
 
 
@@ -177,14 +177,14 @@ def test_precedence_is_flag_then_environment_then_file(tmp_path: Path) -> None:
         tmp_path,
         partition="flagged",
         environ={
-            "AUTORESEARCH_ROOT": "/env/root",
-            "AUTORESEARCH_ACCOUNT": "envacct",
-            "AUTORESEARCH_PARTITION": "envpart",
+            "OUTERLOOP_ROOT": "/env/root",
+            "OUTERLOOP_ACCOUNT": "envacct",
+            "OUTERLOOP_PARTITION": "envpart",
         },
         from_file={
-            "AUTORESEARCH_ROOT": "/file/root",
-            "AUTORESEARCH_ACCOUNT": "fileacct",
-            "AUTORESEARCH_PARTITION": "filepart",
+            "OUTERLOOP_ROOT": "/file/root",
+            "OUTERLOOP_ACCOUNT": "fileacct",
+            "OUTERLOOP_PARTITION": "filepart",
         },
     )
     assert (str(p.root), p.account, p.partition) == ("/env/root", "envacct", "flagged")
@@ -192,8 +192,8 @@ def test_precedence_is_flag_then_environment_then_file(tmp_path: Path) -> None:
 
 def test_home_is_a_checkout_on_slurm_and_optional_for_the_local_loop(tmp_path: Path) -> None:
     home = checkout(tmp_path)
-    base = {"AUTORESEARCH_ROOT": "/r", "AUTORESEARCH_ACCOUNT": "a", "AUTORESEARCH_PARTITION": "p"}
-    with_home = {**base, "AUTORESEARCH_HOME": str(home)}
+    base = {"OUTERLOOP_ROOT": "/r", "OUTERLOOP_ACCOUNT": "a", "OUTERLOOP_PARTITION": "p"}
+    with_home = {**base, "OUTERLOOP_HOME": str(home)}
     assert plan(tmp_path, cwd=tmp_path, environ=with_home).home == home
     assert plan(tmp_path, cwd=tmp_path, local=True, environ=with_home).home == home
     # Slurm deploys from the checkout: none at hand is an error
@@ -203,7 +203,7 @@ def test_home_is_a_checkout_on_slurm_and_optional_for_the_local_loop(tmp_path: P
     assert plan(tmp_path, cwd=tmp_path, local=True, root="/r").home == Path("/r/home")
     # a NAMED home that is not a checkout is still an error, in either mode
     with pytest.raises(StartError, match="source checkout"):
-        plan(tmp_path, cwd=tmp_path, local=True, environ={"AUTORESEARCH_HOME": str(tmp_path)})
+        plan(tmp_path, cwd=tmp_path, local=True, environ={"OUTERLOOP_HOME": str(tmp_path)})
 
 
 def test_slurm_requires_root_but_account_and_partition_are_optional(tmp_path: Path) -> None:
@@ -215,8 +215,8 @@ def test_slurm_requires_root_but_account_and_partition_are_optional(tmp_path: Pa
     p = plan(tmp_path, root="/r")
     assert p.account == "" and p.partition == ""
     assert not any(a.startswith(("--account=", "--partition=")) for a in p.command())
-    assert "AUTORESEARCH_ACCOUNT" not in p.export_env()
-    assert "AUTORESEARCH_PARTITION" not in p.export_env()
+    assert "OUTERLOOP_ACCOUNT" not in p.export_env()
+    assert "OUTERLOOP_PARTITION" not in p.export_env()
     p = plan(tmp_path, root="/r", account="a")
     assert "--account=a" in p.command()
     assert not any(a.startswith("--partition=") for a in p.command())
@@ -226,7 +226,7 @@ def test_slurm_accepts_a_comma_list_partition(tmp_path: Path) -> None:
     # a multi-partition "a,b" now rides the inherited env, not the --export
     # delimiter, so it is accepted and passed through verbatim.
     p = plan(tmp_path, root="/r", account="a", partition="cpu_short,cpu_long")
-    assert p.export_env()["AUTORESEARCH_PARTITION"] == "cpu_short,cpu_long"
+    assert p.export_env()["OUTERLOOP_PARTITION"] == "cpu_short,cpu_long"
     assert "--partition=cpu_short,cpu_long" in p.command()
     # a newline would still corrupt the environment / sbatch argv.
     with pytest.raises(StartError, match="newline"):
@@ -236,32 +236,30 @@ def test_slurm_accepts_a_comma_list_partition(tmp_path: Path) -> None:
 @pytest.mark.parametrize("bad", ["0", "-5", "30m", ""])
 def test_cadence_must_be_a_positive_number_in_both_modes(tmp_path: Path, bad: str) -> None:
     if bad == "":
-        assert (
-            plan(tmp_path, local=True, environ={"AUTORESEARCH_CADENCE_MIN": ""}).cadence_min == ""
-        )
+        assert plan(tmp_path, local=True, environ={"OUTERLOOP_CADENCE_MIN": ""}).cadence_min == ""
         return
     with pytest.raises(StartError, match="positive number of minutes"):
-        plan(tmp_path, local=True, environ={"AUTORESEARCH_CADENCE_MIN": bad})
+        plan(tmp_path, local=True, environ={"OUTERLOOP_CADENCE_MIN": bad})
     with pytest.raises(StartError, match="positive number of minutes"):
         plan(
             tmp_path,
             root="/r",
             account="a",
             partition="p",
-            from_file={"AUTORESEARCH_CADENCE_MIN": bad},
+            from_file={"OUTERLOOP_CADENCE_MIN": bad},
         )
 
 
 def test_slurm_resident_minutes_must_be_a_positive_integer(tmp_path: Path) -> None:
     base = dict(root="/r", account="a", partition="p")
-    p = plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "240"})
+    p = plan(tmp_path, **base, environ={"OUTERLOOP_RESIDENT_MINUTES": "240"})
     assert p.resident_minutes == 240
     assert "--time=240" in p.command()
-    assert p.export_env()["AUTORESEARCH_RESIDENT_MINUTES"] == "240"  # successors keep it
+    assert p.export_env()["OUTERLOOP_RESIDENT_MINUTES"] == "240"  # successors keep it
     with pytest.raises(StartError, match="whole number"):
-        plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "4h"})
+        plan(tmp_path, **base, environ={"OUTERLOOP_RESIDENT_MINUTES": "4h"})
     with pytest.raises(StartError, match="positive"):
-        plan(tmp_path, **base, environ={"AUTORESEARCH_RESIDENT_MINUTES": "0"})
+        plan(tmp_path, **base, environ={"OUTERLOOP_RESIDENT_MINUTES": "0"})
 
 
 # ---------------------------------------------------------------- main
@@ -269,7 +267,7 @@ def test_slurm_resident_minutes_must_be_a_positive_integer(tmp_path: Path) -> No
 
 @pytest.fixture
 def clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
-    for key in (*START_KEYS, *TICK_ENV_KEYS, "AUTORESEARCH_HOME"):
+    for key in (*START_KEYS, *TICK_ENV_KEYS, "OUTERLOOP_HOME"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setattr(cli, "ENV_FILE", tmp_path / "absent.env")
     return tmp_path
@@ -300,11 +298,11 @@ def test_local_start_execs_the_loop_with_env_knobs(
         "ENV_FILE",
         env_file(
             clean_env,
-            "AUTORESEARCH_TARGET=o/r\nAUTORESEARCH_PANEL=\nAUTORESEARCH_CADENCE_MIN=15\n"
-            "AUTORESEARCH_PAT_FILE=/home/me/pat\n",
+            "OUTERLOOP_TARGET=o/r\nOUTERLOOP_PANEL=\nOUTERLOOP_CADENCE_MIN=15\n"
+            "OUTERLOOP_PAT_FILE=/home/me/pat\n",
         ),
     )
-    monkeypatch.setenv("AUTORESEARCH_TARGET", "shell/wins")
+    monkeypatch.setenv("OUTERLOOP_TARGET", "shell/wins")
     seen: dict[str, object] = {}
 
     def fake_exec(cmd: list[str], env: dict[str, str]) -> int:
@@ -325,13 +323,13 @@ def test_local_start_execs_the_loop_with_env_knobs(
     ]
     env = seen["env"]
     assert isinstance(env, dict)
-    assert env["AUTORESEARCH_COMPUTE"] == "local"
-    assert env["AUTORESEARCH_ROOT"] == str(clean_env / "state")
-    assert env["AUTORESEARCH_HOME"] == str(home)  # the tick's lanes need the checkout
-    assert env["AUTORESEARCH_TARGET"] == "shell/wins"  # the shell beats the file at launch
-    assert env["AUTORESEARCH_PANEL"] == ""  # an off-switch in the file still lands
-    assert env["AUTORESEARCH_CADENCE_MIN"] == "15"  # the loop's cadence comes from .env too
-    assert env["AUTORESEARCH_PAT_FILE"] == "/home/me/pat"
+    assert env["OUTERLOOP_COMPUTE"] == "local"
+    assert env["OUTERLOOP_ROOT"] == str(clean_env / "state")
+    assert env["OUTERLOOP_HOME"] == str(home)  # the tick's lanes need the checkout
+    assert env["OUTERLOOP_TARGET"] == "shell/wins"  # the shell beats the file at launch
+    assert env["OUTERLOOP_PANEL"] == ""  # an off-switch in the file still lands
+    assert env["OUTERLOOP_CADENCE_MIN"] == "15"  # the loop's cadence comes from .env too
+    assert env["OUTERLOOP_PAT_FILE"] == "/home/me/pat"
 
 
 def test_local_start_needs_no_checkout(clean_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -339,7 +337,7 @@ def test_local_start_needs_no_checkout(clean_env: Path, monkeypatch: pytest.Monk
     installed package, so start must not demand one: home becomes a directory
     under the state root, where flights and logs land (#287)."""
     monkeypatch.setattr(cli.shutil, "which", lambda name: None)
-    monkeypatch.setattr(cli, "ENV_FILE", env_file(clean_env, "AUTORESEARCH_TARGET=o/r\n"))
+    monkeypatch.setattr(cli, "ENV_FILE", env_file(clean_env, "OUTERLOOP_TARGET=o/r\n"))
     seen: dict[str, object] = {}
 
     def fake_exec(cmd: list[str], env: dict[str, str]) -> int:
@@ -353,7 +351,7 @@ def test_local_start_needs_no_checkout(clean_env: Path, monkeypatch: pytest.Monk
     assert main(["start", "--root", str(clean_env / "state")]) == 0
     env = seen["env"]
     assert isinstance(env, dict)
-    assert env["AUTORESEARCH_HOME"] == str(clean_env / "state" / "home")
+    assert env["OUTERLOOP_HOME"] == str(clean_env / "state" / "home")
     assert (clean_env / "state" / "home").is_dir()  # jobs cd into it
 
 
@@ -386,7 +384,7 @@ def test_slurm_start_submits_once_and_reports(
         bin_dir,
         "sbatch",
         f'printf "%s\\n" "$@" > {log}\n'
-        f'printf "%s:%s" "$AUTORESEARCH_RESIDENT" "$AUTORESEARCH_HOME" > {envlog}\n'
+        f'printf "%s:%s" "$OUTERLOOP_RESIDENT" "$OUTERLOOP_HOME" > {envlog}\n'
         'echo "4242;torch"\n',
     )
     shim(bin_dir, "squeue", "exit 0\n")
@@ -498,7 +496,7 @@ def test_local_start_reads_the_env_file_once(
     clean_env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(cli.shutil, "which", lambda name: None)
-    monkeypatch.setattr(cli, "ENV_FILE", env_file(clean_env, "AUTORESEARCH_TARGET=o/r\n"))
+    monkeypatch.setattr(cli, "ENV_FILE", env_file(clean_env, "OUTERLOOP_TARGET=o/r\n"))
     reads: list[tuple[str, ...]] = []
     real = cli.env_file_values
 
@@ -512,7 +510,7 @@ def test_local_start_reads_the_env_file_once(
     monkeypatch.chdir(checkout(clean_env))
     assert main(["start", "--root", str(clean_env / "s")]) == 0
     assert len(reads) == 1
-    assert seen["env"]["AUTORESEARCH_TARGET"] == "o/r"
+    assert seen["env"]["OUTERLOOP_TARGET"] == "o/r"
 
 
 def test_start_errors_are_exit_2_with_the_diagnosis(

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -190,44 +190,44 @@ def test_min_tick_s_from_env_parses_clamps_and_rejects(monkeypatch) -> None:
     from outerloop.tick import _min_tick_s_from_env
 
     # default cadence (30 min) -> safe ceiling = half-cadence = 15 min = 900s
-    monkeypatch.delenv("AUTORESEARCH_CADENCE_MIN", raising=False)
-    monkeypatch.delenv("AUTORESEARCH_MIN_TICK_MINUTES", raising=False)
+    monkeypatch.delenv("OUTERLOOP_CADENCE_MIN", raising=False)
+    monkeypatch.delenv("OUTERLOOP_MIN_TICK_MINUTES", raising=False)
     assert _min_tick_s_from_env() == DEFAULT_MIN_TICK_S  # unset -> default (10 min < ceiling)
-    monkeypatch.setenv("AUTORESEARCH_MIN_TICK_MINUTES", "5")
+    monkeypatch.setenv("OUTERLOOP_MIN_TICK_MINUTES", "5")
     assert _min_tick_s_from_env() == 300.0
-    monkeypatch.setenv("AUTORESEARCH_MIN_TICK_MINUTES", "0")
+    monkeypatch.setenv("OUTERLOOP_MIN_TICK_MINUTES", "0")
     assert _min_tick_s_from_env() == 0.0  # disables
     for bad in ("inf", "nan", "-inf", "abc"):  # non-finite / non-numeric -> default
-        monkeypatch.setenv("AUTORESEARCH_MIN_TICK_MINUTES", bad)
+        monkeypatch.setenv("OUTERLOOP_MIN_TICK_MINUTES", bad)
         assert _min_tick_s_from_env() == DEFAULT_MIN_TICK_S
     # a window at/above half the cadence is clamped so normal ticks aren't coalesced
-    monkeypatch.setenv("AUTORESEARCH_MIN_TICK_MINUTES", "9999")
+    monkeypatch.setenv("OUTERLOOP_MIN_TICK_MINUTES", "9999")
     assert _min_tick_s_from_env() == 900.0  # clamped to the 15-min ceiling
-    monkeypatch.setenv("AUTORESEARCH_MIN_TICK_MINUTES", "25")  # > 15 (half of 30-min cadence)
+    monkeypatch.setenv("OUTERLOOP_MIN_TICK_MINUTES", "25")  # > 15 (half of 30-min cadence)
     assert _min_tick_s_from_env() == 900.0
-    monkeypatch.setenv("AUTORESEARCH_CADENCE_MIN", "10")  # ceiling tracks the cadence
+    monkeypatch.setenv("OUTERLOOP_CADENCE_MIN", "10")  # ceiling tracks the cadence
     assert _min_tick_s_from_env() == 300.0  # clamped to half of 10 min = 5 min
 
 
 def test_default_coalesce_window_scales_with_cadence(monkeypatch) -> None:
     from outerloop.tick import _default_min_tick_s, _min_tick_s_from_env
 
-    monkeypatch.delenv("AUTORESEARCH_MIN_TICK_MINUTES", raising=False)
+    monkeypatch.delenv("OUTERLOOP_MIN_TICK_MINUTES", raising=False)
     # no cadence set -> assume 30-min cadence -> min(10, 15) = 10 min
-    monkeypatch.delenv("AUTORESEARCH_CADENCE_MIN", raising=False)
+    monkeypatch.delenv("OUTERLOOP_CADENCE_MIN", raising=False)
     assert _default_min_tick_s() == DEFAULT_MIN_TICK_S
     # a SHORT cadence scales the window down (half-cadence), so the default can't
     # swallow every on-cadence tick
-    monkeypatch.setenv("AUTORESEARCH_CADENCE_MIN", "6")
+    monkeypatch.setenv("OUTERLOOP_CADENCE_MIN", "6")
     assert _default_min_tick_s() == 180.0  # 6-min cadence -> 3-min window
     # a long cadence stays capped at the ceiling
-    monkeypatch.setenv("AUTORESEARCH_CADENCE_MIN", "120")
+    monkeypatch.setenv("OUTERLOOP_CADENCE_MIN", "120")
     assert _default_min_tick_s() == DEFAULT_MIN_TICK_S
     # garbage cadence -> 30-min fallback -> 10 min
-    monkeypatch.setenv("AUTORESEARCH_CADENCE_MIN", "abc")
+    monkeypatch.setenv("OUTERLOOP_CADENCE_MIN", "abc")
     assert _default_min_tick_s() == DEFAULT_MIN_TICK_S
     # and the unset MIN_TICK path uses this cadence-aware default
-    monkeypatch.setenv("AUTORESEARCH_CADENCE_MIN", "6")
+    monkeypatch.setenv("OUTERLOOP_CADENCE_MIN", "6")
     assert _min_tick_s_from_env() == 180.0
 
 
@@ -1104,7 +1104,7 @@ roadmap: docs/roadmap.md
     assert "--job-minutes 325" in wrap  # the ACTUAL walltime, for the alarm
     assert "--panel verify,review" in wrap  # the pre-PR panel is ON by default
     # config-driven author: the tick threads neither the author key nor the
-    # backend — climb resolves them from AUTORESEARCH_AUTHOR_* env by backend.
+    # backend — climb resolves them from OUTERLOOP_AUTHOR_* env by backend.
     # (FollowupSpec has no author key_file field at all — the tick can't thread it.)
     assert "--key-file" not in wrap and "--author-backend" not in wrap
 
@@ -1833,8 +1833,8 @@ def test_panel_spec_disables_and_reconfigures_the_climb_argv(tmp_path: Path) -> 
 
 
 def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) -> None:
-    """AUTORESEARCH_PANEL/AUTORESEARCH_PANEL_KEY_FILE reach the FollowupSpec
-    through the chain environment, and empty AUTORESEARCH_PANEL turns the
+    """OUTERLOOP_PANEL/OUTERLOOP_PANEL_KEY_FILE reach the FollowupSpec
+    through the chain environment, and empty OUTERLOOP_PANEL turns the
     panel off (not back to the default)."""
     from outerloop.tick import _followup_spec_from_env
 
@@ -1843,14 +1843,14 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
     pat = tmp_path / "pat"
     pat.write_text("t")
     env = {
-        "AUTORESEARCH_PAT_FILE": str(pat),
-        "AUTORESEARCH_ACCOUNT": "a",
-        "AUTORESEARCH_PARTITION": "p",
-        "AUTORESEARCH_IMAGE": str(image),
-        "AUTORESEARCH_HOME": str(tmp_path),
-        "AUTORESEARCH_TARGET": "org/repo",
-        "AUTORESEARCH_PANEL": "verify",
-        "AUTORESEARCH_PANEL_KEY_FILE": "/keys/verifier",
+        "OUTERLOOP_PAT_FILE": str(pat),
+        "OUTERLOOP_ACCOUNT": "a",
+        "OUTERLOOP_PARTITION": "p",
+        "OUTERLOOP_IMAGE": str(image),
+        "OUTERLOOP_HOME": str(tmp_path),
+        "OUTERLOOP_TARGET": "org/repo",
+        "OUTERLOOP_PANEL": "verify",
+        "OUTERLOOP_PANEL_KEY_FILE": "/keys/verifier",
     }
     import outerloop.tick as tick_mod
 
@@ -1860,21 +1860,21 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
     assert spec.target == "org/repo"
     assert spec.panel == "verify" and spec.panel_key_file == "/keys/verifier"
     # no target, no servicing: there is no fallback repo to write to
-    without = {k: v for k, v in env.items() if k != "AUTORESEARCH_TARGET"}
+    without = {k: v for k, v in env.items() if k != "OUTERLOOP_TARGET"}
     monkeypatch.setattr(tick_mod.os, "environ", without)
     assert _followup_spec_from_env(tmp_path) == (None, None)
     monkeypatch.setattr(tick_mod.os, "environ", env)
-    env["AUTORESEARCH_PANEL"] = ""
+    env["OUTERLOOP_PANEL"] = ""
     _github, off = _followup_spec_from_env(tmp_path)
     assert off is not None and off.panel == ""
     # work jobs can ride a longer partition than the tick chain, with the
     # walltime cap raised in lockstep (clamped to the code-side ceiling)
-    env["AUTORESEARCH_JOB_PARTITION"] = "cpu48"
-    env["AUTORESEARCH_MAX_JOB_MINUTES"] = "480"
+    env["OUTERLOOP_JOB_PARTITION"] = "cpu48"
+    env["OUTERLOOP_MAX_JOB_MINUTES"] = "480"
     _github, longer = _followup_spec_from_env(tmp_path)
     assert longer is not None
     assert longer.job_partition == "cpu48" and longer.max_job_minutes == 480
-    env["AUTORESEARCH_MAX_JOB_MINUTES"] = "9000"  # above the ceiling
+    env["OUTERLOOP_MAX_JOB_MINUTES"] = "9000"  # above the ceiling
     _github, capped = _followup_spec_from_env(tmp_path)
     assert capped is not None and capped.max_job_minutes == 600
 
@@ -1905,11 +1905,11 @@ def test_author_config_preflight_blocks_before_side_effects(
             **kw,
         )
 
-    monkeypatch.delenv("AUTORESEARCH_AUTHOR_MODEL", raising=False)
+    monkeypatch.delenv("OUTERLOOP_AUTHOR_MODEL", raising=False)
     # claude (default) is always fine; codex with the claude default model is not
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_BACKEND", "claude")
+    monkeypatch.setenv("OUTERLOOP_AUTHOR_BACKEND", "claude")
     assert _author_config_error(make()) == ""
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_BACKEND", "codex")
+    monkeypatch.setenv("OUTERLOOP_AUTHOR_BACKEND", "codex")
     assert _author_config_error(make()) != ""  # codex + default claude model
     # a codex fleet with no valid model submits NOTHING (no wasted job)
     contract = _self_contract()
@@ -1922,7 +1922,7 @@ def test_author_config_preflight_blocks_before_side_effects(
     out = service_self_initiated(tmp_path, SlurmCompute(runner=runner), make(), contract, NOW)
     assert out is None and submitted == []
     # once the model is set, codex is accepted
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_MODEL", "gpt-5.6-terra")
+    monkeypatch.setenv("OUTERLOOP_AUTHOR_MODEL", "gpt-5.6-terra")
     assert _author_config_error(make()) == ""
 
 
@@ -1982,7 +1982,7 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     judge = tmp_path / "panel_codex_key"
     judge.write_text("sk-judge")
     judge.chmod(0o600)
-    monkeypatch.setenv("AUTORESEARCH_PANEL_CODEX_KEY_FILE", str(judge))
+    monkeypatch.setenv("OUTERLOOP_PANEL_CODEX_KEY_FILE", str(judge))
     no_image = FollowupSpec(
         target="org/pilot",
         account="a",
@@ -1997,15 +1997,15 @@ def test_panel_key_preflight_blocks_claim_and_launch(tmp_path: Path, monkeypatch
     assert "relative" in _panel_preflight_error(make(panel_key_file="good"))
     # role separation: the panel key must not BE the (resolved) author key. The
     # author key is now config-driven — resolved per the fleet backend from env —
-    # so the collision is set via AUTORESEARCH_HARNESS_KEY_FILE, not spec.key_file.
-    monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", str(good))
+    # so the collision is set via OUTERLOOP_HARNESS_KEY_FILE, not spec.key_file.
+    monkeypatch.setenv("OUTERLOOP_HARNESS_KEY_FILE", str(good))
     assert "author key" in _panel_preflight_error(make(panel_key_file=str(good)))
     # ... and a RELATIVE author key path fails too (the climb resolves from a
     # flight dir): a relative env value survives ~-expansion as non-absolute
-    monkeypatch.setenv("AUTORESEARCH_HARNESS_KEY_FILE", "keys/author")
+    monkeypatch.setenv("OUTERLOOP_HARNESS_KEY_FILE", "keys/author")
     rel_err = _panel_preflight_error(make(panel_key_file=str(good)))
     assert "author key path" in rel_err and "relative" in rel_err
-    monkeypatch.delenv("AUTORESEARCH_HARNESS_KEY_FILE")
+    monkeypatch.delenv("OUTERLOOP_HARNESS_KEY_FILE")
 
     # both lanes consult it BEFORE side effects: nothing claimed or submitted
     bad = make(panel_key_file=str(tmp_path / "nope"))
@@ -2192,12 +2192,12 @@ def test_wake_dispatcher_on_switch_lands_dark_by_default(tmp_path, monkeypatch):
     )
 
     # default: no env, no sentinel -> dry sweep, logging dispatcher
-    monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_DISPATCH_WAKE", raising=False)
     dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW, tmp_path)
     assert isinstance(dispatcher, LoggingDispatcher) and live is False
 
     # env on-switch + complete env -> live sweep, real dispatcher
-    monkeypatch.setenv("AUTORESEARCH_DISPATCH_WAKE", "1")
+    monkeypatch.setenv("OUTERLOOP_DISPATCH_WAKE", "1")
     dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW, tmp_path)
     assert isinstance(dispatcher, JobWakeDispatcher) and live is True
 
@@ -2206,7 +2206,7 @@ def test_wake_dispatcher_on_switch_lands_dark_by_default(tmp_path, monkeypatch):
     assert isinstance(dispatcher, LoggingDispatcher) and live is False
 
     # sentinel file arms it too (mirrors PAUSE) — no env var needed
-    monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_DISPATCH_WAKE", raising=False)
     (tmp_path / DISPATCH_WAKE_SENTINEL).touch()
     dispatcher, live = _wake_dispatcher_from_env(compute, spec, NOW, tmp_path)
     assert isinstance(dispatcher, JobWakeDispatcher) and live is True
@@ -3191,12 +3191,12 @@ def test_pending_reason_query_failure_is_an_error_not_a_reason() -> None:
 def test_dispatch_wake_switch_reads_env_or_sentinel(tmp_path: Path, monkeypatch) -> None:
     from outerloop.tick import dispatch_wake_armed
 
-    monkeypatch.delenv("AUTORESEARCH_DISPATCH_WAKE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_DISPATCH_WAKE", raising=False)
     assert not dispatch_wake_armed(tmp_path)
     (tmp_path / "DISPATCH_WAKE").touch()
     assert dispatch_wake_armed(tmp_path)
     (tmp_path / "DISPATCH_WAKE").unlink()
-    monkeypatch.setenv("AUTORESEARCH_DISPATCH_WAKE", "1")
+    monkeypatch.setenv("OUTERLOOP_DISPATCH_WAKE", "1")
     assert dispatch_wake_armed(tmp_path)
 
 
@@ -3364,7 +3364,7 @@ def test_service_syncs_fetches_for_live_sessions(tmp_path: Path, monkeypatch) ->
 def test_followup_spec_needs_no_account_or_partition(monkeypatch: Any, tmp_path: Path) -> None:
     """The followup service comes up without account/partition in both modes
     (#300): on Slurm, empty ones use the cluster's default association and
-    partition, as `start` already allows; under AUTORESEARCH_COMPUTE=local
+    partition, as `start` already allows; under OUTERLOOP_COMPUTE=local
     subprocess jobs have no placement at all. Set, the account passes through."""
     from outerloop.tick import _followup_spec_from_env
 
@@ -3373,10 +3373,10 @@ def test_followup_spec_needs_no_account_or_partition(monkeypatch: Any, tmp_path:
     pat = tmp_path / "pat"
     pat.write_text("t")
     env = {
-        "AUTORESEARCH_PAT_FILE": str(pat),
-        "AUTORESEARCH_IMAGE": str(image),
-        "AUTORESEARCH_HOME": str(tmp_path),
-        "AUTORESEARCH_TARGET": "org/repo",
+        "OUTERLOOP_PAT_FILE": str(pat),
+        "OUTERLOOP_IMAGE": str(image),
+        "OUTERLOOP_HOME": str(tmp_path),
+        "OUTERLOOP_TARGET": "org/repo",
     }
     import outerloop.tick as tick_mod
 
@@ -3384,12 +3384,12 @@ def test_followup_spec_needs_no_account_or_partition(monkeypatch: Any, tmp_path:
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None  # slurm mode, no account, no partition
     assert spec.account == "" and spec.partition == ""
-    env["AUTORESEARCH_ACCOUNT"] = "acct"
+    env["OUTERLOOP_ACCOUNT"] = "acct"
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None
     assert spec.account == "acct" and spec.partition == ""
-    del env["AUTORESEARCH_ACCOUNT"]
-    env["AUTORESEARCH_COMPUTE"] = "local"
+    del env["OUTERLOOP_ACCOUNT"]
+    env["OUTERLOOP_COMPUTE"] = "local"
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None
     assert spec.account == "" and spec.partition == ""
@@ -3397,7 +3397,7 @@ def test_followup_spec_needs_no_account_or_partition(monkeypatch: Any, tmp_path:
 
 def test_resume_gate_needs_only_the_image(monkeypatch: Any, tmp_path: Path, capsys: Any) -> None:
     """The resume gate accepts empty account/partition under
-    AUTORESEARCH_COMPUTE=local (terra #223: locally dispatched wakes died at
+    OUTERLOOP_COMPUTE=local (terra #223: locally dispatched wakes died at
     the parser) and on Slurm (#300: the cluster's defaults apply). Proof of
     admission: the CLI proceeds far enough to complain about the missing
     parked run, not about the placement. Only the image is required: without
@@ -3424,11 +3424,11 @@ def test_resume_gate_needs_only_the_image(monkeypatch: Any, tmp_path: Path, caps
         "--pat-file",
         str(pat),
     ]
-    monkeypatch.delenv("AUTORESEARCH_ACCOUNT", raising=False)
-    monkeypatch.delenv("AUTORESEARCH_PARTITION", raising=False)
+    monkeypatch.delenv("OUTERLOOP_ACCOUNT", raising=False)
+    monkeypatch.delenv("OUTERLOOP_PARTITION", raising=False)
     monkeypatch.setattr(sys, "argv", argv)
 
-    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
+    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
     # past the placement gate, the resume proceeds to the record read and
     # fails THERE (no parked run in this tmp root) — proof of admission
     with pytest.raises(FileNotFoundError, match=r"state\.json"):
@@ -3436,7 +3436,7 @@ def test_resume_gate_needs_only_the_image(monkeypatch: Any, tmp_path: Path, caps
     assert "needs --image" not in capsys.readouterr().err
 
     # Slurm mode, no account, no partition: admitted the same way
-    monkeypatch.delenv("AUTORESEARCH_COMPUTE", raising=False)
+    monkeypatch.delenv("OUTERLOOP_COMPUTE", raising=False)
     with pytest.raises(FileNotFoundError, match=r"state\.json"):
         attempt_mod.main()
     assert "needs --image" not in capsys.readouterr().err
@@ -3493,7 +3493,7 @@ def test_fresh_climb_dispatches_without_account_or_partition(
         "--min-free-gb",
         "0",
     ]
-    for name in ("AUTORESEARCH_COMPUTE", "AUTORESEARCH_ACCOUNT", "AUTORESEARCH_PARTITION"):
+    for name in ("OUTERLOOP_COMPUTE", "OUTERLOOP_ACCOUNT", "OUTERLOOP_PARTITION"):
         monkeypatch.delenv(name, raising=False)
     seen: dict[str, Any] = {}
 
@@ -3533,19 +3533,19 @@ def test_fresh_climb_dispatches_without_account_or_partition(
 
 
 def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> None:
-    """LocalCompute's job-env scrub passes AUTORESEARCH_*/REVIEW_HERMES_*
+    """LocalCompute's job-env scrub passes OUTERLOOP_*/REVIEW_HERMES_*
     through as a prefix rule — a locally submitted wake must arrive still in
     local mode (terra #223), and enumerated names are how flags die."""
     from outerloop.compute import LocalCompute
 
-    monkeypatch.setenv("AUTORESEARCH_COMPUTE", "local")
-    monkeypatch.setenv("AUTORESEARCH_AUTHOR_BACKEND", "codex")
+    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
+    monkeypatch.setenv("OUTERLOOP_AUTHOR_BACKEND", "codex")
     monkeypatch.setenv("REVIEW_HERMES_REPO", "/x/hermes")
     monkeypatch.setenv("APPTAINERENV_EVIL", "1")
     monkeypatch.setenv("OPENROUTER_API_KEY", "sk-live")
-    monkeypatch.setenv("AUTORESEARCH_BOT_PAT", "github_pat_secret")
-    monkeypatch.setenv("AUTORESEARCH_PANEL_KEY", "sk-ant-secret")
-    monkeypatch.setenv("AUTORESEARCH_CODEX_KEY_FILE", "/keys/codex")
+    monkeypatch.setenv("OUTERLOOP_BOT_PAT", "github_pat_secret")
+    monkeypatch.setenv("OUTERLOOP_PANEL_KEY", "sk-ant-secret")
+    monkeypatch.setenv("OUTERLOOP_CODEX_KEY_FILE", "/keys/codex")
     out = tmp_path / "env.txt"
     from outerloop.compute import JobSpec
 
@@ -3560,15 +3560,15 @@ def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> 
         )
     )
     dumped = out.read_text()
-    assert "AUTORESEARCH_COMPUTE=local" in dumped
-    assert "AUTORESEARCH_AUTHOR_BACKEND=codex" in dumped
+    assert "OUTERLOOP_COMPUTE=local" in dumped
+    assert "OUTERLOOP_AUTHOR_BACKEND=codex" in dumped
     assert "REVIEW_HERMES_REPO=/x/hermes" in dumped
     assert "APPTAINERENV_EVIL" not in dumped  # would cross --cleanenv
     assert "OPENROUTER_API_KEY" not in dumped  # raw secrets never pass
     # secret-VALUED names under the prefix are excluded; path names survive
-    assert "AUTORESEARCH_BOT_PAT" not in dumped
-    assert "AUTORESEARCH_PANEL_KEY" not in dumped
-    assert "AUTORESEARCH_CODEX_KEY_FILE=/keys/codex" in dumped
+    assert "OUTERLOOP_BOT_PAT" not in dumped
+    assert "OUTERLOOP_PANEL_KEY" not in dumped
+    assert "OUTERLOOP_CODEX_KEY_FILE=/keys/codex" in dumped
 
 
 def test_loop_cadence_is_clamped_finite(monkeypatch: Any) -> None:
@@ -3579,7 +3579,7 @@ def test_loop_cadence_is_clamped_finite(monkeypatch: Any) -> None:
 
     from outerloop.tick import _loop_cadence_s
 
-    monkeypatch.setenv("AUTORESEARCH_CADENCE_MIN", "45")
+    monkeypatch.setenv("OUTERLOOP_CADENCE_MIN", "45")
     for raw, expect in ((math.inf, 24 * 3600.0), (0.0001, 60.0), (30.0, 1800.0)):
         clamped = _loop_cadence_s(raw)
         assert clamped == expect
@@ -4274,7 +4274,7 @@ def test_jobs_run_the_installed_interpreter_outside_a_checkout(tmp_path: Path) -
 
 
 def test_local_mode_runs_uncontained_without_an_image(monkeypatch: Any, tmp_path: Path) -> None:
-    """A laptop has no Apptainer image. Under AUTORESEARCH_COMPUTE=local the
+    """A laptop has no Apptainer image. Under OUTERLOOP_COMPUTE=local the
     servicing spec still comes up, with an empty image, and the job argv says
     --uncontained; Slurm mode without the image stays disabled (#289)."""
     from outerloop.tick import _containment, _followup_spec_from_env
@@ -4282,24 +4282,24 @@ def test_local_mode_runs_uncontained_without_an_image(monkeypatch: Any, tmp_path
     pat = tmp_path / "pat"
     pat.write_text("t")
     env = {
-        "AUTORESEARCH_PAT_FILE": str(pat),
-        "AUTORESEARCH_IMAGE": str(tmp_path / "missing.sif"),
-        "AUTORESEARCH_HOME": str(tmp_path),
-        "AUTORESEARCH_TARGET": "org/repo",
-        "AUTORESEARCH_ACCOUNT": "a",
-        "AUTORESEARCH_PARTITION": "p",
+        "OUTERLOOP_PAT_FILE": str(pat),
+        "OUTERLOOP_IMAGE": str(tmp_path / "missing.sif"),
+        "OUTERLOOP_HOME": str(tmp_path),
+        "OUTERLOOP_TARGET": "org/repo",
+        "OUTERLOOP_ACCOUNT": "a",
+        "OUTERLOOP_PARTITION": "p",
     }
     import outerloop.tick as tick_mod
 
     monkeypatch.setattr(tick_mod.os, "environ", env)
     assert _followup_spec_from_env(tmp_path) == (None, None)  # slurm: image required
-    env["AUTORESEARCH_COMPUTE"] = "local"
+    env["OUTERLOOP_COMPUTE"] = "local"
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None and spec.image == ""
     assert spec.panel == ""  # an uncontained judge is opt-in
-    assert "AUTORESEARCH_IMAGE" not in env  # the jobs do not inherit a missing image
+    assert "OUTERLOOP_IMAGE" not in env  # the jobs do not inherit a missing image
     assert _containment(spec.image) == ["--uncontained"]
     assert _containment("/img/a.sif") == ["--image", "/img/a.sif"]
-    env["AUTORESEARCH_PANEL_UNCONTAINED"] = "1"
+    env["OUTERLOOP_PANEL_UNCONTAINED"] = "1"
     _github, spec = _followup_spec_from_env(tmp_path)
     assert spec is not None and spec.panel == "verify,review"

--- a/tests/test_tick_chain_successors.py
+++ b/tests/test_tick_chain_successors.py
@@ -24,9 +24,9 @@ def test_successors_are_singleton_on_the_grid_without_a_deadline() -> None:
     assert '--begin="$begin"' in line
     assert "--deadline" not in line and "--deadline" not in CHAIN
     # partition is optional now: passed through only when set (part_arg is
-    # derived from AUTORESEARCH_PARTITION near the top of the chain).
+    # derived from OUTERLOOP_PARTITION near the top of the chain).
     assert '${part_arg:+"$part_arg"}' in line
-    assert 'part_arg="--partition=${AUTORESEARCH_PARTITION}"' in CHAIN
+    assert 'part_arg="--partition=${OUTERLOOP_PARTITION}"' in CHAIN
 
 
 def _grid(epoch_now: int, cadence_s: int, pending: int, i: int) -> int:

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -65,14 +65,14 @@ def _env(home: Path, root: Path, bindir: Path, **extra: str) -> dict[str, str]:
         **os.environ,
         "PATH": f"{bindir}:{os.environ['PATH']}",
         "USER": os.environ.get("USER", "u"),
-        "AUTORESEARCH_HOME": str(home),
-        "AUTORESEARCH_ROOT": str(root),
-        "AUTORESEARCH_ACCOUNT": "acct",
-        "AUTORESEARCH_PARTITION": "cpu_short",
+        "OUTERLOOP_HOME": str(home),
+        "OUTERLOOP_ROOT": str(root),
+        "OUTERLOOP_ACCOUNT": "acct",
+        "OUTERLOOP_PARTITION": "cpu_short",
         "HOME": str(home),  # no ~/.config/autoresearch/.env
     }
-    env.pop("AUTORESEARCH_PAT_FILE", None)
-    env.pop("AUTORESEARCH_RESIDENT", None)
+    env.pop("OUTERLOOP_PAT_FILE", None)
+    env.pop("OUTERLOOP_RESIDENT", None)
     env.update(extra)
     return env
 
@@ -112,9 +112,9 @@ def test_resident_loop_keeps_one_successor_resubmits_on_shim_change_and_pauses_c
         home,
         root,
         bindir,
-        AUTORESEARCH_RESIDENT="1",
-        AUTORESEARCH_RESIDENT_CADENCE_S="1",
-        AUTORESEARCH_RESIDENT_MINUTES="360",
+        OUTERLOOP_RESIDENT="1",
+        OUTERLOOP_RESIDENT_CADENCE_S="1",
+        OUTERLOOP_RESIDENT_MINUTES="360",
         SLURM_JOB_ID="42",
     )
     proc = _run_chain(home, env)
@@ -157,9 +157,9 @@ def _resident_env(home: Path, root: Path, bindir: Path, **extra: str) -> dict[st
         home,
         root,
         bindir,
-        AUTORESEARCH_RESIDENT="1",
-        AUTORESEARCH_RESIDENT_CADENCE_S="1",
-        AUTORESEARCH_RESIDENT_MINUTES="360",
+        OUTERLOOP_RESIDENT="1",
+        OUTERLOOP_RESIDENT_CADENCE_S="1",
+        OUTERLOOP_RESIDENT_MINUTES="360",
         SLURM_JOB_ID="42",
         **extra,
     )
@@ -269,7 +269,7 @@ echo "$((500 + n))"
 """
     )
     proc = _run_chain(
-        home, _resident_env(home, root, bindir, AUTORESEARCH_RESIDENT_RETRY_S="0"), timeout=120
+        home, _resident_env(home, root, bindir, OUTERLOOP_RESIDENT_RETRY_S="0"), timeout=120
     )
     assert proc.returncode == 0, proc.stderr
     assert len((shimlog / "sbatch").read_text().splitlines()) == 5
@@ -283,10 +283,10 @@ def test_a_misconfigured_resident_start_fails_loudly_before_queuing_anything(
 ) -> None:
     home, root, bindir, shimlog = _install(tmp_path)
     env = _resident_env(home, root, bindir)
-    env.pop("AUTORESEARCH_ROOT")
+    env.pop("OUTERLOOP_ROOT")
     proc = _run_chain(home, env)
     assert proc.returncode == 1
-    assert "resident tick misconfigured; missing: AUTORESEARCH_ROOT" in proc.stderr
+    assert "resident tick misconfigured; missing: OUTERLOOP_ROOT" in proc.stderr
     assert not (shimlog / "sbatch").exists() and not (shimlog / "ticks").exists()
 
 
@@ -343,16 +343,16 @@ exit 0
     env = {
         **os.environ,
         "PATH": f"{bindir}:{os.environ['PATH']}",
-        "AUTORESEARCH_HOME": str(home),
-        "AUTORESEARCH_ROOT": str(root),
-        "AUTORESEARCH_PAT_FILE": str(pat),
+        "OUTERLOOP_HOME": str(home),
+        "OUTERLOOP_ROOT": str(root),
+        "OUTERLOOP_PAT_FILE": str(pat),
         "HOME": str(tmp_path),
     }
     proc = subprocess.run(
         [
             "bash",
             "-c",
-            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$AUTORESEARCH_DEPLOY_BROKEN"',
+            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$OUTERLOOP_DEPLOY_BROKEN"',
         ],
         env=env,
         capture_output=True,
@@ -369,7 +369,7 @@ exit 0
 
 def test_a_failed_rollback_marks_the_deploy_broken_so_no_tick_runs(tmp_path: Path) -> None:
     """When the sync fails AND the reset back to the previous commit fails,
-    the deploy exports AUTORESEARCH_DEPLOY_BROKEN=1 and the tick callers skip
+    the deploy exports OUTERLOOP_DEPLOY_BROKEN=1 and the tick callers skip
     the tick: new source must never run against the old environment."""
     home = tmp_path / "home"
     (home / "scripts").mkdir(parents=True)
@@ -399,16 +399,16 @@ exit 0
     env = {
         **os.environ,
         "PATH": f"{bindir}:{os.environ['PATH']}",
-        "AUTORESEARCH_HOME": str(home),
-        "AUTORESEARCH_ROOT": str(root),
-        "AUTORESEARCH_PAT_FILE": str(pat),
+        "OUTERLOOP_HOME": str(home),
+        "OUTERLOOP_ROOT": str(root),
+        "OUTERLOOP_PAT_FILE": str(pat),
         "HOME": str(tmp_path),
     }
     proc = subprocess.run(
         [
             "bash",
             "-c",
-            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$AUTORESEARCH_DEPLOY_BROKEN"',
+            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$OUTERLOOP_DEPLOY_BROKEN"',
         ],
         env=env,
         capture_output=True,
@@ -420,9 +420,9 @@ exit 0
     assert "BROKEN=1" in proc.stdout
     # and the chain honours it: no tick, successors untouched, clean exit
     shim = (ROOT / "scripts" / "tick_chain.sbatch").read_text()
-    assert 'AUTORESEARCH_DEPLOY_BROKEN:-}" = "1"' in shim and "tick skipped" in shim
+    assert 'OUTERLOOP_DEPLOY_BROKEN:-}" = "1"' in shim and "tick skipped" in shim
     resident = (ROOT / "scripts" / "tick_resident.sh").read_text()
-    assert 'AUTORESEARCH_DEPLOY_BROKEN:-}" = "1"' in resident and "tick skipped" in resident
+    assert 'OUTERLOOP_DEPLOY_BROKEN:-}" = "1"' in resident and "tick skipped" in resident
 
 
 def test_a_failed_sync_with_unchanged_lock_keeps_ticking_on_the_current_env(tmp_path: Path) -> None:
@@ -459,16 +459,16 @@ exit 0
     env = {
         **os.environ,
         "PATH": f"{bindir}:{os.environ['PATH']}",
-        "AUTORESEARCH_HOME": str(home),
-        "AUTORESEARCH_ROOT": str(root),
-        "AUTORESEARCH_PAT_FILE": str(pat),
+        "OUTERLOOP_HOME": str(home),
+        "OUTERLOOP_ROOT": str(root),
+        "OUTERLOOP_PAT_FILE": str(pat),
         "HOME": str(tmp_path),
     }
     proc = subprocess.run(
         [
             "bash",
             "-c",
-            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$AUTORESEARCH_DEPLOY_BROKEN"',
+            f'. "{home}/scripts/tick_deploy.sh"; echo "BROKEN=$OUTERLOOP_DEPLOY_BROKEN"',
         ],
         env=env,
         capture_output=True,


### PR DESCRIPTION
The internal flip the bridge's docstring promised. Since the rename the public names were `OUTERLOOP_*`, but the kernel's reads, log lines, chain scripts and tests still said `AUTORESEARCH_*` behind an import-time bridge. An adopter reading the code, or a "missing:" log line, saw the old names (that is how #300 was reported).

## What changed

- **Every internal read uses `OUTERLOOP_*`.** A mechanical rename across src, tests, scripts, docs and the two agent workflows (46 distinct names). `CHANGELOG.md` history is untouched.
- **The bridge is inverted, not removed.** A pre-rename `AUTORESEARCH_*` value is copied into its `OUTERLOOP_*` twin when the twin is unset, at three boundaries: the process environment on import, the `.env` reader in `cli.py`, and the shell loop at the chain's entry (`tick_chain.sbatch`); `tick_deploy.sh`'s allowlist grep takes either spelling. Existing deployments keep working for one release. The CHANGELOG says the old names go away in the release after 0.1.
- **Review footer** now reads "Advisory findings from `outerloop`" (`review.py`).
- **CLI help pass**: `outerloop --version`; a top-level epilog naming the init-then-start order and the config file; descriptions for `start`, `tick` and `init`; help for `tick --grace-s` and `--lease-ttl-s`; `init --author-backend` lists the backends; the free-disk help is a full sentence.

## Hand-fixed after the mechanical pass

The rename produced four sentences that named the same variable twice or lost the legacy spelling; each is restored: `_home`'s `AUTORESEARCH_HOME` fallback for an explicit environ, the state-root error message, the `.env` cross-spelling test fixture, and the author key-file docstring. The `test_env_bridge.py` suite is rewritten for the new direction (Python bridge, `.env` reader, shell loop, deploy allowlist).

## Left as is, on purpose

On-disk and queue names stay: `~/.autoresearch` as the local state root, `autoresearch-resident` as the resident job name, `~/autoresearch-images/` as the default image path, `~/.config/autoresearch/` and `.autoresearch.yaml` as honored legacy locations. Renaming those changes what is on every deployment's disk and in its queue, and is a separate decision.

Gate: ruff check, ruff format --check, mypy, `bash -n` on the scripts, pytest (1227 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
