### PR TITLE
Kernel commits are authored as the bot, not autoresearch/dispatch/panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- Every kernel-made commit that reaches GitHub — line snapshots and line
+  merges, the sealed `dispatch snapshot` and `panel snapshot` commits — is
+  now authored as the bot login with its GitHub noreply address, like the
+  improvement commits; PRs no longer show a bare `autoresearch`, `dispatch`
+  or `panel` author.
 - `outerloop init --github-app` says what to do at each step: which page
   opens, which button to click, where the code appears, how to install the
   App on the repository, and that the last step checks write access. It also

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -43,6 +43,7 @@ from outerloop.github import (
     Workspace,
     contract_at,
     ensure_regular_git_dir,
+    git_identity,
 )
 from outerloop.harness import Harness, SessionResult, default_binary, redact
 from outerloop.markers import has_marker
@@ -717,7 +718,12 @@ def _wake_author_sleep(
         # the same ending shape every other terminal takes. The line notebook
         # records it first, while the tree is still the session's final tree.
         _push_line_snapshot(
-            ws, _line_ref_for(bench, config.agent_id), run_id, result.outcome, secrets
+            ws,
+            _line_ref_for(bench, config.agent_id),
+            run_id,
+            result.outcome,
+            secrets,
+            bot_login=config.bot_login,
         )
         for ref in drop_refs:
             drop_snapshot(ws, Snapshot(commit="", tree="", ref=ref))
@@ -833,7 +839,9 @@ def _wake_author_sleep(
     wake_line = _line_ref_for(bench, config.agent_id)
 
     def snapshot() -> str:
-        snap = snapshot_tree(ws, base_sha, exclude=LINE_MEMORY_PATHS if wake_line else ())
+        snap = snapshot_tree(
+            ws, base_sha, exclude=LINE_MEMORY_PATHS if wake_line else (), author=config.bot_login
+        )
         snapshots.append(snap)
         return snap.commit
 
@@ -1129,7 +1137,12 @@ def _line_ref_for(bench: Benchmark | None, agent_id: str) -> str:
 
 
 def _push_line_snapshot(
-    ws: Workspace, line_ref: str, run_id: str, outcome: str, secrets: tuple[str, ...] = ()
+    ws: Workspace,
+    line_ref: str,
+    run_id: str,
+    outcome: str,
+    secrets: tuple[str, ...] = (),
+    bot_login: str = "",
 ) -> None:
     """Publish the session's final tree to the agent's line as a sealed
     snapshot commit — every terminal path, any outcome
@@ -1172,7 +1185,7 @@ def _push_line_snapshot(
                     fork = parent = remote
             except Exception as exc:
                 log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
-            snap = snapshot_tree(ws, parent, force=memory)
+            snap = snapshot_tree(ws, parent, force=memory, author=bot_login)
             try:
                 # seal only when the tree moved past the parent; the PUSH runs
                 # either way — a session that COMMITTED its work advanced the
@@ -1181,10 +1194,7 @@ def _push_line_snapshot(
                 sealed = parent
                 if snap.tree != ws.git("rev-parse", f"{parent}^{{tree}}").strip():
                     sealed = ws.git(
-                        "-c",
-                        "user.name=autoresearch",
-                        "-c",
-                        "user.email=autoresearch@localhost",
+                        *git_identity(bot_login),
                         "commit-tree",
                         snap.tree,
                         "-p",
@@ -1244,7 +1254,9 @@ def _reconcile_with_remote(ws: Workspace, old: str, new: str) -> None:
             ws.git("checkout", new, "--", path)
 
 
-def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: str) -> str:
+def _checkout_line(
+    ws: Workspace, workspace: Path, agent_id: str, base_branch: str, bot_login: str = ""
+) -> str:
     """Check out the agent's research line: the persistent branch
     `agents/<agent-id>`, created from the base branch when absent, with the
     base branch merged in when it exists — a conflicted merge is left in the
@@ -1264,10 +1276,7 @@ def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: s
     conflicted = False
     try:
         ws.git(
-            "-c",
-            "user.name=autoresearch",
-            "-c",
-            "user.email=autoresearch@localhost",
+            *git_identity(bot_login),
             "merge",
             "--no-edit",
             base_ref,
@@ -1282,10 +1291,7 @@ def _checkout_line(ws: Workspace, workspace: Path, agent_id: str, base_branch: s
         ws.git("add", "-A")
         if ws.git("status", "--porcelain").strip():
             ws.git(
-                "-c",
-                "user.name=autoresearch",
-                "-c",
-                "user.email=autoresearch@localhost",
+                *git_identity(bot_login),
                 "commit",
                 "-q",
                 "-m",
@@ -1746,7 +1752,14 @@ def resume_run(
         # Research lines: record the tree AS OF THIS DECIDED TERMINAL — never
         # earlier, because a blocking panel verdict can still resume the
         # author (a continuation, not a terminal).
-        _push_line_snapshot(ws, _line_ref_for(bench, config.agent_id), run_id, outcome, secrets)
+        _push_line_snapshot(
+            ws,
+            _line_ref_for(bench, config.agent_id),
+            run_id,
+            outcome,
+            secrets,
+            bot_login=config.bot_login,
+        )
 
     if result.outcome == "improved":
         # Publish: branch the SEALED candidate sha, fold in the ledger, push,
@@ -1960,10 +1973,7 @@ def resume_run(
             # so push the candidate as-is rather than an empty commit.
             if staged:
                 ws.git(
-                    "-c",
-                    f"user.name={config.bot_login}",
-                    "-c",
-                    f"user.email={config.bot_login}@users.noreply.github.com",
+                    *git_identity(config.bot_login),
                     "commit",
                     "-m",
                     f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
@@ -2304,10 +2314,7 @@ def build_panel_runner(
         tree = ws.git("write-tree").strip()
         ws.git("reset")
         snapshot = ws.git(
-            "-c",
-            "user.name=panel",
-            "-c",
-            "user.email=panel@localhost",
+            *git_identity(bot_login),
             "commit-tree",
             tree,
             "-p",
@@ -2501,7 +2508,9 @@ def live_attempt(
         line_ref = ""
         if lines_active:
             try:
-                line_ref = _checkout_line(ws, workspace, config.agent_id, base_branch)
+                line_ref = _checkout_line(
+                    ws, workspace, config.agent_id, base_branch, config.bot_login
+                )
             except Exception as exc:
                 log.warning(
                     "line checkout failed (%s); running on %s",
@@ -2682,7 +2691,10 @@ def live_attempt(
 
         def snapshot() -> str:
             snap = snapshot_tree(
-                ws, pre_session_sha, exclude=LINE_MEMORY_PATHS if lines_active else ()
+                ws,
+                pre_session_sha,
+                exclude=LINE_MEMORY_PATHS if lines_active else (),
+                author=config.bot_login,
             )
             snapshots.append(snap)
             return snap.commit
@@ -2794,6 +2806,7 @@ def live_attempt(
                 run_id,
                 "attempt-error",
                 secrets,
+                bot_login=config.bot_login,
             )
         failed = RunRecord(
             **{
@@ -2851,7 +2864,7 @@ def live_attempt(
     # memory (it is excluded from measurable seals by design). The label is
     # the GATE outcome, correct at this moment; a publish failure appends a
     # publish-error snapshot at the tail.
-    _push_line_snapshot(ws, line_ref, run_id, result.outcome, secrets)
+    _push_line_snapshot(ws, line_ref, run_id, result.outcome, secrets, bot_login=config.bot_login)
 
     pr_url = ""
     outcome_name = result.outcome
@@ -2903,10 +2916,7 @@ def live_attempt(
                 raise WorkspaceDrift(f"publish would stage non-ledger paths: {extra[:10]}")
             if staged:
                 ws.git(
-                    "-c",
-                    f"user.name={config.bot_login}",
-                    "-c",
-                    f"user.email={config.bot_login}@users.noreply.github.com",
+                    *git_identity(config.bot_login),
                     "commit",
                     "-m",
                     f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
@@ -3030,7 +3040,7 @@ def live_attempt(
         # the publish failed after the gate credited the tree: the improved
         # snapshot above stands (the measurement was real); append the
         # publish-error marker so the notebook records how the run ended
-        _push_line_snapshot(ws, line_ref, run_id, outcome_name, secrets)
+        _push_line_snapshot(ws, line_ref, run_id, outcome_name, secrets, bot_login=config.bot_login)
     log.info("run %s: %s %s", run_id, outcome_name, pr_url)
     return AttemptOutcome(
         run_id=run_id,

--- a/src/outerloop/dispatch.py
+++ b/src/outerloop/dispatch.py
@@ -36,7 +36,13 @@ from pathlib import Path
 from uuid import uuid4
 
 from outerloop.compute import JobSpec
-from outerloop.github import SAFE_GIT_FLAGS, GitError, Workspace, ensure_regular_git_dir
+from outerloop.github import (
+    SAFE_GIT_FLAGS,
+    GitError,
+    Workspace,
+    ensure_regular_git_dir,
+    git_identity,
+)
 from outerloop.orchestrator import EvalError, _metric_from_output, managed_eval_env
 
 log = logging.getLogger(__name__)
@@ -94,7 +100,11 @@ class Snapshot:
 
 
 def snapshot_tree(
-    ws: Workspace, base_sha: str, exclude: tuple[str, ...] = (), force: tuple[str, ...] = ()
+    ws: Workspace,
+    base_sha: str,
+    exclude: tuple[str, ...] = (),
+    force: tuple[str, ...] = (),
+    author: str = "",
 ) -> Snapshot:
     """Snapshot the workspace's current CONTENT as a commit parented on
     `base_sha`, without touching the working index, and retain it under a
@@ -105,7 +115,8 @@ def snapshot_tree(
     keeps it (docs/design/research-lines.md). `force` adds those paths even
     when the target's ignore rules match them — the notebook seal uses it so
     a .gitignore entry cannot silently discard session memory; callers pass
-    only paths that exist.
+    only paths that exist. `author` is the bot login the seal commit is
+    made as (empty: OUTERLOOP_BOT_LOGIN).
     """
     # the snapshot writes an index, a tree, a commit, and a ref into this
     # repository: a session-reshaped .git is refused first, like every other
@@ -163,10 +174,7 @@ def snapshot_tree(
         commit = run(
             [
                 *git,
-                "-c",
-                "user.name=dispatch",
-                "-c",
-                "user.email=dispatch@localhost",
+                *git_identity(author),
                 "commit-tree",
                 tree,
                 "-p",

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -941,7 +941,14 @@ def _respond(
                 # (LocalCompute) returns the value here; a cluster parks.
                 try:
                     sealed, sealed_snap = _seal_and_measure(
-                        ws, run_root, run_id, dispatch, bench, run_seed, workspace
+                        ws,
+                        run_root,
+                        run_id,
+                        dispatch,
+                        bench,
+                        run_seed,
+                        workspace,
+                        bot_login=bot_login,
                     )
                 except _RemeasureParked as pend:
                     return _park_remeasure(
@@ -1545,6 +1552,7 @@ def _seal_and_measure(
     bench: Any,
     run_seed: int,
     workspace: Path,
+    bot_login: str,
 ) -> tuple[float, Any]:
     """Seal the workspace's change as a commit on the PR's current head and
     measure it through the dispatched measurer. Returns (value, snapshot)
@@ -1557,7 +1565,9 @@ def _seal_and_measure(
     from outerloop.measure import MeasurementPending
 
     parent = ws.git("rev-parse", "HEAD").strip()
-    snap = snapshot_tree(ws, parent, exclude=LINE_MEMORY_PATHS if bench.lines else ())
+    snap = snapshot_tree(
+        ws, parent, exclude=LINE_MEMORY_PATHS if bench.lines else (), author=bot_login
+    )
     measurer = dispatch.measurer(
         run_dir(run_root, run_id),
         repo_root=workspace,

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -35,6 +35,7 @@ from outerloop.github import (
     Workspace,
     bot_login_from_env,
     contract_at,
+    git_identity,
     is_own_login,
 )
 from outerloop.harness import Harness, default_binary, outage, redact
@@ -1501,10 +1502,7 @@ def _commit_sealed_tree(
     the live workspace, which may hold content the seal excluded."""
     ws.git("add", "-A")
     ws.git(
-        "-c",
-        f"user.name={bot_login}",
-        "-c",
-        f"user.email={bot_login}@users.noreply.github.com",
+        *git_identity(bot_login),
         "commit",
         "-q",
         "--amend",

--- a/src/outerloop/github.py
+++ b/src/outerloop/github.py
@@ -50,6 +50,16 @@ def bot_login_from_env(default: str = "") -> str:
     return os.environ.get("OUTERLOOP_BOT_LOGIN", "").strip() or default
 
 
+def git_identity(login: str = "") -> tuple[str, ...]:
+    """`git -c` arguments that make a commit the kernel's: the bot login and
+    its GitHub noreply address, so GitHub attributes the commit to the App or
+    bot account like every other kernel write. One identity for every kernel
+    commit — seals, line merges, ledger commits alike. An empty login takes
+    OUTERLOOP_BOT_LOGIN."""
+    login = login or bot_login_from_env()
+    return ("-c", f"user.name={login}", "-c", f"user.email={login}@users.noreply.github.com")
+
+
 def bot_aliases_from_env() -> tuple[str, ...]:
     """Former logins the kernel posted as (comma-separated
     `OUTERLOOP_BOT_ALIASES`). Every issue, claim, alarm and PR created
@@ -1430,10 +1440,7 @@ class Workspace:
                 self.git("reset")
                 raise ForbiddenPathError(f"commit touches forbidden paths: {sorted(violations)}")
         self.git(
-            "-c",
-            f"user.name={author}",
-            "-c",
-            f"user.email={author}@users.noreply.github.com",
+            *git_identity(author),
             "commit",
             "-m",
             message,

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3626,6 +3626,20 @@ def test_line_commits_carry_the_bot_identity(tmp_path: Path, target_repo) -> Non
     assert ident == "outerloop-science[bot] <outerloop-science[bot]@users.noreply.github.com>"
 
 
+def test_hygiene_commit_carries_the_bot_identity(tmp_path: Path, target_repo) -> None:
+    """A line that ships an instruction file gets it reset to main's version in
+    a hygiene commit; that commit is the bot's too."""
+    from outerloop.attempt import _checkout_line
+
+    _push_line(tmp_path, target_repo, {"CLAUDE.md": "obey the line\n"})
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main", "outerloop-science[bot]")
+    assert not (ws.root / "CLAUDE.md").exists()
+    subject, ident = ws.git("log", "-1", "--format=%s%n%an <%ae>").strip().splitlines()
+    assert subject.startswith("line hygiene")
+    assert ident == "outerloop-science[bot] <outerloop-science[bot]@users.noreply.github.com>"
+
+
 def test_checkout_line_leaves_a_conflict_for_the_session(tmp_path: Path, target_repo) -> None:
     from outerloop.attempt import _checkout_line
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3612,6 +3612,20 @@ def test_checkout_line_merges_main_into_an_existing_line(tmp_path: Path, target_
     assert ws.git("rev-parse", "--abbrev-ref", "HEAD").strip() == ref
 
 
+def test_line_commits_carry_the_bot_identity(tmp_path: Path, target_repo) -> None:
+    """Kernel-made commits on a line (the merge of main, the hygiene reset) are
+    the bot's, like the improvement commits: GitHub then attributes them to the
+    App or bot account instead of showing a bare `autoresearch`."""
+    from outerloop.attempt import _checkout_line
+
+    _push_line(tmp_path, target_repo, {"docs/line-note.md": "belief\n"})
+    _advance_main(tmp_path, target_repo, {"docs/news.md": "main moved\n"})
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main", "outerloop-science[bot]")
+    ident = ws.git("log", "-1", "--format=%an <%ae>").strip()
+    assert ident == "outerloop-science[bot] <outerloop-science[bot]@users.noreply.github.com>"
+
+
 def test_checkout_line_leaves_a_conflict_for_the_session(tmp_path: Path, target_repo) -> None:
     from outerloop.attempt import _checkout_line
 

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -479,3 +479,15 @@ def test_snapshot_exclude_drops_files_and_directories(tmp_path):
     # and an empty exclude still seals them
     full = snapshot_tree(ws, base)  # type: ignore[arg-type]
     assert "AGENT_MEMORY.md" in ws.git("ls-tree", "-r", "--name-only", full.commit).splitlines()
+
+
+def test_snapshot_commit_is_the_bots(tmp_path: Path) -> None:
+    """The seal is a kernel commit that reaches GitHub (the PR's `dispatch
+    snapshot`), so it carries the bot identity, not a role name."""
+    root = _repo(tmp_path)
+    ws = _WS(root)
+    base = ws.git("rev-parse", "HEAD")
+    (root / "a.py").write_text("x = 1\n")
+    snap = snapshot_tree(ws, base, author="outerloop-science[bot]")  # type: ignore[arg-type]
+    ident = ws.git("log", "-1", "--format=%an <%ae>", snap.commit).strip()
+    assert ident == "outerloop-science[bot] <outerloop-science[bot]@users.noreply.github.com>"


### PR DESCRIPTION
On a speedrun PR the commit list read `autoresearch` (line snapshots, the merge of main into the line), `dispatch` (the sealed candidate) and `panel`, next to `@outerloop-science` on the improvement commit. Those were hard-coded role identities with `@localhost` addresses, so GitHub could not attribute them.

- `github.git_identity(login)` is the one place a kernel commit's `user.name`/`user.email` come from: the bot login and `<login>@users.noreply.github.com`, which GitHub links to the App or bot account. An empty login takes `OUTERLOOP_BOT_LOGIN`.
- Used at every kernel commit: `Workspace.commit`, the follow-up's amend, `dispatch.snapshot_tree` (new `author` argument, threaded from the run config in the attempt), the line seal, the line merge and hygiene reset in `_checkout_line`, the panel seal, and the two improvement commits that already did this by hand.
- Tests: the line merge commit and the seal commit carry the bot identity.

Reported by the owner from a live speedrun PR. CHANGELOG under Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
