### PR TITLE
Adopter path: init fails on a dead credential, records the login and the harness binary; local jobs keep output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,21 @@ Versions follow [SemVer](https://semver.org).
   keeps its priority age, where a re-launch would start over at the back.
   Reasons that never clear (a dependency that cannot be satisfied, per-job
   limits, an invalid account or QOS, a held job) still cancel and wake.
+- `outerloop init` stops with exit 1 when the credential cannot open pull
+  requests on the target (401, 403, 404, or no write access) instead of
+  printing a warning and `next: outerloop start` (#285); a network failure stays
+  a warning. The PAT path records the token's login as `OUTERLOOP_BOT_LOGIN`,
+  and the tick warns when the login is unset and the lab default applies (#298).
+- `init` locates the author's CLI (`claude`/`codex`) on PATH or in
+  `~/.local/bin`, records it as `OUTERLOOP_CLAUDE_BIN`/`OUTERLOOP_CODEX_BIN`, and
+  says how to install it when absent; `attempt --claude-bin` honors that
+  setting; `start` refuses to launch when a recorded binary is missing; a
+  `spawn-error` names the binary and the OS error (#294).
+- Local jobs keep their combined stdout/stderr in `local_jobs/<id>.out` beside
+  the state file, and the log line names it when the job did not complete (#295).
+- `cryptography` is a base dependency, so the GitHub App identity works from a
+  plain `pip install`; the `app-auth` extra is now a no-op (#293). The `tick`
+  subcommand's help no longer uses lab-internal vocabulary (#286).
 
 ### Added
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license-files = ["LICENSE", "NOTICE"]
 requires-python = ">=3.12"
 authors = [{ name = "Agentic Learning AI Lab, New York University" }]
 dependencies = [
+    "cryptography>=42",  # GitHub App auth (RS256 JWTs), the recommended identity
     "pydantic>=2",
     "pyyaml>=6",
 ]
@@ -24,9 +25,10 @@ dependencies = [
 outerloop = "outerloop.cli:main"
 
 [project.optional-dependencies]
-# GitHub App auth: RS256 signing for App JWTs (docs/design/github-app-auth.md).
-# Install where OUTERLOOP_GITHUB_APP_FILE is set; the PAT path needs nothing.
-app-auth = ["cryptography>=42"]
+# `cryptography` is a base dependency since 0.1.0.dev2 (the App identity init
+# recommends must work from a plain install, #293); the extra stays as a no-op so
+# `pip install "outerloop-science[app-auth]"` keeps working.
+app-auth = []
 
 [dependency-groups]
 dev = [
@@ -75,6 +77,7 @@ testpaths = ["tests"]
 # the tests affected by your edits.
 addopts = "-ra --strict-markers -n auto"
 markers = [
+    "real_locate_harness: exercises the real harness lookup (test_init fixture skips its patch)",
     "slow: long-running; nightly/manual only",
     "llm: calls a paid LLM API; manual only, never CI",
     "slurm: needs a Slurm cluster; manual only, never CI",

--- a/scripts/tick_deploy.sh
+++ b/scripts/tick_deploy.sh
@@ -95,7 +95,7 @@ if [ -r "$ENV_FILE" ]; then
     owner=$(stat -c "%u" "$ENV_FILE" 2>/dev/null || echo -1)
     if [ "$owner" = "$(id -u)" ] && [ $((8#$perms & 8#022)) -eq 0 ]; then
         for _k in OUTERLOOP_AUTHOR_BACKEND OUTERLOOP_AUTHOR_MODEL \
-                  OUTERLOOP_CODEX_BIN OUTERLOOP_CODEX_KEY_FILE \
+                  OUTERLOOP_CLAUDE_BIN OUTERLOOP_CODEX_BIN OUTERLOOP_CODEX_KEY_FILE \
                   OUTERLOOP_CLAUDE_KEY_FILE OUTERLOOP_HARNESS_KEY_FILE \
                   OUTERLOOP_VERTEX_PROJECT OUTERLOOP_VERTEX_REGION \
                   OUTERLOOP_VERTEX_ADC \

--- a/src/outerloop/appauth.py
+++ b/src/outerloop/appauth.py
@@ -172,8 +172,8 @@ def signer_from_private_key(pem_path: Path) -> Signer:
         from cryptography.hazmat.primitives.asymmetric import padding, rsa
     except ImportError as exc:  # pragma: no cover - exercised only without the extra
         raise ImportError(
-            "GitHub App auth needs the 'app-auth' extra (cryptography); "
-            "install it before selecting the App token provider"
+            "GitHub App auth needs the cryptography package "
+            "(pip install cryptography), a base dependency since 0.1.0.dev2"
         ) from exc
 
     key = serialization.load_pem_private_key(pem_path.read_bytes(), password=None)

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -3166,7 +3166,11 @@ def main() -> int:
         help="run WITHOUT a container (dev only: sessions can then read "
         "same-user files, including credential files)",
     )
-    parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
+    parser.add_argument(
+        "--claude-bin",
+        default=os.path.expanduser(os.environ.get("OUTERLOOP_CLAUDE_BIN") or "~/.local/bin/claude"),
+        help="host claude binary for the claude author (OUTERLOOP_CLAUDE_BIN, which init records)",
+    )
     parser.add_argument(
         "--codex-bin",
         default=os.path.expanduser(os.environ.get("OUTERLOOP_CODEX_BIN") or "~/.local/bin/codex"),

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -44,7 +44,7 @@ from outerloop.github import (
     contract_at,
     ensure_regular_git_dir,
 )
-from outerloop.harness import Harness, SessionResult, redact
+from outerloop.harness import Harness, SessionResult, default_binary, redact
 from outerloop.markers import has_marker
 from outerloop.measure import DispatchedMeasurer, DispatchSettings
 from outerloop.orchestrator import (
@@ -3168,12 +3168,12 @@ def main() -> int:
     )
     parser.add_argument(
         "--claude-bin",
-        default=os.path.expanduser(os.environ.get("OUTERLOOP_CLAUDE_BIN") or "~/.local/bin/claude"),
+        default=default_binary("claude"),
         help="host claude binary for the claude author (OUTERLOOP_CLAUDE_BIN, which init records)",
     )
     parser.add_argument(
         "--codex-bin",
-        default=os.path.expanduser(os.environ.get("OUTERLOOP_CODEX_BIN") or "~/.local/bin/codex"),
+        default=default_binary("codex"),
         help="host codex binary for the codex author; bind-mounted into apptainer "
         "(must be an absolute path).",
     )

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -51,6 +51,7 @@ START_KEYS = (
 TICK_ENV_KEYS = (
     "OUTERLOOP_AUTHOR_BACKEND",
     "OUTERLOOP_AUTHOR_MODEL",
+    "OUTERLOOP_CLAUDE_BIN",
     "OUTERLOOP_CODEX_BIN",
     "OUTERLOOP_CODEX_KEY_FILE",
     "OUTERLOOP_CLAUDE_KEY_FILE",
@@ -338,9 +339,26 @@ def _exec(cmd: list[str], env: dict[str, str]) -> int:
     return 1  # unreachable; keeps the signature honest for tests that stub this
 
 
+HARNESS_BIN_KEYS = ("OUTERLOOP_CLAUDE_BIN", "OUTERLOOP_CODEX_BIN")
+
+
+def missing_harness_binary(values: Mapping[str, str], environ: Mapping[str, str]) -> str:
+    """Why start must not launch: a recorded harness binary that is not there
+    (init records the path; a moved or uninstalled CLI would end every climb
+    with spawn-error). "" when every recorded binary exists or none is set."""
+    for key in HARNESS_BIN_KEYS:
+        path = (environ.get(key) or values.get(key) or "").strip()
+        if path and not Path(path).expanduser().is_file():
+            return f"{key}={path} is not a file; reinstall the CLI or run `outerloop init --force`"
+    return ""
+
+
 def start(args: argparse.Namespace) -> int:
     try:
         values = env_file_values(ENV_FILE, START_KEYS + TICK_ENV_KEYS)  # one read for everything
+        problem = missing_harness_binary(values, os.environ)
+        if problem:
+            raise StartError(problem)
         from_file = {k: v for k, v in values.items() if k in START_KEYS}
         plan = plan_start(
             root=args.root or "",
@@ -466,7 +484,9 @@ def main(argv: list[str] | None = None) -> int:
         "--local", action="store_true", help="run the local loop even where sbatch exists"
     )
     p.add_argument("--dry-run", action="store_true", help="print the command and exit")
-    sub.add_parser("tick", help="one tick, or --loop; the chain's own entry", add_help=False)
+    sub.add_parser(
+        "tick", help="run one tick now; --loop keeps ticking (the local loop)", add_help=False
+    )
     sub.add_parser(
         "init",
         help="guided setup: write ~/.config/outerloop/.env and the PAT file",

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -342,14 +342,25 @@ def _exec(cmd: list[str], env: dict[str, str]) -> int:
 HARNESS_BIN_KEYS = ("OUTERLOOP_CLAUDE_BIN", "OUTERLOOP_CODEX_BIN")
 
 
+def _setting_of(key: str, values: Mapping[str, str], environ: Mapping[str, str]) -> str:
+    """The process environment wins over .env, including an explicit empty value
+    (the way to clear a recorded path from the shell)."""
+    return (environ[key] if key in environ else values.get(key, "")).strip()
+
+
 def missing_harness_binary(values: Mapping[str, str], environ: Mapping[str, str]) -> str:
-    """Why start must not launch: a recorded harness binary that is not there
-    (init records the path; a moved or uninstalled CLI would end every climb
-    with spawn-error). "" when every recorded binary exists or none is set."""
-    for key in HARNESS_BIN_KEYS:
-        path = (environ.get(key) or values.get(key) or "").strip()
-        if path and not Path(path).expanduser().is_file():
-            return f"{key}={path} is not a file; reinstall the CLI or run `outerloop init --force`"
+    """Why start must not launch: the CONFIGURED author backend's recorded
+    binary is not there (init records the path; a moved or uninstalled CLI
+    would end every climb with spawn-error). The other backend's path is not
+    consulted: a stale entry for a backend the loop never spawns must not block
+    it. "" when the binary exists or none is recorded."""
+    backend = _setting_of("OUTERLOOP_AUTHOR_BACKEND", values, environ).lower() or "claude"
+    key = f"OUTERLOOP_{backend.upper()}_BIN"
+    if key not in HARNESS_BIN_KEYS:
+        return ""  # an unknown backend is init's error to report, not this check's
+    path = _setting_of(key, values, environ)
+    if path and not Path(path).expanduser().is_file():
+        return f"{key}={path} is not a file; reinstall the CLI or run `outerloop init --force`"
     return ""
 
 

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -416,7 +416,11 @@ class LocalCompute:
                 os.replace(tmp, state_dir / job_id)
                 # the job's combined stdout/stderr beside its state: a failed local
                 # job otherwise leaves nothing to read (#295)
-                (state_dir / f"{job_id}.out").write_text(output)
+                out_fd = os.open(
+                    state_dir / f"{job_id}.out", os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600
+                )
+                with os.fdopen(out_fd, "w") as fh:
+                    fh.write(output)
                 # opportunistic prune: one entry per job would leak forever
                 # on a long-running loop; anything the sweep could still want
                 # is far younger than a day

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -414,6 +414,9 @@ class LocalCompute:
                 tmp = state_dir / f".{job_id}.{os.getpid()}.tmp"
                 tmp.write_text(state)
                 os.replace(tmp, state_dir / job_id)
+                # the job's combined stdout/stderr beside its state: a failed local
+                # job otherwise leaves nothing to read (#295)
+                (state_dir / f"{job_id}.out").write_text(output)
                 # opportunistic prune: one entry per job would leak forever
                 # on a long-running loop; anything the sweep could still want
                 # is far younger than a day
@@ -433,7 +436,12 @@ class LocalCompute:
             except OSError as exc:
                 log.warning("local job %s: output write failed: %s", spec.job_name, exc)
         self._states[job_id] = state
-        log.info("ran %s locally as job %s: %s", spec.job_name, job_id, state)
+        where = (
+            f"; output in {state_dir / (job_id + '.out')}"
+            if state_dir and state != "COMPLETED"
+            else ""
+        )
+        log.info("ran %s locally as job %s: %s%s", spec.job_name, job_id, state, where)
         return job_id
 
     def status(self, job_id: str) -> str:

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -37,7 +37,7 @@ from outerloop.github import (
     contract_at,
     is_own_login,
 )
-from outerloop.harness import Harness, outage, redact
+from outerloop.harness import Harness, default_binary, outage, redact
 from outerloop.markers import has_marker, marker
 from outerloop.orchestrator import (
     Evaluator,
@@ -1963,10 +1963,10 @@ def main() -> int:
     parser.add_argument("--run-id", required=True)
     parser.add_argument("--image", default="")
     parser.add_argument("--uncontained", action="store_true")
-    parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
+    parser.add_argument("--claude-bin", default=default_binary("claude"))
     parser.add_argument(
         "--codex-bin",
-        default=os.path.expanduser(os.environ.get("OUTERLOOP_CODEX_BIN") or "~/.local/bin/codex"),
+        default=default_binary("codex"),
     )
     parser.add_argument(
         "--model",

--- a/src/outerloop/harness.py
+++ b/src/outerloop/harness.py
@@ -609,7 +609,7 @@ class ClaudeCodeHarness:
             )
         except OSError as exc:
             log.warning("could not spawn %s: %s", self.binary, exc)
-            return _error_result("spawn-error")
+            return _error_result("spawn-error", detail=f"could not spawn {self.binary}: {exc}")
 
         try:
             stdout, stderr = process.communicate(input=brief_text, timeout=self.timeout_s)
@@ -1061,7 +1061,7 @@ class CodexHarness:
         except OSError as exc:
             log.warning("could not spawn %s: %s", self.binary, exc)
             self._purge_auth(session_home)
-            return _error_result("spawn-error")
+            return _error_result("spawn-error", detail=f"could not spawn {self.binary}: {exc}")
         try:
             stdout, stderr = process.communicate(input=brief_text, timeout=self.timeout_s)
         except subprocess.TimeoutExpired:

--- a/src/outerloop/harness.py
+++ b/src/outerloop/harness.py
@@ -199,6 +199,17 @@ def redact(text: str, secrets: tuple[str, ...]) -> str:
     return text
 
 
+def default_binary(backend: str) -> str:
+    """The host CLI a job spawns for `backend`: the path init recorded
+    (`OUTERLOOP_<BACKEND>_BIN`), else `~/.local/bin/<backend>` where the native
+    installers put it. One rule for the climb, the follow-up and the steward,
+    so a CLI installed anywhere else works in every lane."""
+    name = backend.strip().lower() or "claude"
+    return os.path.expanduser(
+        os.environ.get(f"OUTERLOOP_{name.upper()}_BIN") or f"~/.local/bin/{name}"
+    )
+
+
 def _error_result(stop_reason: str, transcript_path: str = "", detail: str = "") -> SessionResult:
     return SessionResult(
         stop_reason=stop_reason,

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -146,9 +146,9 @@ def _token_login(token: str) -> str:
 
 def _auth_is_fatal(problem: str) -> bool:
     """A credential the loop cannot open pull requests with fails setup; not
-    being able to ask GitHub right now does not."""
+    being able to ask GitHub right now (network, 5xx, rate limit) does not."""
     return bool(problem) and not problem.startswith(
-        ("could not reach GitHub", "could not read the App")
+        ("could not reach GitHub", "could not read the App", "could not check the App")
     )
 
 
@@ -213,6 +213,9 @@ def _check_repo_access(token: str, target: str) -> str:
             return "the token is invalid or expired (GitHub returned 401)"
         if exc.code == 403:
             return f"the token is not allowed to access {target} (GitHub returned 403)"
+        if exc.code == 429 or exc.code >= 500:
+            # GitHub's problem, not the credential's: never fatal
+            return f"could not reach GitHub: it returned {exc.code} for {target}"
         return f"GitHub returned {exc.code} for {target}"
     except urllib.error.URLError as exc:
         return f"could not reach GitHub: {exc.reason}"
@@ -260,6 +263,8 @@ def _check_app_access(provider: Any, target: str) -> str:
             )
         return ""
     except urllib.error.HTTPError as exc:
+        if exc.code == 429 or exc.code >= 500:
+            return f"could not reach GitHub: it returned {exc.code} while checking the App"
         return f"GitHub returned {exc.code} while checking the App"
     except urllib.error.URLError as exc:
         return f"could not reach GitHub: {exc.reason}"
@@ -355,12 +360,62 @@ def _owner_type(owner: str) -> str:
         return ""
 
 
-def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
+def _app_failure(answers: InitAnswers, slug: str, problem: str) -> int:
+    """The App cannot write the target: say so, keep the credentials, and point
+    at the fix and the re-check. Never `start` — the check just failed."""
+    print(f"  auth check: FAILED — {problem}", file=sys.stderr)
+    print(
+        f"outerloop init: the App '{slug}' cannot write {answers.target}. On\n"
+        f"  https://github.com/apps/{slug}/installations/new (or the App's page under\n"
+        "  Settings > Installations > Configure) install it on that repository and accept\n"
+        "  contents, issues and pull-request write access, then run\n"
+        "  `outerloop init --force --github-app` to re-check with these credentials.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _github_app_recheck(answers: InitAnswers, app_json: Path) -> int:
+    """Re-run Step 3 for an App this machine already created: confirm it can
+    write the target, then point the .env at it."""
+    from outerloop.appauth import app_provider_from_file
+
+    slug = app_json.name[len("github_app.") : -len(".json")]
+    print(f"Re-checking the existing App '{slug}' ({app_json}) against {answers.target}.")
+    try:
+        problem = _check_app_access(app_provider_from_file(app_json), answers.target)
+    except Exception as exc:
+        problem = f"could not read the App credentials: {exc}"
+    env_path = CONFIG_DIR / ENV_FILE.name
+    write_private(env_path, render_env(answers, app_file=str(app_json), bot_login=f"{slug}[bot]"))
+    if _auth_is_fatal(problem):
+        return _app_failure(answers, slug, problem)
+    print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
+    print(f"wrote {env_path}")
+    _author_key_hint(answers)
+    _harness_hint(answers)
+    print("next: outerloop start")
+    return 0
+
+
+def _github_app_setup(
+    answers: InitAnswers, app_name: str, org: str, *, interactive: bool = True
+) -> int:
     """The `--github-app` path: create the adopter's own App via the manifest
     flow, write its creds, help install it, then point the .env at the App file.
     Interactive by nature (a browser click + install), so no `--yes` variant."""
     from outerloop import appmanifest
 
+    existing = sorted(CONFIG_DIR.glob("github_app.*.json"))
+    if len(existing) == 1:
+        # a re-run after fixing the installation: re-check the App this machine
+        # already has rather than creating a second one
+        reuse = True
+        if interactive:
+            answer = _ask(f"Reuse the App credentials at {existing[0]}? (Y/n)", "y")
+            reuse = not answer.lower().startswith("n")
+        if reuse:
+            return _github_app_recheck(answers, existing[0])
     owner = org or answers.target.split("/")[0]
     name = app_name or f"outerloop-{owner}"[:34]  # GitHub caps App names at 34
     code = appmanifest.request_manifest_code(
@@ -407,18 +462,11 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
         except Exception as exc:  # a check failure is a warning, never fails setup
             problem = f"could not read the App credentials: {exc}"
         if _auth_is_fatal(problem):
-            print(f"  auth check: FAILED — {problem}", file=sys.stderr)
             write_private(
                 CONFIG_DIR / ENV_FILE.name,
                 render_env(answers, app_file=str(app_json), bot_login=f"{conversion['slug']}[bot]"),
             )
-            print(
-                f"outerloop init: the App cannot write {answers.target}; give it contents, "
-                "issues and pull-request write permission on that repository, then run "
-                "`outerloop start` (the config is written)",
-                file=sys.stderr,
-            )
-            return 1
+            return _app_failure(answers, str(conversion["slug"]), problem)
         print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
     else:
         print(
@@ -585,7 +633,7 @@ def main(argv: list[str] | None = None) -> int:
                 kind = "User" if answer.strip().lower().startswith("u") else "Organization"
             if kind == "User":
                 org = ""  # a user account: GitHub's personal App page, not an org page
-        return _github_app_setup(answers, args.app_name or "", org)
+        return _github_app_setup(answers, args.app_name or "", org, interactive=interactive)
 
     token = ""
     if not pat_file and interactive:

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -378,11 +378,21 @@ def _app_failure(answers: InitAnswers, slug: str, problem: str) -> int:
 def _github_app_recheck(answers: InitAnswers, app_json: Path) -> int:
     """Re-run Step 3 for an App this machine already created: confirm it can
     write the target, then point the .env at it."""
+    from outerloop import appmanifest
     from outerloop.appauth import app_provider_from_file
 
     slug = app_json.name[len("github_app.") : -len(".json")]
     print(f"Re-checking the existing App '{slug}' ({app_json}) against {answers.target}.")
     try:
+        data = json.loads(app_json.read_text())
+        if not int(data.get("installation_id") or 0):
+            # the earlier run ended before the App was installed: look again
+            iid = appmanifest.capture_installation_id(
+                int(data["app_id"]), Path(str(data["private_key"])), answers.target.split("/")[0]
+            )
+            if iid:
+                appmanifest.set_installation_id(app_json, iid)
+                print(f"  installation id {iid} recorded")
         problem = _check_app_access(app_provider_from_file(app_json), answers.target)
     except Exception as exc:
         problem = f"could not read the App credentials: {exc}"
@@ -469,10 +479,13 @@ def _github_app_setup(
             return _app_failure(answers, str(conversion["slug"]), problem)
         print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
     else:
-        print(
-            f"  still no installation. When it is installed, put its id into {app_json} as "
-            f"installation_id (GitHub shows it in the URL of the App's page under "
-            f"Settings > Installations), then run outerloop start."
+        # the credentials are kept; nothing can run until the App is installed
+        write_private(
+            CONFIG_DIR / ENV_FILE.name,
+            render_env(answers, app_file=str(app_json), bot_login=f"{conversion['slug']}[bot]"),
+        )
+        return _app_failure(
+            answers, str(conversion["slug"]), f"the App is not installed on {answers.target}"
         )
     env_path = CONFIG_DIR / ENV_FILE.name
     write_private(

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -20,6 +20,7 @@ import argparse
 import getpass
 import json
 import os
+import shutil
 import sys
 import time
 import urllib.error
@@ -51,6 +52,7 @@ class InitAnswers:
     author_key_file: str = ""  # the author's model key file, when known
     image: str = ""  # the agent image (OUTERLOOP_IMAGE)
     uncontained: bool = False  # --no-image: write OUTERLOOP_IMAGE= so no image is picked up
+    author_bin: str = ""  # the author harness binary (claude/codex), absolute, when found
 
 
 def render_env(
@@ -88,7 +90,66 @@ def render_env(
         lines.append(f"OUTERLOOP_AUTHOR_MODEL={a.author_model}")
     if a.author_key_file:
         lines.append(f"{author_key_env(a.author_backend)}={a.author_key_file}")
+    if a.author_bin:
+        lines.append(f"{author_bin_env(a.author_backend)}={a.author_bin}")
     return "\n".join(lines) + "\n"
+
+
+def author_bin_env(backend: str) -> str:
+    """The `.env` key naming `backend`'s harness binary (`OUTERLOOP_CLAUDE_BIN`,
+    `OUTERLOOP_CODEX_BIN`), the same names `attempt` reads."""
+    return f"OUTERLOOP_{(backend or AUTHOR_BACKENDS[0]).upper()}_BIN"
+
+
+HARNESS_INSTALL = {
+    "claude": "npm install -g @anthropic-ai/claude-code "
+    "(or: curl -fsSL https://claude.ai/install.sh | bash)",
+    "codex": "npm install -g @openai/codex",
+}
+
+
+def locate_harness(backend: str) -> str:
+    """The absolute path of `backend`'s CLI on this machine: PATH first, then
+    ~/.local/bin (where the native installers put it and where a Slurm job,
+    with no login PATH, would not find it); "" when absent. Recorded in .env so
+    every job spawns the same binary the operator installed."""
+    name = backend or AUTHOR_BACKENDS[0]
+    found = shutil.which(name)
+    if found:
+        return str(Path(found).resolve())
+    local = Path.home() / ".local" / "bin" / name
+    return str(local) if local.is_file() and os.access(local, os.X_OK) else ""
+
+
+def _harness_hint(answers: InitAnswers) -> None:
+    if not answers.author_bin:
+        name = answers.author_backend or AUTHOR_BACKENDS[0]
+        print(
+            f"  no `{name}` binary found on PATH or in ~/.local/bin — the first climb would end\n"
+            f"  with spawn-error. Install it: {HARNESS_INSTALL.get(name, 'see its docs')}\n"
+            "  then run `outerloop init --force` so its path is recorded."
+        )
+
+
+def _token_login(token: str) -> str:
+    """The login a PAT acts as (GET /user), or "" when GitHub does not say."""
+    req = urllib.request.Request(
+        f"{API}/user",
+        headers={"Authorization": f"token {token}", "Accept": "application/vnd.github+json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            return str(json.loads(resp.read()).get("login") or "")
+    except (urllib.error.URLError, OSError, ValueError):
+        return ""
+
+
+def _auth_is_fatal(problem: str) -> bool:
+    """A credential the loop cannot open pull requests with fails setup; not
+    being able to ask GitHub right now does not."""
+    return bool(problem) and not problem.startswith(
+        ("could not reach GitHub", "could not read the App")
+    )
 
 
 def author_key_env(backend: str) -> str:
@@ -148,6 +209,10 @@ def _check_repo_access(token: str, target: str) -> str:
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
             return f"{target} not found, or the token cannot see it"
+        if exc.code == 401:
+            return "the token is invalid or expired (GitHub returned 401)"
+        if exc.code == 403:
+            return f"the token is not allowed to access {target} (GitHub returned 403)"
         return f"GitHub returned {exc.code} for {target}"
     except urllib.error.URLError as exc:
         return f"could not reach GitHub: {exc.reason}"
@@ -264,6 +329,7 @@ def _collect(args: argparse.Namespace, interactive: bool) -> tuple[InitAnswers, 
         author_backend=backend,
         author_model=model,
         image=image,
+        author_bin=locate_harness(backend),
         uncontained=bool(args.no_image) and not image,
     )
     return answers, (args.pat_file or "")
@@ -340,6 +406,19 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
             problem = _check_app_access(app_provider_from_file(app_json), answers.target)
         except Exception as exc:  # a check failure is a warning, never fails setup
             problem = f"could not read the App credentials: {exc}"
+        if _auth_is_fatal(problem):
+            print(f"  auth check: FAILED — {problem}", file=sys.stderr)
+            write_private(
+                CONFIG_DIR / ENV_FILE.name,
+                render_env(answers, app_file=str(app_json), bot_login=f"{conversion['slug']}[bot]"),
+            )
+            print(
+                f"outerloop init: the App cannot write {answers.target}; give it contents, "
+                "issues and pull-request write permission on that repository, then run "
+                "`outerloop start` (the config is written)",
+                file=sys.stderr,
+            )
+            return 1
         print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
     else:
         print(
@@ -354,6 +433,7 @@ def _github_app_setup(answers: InitAnswers, app_name: str, org: str) -> int:
     )
     print(f"wrote {env_path}")
     _author_key_hint(answers)
+    _harness_hint(answers)
     print("next: outerloop start")
     return 0
 
@@ -521,10 +601,32 @@ def main(argv: list[str] | None = None) -> int:
     effective_pat = str(pat_path) if pat_path else pat_file
     if effective_pat:
         problem = validate_pat(effective_pat, answers.target)
+        if _auth_is_fatal(problem):
+            # the loop opens pull requests with this token; sending the adopter
+            # to `start` would fail later and further from the cause
+            print(f"  auth check: FAILED — {problem}", file=sys.stderr)
+            print(
+                f"outerloop init: fix the token in {effective_pat} (write access to "
+                f"{answers.target}), then run `outerloop init --force`",
+                file=sys.stderr,
+            )
+            return 1
         print(f"  auth check: {'ok' if not problem else 'WARNING — ' + problem}")
+        if not problem:
+            # record the login the kernel will post as: every own-comment and
+            # own-PR filter keys on it, and a default that is not this token's
+            # identity would hide the adopter's own PRs from the kernel
+            try:
+                login = _token_login(Path(effective_pat).expanduser().read_text().strip())
+            except OSError:
+                login = ""
+            if login:
+                write_private(env_path, render_env(answers, effective_pat, bot_login=login))
+                print(f"  posting as {login} (OUTERLOOP_BOT_LOGIN)")
     else:
         print("  no PAT set — add OUTERLOOP_PAT_FILE before the agents can open PRs")
     _author_key_hint(answers)
+    _harness_hint(answers)
     print("next: outerloop start")
     return 0
 

--- a/src/outerloop/steward.py
+++ b/src/outerloop/steward.py
@@ -43,7 +43,7 @@ from outerloop.github import (
     bot_login_from_env,
     is_own_login,
 )
-from outerloop.harness import Harness, budget_exhausted, outage, redact
+from outerloop.harness import Harness, budget_exhausted, default_binary, outage, redact
 from outerloop.intake import (
     CLAIM_MARKER,
     RELEASE_MARKER,
@@ -768,7 +768,7 @@ def main() -> int:
         action="store_true",
         help="run WITHOUT a container (dev only)",
     )
-    parser.add_argument("--claude-bin", default=os.path.expanduser("~/.local/bin/claude"))
+    parser.add_argument("--claude-bin", default=default_binary("claude"))
     parser.add_argument("--model", default="claude-opus-5")
     parser.add_argument("--max-turns", type=int, default=60)
     parser.add_argument("--session-minutes", type=int, default=60)

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -3097,6 +3097,16 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     # association and the partition to Slurm's defaults, as `start` already
     # does for the resident. Local compute has no placement at all.
     target = os.environ.get("OUTERLOOP_TARGET", "")
+    if not os.environ.get("OUTERLOOP_BOT_LOGIN", "").strip():
+        # the default is the lab's bot account; under any other credential
+        # the kernel would not recognize its own comments and PRs (#298)
+        from outerloop.github import DEFAULT_BOT_LOGIN
+
+        log.warning(
+            "OUTERLOOP_BOT_LOGIN is not set; posting as the default %r. Set it to the "
+            "login the kernel posts as (init records it) unless that is your account.",
+            DEFAULT_BOT_LOGIN,
+        )
     image_ok = Path(image).is_file()
     panel = os.environ.get("OUTERLOOP_PANEL", "verify,review")
     if not image_ok and local_mode():

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -370,6 +370,7 @@ def test_missing_binary_returns_spawn_error(tmp_path: Path) -> None:
     result = ClaudeCodeHarness(api_key="k", binary=str(tmp_path / "nope")).run("task", tmp_path)
     assert result.is_error
     assert result.stop_reason == "spawn-error"
+    assert "nope" in result.error_detail  # #294: the report names what failed to spawn
 
 
 def test_garbage_output_is_an_error_with_transcript(tmp_path: Path) -> None:

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -843,3 +843,29 @@ def test_role_key_tolerates_a_missing_file_only_under_vertex(tmp_path, monkeypat
     assert role_key(missing) == ""  # ADC-only claude deployment
     with pytest.raises(ValueError):
         role_key(missing, "codex")  # vertex never excuses a non-claude backend
+
+
+def test_default_binary_prefers_the_recorded_path(monkeypatch) -> None:
+    """init records OUTERLOOP_<BACKEND>_BIN; every lane (climb, follow-up, steward)
+    spawns that binary, else the native installer's ~/.local/bin path (#294)."""
+    from outerloop.harness import default_binary
+
+    monkeypatch.delenv("OUTERLOOP_CLAUDE_BIN", raising=False)
+    monkeypatch.delenv("OUTERLOOP_CODEX_BIN", raising=False)
+    assert default_binary("claude").endswith("/.local/bin/claude")
+    assert default_binary("codex").endswith("/.local/bin/codex")
+    monkeypatch.setenv("OUTERLOOP_CLAUDE_BIN", "/opt/bin/claude")
+    assert default_binary("claude") == "/opt/bin/claude"
+    monkeypatch.setenv("OUTERLOOP_CODEX_BIN", "~/tools/codex")
+    assert default_binary("codex").endswith("/tools/codex") and "~" not in default_binary("codex")
+
+
+def test_no_lane_hardcodes_the_harness_path() -> None:
+    """The three job parsers take their binary defaults from default_binary; a
+    literal ~/.local/bin/<cli> in any of them would ignore what init recorded."""
+    from pathlib import Path
+
+    src = Path(__file__).resolve().parents[1] / "src" / "outerloop"
+    for module in ("attempt.py", "followup.py", "steward.py"):
+        text = (src / module).read_text()
+        assert "~/.local/bin/claude" not in text and "~/.local/bin/codex" not in text, module

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -654,3 +654,74 @@ def test_repo_access_messages_name_the_cause(monkeypatch) -> None:
     assert not init._auth_is_fatal("could not reach GitHub: timeout")
     assert not init._auth_is_fatal("could not read the App credentials: x")
     assert not init._auth_is_fatal("")
+
+
+def test_transient_github_failures_are_not_dead_credentials(monkeypatch) -> None:
+    """A 5xx or a rate limit is GitHub's problem, not the credential's: init warns
+    and continues instead of failing (terra, #309)."""
+    import email.message
+    import io
+    import urllib.error
+
+    def raising(code):
+        def urlopen(req, timeout=15):
+            raise urllib.error.HTTPError(
+                req.full_url, code, "x", email.message.Message(), io.BytesIO(b"")
+            )
+
+        return urlopen
+
+    for code in (500, 502, 503, 429):
+        monkeypatch.setattr(init.urllib.request, "urlopen", raising(code))
+        problem = init._check_repo_access("t", "o/r")
+        assert problem.startswith("could not reach GitHub") and not init._auth_is_fatal(problem), (
+            code
+        )
+
+    class _Provider:
+        app_id = 1
+        installation_id = 7
+
+        def _sign(self, data: bytes) -> bytes:
+            return b"sig"
+
+    monkeypatch.setattr("outerloop.appauth.build_app_jwt", lambda *a, **k: "jwt")
+    monkeypatch.setattr(init.urllib.request, "urlopen", raising(502))
+    problem = init._check_app_access(_Provider(), "o/r")
+    assert problem.startswith("could not reach GitHub") and not init._auth_is_fatal(problem)
+    monkeypatch.setattr(init.urllib.request, "urlopen", raising(404))
+    assert init._auth_is_fatal(init._check_app_access(_Provider(), "o/r"))
+
+
+def test_github_app_rerun_rechecks_the_existing_app_instead_of_creating_one(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """After fixing the installation, `init --force --github-app` re-checks the App
+    this machine already has; it never mints a second App (terra, #309)."""
+    from outerloop import appmanifest
+
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    app_json = tmp_path / "github_app.myapp.json"
+    app_json.write_text(json.dumps({"app_id": 1, "installation_id": 7, "private_key": "/k.pem"}))
+
+    def never(*a, **k):
+        raise AssertionError("a second App must not be created")
+
+    monkeypatch.setattr(appmanifest, "request_manifest_code", never)
+    monkeypatch.setattr("outerloop.appauth.app_provider_from_file", lambda path: object())
+    monkeypatch.setattr(init, "_check_app_access", lambda provider, target: "")
+    argv = ["--yes", "--force", "--github-app", "--compute", "local", "--target", "o/r"]
+    assert init.main(argv) == 0
+    env = (tmp_path / ".env").read_text()
+    assert f"OUTERLOOP_GITHUB_APP_FILE={app_json}" in env
+    assert "OUTERLOOP_BOT_LOGIN=myapp[bot]" in env
+    capsys.readouterr()  # drop the successful run's output
+    # still failing: exit 1, credentials kept, the fix and the re-check named, never `start`
+    monkeypatch.setattr(
+        init, "_check_app_access", lambda provider, target: "the App lacks write on contents (x)"
+    )
+    assert init.main(argv) == 1
+    captured = capsys.readouterr()
+    assert "FAILED" in captured.err and "init --force --github-app" in captured.err
+    assert "apps/myapp/installations/new" in captured.err
+    assert "next: outerloop start" not in captured.out and app_json.exists()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -138,9 +138,13 @@ def test_main_yes_writes_config(tmp_path: Path, monkeypatch, capsys) -> None:
 
 
 @pytest.fixture(autouse=True)
-def _no_image_download(monkeypatch):
-    """init never reaches the network in tests: no image is found or fetched."""
+def _no_image_download(monkeypatch, request):
+    """init never reaches the network in tests: no image is found or fetched, the
+    token's login is not looked up, and no harness binary is found on this machine."""
     monkeypatch.setattr(init, "ensure_image", lambda **kw: "")
+    monkeypatch.setattr(init, "_token_login", lambda token: "")
+    if not request.node.get_closest_marker("real_locate_harness"):
+        monkeypatch.setattr(init, "locate_harness", lambda backend: "")
 
 
 def test_the_image_reaches_the_tick() -> None:
@@ -559,3 +563,94 @@ def test_app_check_asks_the_installation_not_the_repo_permissions(monkeypatch) -
     assert "lacks write on contents" in init._check_app_access(Provider(), "o/r")
     answers["repos/o/r/installation"] = {"id": 9, "permissions": {"contents": "write"}}
     assert "installation 9" in init._check_app_access(Provider(), "o/r")
+
+
+def test_a_credential_that_cannot_open_prs_fails_init(tmp_path: Path, monkeypatch, capsys) -> None:
+    """#285: a 401/403/404 or no write access exits 1 and never says
+    `next: outerloop start`; a network failure stays a warning."""
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    base = ["--yes", "--compute", "local", "--target", "o/r", "--pat-file", "/some/pat"]
+    for problem in (
+        "the token is invalid or expired (GitHub returned 401)",
+        "o/r not found, or the token cannot see it",
+        "reaches o/r but lacks write access (it opens PRs)",
+    ):
+        monkeypatch.setattr(init, "validate_pat", lambda pf, t, p=problem: p)
+        assert init.main([*base, "--force"]) == 1, problem
+        captured = capsys.readouterr()
+        assert "FAILED" in captured.err and "init --force" in captured.err
+        assert "next: outerloop start" not in captured.out
+    monkeypatch.setattr(init, "validate_pat", lambda pf, t: "could not reach GitHub: timed out")
+    assert init.main([*base, "--force"]) == 0
+    captured = capsys.readouterr()
+    assert "WARNING" in captured.out and "next: outerloop start" in captured.out
+
+
+def test_pat_path_records_the_tokens_login(tmp_path: Path, monkeypatch) -> None:
+    """#298: the kernel posts as this token; its login is recorded so every
+    own-comment and own-PR filter keys on the adopter's identity, not the lab's."""
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(init, "validate_pat", lambda pf, t: "")
+    pat = tmp_path / "pat"
+    pat.write_text("ghp_x")
+    monkeypatch.setattr(init, "_token_login", lambda token: "someone" if token == "ghp_x" else "")
+    base = ["--yes", "--compute", "local", "--target", "o/r", "--pat-file", str(pat)]
+    assert init.main(base) == 0
+    assert "OUTERLOOP_BOT_LOGIN=someone" in (tmp_path / ".env").read_text()
+
+
+def test_init_records_the_harness_binary_or_says_how_to_install_it(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """#294: the author's CLI path is recorded (jobs have no login PATH); when it
+    is absent, init says so and how to install it instead of a later spawn-error."""
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(init, "validate_pat", lambda pf, t: "")
+    base = ["--yes", "--compute", "local", "--target", "o/r", "--pat-file", "/some/pat"]
+    monkeypatch.setattr(init, "locate_harness", lambda backend: f"/opt/bin/{backend or 'claude'}")
+    assert init.main([*base, "--author-backend", "codex"]) == 0
+    assert "OUTERLOOP_CODEX_BIN=/opt/bin/codex" in (tmp_path / ".env").read_text()
+    monkeypatch.setattr(init, "locate_harness", lambda backend: "")
+    assert init.main([*base, "--force"]) == 0
+    out = capsys.readouterr().out
+    assert "no `claude` binary" in out and "npm install -g @anthropic-ai/claude-code" in out
+    assert "OUTERLOOP_CLAUDE_BIN" not in (tmp_path / ".env").read_text()
+
+
+@pytest.mark.real_locate_harness
+def test_locate_harness_prefers_path_then_local_bin(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(init.shutil, "which", lambda name: None)
+    monkeypatch.setattr(init.Path, "home", classmethod(lambda cls: tmp_path))
+    assert init.locate_harness("claude") == ""
+    local = tmp_path / ".local" / "bin" / "claude"
+    local.parent.mkdir(parents=True)
+    local.write_text("#!/bin/sh\n")
+    local.chmod(0o755)
+    assert init.locate_harness("claude") == str(local)
+    monkeypatch.setattr(init.shutil, "which", lambda name: str(tmp_path / "onpath" / name))
+    (tmp_path / "onpath").mkdir()
+    (tmp_path / "onpath" / "claude").write_text("")
+    assert init.locate_harness("claude").endswith("onpath/claude")
+
+
+def test_repo_access_messages_name_the_cause(monkeypatch) -> None:
+    import email.message
+    import io
+    import urllib.error
+
+    def raising(code):
+        def urlopen(req, timeout=15):
+            raise urllib.error.HTTPError(
+                req.full_url, code, "x", email.message.Message(), io.BytesIO(b"")
+            )
+
+        return urlopen
+
+    monkeypatch.setattr(init.urllib.request, "urlopen", raising(401))
+    assert "invalid or expired" in init._check_repo_access("t", "o/r")
+    monkeypatch.setattr(init.urllib.request, "urlopen", raising(403))
+    assert "not allowed" in init._check_repo_access("t", "o/r")
+    assert init._auth_is_fatal("the token is invalid or expired (GitHub returned 401)")
+    assert not init._auth_is_fatal("could not reach GitHub: timeout")
+    assert not init._auth_is_fatal("could not read the App credentials: x")
+    assert not init._auth_is_fatal("")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -259,7 +259,9 @@ def test_github_app_run_asks_only_for_the_organization(tmp_path: Path, monkeypat
     monkeypatch.setattr(appmanifest, "capture_installation_id", lambda *a, **k: 0)
     monkeypatch.setattr(init, "_owner_type", lambda owner: "Organization")
     monkeypatch.setattr("builtins.input", lambda *a: "")
-    assert init.main(["--github-app", "--compute", "local", "--target", "o/r"]) == 0
+    # capture_installation_id returned 0: the App was never installed, so init keeps
+    # the credentials but exits 1 and never says start (terra, #309)
+    assert init.main(["--github-app", "--compute", "local", "--target", "o/r"]) == 1
     written = (tmp_path / ".env").read_text()
     assert "OUTERLOOP_BOT_LOGIN=s[bot]" in written  # the login it recognizes itself by
     # the organization question is the only prompt; nothing about the author
@@ -468,7 +470,9 @@ def test_github_app_run_never_asks_for_the_key(tmp_path: Path, monkeypatch) -> N
         raise AssertionError("the focused --github-app run must not ask for a key")
 
     monkeypatch.setattr(init.getpass, "getpass", boom)
-    assert init.main(["--github-app", "--compute", "local", "--target", "o/r"]) == 0
+    # capture_installation_id returned 0: the App was never installed, so init keeps
+    # the credentials but exits 1 and never says start (terra, #309)
+    assert init.main(["--github-app", "--compute", "local", "--target", "o/r"]) == 1
 
 
 def test_write_private_never_widens(tmp_path: Path, monkeypatch) -> None:
@@ -725,3 +729,35 @@ def test_github_app_rerun_rechecks_the_existing_app_instead_of_creating_one(
     assert "FAILED" in captured.err and "init --force --github-app" in captured.err
     assert "apps/myapp/installations/new" in captured.err
     assert "next: outerloop start" not in captured.out and app_json.exists()
+
+
+def test_github_app_rerun_captures_a_missing_installation_id(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A first run that ended before the App was installed left installation_id 0;
+    the re-run looks the installation up, records it, then checks access."""
+    from outerloop import appmanifest
+
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    app_json = tmp_path / "github_app.myapp.json"
+    creds = {"app_id": 1, "installation_id": 0, "private_key": "/k.pem"}
+    app_json.write_text(json.dumps(creds))
+    monkeypatch.setattr(
+        appmanifest, "request_manifest_code", lambda *a, **k: pytest.fail("no new App")
+    )
+    monkeypatch.setattr(appmanifest, "capture_installation_id", lambda app_id, pem, owner: 7)
+    monkeypatch.setattr("outerloop.appauth.app_provider_from_file", lambda path: object())
+    monkeypatch.setattr(init, "_check_app_access", lambda provider, target: "")
+    argv = ["--yes", "--force", "--github-app", "--compute", "local", "--target", "o/r"]
+    assert init.main(argv) == 0
+    assert json.loads(app_json.read_text())["installation_id"] == 7
+    assert "installation id 7 recorded" in capsys.readouterr().out
+    # still not installed: exit 1 with the install page, credentials kept
+    app_json.write_text(json.dumps(creds))
+    monkeypatch.setattr(appmanifest, "capture_installation_id", lambda app_id, pem, owner: 0)
+    monkeypatch.setattr(
+        init, "_check_app_access", lambda provider, target: "the App is not installed on o/r"
+    )
+    assert init.main(argv) == 1
+    err = capsys.readouterr().err
+    assert "apps/myapp/installations/new" in err and "init --force --github-app" in err

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -320,3 +320,4 @@ def test_local_job_output_is_kept_beside_its_state(tmp_path: Path, monkeypatch) 
     assert compute.status(job_id) == "FAILED"
     out = tmp_path / "local_jobs" / f"{job_id}.out"
     assert out.read_text().strip() == "boom"
+    assert out.stat().st_mode & 0o777 == 0o600  # a job may print a credential

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -303,3 +303,20 @@ def test_local_mode_places_gpu_measures_without_a_lane(monkeypatch) -> None:
 
     with pytest.raises(ValueError, match="no GPU lane"):
         settings.placement(1)  # slurm mode still refuses loudly
+
+
+def test_local_job_output_is_kept_beside_its_state(tmp_path: Path, monkeypatch) -> None:
+    """#295: a failed local job used to leave only COMPLETED/FAILED; its combined
+    stdout/stderr now lands in local_jobs/<id>.out."""
+    from outerloop.compute import JobSpec, LocalCompute
+
+    monkeypatch.setenv("OUTERLOOP_ROOT", str(tmp_path))
+    compute = LocalCompute()
+    job_id = compute.submit(
+        JobSpec(
+            job_name="j", account="", partition="", time_minutes=1, command="echo boom >&2; exit 3"
+        )
+    )
+    assert compute.status(job_id) == "FAILED"
+    out = tmp_path / "local_jobs" / f"{job_id}.out"
+    assert out.read_text().strip() == "boom"

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -591,21 +591,49 @@ def test_tick_subcommand_forwards_to_the_tick_entry(monkeypatch: pytest.MonkeyPa
     assert seen[1:] == ["--root", "/r", "--loop"]
 
 
-def test_start_refuses_a_missing_recorded_harness_binary(tmp_path: Path) -> None:
-    """#294: init records the CLI path; if it is gone, every climb would end with
-    spawn-error, so start says so instead of launching."""
+def test_missing_harness_binary_checks_only_the_configured_backend(tmp_path: Path) -> None:
+    """#294: init records the CLI path; a missing one would end every climb with
+    spawn-error. Only the configured backend's path counts, and an explicit empty
+    value in the environment clears a stale recorded path."""
     from outerloop.cli import missing_harness_binary
 
     present = tmp_path / "claude"
     present.write_text("")
+    nope = str(tmp_path / "nope")
     assert missing_harness_binary({"OUTERLOOP_CLAUDE_BIN": str(present)}, {}) == ""
     assert missing_harness_binary({}, {}) == ""
-    problem = missing_harness_binary({"OUTERLOOP_CLAUDE_BIN": str(tmp_path / "nope")}, {})
+    problem = missing_harness_binary({"OUTERLOOP_CLAUDE_BIN": nope}, {})
     assert "OUTERLOOP_CLAUDE_BIN" in problem and "init --force" in problem
-    # the process environment wins over the file
+    # a stale path for the backend the loop never spawns does not block it
+    stale_other = {"OUTERLOOP_CLAUDE_BIN": nope, "OUTERLOOP_AUTHOR_BACKEND": "codex"}
+    assert missing_harness_binary(stale_other, {}) == ""
+    assert missing_harness_binary(
+        {"OUTERLOOP_CODEX_BIN": nope}, {"OUTERLOOP_AUTHOR_BACKEND": "codex"}
+    )
+    # the environment wins over the file, and an explicit empty value clears the path
     assert (
         missing_harness_binary(
-            {"OUTERLOOP_CODEX_BIN": str(tmp_path / "nope")}, {"OUTERLOOP_CODEX_BIN": str(present)}
+            {"OUTERLOOP_CLAUDE_BIN": nope}, {"OUTERLOOP_CLAUDE_BIN": str(present)}
         )
         == ""
     )
+    assert (
+        missing_harness_binary({"OUTERLOOP_CLAUDE_BIN": nope}, {"OUTERLOOP_CLAUDE_BIN": ""}) == ""
+    )
+
+
+def test_start_refuses_a_missing_recorded_harness_binary(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Through `start` itself: a recorded binary that is gone stops the launch
+    before any plan is made."""
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/usr/bin/sbatch")
+    monkeypatch.chdir(checkout(clean_env))
+    monkeypatch.setenv("OUTERLOOP_CLAUDE_BIN", str(clean_env / "gone"))
+    assert main(["start"]) == 2
+    err = capsys.readouterr().err
+    assert "OUTERLOOP_CLAUDE_BIN" in err and "is not a file" in err
+    # the same stale path is ignored when the loop is configured for codex
+    monkeypatch.setenv("OUTERLOOP_AUTHOR_BACKEND", "codex")
+    assert main(["start"]) == 2
+    assert "state root" in capsys.readouterr().err  # past the binary check

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -589,3 +589,23 @@ def test_tick_subcommand_forwards_to_the_tick_entry(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(tick, "main", fake_main)
     assert main(["tick", "--root", "/r", "--loop"]) == 7
     assert seen[1:] == ["--root", "/r", "--loop"]
+
+
+def test_start_refuses_a_missing_recorded_harness_binary(tmp_path: Path) -> None:
+    """#294: init records the CLI path; if it is gone, every climb would end with
+    spawn-error, so start says so instead of launching."""
+    from outerloop.cli import missing_harness_binary
+
+    present = tmp_path / "claude"
+    present.write_text("")
+    assert missing_harness_binary({"OUTERLOOP_CLAUDE_BIN": str(present)}, {}) == ""
+    assert missing_harness_binary({}, {}) == ""
+    problem = missing_harness_binary({"OUTERLOOP_CLAUDE_BIN": str(tmp_path / "nope")}, {})
+    assert "OUTERLOOP_CLAUDE_BIN" in problem and "init --force" in problem
+    # the process environment wins over the file
+    assert (
+        missing_harness_binary(
+            {"OUTERLOOP_CODEX_BIN": str(tmp_path / "nope")}, {"OUTERLOOP_CODEX_BIN": str(present)}
+        )
+        == ""
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -482,13 +482,9 @@ wheels = [
 name = "outerloop-science"
 source = { editable = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "pydantic" },
     { name = "pyyaml" },
-]
-
-[package.optional-dependencies]
-app-auth = [
-    { name = "cryptography" },
 ]
 
 [package.dev-dependencies]
@@ -504,7 +500,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cryptography", marker = "extra == 'app-auth'", specifier = ">=42" },
+    { name = "cryptography", specifier = ">=42" },
     { name = "pydantic", specifier = ">=2" },
     { name = "pyyaml", specifier = ">=6" },
 ]


### PR DESCRIPTION
The adopter issues found walking the pip-only path on cluster0, in one pass. Fixes #285, #293, #294, #295; moves #298 and #286 most of the way (notes below).

## What changed

- **#285, a dead credential fails init.** `outerloop init` exits 1 when the credential cannot open pull requests on the target (401, 403, 404, or no write access) and does not print `next: outerloop start`; it says what to fix and to re-run with `--force`. A network failure stays a warning. 401 and 403 now name the cause ("the token is invalid or expired"). The App path does the same after the installation check, keeping the credentials it wrote.
- **#294, the harness binary.** `init` locates the author's CLI (`claude` or `codex`) on PATH, then `~/.local/bin` (where the native installers put it and a job without a login PATH would not find it), records it as `OUTERLOOP_CLAUDE_BIN`/`OUTERLOOP_CODEX_BIN`, and when absent prints the install command and asks for `init --force` after. `attempt --claude-bin` honors `OUTERLOOP_CLAUDE_BIN` (codex already did). `start` refuses when a recorded binary is not a file. A `spawn-error` now carries the binary path and the OS error in `error_detail`.
- **#295, local job output.** `LocalCompute` writes the job's combined stdout/stderr to `local_jobs/<id>.out` beside the state file, and the "ran … locally" log line names it when the state is not COMPLETED. The daily prune covers these files.
- **#293, App auth from a plain install.** `cryptography` is a base dependency; the `app-auth` extra stays as a no-op so existing install lines keep working. `uv.lock` regenerated.
- **#298, partial.** The PAT path records the token's login (`GET /user`) as `OUTERLOOP_BOT_LOGIN`, so both identity paths now write it, and the tick logs a warning when the login is unset and the lab default applies. Removing the default outright is deferred: it would disable servicing on any deployment whose `.env` does not set the login, and I could not confirm the Torch fleet's `.env` tonight. Left on the issue.
- **#286.** The `tick` subcommand's help no longer says "the chain's own entry"; the PyPI description and `start` messages were already fixed by earlier PRs.

## Tests

`test_init`: a 401/404/no-write credential exits 1 without the start hint and a network error stays a warning; the PAT login is recorded; the binary is recorded or the install hint printed; `locate_harness` order (a registered `real_locate_harness` marker lets that one test bypass the module's hermetic fixture); 401/403 messages and `_auth_is_fatal`. `test_start`: `missing_harness_binary` (present, absent, unset, environ over file). `test_local_compute`: a failing job's `.out`. `test_harness`: spawn-error carries the binary.

Gate: ruff check, ruff format --check, mypy, `bash -n`, pytest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
