### PR TITLE
Experiment launches carry --nice: verification goes first when the cap frees a slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Experiment launches are submitted with `--nice=5000`, so among the kernel's
+  own pending jobs a gate eval or a follow-up re-measure starts before a new
+  experiment when the GPU cap frees a slot. Other users' jobs and the cap are
+  untouched.
 - The session watcher (docs/design/session-watcher.md): a thread beside the
   live author session answers two new tool verbs within seconds. `queue`
   shows the kernel's jobs in the cluster queue, every agent's, each launch

--- a/docs/design/session-watcher.md
+++ b/docs/design/session-watcher.md
@@ -83,6 +83,13 @@ Two small additions make this complete:
   sweep cancels them. Nothing would read their results.
 - **#315's admission check comes out.** `queue_saturated` and the refusal
   for cap reasons are removed; throttled arrays below replace them.
+- **Experiments yield to verification.** Every kernel job is one Slurm
+  user, so the order among the kernel's own pending jobs is ours to set.
+  Launches carry `--nice` (5000 on Torch, above the age factor's 1000
+  ceiling and the size and per-GPU factors), gate evals and follow-up
+  re-measures do not, so a slot the cap frees goes to verifying claimed work
+  before starting new experiments. Other users' jobs and the cap itself are
+  untouched. Shipped ahead of the rest of this section.
 
 ## Sweeps as throttled arrays
 

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -626,6 +626,16 @@ def _dispatch_settings(args: argparse.Namespace) -> DispatchSettings:
     )
 
 
+# Experiments yield to verification. Every kernel job is one Slurm user, so
+# among the kernel's own pending jobs the priority order is ours: launches
+# carry this nice so a gate eval or a follow-up re-measure (nice 0) starts
+# first when the cap frees a slot. Sized above the factors that differ between
+# our jobs on Torch — age tops out at 1000 after a week, job size at 1000, the
+# per-GPU TRES share stays in the hundreds — so the order holds however long a
+# launch has waited. Other users' jobs and the group cap are untouched.
+LAUNCH_NICE = 5000
+
+
 def _make_launcher(
     dispatch: DispatchSettings, run_dir: Path, workspace: Path, run_id: str, gpus: int = 0
 ):
@@ -665,6 +675,7 @@ def _make_launcher(
                         partition=partition,
                         eval_minutes=launch.minutes,
                         gpus=gpus,
+                        nice=LAUNCH_NICE,
                     )
                     ids.append(dispatch.compute.submit(spec))
         except Exception:

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -91,6 +91,9 @@ class JobSpec:
     mem: str = "2G"
     gpus: int = 0
     qos: str = ""
+    # a positive nice LOWERS priority (Slurm, like Unix): experiments yield to
+    # the kernel's own evals and re-measures when a slot frees
+    nice: int = 0
     output: str = "/dev/null"
     # Slurm scheduling controls
     dependency: str = ""  # e.g. "afterany:12345" or "singleton"
@@ -121,6 +124,8 @@ class JobSpec:
             argv.append(f"--gpus-per-node={self.gpus}")
         if self.qos:
             argv.append(f"--qos={self.qos}")
+        if self.nice:
+            argv.append(f"--nice={self.nice}")
         if self.dependency:
             argv.append(f"--dependency={self.dependency}")
         if self.begin:

--- a/src/outerloop/dispatch.py
+++ b/src/outerloop/dispatch.py
@@ -486,6 +486,7 @@ def eval_job_spec(
     cpus: int = 4,
     mem: str = "8G",
     gpus: int = 0,
+    nice: int = 0,
 ) -> JobSpec:
     """The JobSpec for one dispatched eval: the hint CLAMPED to our ceiling
     plus setup slack — a contract value above EVAL_JOB_MINUTES_CEILING must
@@ -494,7 +495,8 @@ def eval_job_spec(
     the GPU lane (DispatchSettings.placement) when it is nonzero, and the
     job is sized for it: a GPU eval gets at least EVAL_CPUS_PER_GPU cores
     and EVAL_MEM_GB_PER_GPU GB per GPU (a training eval's data loading and
-    torch.compile workers do not fit the CPU eval's 4 cores / 8 GB)."""
+    torch.compile workers do not fit the CPU eval's 4 cores / 8 GB). `nice`
+    lowers the job's priority below the kernel's evals (the launcher sets it)."""
     if gpus > 0:
         cpus = max(cpus, EVAL_CPUS_PER_GPU * gpus)
         given = _mem_gb(mem)
@@ -511,6 +513,7 @@ def eval_job_spec(
         cpus=cpus,
         mem=mem,
         gpus=gpus,
+        nice=nice,
     )
 
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -785,8 +785,10 @@ def _fake_dispatch(image="/img.sif", account="acct", partition="cpu", cancelled=
     from outerloop.measure import DispatchSettings
 
     ids = iter(range(1000, 1100))
+    seen: list[list[str]] = []  # every argv, for tests that inspect a submission
 
     def runner(argv, timeout_s):
+        seen.append(list(argv))
         if argv[0] == "sbatch":
             return CommandResult(0, f"{next(ids)}\n", "")
         if argv[0] == "squeue":
@@ -797,6 +799,7 @@ def _fake_dispatch(image="/img.sif", account="acct", partition="cpu", cancelled=
             return CommandResult(0, "", "")
         raise AssertionError(f"unexpected slurm call: {argv[0]}")
 
+    runner.seen = seen  # type: ignore[attr-defined]
     return DispatchSettings(
         compute=SlurmCompute(runner=runner),
         image=image,
@@ -1954,7 +1957,7 @@ def test_author_sleep_live_parks_and_submits_launch_jobs(
             ),
         },
         values=[],  # parked before any measurement
-        dispatch=_fake_dispatch(),
+        dispatch=(dispatch := _fake_dispatch()),
     )
     assert outcome.outcome == "parked"
     assert github.prs == []
@@ -1962,6 +1965,14 @@ def test_author_sleep_live_parks_and_submits_launch_jobs(
     assert record.state == "waiting"
     assert record.stage["phase"] == "author-sleep"
     assert record.stage["afterany"] == "afterany:1000"
+    # experiments yield to verification: the launch went in below the kernel's
+    # own evals (which carry no nice)
+    from outerloop.attempt import LAUNCH_NICE
+
+    launch_argv = next(
+        a for a in dispatch.compute.runner.seen if "--job-name=tsp-1-launch-probe" in a
+    )
+    assert f"--nice={LAUNCH_NICE}" in launch_argv
     assert record.stage["syscall_launches"] == [
         {"name": "probe", "minutes": 45, "artifacts": ["out/tails.json"]}
     ]

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -53,7 +53,9 @@ def test_account_and_partition_are_optional_in_the_argv() -> None:
     assert not any(a.startswith("--nice") for a in with_both.to_argv())  # 0 = not passed
     assert (
         "--nice=5000"
-        in JobSpec(job_name="l", account="", partition="", time_minutes=5, nice=5000).to_argv()
+        in JobSpec(
+            job_name="l", account="", partition="", time_minutes=5, command="x", nice=5000
+        ).to_argv()
     )
     # unset: Slurm bills the default association and picks the default partition
     bare = JobSpec(job_name="j", account="", partition="", time_minutes=1, command="x")

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -50,6 +50,11 @@ def test_account_and_partition_are_optional_in_the_argv() -> None:
     with_both = JobSpec(job_name="j", account="a", partition="cpu,gpu", time_minutes=1, command="x")
     assert "--account=a" in with_both.to_argv()
     assert "--partition=cpu,gpu" in with_both.to_argv()  # comma-list passes through
+    assert not any(a.startswith("--nice") for a in with_both.to_argv())  # 0 = not passed
+    assert (
+        "--nice=5000"
+        in JobSpec(job_name="l", account="", partition="", time_minutes=5, nice=5000).to_argv()
+    )
     # unset: Slurm bills the default association and picks the default partition
     bare = JobSpec(job_name="j", account="", partition="", time_minutes=1, command="x")
     assert not any(a.startswith(("--account", "--partition")) for a in bare.to_argv())


### PR DESCRIPTION
On Torch today, two 8-GPU evals fill the 16-GPU cap and everything else waits in submission order: agent-01's sweep (07:04), agent-02's gate evals (10:30), and the follow-up re-measure that gates speedrun #12's push (12:02). A new experiment and the verification of claimed work compete as equals.

Every kernel job is one Slurm user, so the order among our own pending jobs is ours to set. This PR submits experiment launches with `--nice=5000`; gate evals and follow-up re-measures carry none, so when the cap frees a slot, verification starts first. Other users' jobs and the group cap are untouched.

- `JobSpec.nice` (0 = not passed), threaded through `eval_job_spec(nice=)`; `_make_launcher` sets `LAUNCH_NICE = 5000`.
- Sized against Torch's `sprio -w`: age tops out at 1000 after a week, job size at 1000, the per-GPU TRES share stays in the hundreds; fair-share, association and partition are identical for our jobs.
- Design note (session-watcher.md, "Always queue") records the rule: experiments yield to verification. CHANGELOG under Added.
- Tests: the argv, and the live author-sleep test asserts the launch job went in with the nice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
