### PR TITLE
Follow-up note: the re-measured change is not pushed yet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- The follow-up's note on a re-measured change says the change is not pushed
+  yet and that GitHub still shows the previous head (conflict included) until
+  the number lands; the old wording read as if the merge were already on the
+  branch.
 - Every kernel-made commit that reaches GitHub — line snapshots and line
   merges, the sealed `dispatch snapshot` and `panel snapshot` commits — is
   now authored as the bot login with its GitHub noreply address, like the

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -1632,9 +1632,11 @@ def _park_remeasure(
         "eval_minutes": int(bench.eval_minutes or 0),
     }
     note = (
-        "\n\n_(A code change was made; its re-measure is running on the GPU lane "
-        f"({len(pend.job_ids)} job(s)) — the change is pushed with its number once the "
-        "measurement lands. Comments posted meanwhile are answered after that.)_"
+        "\n\n_(Not pushed yet: the change above is local so far. The changed tree is "
+        f"being re-measured on the GPU lane first ({len(pend.job_ids)} job(s) queued), "
+        "and the branch is updated with the number when that lands — until then GitHub "
+        "still shows the previous head, conflict included. Comments posted meanwhile are "
+        "answered after that.)_"
     )
     stage["reply_note"] = note
     stage["reply_posted"] = False

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -1633,10 +1633,10 @@ def _park_remeasure(
     }
     note = (
         "\n\n_(Not pushed yet: the change above is local so far. The changed tree is "
-        f"being re-measured on the GPU lane first ({len(pend.job_ids)} job(s) queued), "
-        "and the branch is updated with the number when that lands — until then GitHub "
-        "still shows the previous head, conflict included. Comments posted meanwhile are "
-        "answered after that.)_"
+        f"being re-measured on the GPU lane first ({len(pend.job_ids)} job(s) pending), "
+        "and if the result can be applied the branch is updated with it and its number — "
+        "until then GitHub still shows the previous head, including any conflict. "
+        "Comments posted meanwhile are answered after that.)_"
     )
     stage["reply_note"] = note
     stage["reply_posted"] = False

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2435,8 +2435,7 @@ def test_a_gpu_change_is_sealed_and_parked_on_its_dispatched_measure(review_run)
     assert outcome.action == "parked" and "9001" in outcome.note
     # the author's reply went out now, with the parked note; nothing was pushed
     assert (
-        "addressed" in github.posted[0]
-        and "being re-measured on the GPU lane" in github.posted[0]
+        "addressed" in github.posted[0] and "being re-measured on the GPU lane" in github.posted[0]
     )
     assert not _origin_has_branch(bare)  # nothing pushed
     rec = load_record(root, "tsp-r1")

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -2436,7 +2436,7 @@ def test_a_gpu_change_is_sealed_and_parked_on_its_dispatched_measure(review_run)
     # the author's reply went out now, with the parked note; nothing was pushed
     assert (
         "addressed" in github.posted[0]
-        and "re-measure is running on the GPU lane" in github.posted[0]
+        and "being re-measured on the GPU lane" in github.posted[0]
     )
     assert not _origin_has_branch(bare)  # nothing pushed
     rec = load_record(root, "tsp-r1")
@@ -2859,7 +2859,7 @@ def test_a_parked_stage_is_durable_before_the_reply_and_the_reply_is_retried(rev
         dispatch=FakeDispatch(FakeMeasurer()),  # type: ignore[arg-type]
     )
     assert out2.action == "no-op"
-    assert len(github2.posted) == 1 and "re-measure is running" in github2.posted[0]
+    assert len(github2.posted) == 1 and "Not pushed yet" in github2.posted[0]
     assert load_record(root, "tsp-r1").followup_stage["reply_posted"] is True
 
 


### PR DESCRIPTION
On gpt-speedrun #12 the follow-up merged `origin/main` locally, resolved the ledger conflicts and parked on a GPU re-measure (by design: the merged tree was never measured, and main had moved). Its reply read "Merged `origin/main` into the PR branch" while GitHub kept showing the conflict, because nothing is pushed until the number lands.

The kernel's appended note now says so plainly: the change is local so far, the tree is being re-measured first (with the job count), the branch is updated when the number lands, and GitHub shows the previous head, conflict included, until then. Two tests pinned the old sentence and follow the new one. CHANGELOG under Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
