### PR TITLE
Release 0.1.0.dev2

### DIFF
--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-__version__ = "0.1.0.dev1"
+__version__ = "0.1.0.dev2"
 
 
 def _bridge_legacy_env() -> None:


### PR DESCRIPTION
Version bump only, per RELEASING.md: a pre-release moves the version and leaves the Unreleased section in place. Since dev1: the published agent image and init's download/detection flow (#305, #306), launch admission (#308), the adopter-path fixes (#309), the internal rename to OUTERLOOP_* with the one-release bridge (#302, #303), the queue-wait sweep fix (#304), the optional Slurm account/partition (#301), and the flaky-test fix (#310).

After merge: tag v0.1.0.dev2, the release workflow publishes to PyPI, then a prerelease on GitHub and a fresh-venv install check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)