### PR TITLE
docs: community channels — Discord via GitHub webhooks, X/Bluesky human-written, announce step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `docs/community.md`: the Discord channels and the GitHub webhooks that feed
+  them, the X and Bluesky accounts and what gets posted where; the release
+  checklist gains the announcement step.
 - Experiment launches are submitted with `--nice=5000`, so among the kernel's
   own pending jobs a gate eval or a follow-up re-measure starts before a new
   experiment when the GPU cap frees a slot. Other users' jobs and the cap are

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,9 +16,11 @@
    and publishes `outerloop-science` to PyPI through Trusted Publishing; the
    one-time PyPI setup is described at the top of
    `.github/workflows/release.yml`.
-3. `gh release create vX.Y.Z --generate-notes`, with `--prerelease` for a dev
+3. `pip install outerloop-science==X.Y.Z` in a fresh venv, then `outerloop --help`.
+   This comes before the GitHub release: publishing it is what Discord
+   announces, so nothing is announced that did not install.
+4. `gh release create vX.Y.Z --generate-notes`, with `--prerelease` for a dev
    or rc tag.
-4. `pip install outerloop-science==X.Y.Z` in a fresh venv, then `outerloop --help`.
 5. Announce. Discord's `#announcements` gets the release from the GitHub
    webhook on its own (docs/community.md). For a final release, also write
    the post for X (`@outerloop_sci`) and Bluesky (`@outerloop.science`): one

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,9 +16,10 @@
    and publishes `outerloop-science` to PyPI through Trusted Publishing; the
    one-time PyPI setup is described at the top of
    `.github/workflows/release.yml`.
-3. `pip install outerloop-science==X.Y.Z` in a fresh venv, then `outerloop --help`.
-   This comes before the GitHub release: publishing it is what Discord
-   announces, so nothing is announced that did not install.
+3. Once the `release` workflow run for the tag is green (`gh run watch` on
+   it), `pip install outerloop-science==X.Y.Z` in a fresh venv, then
+   `outerloop --help`. This comes before the GitHub release: publishing it is
+   what Discord announces, so nothing is announced that did not install.
 4. `gh release create vX.Y.Z --generate-notes`, with `--prerelease` for a dev
    or rc tag.
 5. Announce. Discord's `#announcements` gets the release from the GitHub

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,6 +19,11 @@
 3. `gh release create vX.Y.Z --generate-notes`, with `--prerelease` for a dev
    or rc tag.
 4. `pip install outerloop-science==X.Y.Z` in a fresh venv, then `outerloop --help`.
+5. Announce. Discord's `#announcements` gets the release from the GitHub
+   webhook on its own (docs/community.md). For a final release, also write
+   the post for X (`@outerloop_sci`) and Bluesky (`@outerloop.science`): one
+   or two sentences on what changed for the reader, the install line, the
+   link to the release. Dev and rc pre-releases are not posted.
 
 ## Public repo
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,8 @@
    webhook on its own (docs/community.md). For a final release, also write
    the post for X (`@outerloop_sci`) and Bluesky (`@outerloop.science`): one
    or two sentences on what changed for the reader, the install line, the
-   link to the release. Dev and rc pre-releases are not posted.
+   link to the release. Dev and rc pre-releases are not posted to X or
+   Bluesky; Discord gets them through the webhook like any release.
 
 ## Public repo
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,54 @@
+# Community channels
+
+Where Outerloop talks to the people using it, and what each channel carries.
+Discord is the frequent channel: releases, merged work, and what the fleet is
+doing. X and Bluesky are the public voice, for releases worth a sentence to
+people who do not follow the repo; a human writes those.
+
+## Discord
+
+Server: [discord.gg/W5fuTFtJwF](https://discord.gg/W5fuTFtJwF), linked from
+the landing page.
+
+| channel | what goes there | source |
+|---|---|---|
+| `#announcements` | releases of `outerloop-science`, with the release notes | GitHub → Discord webhook on `outerloop-science/outerloop`, event **Releases** |
+| `#dev` | pull requests on the kernel: opened, merged, closed | same webhook, event **Pull requests** |
+| `#speedrun` | the agents' pull requests on `gpt-speedrun`: opened, merged, closed, with the title's metric change | GitHub → Discord webhook on the target repo, event **Pull requests** |
+| `#help` | adopters' questions about install and setup | people |
+| `#general` | everything else | people |
+
+The two webhooks are GitHub's own Discord integration, so a message is always
+a GitHub event and never a second copy of state. Setting one up, once per
+channel:
+
+1. Discord: Server Settings → Integrations → Webhooks → New Webhook, pick the
+   channel, copy the webhook URL. The URL is a credential: it lets anyone post
+   to that channel. It lives in GitHub's webhook settings and nowhere else.
+2. GitHub: the repo's Settings → Webhooks → Add webhook. Payload URL is the
+   Discord URL with `/github` appended; content type `application/json`;
+   under "Let me select individual events" tick only the events in the table
+   (Releases for `#announcements`, Pull requests for `#dev` and `#speedrun`).
+   Leave pushes, issues and comments unticked, or the channel drowns.
+3. Send the test payload GitHub offers and check the channel.
+
+A target repo that wants its own channel repeats step 2 on that repo with a
+webhook for its channel.
+
+## X and Bluesky
+
+`@outerloop_sci` on X and `@outerloop.science` on Bluesky, both linked from
+the landing page. Posts are written by a person, for final releases and
+results worth the attention of people who do not read the changelog; dev and
+rc pre-releases go to Discord only. The release checklist in `RELEASING.md`
+has the post as a step, so it is not left to memory.
+
+## Later: the fleet posting its own wins
+
+The kernel could emit typed events — an agent's pull request merged with its
+metric change, a release published, the weekly digest — to config-driven
+sinks, a Discord webhook first, so an adopter's fleet reports into their own
+server without anyone reading GitHub notifications. One event type, several
+sinks, each with a filter, so a new sink is a configuration line rather than a
+second integration. Not built; it waits on the maintainer digest, which is the
+content worth posting on a schedule.

--- a/docs/community.md
+++ b/docs/community.md
@@ -14,7 +14,7 @@ the landing page.
 |---|---|---|
 | `#announcements` | releases of `outerloop-science`, with the release notes | a webhook on `outerloop-science/outerloop`, event **Releases** |
 | `#dev` | pull requests on the kernel: opened, closed, merged, reopened | a second webhook on `outerloop-science/outerloop`, event **Pull requests** |
-| `#speedrun` | the agents' pull requests on `gpt-speedrun`: opened, closed, merged, reopened, with the title's metric change | a webhook on the target repo, event **Pull requests** |
+| `#speedrun` | every pull request on `gpt-speedrun` — the agents' carry the metric change in the title, and a person's shows up the same way: opened, closed, merged, reopened | a webhook on the target repo, event **Pull requests** |
 | `#help` | adopters' questions about install and setup | people |
 | `#general` | everything else | people |
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -12,15 +12,19 @@ the landing page.
 
 | channel | what goes there | source |
 |---|---|---|
-| `#announcements` | releases of `outerloop-science`, with the release notes | GitHub → Discord webhook on `outerloop-science/outerloop`, event **Releases** |
-| `#dev` | pull requests on the kernel: opened, merged, closed | same webhook, event **Pull requests** |
-| `#speedrun` | the agents' pull requests on `gpt-speedrun`: opened, merged, closed, with the title's metric change | GitHub → Discord webhook on the target repo, event **Pull requests** |
+| `#announcements` | releases of `outerloop-science`, with the release notes | a webhook on `outerloop-science/outerloop`, event **Releases** |
+| `#dev` | pull requests on the kernel: opened, closed, merged, reopened | a second webhook on `outerloop-science/outerloop`, event **Pull requests** |
+| `#speedrun` | the agents' pull requests on `gpt-speedrun`: opened, closed, merged, reopened, with the title's metric change | a webhook on the target repo, event **Pull requests** |
 | `#help` | adopters' questions about install and setup | people |
 | `#general` | everything else | people |
 
-The two webhooks are GitHub's own Discord integration, so a message is always
-a GitHub event and never a second copy of state. Setting one up, once per
-channel:
+That is three webhooks — one Discord webhook posts to one channel, and one
+GitHub webhook has one destination — all through GitHub's own Discord
+integration, so a message is always a GitHub event and never a second copy of
+state. GitHub sends every pull-request action; Discord's formatter posts the
+opened, closed, merged and reopened ones and drops the rest (pushes to the
+branch, labels, drafts), which is what the table promises. Setting one up,
+once per channel:
 
 1. Discord: Server Settings → Integrations → Webhooks → New Webhook, pick the
    channel, copy the webhook URL. The URL is a credential: it lets anyone post
@@ -32,8 +36,7 @@ channel:
    Leave pushes, issues and comments unticked, or the channel drowns.
 3. Send the test payload GitHub offers and check the channel.
 
-A target repo that wants its own channel repeats step 2 on that repo with a
-webhook for its channel.
+A target repo that wants its own channel repeats steps 1 and 2 for it.
 
 ## X and Bluesky
 
@@ -45,10 +48,7 @@ has the post as a step, so it is not left to memory.
 
 ## Later: the fleet posting its own wins
 
-The kernel could emit typed events — an agent's pull request merged with its
-metric change, a release published, the weekly digest — to config-driven
-sinks, a Discord webhook first, so an adopter's fleet reports into their own
-server without anyone reading GitHub notifications. One event type, several
-sinks, each with a filter, so a new sink is a configuration line rather than a
-second integration. Not built; it waits on the maintainer digest, which is the
-content worth posting on a schedule.
+Outerloop may later send its own notices — an agent's pull request merged with
+its metric change, a release, a weekly summary — to Discord or another
+service, so an adopter's fleet reports into their own server. Each service
+would choose which notices to receive. Not built yet.


### PR DESCRIPTION
Getting ready for the public release cycle: where Outerloop talks to people, and what goes where.

- **Discord** carries the frequent updates through GitHub's own Discord integration, no kernel code: `#announcements` (releases), `#dev` (kernel PRs), `#speedrun` (the agents' PRs on the target repo), `#help`, `#general`. The doc has the channel-to-event table and the webhook setup, with the webhook URL treated as the credential it is.
- **X and Bluesky** are human-written, final releases only. `RELEASING.md` gains step 5, the announcement, so it is a checklist item rather than a memory.
- **Later**: the kernel emitting typed events (merged agent PR with its metric change, release, digest) to config-driven sinks, so an adopter's fleet posts to their own server. Recorded as a direction, not built.

Docs only. CHANGELOG under Added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
