### PR TITLE
No default bot login: the tick refuses a target without OUTERLOOP_BOT_LOGIN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ Versions follow [SemVer](https://semver.org).
   honored pre-rename name (`~/.config/autoresearch/`, `.autoresearch.yaml`, the
   `.autoresearch` channel dir, the old root, image and job names) is dropped in
   the release after 0.1; the comment marker keeps recognizing old comments.
+- No default bot login (#298). `OUTERLOOP_BOT_LOGIN` has no built-in value: the
+  tick lists it as missing and does not service a target without it, and the
+  follow-up CLI requires it. `init` records it on both auth paths, so a fresh
+  setup always has one; a deployment set up before this must add the line.
 
 ### Changed
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -222,7 +222,9 @@ Slurm bill the default association and pick the default partition),
 `OUTERLOOP_ROOT` locate the checkout and the state, `OUTERLOOP_IMAGE`
 the container. The rest is re-read from `~/.config/outerloop/.env` each
 tick, so changes take effect at the next cadence: `OUTERLOOP_TARGET`
-names the repo being climbed; `OUTERLOOP_GPU_PARTITION` (optionally
+names the repo being climbed; `OUTERLOOP_BOT_LOGIN` is the login the kernel
+posts as (`init` records it on both auth paths; there is no default, and the
+tick does not service a target without it); `OUTERLOOP_GPU_PARTITION` (optionally
 `OUTERLOOP_GPU_ACCOUNT`) is the lane for GPU evals and launches;
 `OUTERLOOP_MAX_LAUNCH_GPUS` is the per-user GPU cap (your QOS's
 `MaxTRESPerUser`) under which the tick admits author launches, unset = queue

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -1986,7 +1986,11 @@ def main() -> int:
     # the tick passes the effective limit explicitly; this fallback follows
     # the harness ceiling so a bare CLI run is never silently starved
     parser.add_argument("--max-turns", type=int, default=DEFAULT_MAX_TURNS)
-    parser.add_argument("--bot-login", default=bot_login_from_env())
+    parser.add_argument(
+        "--bot-login",
+        default=bot_login_from_env(),
+        help="the login the kernel posts as (OUTERLOOP_BOT_LOGIN); required",
+    )
     parser.add_argument(
         "--job-minutes",
         type=int,
@@ -2025,6 +2029,8 @@ def main() -> int:
         "the read is skipped and said so; the author's budget is never the panel's)",
     )
     args = parser.parse_args()
+    if not args.bot_login.strip():
+        parser.error("--bot-login / OUTERLOOP_BOT_LOGIN is required (no default identity, #298)")
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
     if not args.image and not args.uncontained:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")

--- a/src/outerloop/github.py
+++ b/src/outerloop/github.py
@@ -37,15 +37,16 @@ from typing import Any, Protocol
 from outerloop.contract import CONTRACT_NAMES, find_contract
 from outerloop.markers import legacy_marker, marker
 
-DEFAULT_BOT_LOGIN = "agentic-learning-bot"
 
-
-def bot_login_from_env(default: str = DEFAULT_BOT_LOGIN) -> str:
+def bot_login_from_env(default: str = "") -> str:
     """The login the kernel posts and pushes as — the bot ACCOUNT under a PAT,
     the App's `<slug>[bot]` under App auth (docs/design/github-app-auth.md).
     `OUTERLOOP_BOT_LOGIN` sets it for every role at once (the tick exports
     it, jobs inherit it); every own-comment filter, alarm-issue lookup and
-    intake-claim scan keys on this string, so it must follow the credential."""
+    intake-claim scan keys on this string, so it must follow the credential.
+    There is no built-in default (#298): a wrong identity hides the kernel's
+    own PRs from it, so an unset login fails closed — the tick refuses to
+    service a target without one, and `init` records it on both auth paths."""
     return os.environ.get("OUTERLOOP_BOT_LOGIN", "").strip() or default
 
 

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -424,7 +424,7 @@ def contract_alarm(
     target: str,
     error: str | None,
     now: float,
-    bot_login: str = "agentic-learning-bot",
+    bot_login: str = "",
 ) -> None:
     """Persistent contract failure must surface where humans look.
 
@@ -433,6 +433,7 @@ def contract_alarm(
     opens ONE issue on the target repo; the next successful load closes
     it and says so. Alarm plumbing is best-effort by construction: it
     must never break the tick it reports for."""
+    bot_login = bot_login or _bot_login_default()
     state_path = root / "contract-alarm.json"
     try:
         state = json.loads(state_path.read_text())
@@ -3240,16 +3241,9 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
     # association and the partition to Slurm's defaults, as `start` already
     # does for the resident. Local compute has no placement at all.
     target = os.environ.get("OUTERLOOP_TARGET", "")
-    if not os.environ.get("OUTERLOOP_BOT_LOGIN", "").strip():
-        # the default is the lab's bot account; under any other credential
-        # the kernel would not recognize its own comments and PRs (#298)
-        from outerloop.github import DEFAULT_BOT_LOGIN
-
-        log.warning(
-            "OUTERLOOP_BOT_LOGIN is not set; posting as the default %r. Set it to the "
-            "login the kernel posts as (init records it) unless that is your account.",
-            DEFAULT_BOT_LOGIN,
-        )
+    # no default identity (#298): every own-comment and own-PR filter keys on
+    # this login, and a wrong one is worse than none
+    bot_login = os.environ.get("OUTERLOOP_BOT_LOGIN", "").strip()
     image_ok = Path(image).is_file()
     panel = os.environ.get("OUTERLOOP_PANEL", "verify,review")
     if not image_ok and local_mode():
@@ -3276,7 +3270,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
         # the jobs must not inherit a path to an image that is not there
         os.environ.pop("OUTERLOOP_IMAGE", None)
         image, image_ok = "", True
-    if (pat_file or app_file) and home and target and image_ok:
+    if (pat_file or app_file) and home and target and bot_login and image_ok:
         from outerloop.appauth import resolve_bot_auth
         from outerloop.github import GitHubClient
 
@@ -3310,6 +3304,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
             ("OUTERLOOP_PAT_FILE or _GITHUB_APP_FILE", pat_file or app_file),
             ("OUTERLOOP_HOME", home),
             ("OUTERLOOP_TARGET", target),
+            ("OUTERLOOP_BOT_LOGIN", bot_login),
         ]
         if not value
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 TIERS = ("slow", "llm", "slurm")
@@ -48,3 +50,12 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     if dropped:
         config.hook.pytest_deselected(items=dropped)
         items[:] = kept
+
+
+@pytest.fixture(autouse=True)
+def _configured_bot_login(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The kernel has no built-in identity (#298); a deployment always sets
+    OUTERLOOP_BOT_LOGIN (init records it). Tests run as such a deployment unless
+    they unset it themselves to exercise the fail-closed paths."""
+    if "OUTERLOOP_BOT_LOGIN" not in os.environ:
+        monkeypatch.setenv("OUTERLOOP_BOT_LOGIN", "agentic-learning-bot")

--- a/tests/test_bot_login.py
+++ b/tests/test_bot_login.py
@@ -2,14 +2,14 @@
 
 from __future__ import annotations
 
-from outerloop.github import DEFAULT_BOT_LOGIN, bot_login_from_env
+from outerloop.github import bot_login_from_env
 
 
 def test_bot_login_defaults_to_the_account_and_follows_the_knob(monkeypatch) -> None:
     monkeypatch.delenv("OUTERLOOP_BOT_LOGIN", raising=False)
-    assert bot_login_from_env() == DEFAULT_BOT_LOGIN
+    assert bot_login_from_env() == ""  # no built-in identity (#298)
     monkeypatch.setenv("OUTERLOOP_BOT_LOGIN", "   ")
-    assert bot_login_from_env() == DEFAULT_BOT_LOGIN  # blank is unset
+    assert bot_login_from_env() == ""  # blank is unset
     monkeypatch.setenv("OUTERLOOP_BOT_LOGIN", "outerloop-autoresearch[bot]")
     assert bot_login_from_env() == "outerloop-autoresearch[bot]"
 
@@ -28,4 +28,4 @@ def test_every_role_config_reads_the_login_at_construction(monkeypatch, tmp_path
     assert StewardConfig(target="o/r", benchmark="b").bot_login == "outerloop-autoresearch[bot]"
     assert RunConfig(target="o/r", benchmark="b", bot_login="x").bot_login == "x"
     monkeypatch.delenv("OUTERLOOP_BOT_LOGIN")
-    assert RunConfig(target="o/r", benchmark="b").bot_login == DEFAULT_BOT_LOGIN
+    assert RunConfig(target="o/r", benchmark="b").bot_login == ""

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -1923,6 +1923,7 @@ def test_panel_env_knobs_flow_into_the_spec(monkeypatch: Any, tmp_path: Path) ->
         "OUTERLOOP_IMAGE": str(image),
         "OUTERLOOP_HOME": str(tmp_path),
         "OUTERLOOP_TARGET": "org/repo",
+        "OUTERLOOP_BOT_LOGIN": "agentic-learning-bot",
         "OUTERLOOP_PANEL": "verify",
         "OUTERLOOP_PANEL_KEY_FILE": "/keys/verifier",
     }
@@ -3451,6 +3452,7 @@ def test_followup_spec_needs_no_account_or_partition(monkeypatch: Any, tmp_path:
         "OUTERLOOP_IMAGE": str(image),
         "OUTERLOOP_HOME": str(tmp_path),
         "OUTERLOOP_TARGET": "org/repo",
+        "OUTERLOOP_BOT_LOGIN": "agentic-learning-bot",
     }
     import outerloop.tick as tick_mod
 
@@ -4360,6 +4362,7 @@ def test_local_mode_runs_uncontained_without_an_image(monkeypatch: Any, tmp_path
         "OUTERLOOP_IMAGE": str(tmp_path / "missing.sif"),
         "OUTERLOOP_HOME": str(tmp_path),
         "OUTERLOOP_TARGET": "org/repo",
+        "OUTERLOOP_BOT_LOGIN": "agentic-learning-bot",
         "OUTERLOOP_ACCOUNT": "a",
         "OUTERLOOP_PARTITION": "p",
     }
@@ -4569,3 +4572,28 @@ def test_launcher_submits_gpu_launches_held_under_admission(
     monkeypatch.delenv("OUTERLOOP_MAX_LAUNCH_GPUS")
     attempt_mod._make_launcher(settings, tmp_path, tmp_path, "run1", gpus=8)("sha", request)
     assert seen[-1].hold is False  # admission off: queue as submitted
+
+
+def test_followup_spec_needs_the_bot_login(monkeypatch: Any, tmp_path: Path) -> None:
+    """#298: no built-in identity. Without OUTERLOOP_BOT_LOGIN the tick does not
+    service the target and names the setting; with it, the spec carries it."""
+    from outerloop.tick import _followup_spec_from_env
+
+    image = tmp_path / "agent.sif"
+    image.write_text("")
+    pat = tmp_path / "pat"
+    pat.write_text("t")
+    env = {
+        "OUTERLOOP_PAT_FILE": str(pat),
+        "OUTERLOOP_IMAGE": str(image),
+        "OUTERLOOP_HOME": str(tmp_path),
+        "OUTERLOOP_TARGET": "org/repo",
+    }
+    import outerloop.tick as tick_mod
+
+    monkeypatch.setattr(tick_mod.os, "environ", env)
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is None
+    env["OUTERLOOP_BOT_LOGIN"] = "someone[bot]"
+    _github, spec = _followup_spec_from_env(tmp_path)
+    assert spec is not None and spec.bot_login == "someone[bot]"


### PR DESCRIPTION
Fixes #298. Completes what #309 started.

`DEFAULT_BOT_LOGIN` was the lab's bot account; an adopter without `OUTERLOOP_BOT_LOGIN` ran with an identity that was not theirs, so every own-comment filter, alarm lookup, intake-claim scan and own-PR scan missed the kernel's own work. A wrong default is worse than none.

- `bot_login_from_env()` returns "" when the knob is unset; the constant is gone.
- The tick lists `OUTERLOOP_BOT_LOGIN` in its missing-settings line and does not service a target without it; `contract_alarm` falls back to the same knob instead of a hardcoded account.
- The follow-up CLI requires `--bot-login` (default from the knob).
- `init` records the login on both auth paths (PAT: the token's login; App: `<slug>[bot]`), so a fresh setup always has one. A deployment set up before this adds the line; the Torch fleet already sets it (`outerloop-science[bot]`, confirmed on the login node).
- Tests run as a configured deployment through an autouse fixture in `conftest.py`; the tick's fail-closed path has its own test. `docs/install.md` names the setting; CHANGELOG under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)