### PR TITLE
On-disk and queue names follow the rename; pre-rename names honored one release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,18 @@ Versions follow [SemVer](https://semver.org).
   dropped in the release after 0.1. The review footer names `outerloop`, and
   `outerloop --version` exists; `start`, `tick` and `init` describe themselves
   and every flag in `--help`.
+- The on-disk and queue names follow the rename: the resident tick job is
+  `outerloop-resident` (the per-cadence chain `outerloop-tick`), the local
+  state root defaults to `~/.outerloop`, the default image path is
+  `~/outerloop-images/agent-py312.sif`. `outerloop start` refuses while a
+  pre-rename `autoresearch-resident` is queued or running, since Slurm's
+  singleton serializes by name; cancel it first. An existing `~/.autoresearch`
+  or `~/autoresearch-images/` is used while the new path does not exist. A
+  chain-mode deployment (manual `tick_chain.sbatch`) must be stopped with
+  `scancel --name autoresearch-tick` before deploying this version. Every
+  honored pre-rename name (`~/.config/autoresearch/`, `.autoresearch.yaml`, the
+  `.autoresearch` channel dir, the old root, image and job names) is dropped in
+  the release after 0.1; the comment marker keeps recognizing old comments.
 
 ### Changed
 

--- a/docs/design/resident-tick.md
+++ b/docs/design/resident-tick.md
@@ -97,7 +97,7 @@ covers it.
    resident chain is STARTED with an explicit walltime and its own job name:
 
    ```
-   sbatch --time=360 --job-name=autoresearch-resident --dependency=singleton \
+   sbatch --time=360 --job-name=outerloop-resident --dependency=singleton \
      --account=… --partition=cpu_short \
      --export=ALL,OUTERLOOP_RESIDENT=1,OUTERLOOP_HOME=…,OUTERLOOP_ROOT=…,\
    OUTERLOOP_ACCOUNT=…,OUTERLOOP_PARTITION=cpu_short,OUTERLOOP_PAT_FILE=… \

--- a/docs/design/role-cli.md
+++ b/docs/design/role-cli.md
@@ -40,7 +40,7 @@ The invariants, proven on #132/#133 and non-negotiable everywhere:
    in the same PR — never two ways to say the same thing.
 4. **Verbs are RoleSpec-gated.** The RoleSpec already caps each role's
    tools/scope/key; the CLI's live verbs are part of that cap. It is ONE tool
-   (`.autoresearch/syscall`) whose verbs the brief exposes per role — an author
+   (`.outerloop/syscall`) whose verbs the brief exposes per role — an author
    uses `launch`/`sleep`, a judge uses `finding`/`conclude` — and a syscall is
    TYPED, so the kernel dispatches by type (a sleep parks + wakes; a verdict is
    read back). Every role runs the tool the same way: a shell in the jail. Roles
@@ -49,7 +49,7 @@ The invariants, proven on #132/#133 and non-negotiable everywhere:
 
 ## End-state
 
-One `.autoresearch/syscall` tool, its live verbs gated per role by RoleSpec:
+One `.outerloop/syscall` tool, its live verbs gated per role by RoleSpec:
 
 | Role | Verbs | Win | Installed where |
 | --- | --- | --- | --- |
@@ -70,7 +70,7 @@ lands with tests, and deletes what it replaces.
 ### Phase 0 — finish Phase A (in flight, prerequisite)
 
 The wake for `author-sleep` parks: gather each launch's results from the run
-dir, deliver declared artifacts into `.autoresearch/results/<name>/`, resume
+dir, deliver declared artifacts into `.outerloop/results/<name>/`, resume
 the **same session** through the climb's resume-entry (#129) with the results
 data-fenced, update the budget file. (The transitional `AUTHOR_SLEEP_WAKE_READY`
 constant and env-flag arming have since retired: enablement is contract-driven.) Plus
@@ -95,7 +95,7 @@ findings drafts the PR for a human. A submit costs the sleep it rides on.
 
 A verdict is not a second tool — it is a syscall TYPE on the one surface.
 Reviewer/verifier/panel stop emitting one schema-constrained final message.
-Instead: `python .autoresearch/syscall finding --file --line --confidence
+Instead: `python .outerloop/syscall finding --file --line --confidence
 --summary --detail [--blocking] [--kind] [--category]` per finding, then
 `... conclude --notes ...` to commit — each call validated on the spot, the
 verdict assembled kernel-side (`type: "verdict"`), well-formed by construction.

--- a/docs/install.md
+++ b/docs/install.md
@@ -234,7 +234,7 @@ first; `OUTERLOOP_PANEL` names the verify/review lenses (with
 still read). A Codex author always runs contained, so it also needs the image
 (`OUTERLOOP_IMAGE`) and a Codex model in `OUTERLOOP_AUTHOR_MODEL`. On a
 cluster, evals run inside the Apptainer image at `OUTERLOOP_IMAGE` (default
-`~/autoresearch-images/agent-py312.sif`) in a jail that binds only the
+`~/outerloop-images/agent-py312.sif`) in a jail that binds only the
 checked-out tree — an eval that needs data must fetch it into the tree, and
 GPU jobs are requested per node (`--gpus-per-node`).
 

--- a/docs/validation/author-syscalls.md
+++ b/docs/validation/author-syscalls.md
@@ -36,17 +36,17 @@ the brief only when armed).
 
 The lifecycle to confirm, in order:
 
-1. **Tool installed:** `<run_dir>/ws/.autoresearch/syscall` exists, and
-   `.autoresearch/budget.json` shows `depth_k` / `sleep_k`.
+1. **Tool installed:** `<run_dir>/ws/.outerloop/syscall` exists, and
+   `.outerloop/budget.json` shows `depth_k` / `sleep_k`.
 2. **Author sleeps:** the session ends having written
-   `.autoresearch/syscall.json` (`type: "sleep"`, one+ launches).
+   `.outerloop/syscall.json` (`type: "sleep"`, one+ launches).
 3. **Park:** the run record is `waiting`, `stage.phase == "author-sleep"`, with
    `stage.afterany` naming the submitted launch job(s), `syscall_launches`, and
    `launches_used` / `sleeps_used` counts.
 4. **Launch job runs:** `<run_dir>/eval-launch-<name>/` fills with `exit-code`,
    `stdout`, `stderr`, and `artifacts/` (the declared files, copied out).
 5. **Wake:** the tick wakes the parked run; `gather_results` delivers artifacts
-   into `<ws>/.autoresearch/results/<name>/`, and the SAME session resumes
+   into `<ws>/.outerloop/results/<name>/`, and the SAME session resumes
    (`resume_session_id` unchanged) with the results data-fenced + the author's
    note echoed back.
 6. **Terminate:** the woken author either sleeps again (a fresh author-sleep

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -29,7 +29,7 @@
 # a live config change (e.g. OUTERLOOP_AUTHOR_BACKEND=codex + its key file)
 # needs no chain restart — just an edit to that file.
 #
-#SBATCH --job-name=autoresearch-tick
+#SBATCH --job-name=outerloop-tick
 #SBATCH --time=15
 #SBATCH --mem=4G
 #SBATCH --cpus-per-task=2
@@ -46,8 +46,10 @@ for _ov in $(env | sed -n 's/^AUTORESEARCH_\([A-Z_][A-Z0-9_]*\)=.*/\1/p'); do
     eval "[ -n \"\${OUTERLOOP_${_ov}+set}\" ] || export OUTERLOOP_${_ov}=\"\${AUTORESEARCH_${_ov}}\""
 done
 CADENCE_MIN="${OUTERLOOP_CADENCE_MIN:-30}"
-JOB_NAME="autoresearch-tick"
-RESIDENT_JOB_NAME="autoresearch-resident"
+JOB_NAME="outerloop-tick"
+RESIDENT_JOB_NAME="outerloop-resident"
+# a resident submitted before the rename; dropped in the release after 0.1
+LEGACY_RESIDENT_JOB_NAME="autoresearch-resident"
 missing=""
 for var in OUTERLOOP_HOME OUTERLOOP_ROOT; do
     eval "val=\${$var:-}"
@@ -77,7 +79,7 @@ fi
 # --- 1. keep two successors queued (singleton serializes same-name jobs) ---
 # A resident tick (design/resident-tick.md) supersedes this chain: while one
 # is queued or running, stop topping up so the per-cadence chain drains.
-if squeue -u "$USER" --name="$RESIDENT_JOB_NAME" -h 2>/dev/null | grep -q '[0-9]'; then
+if squeue -u "$USER" --name="$RESIDENT_JOB_NAME,$LEGACY_RESIDENT_JOB_NAME" -h 2>/dev/null | grep -q '[0-9]'; then
     echo "chain: a resident tick exists; not queuing successors (draining)"
     need=0
     pending=0

--- a/scripts/tick_chain.sbatch
+++ b/scripts/tick_chain.sbatch
@@ -21,7 +21,7 @@
 #                             sleep, with a single afterany:self successor.
 #                             `outerloop start` submits it (walltime,
 #                             name, and exports filled in); by hand:
-#                             `sbatch --time=360 --job-name=autoresearch-resident
+#                             `sbatch --time=360 --job-name=outerloop-resident
 #                             --export=ALL,OUTERLOOP_RESIDENT=1,...`. The
 #                             per-cadence chain drains itself once a resident
 #                             job exists. Unset = the per-cadence chain below.

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -383,7 +383,7 @@ def start(args: argparse.Namespace) -> int:
         print(
             "outerloop start: could not ask the scheduler whether a resident tick "
             "exists (squeue failed); nothing submitted. Retry, or check "
-            f"`squeue --name {RESIDENT_JOB_NAME}`.",
+            f"`squeue --name {RESIDENT_JOB_NAME},{LEGACY_RESIDENT_JOB_NAME}`.",
             file=sys.stderr,
         )
         return 1

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -18,14 +18,21 @@ import shutil
 import stat
 import subprocess
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
 from outerloop import paths
 
-RESIDENT_JOB_NAME = "autoresearch-resident"
+RESIDENT_JOB_NAME = "outerloop-resident"
+# A resident submitted before the rename. Slurm's singleton serializes jobs by
+# NAME, so `start` must refuse while one of these is queued or running (two
+# residents on one root is what the singleton prevents). Dropped in the
+# release after 0.1.
+LEGACY_RESIDENT_JOB_NAME = "autoresearch-resident"
 DEFAULT_RESIDENT_MINUTES = 360  # cpu_short's ceiling on Torch; the loop hands over to itself
-DEFAULT_LOCAL_ROOT = Path.home() / ".autoresearch"
+DEFAULT_LOCAL_ROOT = Path.home() / ".outerloop"
+LEGACY_LOCAL_ROOT_NAME = ".autoresearch"  # pre-rename; honored until the release after 0.1
 ENV_FILE = paths.ENV_FILE  # ~/.config/outerloop/.env, or the pre-rename dir (see paths.py)
 
 # What start itself decides from: mode, placement, root, cadence, walltime.
@@ -223,7 +230,7 @@ def plan_start(
     # Slurm runs from a checkout; the local loop runs the installed package
     # and needs only a directory (the launch lanes and GitHub servicing
     # switch off without OUTERLOOP_HOME, so one is always set)
-    local_root = Path(root_s).expanduser() if root_s else DEFAULT_LOCAL_ROOT
+    local_root = Path(root_s).expanduser() if root_s else default_local_root(environ)
     home = _home(environ, cwd, local=(mode == "local"), root=local_root)
     if mode == "local":
         return StartPlan(
@@ -277,16 +284,30 @@ def plan_start(
     )
 
 
+def default_local_root(environ: Mapping[str, str]) -> Path:
+    """The local-mode state root when none is given: ~/.outerloop, or the
+    pre-rename ~/.autoresearch when only that one exists (state is never moved
+    behind the operator's back). The home comes from `environ` so a caller
+    with no HOME gets the plain default."""
+    home_s = environ.get("HOME", "")
+    if not home_s:
+        return DEFAULT_LOCAL_ROOT
+    home = Path(home_s)
+    new, old = home / DEFAULT_LOCAL_ROOT.name, home / LEGACY_LOCAL_ROOT_NAME
+    return old if (not new.exists() and old.is_dir()) else new
+
+
 def _resident_jobs() -> list[str] | None:
-    """Ids of queued or running resident ticks, lowest first; None when the
-    scheduler could not be asked (a failed lookup must never read as 'none')."""
+    """Ids of queued or running resident ticks under either name, lowest first;
+    None when the scheduler could not be asked (a failed lookup must never
+    read as 'none')."""
     try:
         proc = subprocess.run(
             [
                 "squeue",
                 "-u",
                 os.environ.get("USER", ""),
-                f"--name={RESIDENT_JOB_NAME}",
+                f"--name={RESIDENT_JOB_NAME},{LEGACY_RESIDENT_JOB_NAME}",
                 "-h",
                 "-o",
                 "%i",
@@ -369,7 +390,7 @@ def start(args: argparse.Namespace) -> int:
     if existing:
         print(
             f"a resident tick is already queued or running (job {existing[0]}); nothing "
-            f"submitted. Stop it with `scancel --name {RESIDENT_JOB_NAME}`, or pause it "
+            f"submitted. Stop it with `scancel {existing[0]}`, or pause it "
             f"with `touch {plan.root}/PAUSE`.",
             file=sys.stderr,
         )
@@ -431,7 +452,7 @@ def main(argv: list[str] | None = None) -> int:
         "~/.config/outerloop/.env, written by `outerloop init`.",
     )
     p.add_argument(
-        "--root", help="state root (shared filesystem on Slurm; default ~/.autoresearch locally)"
+        "--root", help="state root (shared filesystem on Slurm; default ~/.outerloop locally)"
     )
     p.add_argument(
         "--account", help="Slurm account (optional; unset bills your default association)"

--- a/src/outerloop/contract.py
+++ b/src/outerloop/contract.py
@@ -26,6 +26,7 @@ SELF_REPO = "outerloop-science/outerloop"
 # `.autoresearch.yaml` (targets written before the rename) is still honored. Every
 # read goes through `find_contract`, which tries the new name first. Neither is
 # ever a writable path for the agent.
+# The pre-rename name is dropped in the release after 0.1.
 CONTRACT_NAMES: tuple[str, ...] = (".outerloop.yaml", ".autoresearch.yaml")
 CONTRACT_NAME = CONTRACT_NAMES[0]  # what the docs and new contracts use
 ALWAYS_FORBIDDEN: tuple[str, ...] = (".github", *CONTRACT_NAMES)

--- a/src/outerloop/orchestrator.py
+++ b/src/outerloop/orchestrator.py
@@ -361,7 +361,7 @@ class SubprocessEvaluator:
             )
         except OSError as exc:
             raise EvalError(f"could not create check home: {exc}") from exc
-        cache_dir = Path(tempfile.mkdtemp(prefix="autoresearch-check-cache-"))
+        cache_dir = Path(tempfile.mkdtemp(prefix="outerloop-check-cache-"))
         try:
             self._run(workspace, command, eval_home, cache_dir)
         finally:

--- a/src/outerloop/paths.py
+++ b/src/outerloop/paths.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
-CONFIG_DIR_NAMES: tuple[str, ...] = ("outerloop", "autoresearch")  # new first
+# New name first; the pre-rename name is dropped in the release after 0.1.
+CONFIG_DIR_NAMES: tuple[str, ...] = ("outerloop", "autoresearch")
 
 
 def config_dir(home: Path | None = None) -> Path:

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -50,6 +50,7 @@ from outerloop.compute import GONE
 # workspace and the session's own memory of the path both predate the rename.
 # `channel_dir(ws)` resolves per workspace: existing dir (new name first), else
 # the new default. Every site keys off it, so a resumed run finds its own path.
+# The pre-rename name is dropped in the release after 0.1.
 CHANNEL_DIR_NAMES: tuple[str, ...] = (".outerloop", ".autoresearch")
 SYSCALL_DIR = CHANNEL_DIR_NAMES[0]  # the new default (a fresh clone installs this)
 SYSCALL_FILE = "syscall.json"

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -3028,7 +3028,7 @@ def _default_image() -> str:
     0.1."""
     new = os.path.expanduser("~/outerloop-images/agent-py312.sif")
     old = os.path.expanduser("~/autoresearch-images/agent-py312.sif")
-    return old if (not os.path.exists(new) and os.path.isfile(old)) else new
+    return old if (not os.path.isfile(new) and os.path.isfile(old)) else new
 
 
 def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -3022,6 +3022,15 @@ def _min_tick_s_from_env() -> float:
     return seconds
 
 
+def _default_image() -> str:
+    """~/outerloop-images/agent-py312.sif, or the pre-rename ~/autoresearch-images
+    path when only that one exists. The fallback is dropped in the release after
+    0.1."""
+    new = os.path.expanduser("~/outerloop-images/agent-py312.sif")
+    old = os.path.expanduser("~/autoresearch-images/agent-py312.sif")
+    return old if (not os.path.exists(new) and os.path.isfile(old)) else new
+
+
 def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     """GitHub client + FollowupSpec from the chain environment, or Nones when
     the environment is incomplete (the tick then runs without in-review
@@ -3030,10 +3039,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     app_file = os.environ.get("OUTERLOOP_GITHUB_APP_FILE", "")
     account = os.environ.get("OUTERLOOP_ACCOUNT", "")
     partition = os.environ.get("OUTERLOOP_PARTITION", "")
-    image = os.environ.get(
-        "OUTERLOOP_IMAGE",
-        os.path.expanduser("~/autoresearch-images/agent-py312.sif"),
-    )
+    image = os.environ.get("OUTERLOOP_IMAGE", _default_image())
     home = os.environ.get("OUTERLOOP_HOME", "")
     # Account and partition are optional on Slurm: empty ones leave the billing
     # association and the partition to Slurm's defaults, as `start` already

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -144,6 +144,28 @@ def test_resident_lookup_asks_for_both_names(monkeypatch: Any) -> None:
     assert "--name=outerloop-resident,autoresearch-resident" in seen[0]
 
 
+def test_default_image_falls_back_only_to_a_usable_legacy_file(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """The pre-rename image is used while the new path is not a FILE (absent, or
+    a stray directory); a real new image always wins."""
+    from outerloop.tick import _default_image
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    new = tmp_path / "outerloop-images" / "agent-py312.sif"
+    old = tmp_path / "autoresearch-images" / "agent-py312.sif"
+    assert _default_image() == str(new)  # neither exists: the new default
+    old.parent.mkdir()
+    old.write_text("")
+    assert _default_image() == str(old)
+    new.parent.mkdir()
+    new.mkdir()  # a directory at the new path is not an image
+    assert _default_image() == str(old)
+    new.rmdir()
+    new.write_text("")
+    assert _default_image() == str(new)
+
+
 def test_local_without_sbatch_defaults_the_root(tmp_path: Path) -> None:
     p = plan(tmp_path, sbatch_on_path=False)
     assert p.mode == "local"

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -111,6 +111,39 @@ def plan(tmp_path: Path, **kw: Any) -> StartPlan:
     return plan_start(**args)
 
 
+def test_default_local_root_honors_a_pre_rename_state_dir(tmp_path: Path) -> None:
+    """~/.outerloop is the default; an existing ~/.autoresearch is used only while
+    no ~/.outerloop exists (state is never moved); no HOME means the plain
+    default."""
+    from outerloop.cli import default_local_root
+
+    env = {"HOME": str(tmp_path)}
+    assert default_local_root(env) == tmp_path / ".outerloop"
+    (tmp_path / ".autoresearch").mkdir()
+    assert default_local_root(env) == tmp_path / ".autoresearch"
+    (tmp_path / ".outerloop").mkdir()
+    assert default_local_root(env) == tmp_path / ".outerloop"
+    assert default_local_root({}) == DEFAULT_LOCAL_ROOT
+
+
+def test_resident_lookup_asks_for_both_names(monkeypatch: Any) -> None:
+    """A resident submitted before the rename must still block `start`: the
+    singleton serializes by name, so two names would mean two residents."""
+    import subprocess
+
+    from outerloop import cli as cli_mod
+
+    seen: list[list[str]] = []
+
+    def fake_run(argv: list[str], **kw: Any) -> Any:
+        seen.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="900\n777\n", stderr="")
+
+    monkeypatch.setattr(cli_mod.subprocess, "run", fake_run)
+    assert cli_mod._resident_jobs() == ["777", "900"]
+    assert "--name=outerloop-resident,autoresearch-resident" in seen[0]
+
+
 def test_local_without_sbatch_defaults_the_root(tmp_path: Path) -> None:
     p = plan(tmp_path, sbatch_on_path=False)
     assert p.mode == "local"

--- a/tests/test_tick_resident.py
+++ b/tests/test_tick_resident.py
@@ -126,7 +126,7 @@ def test_resident_loop_keeps_one_successor_resubmits_on_shim_change_and_pauses_c
     assert len(sbatch) == 2
     for line in sbatch:
         assert "--dependency=afterany:42,singleton" in line
-        assert "--time=360" in line and "--job-name=autoresearch-resident" in line
+        assert "--time=360" in line and "--job-name=outerloop-resident" in line
         assert "--export=ALL" in line and "--begin" not in line
     scancel = (shimlog / "scancel").read_text().split()
     assert scancel == ["501", "502"]  # the shim-change resubmit, then the pause
@@ -139,7 +139,8 @@ def test_resident_loop_keeps_one_successor_resubmits_on_shim_change_and_pauses_c
 
 def test_per_cadence_chain_drains_when_a_resident_exists(tmp_path: Path) -> None:
     home, root, bindir, shimlog = _install(tmp_path)
-    # squeue reports a resident job of ours
+    # squeue reports a resident job of ours (a pre-rename one: the drain check
+    # asks for both names)
     (bindir / "squeue").write_text(
         '#!/bin/sh\ncase "$*" in *autoresearch-resident*) echo "777";; esac\nexit 0\n'
     )


### PR DESCRIPTION
The last of the rename, after #302: the names on disk and in the queue. Every pre-rename name stays honored for one release and is dropped in the release after 0.1; the CHANGELOG lists them.

## What changed

- **Resident tick job `outerloop-resident`** (per-cadence chain `outerloop-tick`). Slurm's singleton dependency serializes jobs by name, so a new-named resident would run beside an old one. `outerloop start` now queries both names and refuses while a pre-rename `autoresearch-resident` is queued or running, naming the job id to cancel. The chain script's drain check asks for both names too. A running resident's own successor is submitted `afterany:self`, so a deployment hands over without overlap.
- **Local state root `~/.outerloop`.** An existing `~/.autoresearch` is used while no `~/.outerloop` exists; state is never moved. The home comes from the environ handed to `plan_start`, so callers with no HOME (tests) get the plain default.
- **Default image `~/outerloop-images/agent-py312.sif`**, falling back to the pre-rename path when only it exists.
- **Temp prefix** `outerloop-check-cache-`.
- **Expiry notes** on the three already-honored legacy names (config dir, contract file, channel dir). The comment marker keeps recognizing old comments on gpt-speedrun and yolo-jepa for good.
- Docs use the new paths and job name.

## Operators

A chain-mode deployment (manual `tick_chain.sbatch`) has no start-time guard: stop it with `scancel --name autoresearch-tick` before deploying this version. Resident-mode deployments, which `start` submits, are covered by the guard.

## Alongside

agentic-learning-ai-lab/gpt-speedrun#11 and agentic-learning-ai-lab/yolo-jepa#17 rename the contract files to `.outerloop.yaml`.

## Tests

`test_default_local_root_honors_a_pre_rename_state_dir`, `test_resident_lookup_asks_for_both_names`; the resident chain tests assert the new job name and that the drain check still sees a pre-rename resident.

Gate: ruff check, ruff format --check, mypy, `bash -n` on the scripts, pytest (1230 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
