### PR TITLE
Sweep: a launch queued past its deadline for a wait reason is extended, not cancelled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,14 @@ Versions follow [SemVer](https://semver.org).
   need only the image, and every sbatch the kernel builds passes `--account`
   and `--partition` only when set, so Slurm bills the caller's default
   association and picks its default partition.
+- A launch still queued past its deadline is no longer cancelled and woken as
+  "unschedulable" when Slurm's pending reason is a wait: a busy queue
+  (Priority, Resources), a reservation or dependency, or the account's own
+  per-user/per-account/group cap (`QOSMaxGRESPerUser` and kin). The sweep
+  extends the deadline by one slack window and logs the reasons; a queued job
+  keeps its priority age, where a re-launch would start over at the back.
+  Reasons that never clear (a dependency that cannot be satisfied, per-job
+  limits, an invalid account or QOS, a held job) still cancel and wake.
 
 ### Added
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -371,8 +371,12 @@ failure can strand a run:
    `deadline = submit_time + walltime + slack` (recomputed from `start_time`
    once the job starts, so late scheduling never truncates a healthy run).
    Past the deadline the sweep consults `sacct` and acts on what it finds:
-   still PENDING → the experiment is unschedulable in practice; cancel it and
-   wake the run with that fact. No record on a *successful* query → the job
+   still PENDING → ask squeue why: a wait (Priority/Resources, a reservation
+   or dependency, the account's own per-user/group cap such as
+   `QOSMaxGRESPerUser`) moves the deadline out by one slack window, since a
+   queued job keeps its priority age and a re-launch would start over; any
+   other reason means unschedulable in practice — cancel it and wake the
+   run with that fact. No record on a *successful* query → the job
    vanished; wake with that fact. Query failed or timed out → that is
    "Slurm unknown", never "job gone" — defer to the next tick, and only a
    sustained outage (its own alert via the watchdog) escalates. A fail-safe

--- a/docs/design/dispatcher.md
+++ b/docs/design/dispatcher.md
@@ -234,7 +234,9 @@ dies -> the `eval-error` outcome at wake (ending `aborted`, exactly as the
 in-job eval failure maps today); a LOST wake -> the sweep's primary backup,
 which wakes any run whose job reads terminal after the grace period —
 plus GONE past the deadline (vanished) and PENDING past the deadline
-(cancel, then wake as unschedulable); a still-RUNNING job is deliberately
+(when Slurm's reason is a wait — a busy queue, a reservation or dependency,
+the account's own per-user/group cap — the deadline moves out by one slack
+window; otherwise cancel, then wake as unschedulable); a still-RUNNING job is deliberately
 left alone, bounded by its own walltime; wakes that fire without producing
 progress -> `stuck` at MAX_WAKE_ATTEMPTS (a landed re-measure has its own
 allowance of MAX_WAKE_ATTEMPTS finishing follow-ups, counted on the stage). A moved base during the wait is

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -88,6 +88,32 @@ DEFAULT_GRACE_S = 15 * 60
 # a blind park (no job ids to poll) waits its eval walltime plus this queue
 # slack before a follow-up is sent to look for the result
 BLIND_PARK_SLACK_MIN = 12 * 60
+
+# Slurm pending reasons that mean "the job will run when its turn comes": the
+# queue is busy, a reservation or dependency is ahead of it, or the account's
+# OWN jobs hold a per-user/per-account/group cap that clears as they finish. A
+# job in this state keeps accruing priority age; cancelling and resubmitting
+# would put it at the back of the queue behind itself. Per-job limits
+# (`...PerJob...`), a dependency that can never be satisfied, an invalid
+# account/QOS or a held job are NOT waits: those never clear on their own.
+QUEUE_WAIT_REASONS = frozenset(
+    {"Priority", "Resources", "Reservation", "Dependency", "ReqNodeNotAvail"}
+)
+
+
+def is_queue_wait(reason: str) -> bool:
+    """Whether a squeue pending reason describes a healthy wait (see
+    QUEUE_WAIT_REASONS). Reasons arrive as `Name` or `Name, detail...`."""
+    head = reason.strip().split(",")[0].split(" ")[0].strip()
+    if not head:
+        return False
+    if head in QUEUE_WAIT_REASONS:
+        return True
+    if "PerJob" in head:
+        return False
+    return any(tag in head for tag in ("PerUser", "PerAccount", "Grp"))
+
+
 # A held lease is stale after the session timeout plus slack.
 DEFAULT_LEASE_TTL_S = 3600 + 15 * 60
 # Coalesce guard: skip a tick's work if another ran within this window. Under
@@ -1612,6 +1638,32 @@ def _sweep_one(
             if now - record.terminal_seen >= grace_s:
                 wake(record, f"experiment {state}", state)
         elif any(is_pending(s) for s in states) and record.deadline > 0 and now > record.deadline:
+            # Past the deadline with a job still queued. Ask Slurm WHY before
+            # calling it unschedulable: a busy queue or the account's own cap is
+            # a wait a scientist would sit out, so the deadline moves out by one
+            # slack window instead (Torch 2026-09-06: four launches pending on
+            # QOSMaxGRESPerUser were about to be cancelled and re-launched into
+            # the same cap). Local compute has no queue and no reasons.
+            pending = [j for j, s in zip(job_ids, states, strict=True) if is_pending(s)]
+            reason_of = getattr(compute, "pending_reason", None)
+            reasons: dict[str, str] = {}
+            if reason_of is not None:
+                try:
+                    reasons = {j: str(reason_of(j)) for j in pending}
+                except SlurmQueryError:
+                    deferred.append(record.run_id)  # unknown is never "cancel"
+                    return
+            if reasons and all(is_queue_wait(r) for r in reasons.values()):
+                extended = now + BLIND_PARK_SLACK_MIN * 60
+                if not dry_run:
+                    save_record(root, replace(record, deadline=extended), now)
+                log.info(
+                    "sweep: %s waits in the queue (%s); deadline extended by %d min",
+                    record.run_id,
+                    ", ".join(f"{j}={r}" for j, r in reasons.items()),
+                    BLIND_PARK_SLACK_MIN,
+                )
+                return
             # Unschedulable in practice: cancel every non-terminal job
             # (best-effort — scancel trouble must not abort the sweep), then
             # wake with that fact.

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -62,6 +62,8 @@ class FakeSlurm:
                 jid = argv[argv.index("-j") + 1]
                 table = self.partitions if "%P" in argv else self.reasons
                 value = table.get(jid, "")
+                if value == "!":
+                    return CommandResult(1, "", "squeue down")
                 return CommandResult(0, value + "\n" if value else "", "")
             return CommandResult(0, "", "")  # no live jobs
         raise AssertionError(f"unexpected command {argv}")
@@ -406,6 +408,67 @@ def test_pending_past_deadline_cancels_then_wakes(tmp_path: Path) -> None:
     report, _dispatcher = run_tick(tmp_path, slurm)
     assert slurm.cancelled == ["100"]
     assert report.woken == (("r1", "unschedulable"),)
+
+
+def test_pending_past_deadline_on_a_queue_wait_extends_instead(tmp_path: Path) -> None:
+    """A launch pending on a busy queue or on the account's own GPU cap is a
+    wait, not an unschedulable job: no cancel, no wake, the deadline moves out
+    by one slack window (Torch 2026-09-06, four launches on QOSMaxGRESPerUser)."""
+    from outerloop.tick import BLIND_PARK_SLACK_MIN
+
+    for reason in ("QOSMaxGRESPerUser", "Priority", "Resources", "AssocGrpGRES"):
+        root = tmp_path / reason  # one root per case: ticks on one root coalesce
+        waiting_run(root, deadline=NOW - 1)
+        slurm = FakeSlurm(states={"100": "PENDING"}, reasons={"100": reason})
+        report, dispatcher = run_tick(root, slurm)
+        assert slurm.cancelled == [], reason
+        assert report.woken == () and dispatcher.dispatched == [], reason
+        assert load_record(root, "r1").deadline == NOW + BLIND_PARK_SLACK_MIN * 60, reason
+    # reasons that never clear on their own still cancel and wake
+    for reason in ("DependencyNeverSatisfied", "QOSMaxWallDurationPerJobLimit", "InvalidAccount"):
+        root = tmp_path / reason
+        waiting_run(root, deadline=NOW - 1)
+        slurm = FakeSlurm(states={"100": "PENDING"}, reasons={"100": reason})
+        report, _dispatcher = run_tick(root, slurm)
+        assert slurm.cancelled == ["100"], reason
+        assert report.woken == (("r1", "unschedulable"),), reason
+
+
+def test_pending_past_deadline_reason_query_failure_defers(tmp_path: Path) -> None:
+    """squeue failing on the reason is 'Slurm unknown': neither cancel nor wake."""
+    waiting_run(tmp_path, deadline=NOW - 1)
+    slurm = FakeSlurm(states={"100": "PENDING"}, reasons={"100": "!"})
+    report, _dispatcher = run_tick(tmp_path, slurm)
+    assert slurm.cancelled == [] and report.woken == ()
+    assert report.deferred == ("r1",)
+
+
+def test_is_queue_wait_classifies_slurm_reasons() -> None:
+    from outerloop.tick import is_queue_wait
+
+    waits = [
+        "Priority",
+        "Resources",
+        "Dependency",
+        "QOSMaxGRESPerUser",
+        "QOSMaxJobsPerUserLimit",
+        "AssocGrpGRES",
+        "QOSGrpCpuLimit",
+        "ReqNodeNotAvail, UnavailableNodes:gpu-01",
+    ]
+    nevers = [
+        "",
+        "DependencyNeverSatisfied",
+        "QOSMaxWallDurationPerJobLimit",
+        "QOSMaxGRESPerJob",
+        "InvalidAccount",
+        "InvalidQOS",
+        "PartitionDown",
+        "JobHeldUser",
+        "BadConstraints",
+    ]
+    assert [r for r in waits if not is_queue_wait(r)] == []
+    assert [r for r in nevers if is_queue_wait(r)] == []
 
 
 def test_pending_before_deadline_is_left_alone(tmp_path: Path) -> None:


### PR DESCRIPTION
Live on Torch today: four speedrun launches (agent-03, agent-04) pending 16 hours with reason `QOSMaxGRESPerUser`, because the account's two eligible launches (agent-01, agent-02, pending on `Priority`) hold its per-user GPU cap. At the parked deadline (launch + walltime + 12 h) the sweep cancels queued launches and wakes the author as "unschedulable". The author re-launches into the same cap, at the back of the queue, and after `MAX_WAKE_ATTEMPTS` the run is abandoned with no GPU time spent.

## What changed

- **The sweep asks squeue why before cancelling.** `SlurmCompute.pending_reason` already existed. In the pending-past-deadline branch, a wait reason moves the deadline out by one slack window (`BLIND_PARK_SLACK_MIN`, 12 h) and logs the reasons; nothing is cancelled or woken. A queued job keeps accruing priority age, where a re-launch starts over.
- **`is_queue_wait(reason)`** names the waits: `Priority`, `Resources`, `Reservation`, `Dependency`, `ReqNodeNotAvail`, and any per-user/per-account/group cap (`QOSMaxGRESPerUser`, `AssocGrpGRES`, `QOSGrp...`). Per-job limits (`...PerJob...`), `DependencyNeverSatisfied`, invalid account/QOS, held jobs and unknown reasons still cancel and wake as before.
- A failed reason query defers the run, the same "Slurm unknown is never gone" rule as the status query. Local compute has no `pending_reason` and keeps the old path.
- Design docs (`dispatcher.md`, `architecture.md`) state the new rule; CHANGELOG under Unreleased.

## Not in this PR

Launch admission: with a 16-GPU per-user cap and 8-GPU launches, the fleet can only ever run two launches at once, so the tick should hold new launches beyond the cap instead of queueing six. That is the structural fix and a separate PR.

## Tests

`test_pending_past_deadline_on_a_queue_wait_extends_instead` (four wait reasons extend, three never-reasons cancel and wake), `test_pending_past_deadline_reason_query_failure_defers`, `test_is_queue_wait_classifies_slurm_reasons`. The existing cancel-and-wake test is unchanged.

Gate: ruff check, ruff format --check, mypy, pytest (1234 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
