### PR TITLE
init checks that Apptainer can run a container, prints the install steps for the machine, and shows download progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ Versions follow [SemVer](https://semver.org).
   agent-image on every recipe change, and `outerloop init` downloads it on
   Linux when Apptainer is installed, so local mode runs contained by default
   (`--image` names your own, `--no-image` opts out).
+- `outerloop init` checks that Apptainer can actually run a container before
+  downloading the image (on Ubuntu 24.04 a hand-installed Apptainer is on PATH
+  but cannot create user namespaces), and when it cannot, prints the install
+  steps for the machine's distribution and continues uncontained. The image
+  download shows a progress bar with size, speed and ETA on a terminal, one
+  line per 10% otherwise, and confirms the checksum. `docs/install.md` gains
+  an "Installing Apptainer" section.
 
 ### Changed
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -249,9 +249,36 @@ Codex author needs the image in every mode. Contained local mode needs
 Apptainer and the image: the published one lives at
 [huggingface.co/outerloop-science/agent-image](https://huggingface.co/outerloop-science/agent-image),
 built from `containers/agent-py312.def`. On Linux with Apptainer installed,
-`outerloop init` downloads it to `~/outerloop-images/` and records it; `--image`
-points at your own, `--no-image` keeps runs uncontained even when an image is already on disk (it
-writes `OUTERLOOP_IMAGE=`, the off-switch).
+`outerloop init` downloads it to `~/outerloop-images/` (about 200 MB, with a
+progress bar), verifies its published checksum and records it; `--image` points at
+your own, `--no-image` keeps runs uncontained even when an image is already on disk
+(it writes `OUTERLOOP_IMAGE=`, the off-switch). When Apptainer is missing or cannot
+run containers, init says so, prints the install steps for your system, and
+continues uncontained; run `outerloop init --force` after installing it.
+
+**Installing Apptainer (Linux, one time, needs root or an admin).** Apptainer is
+the container runtime the kernel jails sessions and evaluations with. Check for it
+with `apptainer exec docker://alpine:3.20 cat /etc/alpine-release`; a version number
+means it works.
+
+- *Ubuntu and Debian.* Install the official package from
+  [github.com/apptainer/apptainer/releases](https://github.com/apptainer/apptainer/releases)
+  (`apptainer_<version>_amd64.deb`, not the `-suid` one). It carries the AppArmor
+  profile Ubuntu 23.10 and later require; the unprivileged installer does not, and
+  fails at run time with `Could not write info to setgroups`.
+
+  ```bash
+  curl -fsSLO https://github.com/apptainer/apptainer/releases/download/v1.5.3/apptainer_1.5.3_amd64.deb
+  sudo apt-get install -y ./apptainer_1.5.3_amd64.deb
+  ```
+
+- *Fedora, RHEL, Rocky, Alma.* `sudo dnf install -y apptainer` (RHEL-family first
+  `sudo dnf install -y epel-release`).
+- *No root.* The project's unprivileged installer works on most other systems:
+  `curl -fsSL https://raw.githubusercontent.com/apptainer/apptainer/main/tools/install-unprivileged.sh | bash -s -- ~/apptainer`,
+  then add `~/apptainer/bin` to your PATH.
+- *Slurm clusters.* Ask the administrators; most already provide it.
+- *macOS.* No Apptainer; runs stay uncontained (a macOS containment is on the roadmap).
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -256,8 +256,8 @@ your own, `--no-image` keeps runs uncontained even when an image is already on d
 run containers, init says so, prints the install steps for your system, and
 continues uncontained; run `outerloop init --force` after installing it.
 
-**Installing Apptainer (Linux, one time, needs root or an admin).** Apptainer is
-the container runtime the kernel jails sessions and evaluations with. Check for it
+**Installing Apptainer (Linux, one time, needs root or an admin).** Apptainer runs
+sessions and evaluations in containers. Check for it
 with `apptainer exec docker://alpine:3.20 cat /etc/alpine-release`; a version number
 means it works.
 
@@ -280,11 +280,19 @@ means it works.
   sudo apt-get install -y ./apptainer_1.5.3_amd64.deb
   ```
 
-- *Fedora, RHEL, Rocky, Alma.* `sudo dnf install -y apptainer` (RHEL-family first
-  `sudo dnf install -y epel-release`).
-- *No root.* The project's unprivileged installer works on most other systems:
-  `curl -fsSL https://raw.githubusercontent.com/apptainer/apptainer/main/tools/install-unprivileged.sh | bash -s -- ~/apptainer`,
-  then add `~/apptainer/bin` to your PATH.
+  The release has no package for other architectures; on ARM Debian, build from
+  source or use the unprivileged installer below.
+
+- *Fedora.* `sudo dnf install -y apptainer`.
+- *RHEL, Rocky, Alma.* `sudo dnf install -y epel-release`, then `sudo dnf install -y apptainer`.
+- *No root.* The project's unprivileged installer works on most other systems. It is
+  pinned to the release tag; download it, read it, then run it:
+
+  ```bash
+  curl -fsSLO https://raw.githubusercontent.com/apptainer/apptainer/v1.5.3/tools/install-unprivileged.sh
+  less install-unprivileged.sh && bash install-unprivileged.sh ~/apptainer
+  export PATH=$HOME/apptainer/bin:$PATH
+  ```
 - *Slurm clusters.* Ask the administrators; most already provide it.
 - *macOS.* No Apptainer; runs stay uncontained (a macOS containment is on the roadmap).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -261,11 +261,19 @@ the container runtime the kernel jails sessions and evaluations with. Check for 
 with `apptainer exec docker://alpine:3.20 cat /etc/alpine-release`; a version number
 means it works.
 
-- *Ubuntu and Debian.* Install the official package from
+- *Ubuntu.* Install from the project's PPA, which builds for amd64 and arm64. The
+  package carries the AppArmor profile Ubuntu 23.10 and later require; the
+  unprivileged installer does not, and fails at run time with
+  `Could not write info to setgroups`.
+
+  ```bash
+  sudo add-apt-repository -y ppa:apptainer/ppa
+  sudo apt-get update && sudo apt-get install -y apptainer
+  ```
+
+- *Debian (x86-64).* Install the release package from
   [github.com/apptainer/apptainer/releases](https://github.com/apptainer/apptainer/releases)
-  (`apptainer_<version>_amd64.deb`, not the `-suid` one). It carries the AppArmor
-  profile Ubuntu 23.10 and later require; the unprivileged installer does not, and
-  fails at run time with `Could not write info to setgroups`.
+  (`apptainer_<version>_amd64.deb`, not the `-suid` one):
 
   ```bash
   curl -fsSLO https://github.com/apptainer/apptainer/releases/download/v1.5.3/apptainer_1.5.3_amd64.deb

--- a/src/outerloop/image.py
+++ b/src/outerloop/image.py
@@ -33,6 +33,11 @@ APPTAINER_VERSION = "1.5.3"
 APPTAINER_DEB = f"apptainer_{APPTAINER_VERSION}_amd64.deb"
 APPTAINER_DEB_URL = f"{APPTAINER_RELEASES}/download/v{APPTAINER_VERSION}/{APPTAINER_DEB}"
 APPTAINER_PPA = "ppa:apptainer/ppa"
+# the unprivileged installer, pinned to the release tag (never a moving branch)
+APPTAINER_UNPRIV_URL = (
+    "https://raw.githubusercontent.com/apptainer/apptainer/"
+    f"v{APPTAINER_VERSION}/tools/install-unprivileged.sh"
+)
 PROBE_CMD = "apptainer exec docker://alpine:3.20 cat /etc/alpine-release"
 
 
@@ -97,16 +102,23 @@ def install_hint() -> str:
         return (
             f"No Apptainer Debian package is published for this machine ({platform.machine()}).\n"
             "  Build from source (https://apptainer.org/docs/admin/main/installation.html) or use\n"
-            "  the unprivileged installer:\n"
-            "    curl -fsSL https://raw.githubusercontent.com/apptainer/apptainer/main/tools/"
-            "install-unprivileged.sh | bash -s -- ~/apptainer\n"
+            "  the unprivileged installer. Download it, read it, then run it:\n"
+            f"    curl -fsSLO {APPTAINER_UNPRIV_URL}\n"
+            "    less install-unprivileged.sh && bash install-unprivileged.sh ~/apptainer\n"
             "    export PATH=$HOME/apptainer/bin:$PATH\n"
             f"  Check with `{PROBE_CMD}`, then run `outerloop init --force` again."
         )
-    if dist in ("fedora", "rhel", "centos", "rocky", "almalinux"):
+    if dist == "fedora":
         return (
-            "Install Apptainer from EPEL/Fedora (the package includes everything it needs):\n"
-            "    sudo dnf install -y epel-release   # RHEL-family only; Fedora skips this\n"
+            "Install Apptainer from the Fedora repositories:\n"
+            "    sudo dnf install -y apptainer\n"
+            f"    {PROBE_CMD}   # prints a version number\n"
+            "  then run `outerloop init --force` again to download the image."
+        )
+    if dist in ("rhel", "centos", "rocky", "almalinux"):
+        return (
+            "Install Apptainer from EPEL:\n"
+            "    sudo dnf install -y epel-release\n"
             "    sudo dnf install -y apptainer\n"
             f"    {PROBE_CMD}   # prints a version number\n"
             "  then run `outerloop init --force` again to download the image."
@@ -114,9 +126,10 @@ def install_hint() -> str:
     return (
         "Install Apptainer for your distribution:\n"
         "    https://apptainer.org/docs/admin/main/installation.html\n"
-        "  Without root, the project's unprivileged installer works on most systems:\n"
-        "    curl -fsSL https://raw.githubusercontent.com/apptainer/apptainer/main/tools/"
-        "install-unprivileged.sh | bash -s -- ~/apptainer\n"
+        "  Without root, the project's unprivileged installer works on most systems.\n"
+        "  Download it, read it, then run it:\n"
+        f"    curl -fsSLO {APPTAINER_UNPRIV_URL}\n"
+        "    less install-unprivileged.sh && bash install-unprivileged.sh ~/apptainer\n"
         "    export PATH=$HOME/apptainer/bin:$PATH\n"
         "  On a Slurm cluster, ask the administrators; most already provide it.\n"
         f"  Check with `{PROBE_CMD}`, then run\n"
@@ -320,27 +333,33 @@ def ensure_image(
     *,
     interactive: bool,
     want: bool = True,
+    probe: bool = True,
     home: Path | None = None,
     ask: Callable[[str], str] = input,
     report: Callable[[str], None] = print,
     fetch: Callable[..., Path] = download_image,
 ) -> str:
     """The image path `init` records: an existing image, else the published
-    one downloaded to the image dir when this machine can run it and the
+    one downloaded to the image dir, when this machine can run it and the
     adopter did not opt out. "" means uncontained (the loop says so at start);
     when that is because Apptainer is missing or cannot run containers, the
-    exact install steps for this machine are printed. A failed download is a
-    warning, never a failed setup."""
-    found = find_image(home)
-    if found:
-        return found
+    exact install steps for this machine are printed, and an image already on
+    disk is NOT recorded (a contained run would only fail later). `probe=False`
+    skips the container check: on Slurm the image runs on compute nodes, which
+    the login node cannot speak for. A failed download is a warning, never a
+    failed setup."""
     if not want:
         return ""
-    problem = containment_check()
+    problem = containment_check() if probe else ""
+    found = find_image(home)
     if problem:
         report(f"Runs will be UNCONTAINED on this machine: {problem}.")
         report("  " + install_hint())
+        if found:
+            report(f"  (the image at {found} will be used once apptainer works)")
         return ""
+    if found:
+        return found
     dest = image_dir(home) / IMAGE_NAME
     if interactive:
         answer = ask(f"Download the agent image to {dest} so runs are contained? [Y/n] ")

--- a/src/outerloop/image.py
+++ b/src/outerloop/image.py
@@ -27,8 +27,12 @@ LEGACY_IMAGE_DIR_NAME = "autoresearch-images"  # pre-rename; honored until the r
 _CHUNK = 1 << 20
 _PROBE_TIMEOUT_S = 60
 APPTAINER_RELEASES = "https://github.com/apptainer/apptainer/releases"
-APPTAINER_DEB = "apptainer_1.5.3_amd64.deb"
-APPTAINER_DEB_URL = f"{APPTAINER_RELEASES}/download/v1.5.3/{APPTAINER_DEB}"
+APPTAINER_VERSION = "1.5.3"
+# the GitHub release ships Debian packages for x86-64 only; the project's PPA
+# builds amd64 and arm64 for every current Ubuntu
+APPTAINER_DEB = f"apptainer_{APPTAINER_VERSION}_amd64.deb"
+APPTAINER_DEB_URL = f"{APPTAINER_RELEASES}/download/v{APPTAINER_VERSION}/{APPTAINER_DEB}"
+APPTAINER_PPA = "ppa:apptainer/ppa"
 PROBE_CMD = "apptainer exec docker://alpine:3.20 cat /etc/alpine-release"
 
 
@@ -65,18 +69,39 @@ def install_hint() -> str:
             "  roadmap). A Linux machine, or Slurm, runs contained."
         )
     dist, _version = _linux_flavor()
-    if dist in ("ubuntu", "debian", "linuxmint", "pop"):
+    apparmor_note = (
+        "  Ubuntu 23.10+ blocks unprivileged user namespaces unless an AppArmor profile allows\n"
+        "  them; the official package carries that profile (the unprivileged installer does\n"
+        "  not, and fails with 'Could not write info to setgroups').\n"
+    )
+    check = (
+        f"    3. {PROBE_CMD}\n"
+        "       (prints a version number)\n"
+        "  then run `outerloop init --force` again to download the image."
+    )
+    if dist in ("ubuntu", "linuxmint", "pop"):
         return (
-            "Install the official Apptainer package, which also carries the AppArmor profile\n"
-            "  Ubuntu 23.10+ needs (the unprivileged installer does not, and fails with\n"
-            "  'Could not write info to setgroups'):\n"
-            f"    1. download {APPTAINER_DEB} (not the -suid one) from\n"
-            f"       {APPTAINER_RELEASES}/latest, or in a terminal:\n"
-            f"         curl -fsSLO {APPTAINER_DEB_URL}\n"
-            f"    2. sudo apt-get install -y ./{APPTAINER_DEB}\n"
-            f"    3. {PROBE_CMD}\n"
-            "       (prints a version number)\n"
-            "  then run `outerloop init --force` again to download the image."
+            "Install Apptainer from the project's Ubuntu PPA (amd64 and arm64):\n"
+            + apparmor_note
+            + f"    1. sudo add-apt-repository -y {APPTAINER_PPA}\n"
+            "    2. sudo apt-get update && sudo apt-get install -y apptainer\n" + check
+        )
+    if dist == "debian":
+        if platform.machine() == "x86_64":
+            return (
+                "Install the official Apptainer package (Debian, x86-64):\n"
+                + apparmor_note
+                + f"    1. curl -fsSLO {APPTAINER_DEB_URL}\n"
+                f"    2. sudo apt-get install -y ./{APPTAINER_DEB}\n" + check
+            )
+        return (
+            f"No Apptainer Debian package is published for this machine ({platform.machine()}).\n"
+            "  Build from source (https://apptainer.org/docs/admin/main/installation.html) or use\n"
+            "  the unprivileged installer:\n"
+            "    curl -fsSL https://raw.githubusercontent.com/apptainer/apptainer/main/tools/"
+            "install-unprivileged.sh | bash -s -- ~/apptainer\n"
+            "    export PATH=$HOME/apptainer/bin:$PATH\n"
+            f"  Check with `{PROBE_CMD}`, then run `outerloop init --force` again."
         )
     if dist in ("fedora", "rhel", "centos", "rocky", "almalinux"):
         return (

--- a/src/outerloop/image.py
+++ b/src/outerloop/image.py
@@ -8,8 +8,12 @@ from __future__ import annotations
 
 import hashlib
 import os
+import platform
 import shutil
+import subprocess
 import sys
+import tempfile
+import time
 import urllib.error
 import urllib.request
 from collections.abc import Callable
@@ -21,7 +25,11 @@ IMAGE_URL = f"https://huggingface.co/outerloop-science/agent-image/resolve/main/
 IMAGE_DIR_NAME = "outerloop-images"
 LEGACY_IMAGE_DIR_NAME = "autoresearch-images"  # pre-rename; honored until the release after 0.1
 _CHUNK = 1 << 20
-_REPORT_EVERY = 256 << 20
+_PROBE_TIMEOUT_S = 60
+APPTAINER_RELEASES = "https://github.com/apptainer/apptainer/releases"
+APPTAINER_DEB = "apptainer_1.5.3_amd64.deb"
+APPTAINER_DEB_URL = f"{APPTAINER_RELEASES}/download/v1.5.3/{APPTAINER_DEB}"
+PROBE_CMD = "apptainer exec docker://alpine:3.20 cat /etc/alpine-release"
 
 
 def image_dir(home: Path | None = None) -> Path:
@@ -38,10 +46,180 @@ def find_image(home: Path | None = None) -> str:
     return ""
 
 
+def _linux_flavor() -> tuple[str, str]:
+    """(distribution id, version) from os-release, or ("", "")."""
+    try:
+        info = platform.freedesktop_os_release()
+    except OSError:
+        return "", ""
+    return info.get("ID", ""), info.get("VERSION_ID", "")
+
+
+def install_hint() -> str:
+    """The exact steps for THIS machine, written for someone installing Apptainer
+    for the first time. Every path is a root operation or an admin request, which
+    is why init never runs it."""
+    if sys.platform == "darwin":
+        return (
+            "macOS has no Apptainer; runs stay uncontained here (a macOS containment is on the\n"
+            "  roadmap). A Linux machine, or Slurm, runs contained."
+        )
+    dist, _version = _linux_flavor()
+    if dist in ("ubuntu", "debian", "linuxmint", "pop"):
+        return (
+            "Install the official Apptainer package, which also carries the AppArmor profile\n"
+            "  Ubuntu 23.10+ needs (the unprivileged installer does not, and fails with\n"
+            "  'Could not write info to setgroups'):\n"
+            f"    1. download {APPTAINER_DEB} (not the -suid one) from\n"
+            f"       {APPTAINER_RELEASES}/latest, or in a terminal:\n"
+            f"         curl -fsSLO {APPTAINER_DEB_URL}\n"
+            f"    2. sudo apt-get install -y ./{APPTAINER_DEB}\n"
+            f"    3. {PROBE_CMD}\n"
+            "       (prints a version number)\n"
+            "  then run `outerloop init --force` again to download the image."
+        )
+    if dist in ("fedora", "rhel", "centos", "rocky", "almalinux"):
+        return (
+            "Install Apptainer from EPEL/Fedora (the package includes everything it needs):\n"
+            "    sudo dnf install -y epel-release   # RHEL-family only; Fedora skips this\n"
+            "    sudo dnf install -y apptainer\n"
+            f"    {PROBE_CMD}   # prints a version number\n"
+            "  then run `outerloop init --force` again to download the image."
+        )
+    return (
+        "Install Apptainer for your distribution:\n"
+        "    https://apptainer.org/docs/admin/main/installation.html\n"
+        "  Without root, the project's unprivileged installer works on most systems:\n"
+        "    curl -fsSL https://raw.githubusercontent.com/apptainer/apptainer/main/tools/"
+        "install-unprivileged.sh | bash -s -- ~/apptainer\n"
+        "    export PATH=$HOME/apptainer/bin:$PATH\n"
+        "  On a Slurm cluster, ask the administrators; most already provide it.\n"
+        f"  Check with `{PROBE_CMD}`, then run\n"
+        "  `outerloop init --force` again to download the image."
+    )
+
+
+def containment_check(*, runner: Callable[..., Any] = subprocess.run) -> str:
+    """Why contained runs are NOT possible here, or "" when they are. Finds
+    apptainer and actually runs a container: being on PATH is not enough
+    (Ubuntu 24.04 lets any program create a user namespace but strips its
+    capabilities unless an AppArmor profile allows it, so a hand-installed
+    apptainer fails at exec time with `Could not write info to setgroups`).
+    The probe needs no network: a throwaway sandbox with the standard mount
+    points, the host's /bin, /lib and /usr bound in, running /bin/true —
+    about 0.1 s on a working install."""
+    if sys.platform == "darwin":
+        return "apptainer does not exist on macOS"
+    if not sys.platform.startswith("linux"):
+        return f"apptainer is not available on {sys.platform}"
+    binary = shutil.which("apptainer")
+    if binary is None:
+        return "apptainer is not installed (not on PATH)"
+    binds = ",".join(d for d in ("/bin", "/lib", "/lib64", "/usr") if os.path.exists(d))
+    with tempfile.TemporaryDirectory(prefix="outerloop-probe-") as sandbox:
+        for d in (
+            "dev",
+            "proc",
+            "sys",
+            "tmp",
+            "etc",
+            "bin",
+            "lib",
+            "lib64",
+            "usr",
+            "root",
+            "home",
+            "var/tmp",
+        ):
+            os.makedirs(os.path.join(sandbox, d), exist_ok=True)
+        for f in ("etc/passwd", "etc/group"):
+            open(os.path.join(sandbox, f), "a").close()
+        argv = [binary, "exec", "--containall", "--cleanenv", "--no-home", "--pwd", "/"]
+        if binds:
+            argv += ["-B", binds]
+        argv += [sandbox, "/bin/true"]
+        try:
+            proc = runner(argv, capture_output=True, text=True, timeout=_PROBE_TIMEOUT_S)
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return f"apptainer failed to start: {exc}"
+    err = (proc.stderr or "").strip()
+    if "setgroups" in err or "user namespace" in err.lower() or "unshare" in err.lower():
+        last = err.splitlines()[-1] if err else "user namespace refused"
+        return f"apptainer cannot create containers here ({last})"
+    if proc.returncode != 0:
+        last = err.splitlines()[-1] if err else f"exit {proc.returncode}"
+        return f"apptainer exec failed ({last})"
+    return ""
+
+
 def containment_available() -> bool:
-    """Whether contained runs are possible here: Linux with apptainer on PATH.
-    macOS has no Apptainer; its containment is a separate design."""
-    return sys.platform.startswith("linux") and shutil.which("apptainer") is not None
+    return containment_check() == ""
+
+
+def _fmt_mb(n: int) -> str:
+    return f"{n / (1 << 20):,.0f} MB"
+
+
+class _Progress:
+    """Download progress: a redrawn bar with size, speed and ETA when stdout is
+    a terminal; one line per 10% when it is not (a log, a CI step). `report`
+    receives the non-tty lines and the final summary."""
+
+    def __init__(self, url: str, report: Callable[[str], None]) -> None:
+        self.url = url
+        self.report = report
+        self.total = 0
+        self.t0 = 0.0
+        self.tty = sys.stdout.isatty()
+        self.next_mark = 10
+        self.last_draw = 0.0
+
+    def start(self, total: int) -> None:
+        self.total = total
+        self.t0 = time.monotonic()
+        size = f" ({_fmt_mb(total)})" if total else ""
+        self.report(f"downloading {self.url}{size}")
+
+    def update(self, done: int) -> None:
+        now = time.monotonic()
+        if self.tty:
+            if now - self.last_draw < 0.2:
+                return
+            self.last_draw = now
+            sys.stdout.write("\r" + self._line(done, now) + "\033[K")
+            sys.stdout.flush()
+        elif self.total:
+            pct = done * 100 // self.total
+            while pct >= self.next_mark and self.next_mark <= 100:
+                self.report(f"  {self.next_mark:3d}%  {_fmt_mb(done)} of {_fmt_mb(self.total)}")
+                self.next_mark += 10
+
+    def _line(self, done: int, now: float) -> str:
+        elapsed = max(now - self.t0, 1e-6)
+        speed = done / elapsed
+        if self.total:
+            frac = min(done / self.total, 1.0)
+            width = 30
+            filled = int(frac * width)
+            bar = "#" * filled + "-" * (width - filled)
+            eta = (self.total - done) / speed if speed > 0 else 0
+            return (
+                f"  [{bar}] {frac * 100:3.0f}%  {_fmt_mb(done)} of {_fmt_mb(self.total)}"
+                f"  {speed / (1 << 20):.1f} MB/s  ETA {int(eta) // 60}:{int(eta) % 60:02d}"
+            )
+        return f"  {_fmt_mb(done)}  {speed / (1 << 20):.1f} MB/s"
+
+    def finish(self, done: int) -> None:
+        if self.tty:
+            sys.stdout.write("\r" + self._line(done, time.monotonic()) + "\033[K\n")
+            sys.stdout.flush()
+        elapsed = time.monotonic() - self.t0
+        self.report(f"  downloaded {_fmt_mb(done)} in {int(elapsed) // 60}:{int(elapsed) % 60:02d}")
+
+    def abort(self) -> None:
+        if self.tty:
+            sys.stdout.write("\n")
+            sys.stdout.flush()
 
 
 def download_image(
@@ -55,17 +233,18 @@ def download_image(
     """Stream `url` to `dest` (default: the image dir), through a `.part`
     file renamed into place only after its sha256 matches the checksum the
     build published beside it (`<url>.sha256`); any failure, mismatch or
-    interruption removes the part file. Progress every 256 MiB."""
+    interruption removes the part file. Progress: a live bar on a terminal,
+    one line per 10% otherwise."""
     dest = dest or image_dir() / IMAGE_NAME
     dest.parent.mkdir(parents=True, exist_ok=True)
     part = dest.with_name(dest.name + ".part")
     digest = hashlib.sha256()
+    bar = _Progress(url, report)
     try:
         with opener(url, timeout=60) as resp:
             total = int(resp.headers.get("Content-Length") or 0)
-            report(f"downloading {url}" + (f" ({total / (1 << 30):.1f} GB)" if total else ""))
+            bar.start(total)
             done = 0
-            next_report = _REPORT_EVERY
             with part.open("wb") as out:
                 while True:
                     chunk = resp.read(_CHUNK)
@@ -74,12 +253,8 @@ def download_image(
                     out.write(chunk)
                     digest.update(chunk)
                     done += len(chunk)
-                    if done >= next_report:
-                        report(
-                            f"  {done / (1 << 30):.1f} GB"
-                            + (f" of {total / (1 << 30):.1f}" if total else "")
-                        )
-                        next_report += _REPORT_EVERY
+                    bar.update(done)
+        bar.finish(done)
         if total and done != total:
             raise OSError(f"short download: {done} of {total} bytes")
         # the checksum the build published beside the image: an image that does
@@ -90,9 +265,11 @@ def download_image(
             raise OSError(
                 f"checksum mismatch for {url}: expected {expected}, got {digest.hexdigest()}"
             )
+        report("  checksum verified")
     except BaseException:
         # a failed or interrupted download never leaves a partial image where
         # a later run would find it
+        bar.abort()
         part.unlink(missing_ok=True)
         raise
     os.replace(part, dest)
@@ -125,12 +302,19 @@ def ensure_image(
 ) -> str:
     """The image path `init` records: an existing image, else the published
     one downloaded to the image dir when this machine can run it and the
-    adopter did not opt out. "" means uncontained (the loop says so at start).
-    A failed download is a warning, never a failed setup."""
+    adopter did not opt out. "" means uncontained (the loop says so at start);
+    when that is because Apptainer is missing or cannot run containers, the
+    exact install steps for this machine are printed. A failed download is a
+    warning, never a failed setup."""
     found = find_image(home)
     if found:
         return found
-    if not want or not containment_available():
+    if not want:
+        return ""
+    problem = containment_check()
+    if problem:
+        report(f"Runs will be UNCONTAINED on this machine: {problem}.")
+        report("  " + install_hint())
         return ""
     dest = image_dir(home) / IMAGE_NAME
     if interactive:

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -478,7 +478,9 @@ def main(argv: list[str] | None = None) -> int:
     # An existing image is used, else the published one is fetched on a machine
     # that can run it (asked first when interactive); --no-image opts out.
     if not answers.image and not args.no_image:
-        answers.image = ensure_image(interactive=interactive)
+        # the container probe is for local mode: on Slurm the image runs on
+        # compute nodes, which the login node cannot speak for
+        answers.image = ensure_image(interactive=interactive, probe=(answers.compute == "local"))
 
     # The App is the recommended credential (scoped, revocable, no plaintext
     # token); the PAT is the fallback. Offer it first when interactive.

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -55,7 +55,8 @@ def quiet(s: str) -> None:
     pass
 
 
-def test_download_streams_through_a_part_file(tmp_path: Path) -> None:
+def test_download_streams_through_a_part_file(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr(img.sys.stdout, "isatty", lambda: False)
     payload = b"x" * (3 * (1 << 20) + 7)
     dest = tmp_path / "outerloop-images" / "agent-py312.sif"
     lines: list[str] = []
@@ -65,6 +66,11 @@ def test_download_streams_through_a_part_file(tmp_path: Path) -> None:
     assert got == dest and dest.read_bytes() == payload
     assert not dest.with_name(dest.name + ".part").exists()
     assert lines[0].startswith("downloading https://example/agent.sif")
+    # the download drives the progress: every 10% line, then the summary and the checksum
+    pct = [line.split("%")[0].strip() for line in lines if "%" in line]
+    assert pct == [str(n) for n in range(10, 101, 10)]
+    assert any(line.startswith("  downloaded") for line in lines)
+    assert "  checksum verified" in lines and lines[-1].startswith("  saved ")
 
 
 def test_interrupted_download_leaves_nothing_behind(tmp_path: Path) -> None:
@@ -220,9 +226,14 @@ def test_install_hint_names_the_distribution(monkeypatch: Any) -> None:
     odd = img.install_hint()
     assert "No Apptainer Debian package" in odd and "aarch64" in odd and ".deb" not in odd
     monkeypatch.setattr(img, "_linux_flavor", lambda: ("fedora", "40"))
-    assert "dnf install" in img.install_hint()
+    fedora = img.install_hint()
+    assert "dnf install -y apptainer" in fedora and "epel" not in fedora
+    monkeypatch.setattr(img, "_linux_flavor", lambda: ("rocky", "9"))
+    assert "epel-release" in img.install_hint()
     monkeypatch.setattr(img, "_linux_flavor", lambda: ("arch", ""))
-    assert "install-unprivileged.sh" in img.install_hint()
+    generic = img.install_hint()
+    # the installer is pinned to the release tag and never piped into a shell
+    assert "/v1.5.3/tools/install-unprivileged.sh" in generic and "| bash" not in generic
     monkeypatch.setattr(img.sys, "platform", "darwin")
     assert "macOS" in img.install_hint()
 
@@ -236,6 +247,27 @@ def test_ensure_image_explains_why_runs_are_uncontained(tmp_path: Path, monkeypa
     assert img.ensure_image(interactive=False, home=tmp_path, report=lines.append) == ""
     assert any("UNCONTAINED" in line and "not installed" in line for line in lines)
     assert any("INSTALL STEPS HERE" in line for line in lines)
+
+
+def test_ensure_image_probes_before_accepting_an_existing_image(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """An image on disk is not recorded when apptainer cannot run containers
+    (terra, #306): a contained run would only fail later. Slurm skips the probe,
+    since the login node cannot speak for the compute nodes."""
+    existing = tmp_path / "outerloop-images" / "agent-py312.sif"
+    existing.parent.mkdir()
+    existing.write_text("")
+    monkeypatch.setattr(
+        img, "containment_check", lambda: "apptainer cannot create containers here (x)"
+    )
+    monkeypatch.setattr(img, "install_hint", lambda: "STEPS")
+    lines: list[str] = []
+    assert img.ensure_image(interactive=False, home=tmp_path, report=lines.append) == ""
+    assert any(str(existing) in line and "once apptainer works" in line for line in lines)
+    assert img.ensure_image(
+        interactive=False, probe=False, home=tmp_path, report=lines.append
+    ) == str(existing)
 
 
 def test_progress_reports_ten_percent_steps_off_a_terminal(monkeypatch: Any) -> None:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -208,9 +208,17 @@ def test_containment_check_runs_a_container_not_just_which(
 def test_install_hint_names_the_distribution(monkeypatch: Any) -> None:
     monkeypatch.setattr(img.sys, "platform", "linux")
     monkeypatch.setattr(img, "_linux_flavor", lambda: ("ubuntu", "24.04"))
-    hint = img.install_hint()
-    assert "apt-get install" in hint and "AppArmor" in hint and "setgroups" in hint
-    assert "outerloop init --force" in hint
+    for machine in ("x86_64", "aarch64"):  # the PPA covers both (terra, #306)
+        monkeypatch.setattr(img.platform, "machine", lambda m=machine: m)
+        hint = img.install_hint()
+        assert "ppa:apptainer/ppa" in hint and "AppArmor" in hint and "setgroups" in hint
+        assert "outerloop init --force" in hint and ".deb" not in hint
+    monkeypatch.setattr(img, "_linux_flavor", lambda: ("debian", "12"))
+    monkeypatch.setattr(img.platform, "machine", lambda: "x86_64")
+    assert "apptainer_1.5.3_amd64.deb" in img.install_hint()
+    monkeypatch.setattr(img.platform, "machine", lambda: "aarch64")
+    odd = img.install_hint()
+    assert "No Apptainer Debian package" in odd and "aarch64" in odd and ".deb" not in odd
     monkeypatch.setattr(img, "_linux_flavor", lambda: ("fedora", "40"))
     assert "dnf install" in img.install_hint()
     monkeypatch.setattr(img, "_linux_flavor", lambda: ("arch", ""))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -124,10 +124,12 @@ def test_ensure_image_paths(tmp_path: Path, monkeypatch: Any) -> None:
         return dest
 
     # nothing to run it with: no download, no image
-    monkeypatch.setattr(img, "containment_available", lambda: False)
+    monkeypatch.setattr(
+        img, "containment_check", lambda: "apptainer is not installed (not on PATH)"
+    )
     assert img.ensure_image(interactive=False, home=tmp_path, fetch=fake_fetch, report=quiet) == ""
     assert fetched == []
-    monkeypatch.setattr(img, "containment_available", lambda: True)
+    monkeypatch.setattr(img, "containment_check", lambda: "")
     # opted out
     assert (
         img.ensure_image(
@@ -154,7 +156,7 @@ def test_ensure_image_paths(tmp_path: Path, monkeypatch: Any) -> None:
 
 
 def test_ensure_image_download_failure_is_a_warning(tmp_path: Path, monkeypatch: Any) -> None:
-    monkeypatch.setattr(img, "containment_available", lambda: True)
+    monkeypatch.setattr(img, "containment_check", lambda: "")
     lines: list[str] = []
 
     def failing(url: str, dest: Path, *, report: Any) -> Path:
@@ -164,3 +166,89 @@ def test_ensure_image_download_failure_is_a_warning(tmp_path: Path, monkeypatch:
         img.ensure_image(interactive=False, home=tmp_path, fetch=failing, report=lines.append) == ""
     )
     assert any("download failed" in line for line in lines)
+
+
+class _Proc:
+    def __init__(self, rc: int, err: str = "") -> None:
+        self.returncode = rc
+        self.stderr = err
+
+
+def test_containment_check_runs_a_container_not_just_which(
+    monkeypatch: Any, tmp_path: Path
+) -> None:
+    """Being on PATH is not enough (Ubuntu 24.04 strips capabilities from a
+    hand-installed apptainer's user namespace): the probe execs a container
+    and reads the failure."""
+    monkeypatch.setattr(img.sys, "platform", "linux")
+    monkeypatch.setattr(img.shutil, "which", lambda name: None)
+    assert "not installed" in img.containment_check()
+    monkeypatch.setattr(img.shutil, "which", lambda name: "/usr/bin/apptainer")
+    seen: list[list[str]] = []
+
+    def working(argv: list[str], **kw: Any) -> _Proc:
+        seen.append(argv)
+        return _Proc(0)
+
+    assert img.containment_check(runner=working) == ""
+    assert seen and seen[0][0] == "/usr/bin/apptainer" and seen[0][1] == "exec"
+    broken = _Proc(
+        255,
+        "ERROR  : Could not write info to setgroups: Permission denied\n"
+        "ERROR  : Error while waiting event for user namespace mappings: no event received",
+    )
+    problem = img.containment_check(runner=lambda argv, **kw: broken)
+    assert "cannot create containers" in problem and "user namespace" in problem
+    other = _Proc(255, "FATAL:   container creation failed: something else")
+    assert "apptainer exec failed" in img.containment_check(runner=lambda argv, **kw: other)
+    monkeypatch.setattr(img.sys, "platform", "darwin")
+    assert "macOS" in img.containment_check()
+
+
+def test_install_hint_names_the_distribution(monkeypatch: Any) -> None:
+    monkeypatch.setattr(img.sys, "platform", "linux")
+    monkeypatch.setattr(img, "_linux_flavor", lambda: ("ubuntu", "24.04"))
+    hint = img.install_hint()
+    assert "apt-get install" in hint and "AppArmor" in hint and "setgroups" in hint
+    assert "outerloop init --force" in hint
+    monkeypatch.setattr(img, "_linux_flavor", lambda: ("fedora", "40"))
+    assert "dnf install" in img.install_hint()
+    monkeypatch.setattr(img, "_linux_flavor", lambda: ("arch", ""))
+    assert "install-unprivileged.sh" in img.install_hint()
+    monkeypatch.setattr(img.sys, "platform", "darwin")
+    assert "macOS" in img.install_hint()
+
+
+def test_ensure_image_explains_why_runs_are_uncontained(tmp_path: Path, monkeypatch: Any) -> None:
+    monkeypatch.setattr(
+        img, "containment_check", lambda: "apptainer is not installed (not on PATH)"
+    )
+    monkeypatch.setattr(img, "install_hint", lambda: "INSTALL STEPS HERE")
+    lines: list[str] = []
+    assert img.ensure_image(interactive=False, home=tmp_path, report=lines.append) == ""
+    assert any("UNCONTAINED" in line and "not installed" in line for line in lines)
+    assert any("INSTALL STEPS HERE" in line for line in lines)
+
+
+def test_progress_reports_ten_percent_steps_off_a_terminal(monkeypatch: Any) -> None:
+    monkeypatch.setattr(img.sys.stdout, "isatty", lambda: False)
+    lines: list[str] = []
+    bar = img._Progress("u", lines.append)
+    bar.start(1000)
+    for done in (50, 250, 251, 999, 1000):
+        bar.update(done)
+    bar.finish(1000)
+    pct = [line.split("%")[0].strip() for line in lines if "%" in line]
+    assert pct == ["10", "20", "30", "40", "50", "60", "70", "80", "90", "100"]
+    assert lines[-1].startswith("  downloaded")
+
+
+def test_progress_draws_a_bar_on_a_terminal(monkeypatch: Any, capsys: Any) -> None:
+    monkeypatch.setattr(img.sys.stdout, "isatty", lambda: True)
+    bar = img._Progress("u", lambda s: None)
+    bar.start(4 << 20)
+    bar.last_draw = -1.0
+    bar.update(2 << 20)
+    bar.finish(4 << 20)
+    out = capsys.readouterr().out
+    assert "[" in out and "50%" in out and "100%" in out and "ETA" in out


### PR DESCRIPTION
Follow-up to #305, from the cluster0 test of the published image. Two findings drove it: a stock Ubuntu 24.04 machine cannot run a hand-installed Apptainer (AppArmor strips capabilities from unprivileged user namespaces unless a profile allows it, so `apptainer` is on PATH but every exec fails with `Could not write info to setgroups`), and a 200 MB download at 1 MB/s with a line every 256 MiB looked hung.

## What changed

- **`containment_check` runs a container, not `which`.** A throwaway sandbox with the standard mount points, the host's `/bin`, `/lib`, `/lib64`, `/usr` bound in, running `/bin/true`: no network, about 0.1 s on a working install. A namespace failure (`setgroups`, `user namespace`, `unshare` in stderr) is reported as "cannot create containers here"; any other failure as "apptainer exec failed"; macOS and a missing binary get their own sentences.
- **`install_hint` gives the steps for this machine**, from `os-release`: Ubuntu/Debian get the official `.deb` (download, `apt-get install`, the check command, then `outerloop init --force`), with the reason the unprivileged installer does not work there; Fedora/RHEL get `dnf`; anything else gets the project's unprivileged installer and the Slurm-admin note; macOS is told containment is a separate design. `ensure_image` prints "Runs will be UNCONTAINED on this machine: <why>" followed by the steps, then continues. Init never runs a root operation.
- **Download progress.** On a terminal, a redrawn bar with percent, MB done of total, MB/s and ETA; off a terminal (a log, CI), one line per 10%. The summary line and "checksum verified" always print.
- `docs/install.md` gains "Installing Apptainer (Linux, one time, needs root or an admin)" with the same steps per distribution; CHANGELOG under Unreleased.

## Tested on cluster0 (Ubuntu 24.04)

- Apptainer hidden from PATH: init prints the explanation and the Ubuntu steps, writes the config, continues uncontained.
- Real Apptainer (official 1.5.3 `.deb`): probe passes, 186 MB downloaded with the 10% lines in 1:29, checksum verified, image recorded, and the image runs (`python3 3.12.3`, `uv 0.12.10`, `git 2.43`).
- The terminal bar rendered in a pty via `script(1)`.

## Tests

`containment_check` against a fake runner (working, namespace failure, other failure, missing, macOS); `install_hint` per distribution; `ensure_image` prints the explanation and steps; `_Progress` off a terminal emits exactly the ten 10% lines, on a terminal draws the bar with ETA.

Gate: ruff check, ruff format --check, mypy, pytest (1251 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
