### PR TITLE
Sweeps as throttled Slurm job arrays; the contract's GPU ceiling paces them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Sweeps are Slurm job arrays. `launch --array N` submits one job
+  (`--array=0-N%K`) whose tasks derive their job dir and `SWEEP_INDEX` from
+  the array index, so the queue holds one entry per sweep and Slurm runs at
+  most K tasks at once; `--concurrency K` sets the pace and the contract's new
+  `budgets.max_concurrent_gpus` caps it in GPUs (K = ceiling / `gpus`), clamped
+  and said in the wake text, never refused. Local compute runs the tasks in
+  turn. The queue view shows a sweep's pace.
 - `docs/community.md`: the Discord channels and the GitHub webhooks that feed
   them, the X and Bluesky accounts and what gets posted where; the release
   checklist gains the announcement step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
-- Sweeps are Slurm job arrays. `launch --array N` submits one job
-  (`--array=0-N%K`) whose tasks derive their job dir and `SWEEP_INDEX` from
-  the array index, so the queue holds one entry per sweep and Slurm runs at
-  most K tasks at once; `--concurrency K` sets the pace and the contract's new
-  `budgets.max_concurrent_gpus` caps it in GPUs (K = ceiling / `gpus`), clamped
-  and said in the wake text, never refused. Local compute runs the tasks in
-  turn. The queue view shows a sweep's pace.
+- Sweeps are Slurm job arrays. `launch --array N` submits one job,
+  `--array=0-N%K`, and each task derives its job dir and `SWEEP_INDEX` from
+  its array index. The queue holds one entry per sweep. `--concurrency K`
+  sets how many tasks run at once. The contract's new
+  `budgets.max_concurrent_gpus` caps K in GPUs (K = ceiling / `gpus`); a
+  higher ask is clamped and the wake text says so, never refused. Local
+  compute runs the tasks in turn. The queue view shows a sweep's pace.
 - `docs/community.md`: the Discord channels and the GitHub webhooks that feed
   them, the X and Bluesky accounts and what gets posted where; the release
   checklist gains the announcement step.

--- a/docs/contract.md
+++ b/docs/contract.md
@@ -25,6 +25,7 @@ The knobs that shape a climb, all optional:
 | `baseline: paired \| cached` | Re-measure the base tree beside every candidate, or measure it once per base and run only candidates |
 | `depth_k`, `sleep_k` | How many experiments an author may launch and how many times it may sleep for results |
 | `max_active_attempts`, `attempt_cooldown_minutes` | Width: authors abreast on one target; pacing between attempts (0 for a hot loop) |
+| `max_concurrent_gpus` | The pace ceiling for an author's sweeps, in GPUs: a sweep runs at most this many GPUs' worth of tasks at once (`--array=0-N%K`, K = ceiling / `gpus`). Lenient by design; unset = the author's own pace |
 | `steward.allowed` | Paths a separate stewardship lane may maintain (the ruler, the harness) — never the solver |
 | `merge: manual \| auto` | Whether a gate-and-panel-clean PR waits for a human or merges itself |
 

--- a/docs/design/session-watcher.md
+++ b/docs/design/session-watcher.md
@@ -94,6 +94,10 @@ Two small additions make this complete:
 
 ## Sweeps as throttled arrays
 
+*Shipped: a sweep is one job array with `--array=0-N%K`; `launch --concurrency K`
+sets K, `budgets.max_concurrent_gpus` caps it in GPUs, task dirs and
+`SWEEP_INDEX` come from the array index, and the queue view shows the pace.*
+
 All agents share one Slurm identity, so Slurm cannot tell them apart. One
 agent asking for eight launches with sixteen-way arrays submits 128 separate
 jobs and holds the account's cap for hours while its siblings wait behind

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -90,7 +90,13 @@ from outerloop.runstate import (
 from outerloop.runstate import (
     run_dir as run_dir_of,
 )
-from outerloop.syscall import CHANNEL_DIR_NAMES, MAX_ARTIFACT_BYTES, SyscallRequest, channel_dir
+from outerloop.syscall import (
+    CHANNEL_DIR_NAMES,
+    MAX_ARTIFACT_BYTES,
+    SyscallRequest,
+    channel_dir,
+    launch_task_ids,
+)
 from outerloop.syscall import ensure_excluded as syscall_excluded
 from outerloop.syscall import install_tool as syscall_install_tool
 from outerloop.syscall import write_budget as syscall_write_budget
@@ -459,6 +465,7 @@ def _park_run(
                 "artifacts": list(launch.artifacts),
                 **({"array": launch.array} if launch.array > 1 else {}),
                 **({"why": redact(launch.why, secrets)} if launch.why else {}),
+                **({"concurrency": launch.concurrency} if launch.concurrency else {}),
             }
             for launch in parked.syscall.launches
         ]
@@ -648,36 +655,38 @@ def _make_launcher(
 
     def launcher(sha: str, request: SyscallRequest) -> str:
         from outerloop.dispatch import eval_job_spec, write_eval_job
-        from outerloop.syscall import launch_jobs
+        from outerloop.syscall import array_spec
 
         ids: list[str] = []
         try:
             for launch in request.launches:
-                # an array launch is N jobs of one command, each with its
-                # SWEEP_INDEX; one afterany wake covers them all
-                for job_name, extra_env in launch_jobs(launch):
-                    script = write_eval_job(
-                        run_dir,
-                        f"launch-{job_name}",
-                        repo_root=workspace,
-                        snapshot_sha=sha,
-                        command=launch.command,
-                        image=dispatch.image,
-                        extra_env=extra_env,
-                        artifacts=launch.artifacts,
-                        artifact_max_bytes=MAX_ARTIFACT_BYTES,
-                        gpus=gpus,
-                    )
-                    spec = eval_job_spec(
-                        script,
-                        job_name=f"{run_id}-launch-{job_name}",
-                        account=account,
-                        partition=partition,
-                        eval_minutes=launch.minutes,
-                        gpus=gpus,
-                        nice=LAUNCH_NICE,
-                    )
-                    ids.append(dispatch.compute.submit(spec))
+                # a sweep is ONE Slurm job array (`--array=0-N%K`): the queue
+                # holds one entry, Slurm runs at most K tasks at once, each task
+                # derives its job dir and SWEEP_INDEX from its array index, and
+                # one afterany on the array id covers every task
+                script = write_eval_job(
+                    run_dir,
+                    f"launch-{launch.name}",
+                    repo_root=workspace,
+                    snapshot_sha=sha,
+                    command=launch.command,
+                    image=dispatch.image,
+                    artifacts=launch.artifacts,
+                    artifact_max_bytes=MAX_ARTIFACT_BYTES,
+                    gpus=gpus,
+                    array=launch.array,
+                )
+                spec = eval_job_spec(
+                    script,
+                    job_name=f"{run_id}-launch-{launch.name}",
+                    account=account,
+                    partition=partition,
+                    eval_minutes=launch.minutes,
+                    gpus=gpus,
+                    nice=LAUNCH_NICE,
+                    array=array_spec(launch),
+                )
+                ids.append(dispatch.compute.submit(spec))
         except Exception:
             # a partial batch must not orphan: no park record was written yet,
             # so nothing would ever wake or cancel the jobs that DID submit —
@@ -836,6 +845,7 @@ def _wake_author_sleep(
             artifacts=tuple(str(a) for a in item.get("artifacts", [])),
             array=int(item.get("array") or 1),
             why=str(item.get("why") or ""),
+            concurrency=int(item.get("concurrency") or 0),
         )
         for item in _stage_launches(record)
     )
@@ -848,7 +858,9 @@ def _wake_author_sleep(
     # blocks on the scheduler query.
     status_of = getattr(dispatch.compute, "status", None)
     if status_of is not None:
-        results = annotate_launch_states(results, _stage_launch_job_ids(record), status_of)
+        results = annotate_launch_states(
+            results, launch_task_ids(launches, _stage_launch_job_ids(record)), status_of
+        )
     launches_used = int(record.stage.get("launches_used", 0))  # type: ignore[call-overload]
     sleeps_used = int(record.stage.get("sleeps_used", 0))  # type: ignore[call-overload]
     _best_effort(
@@ -868,6 +880,13 @@ def _wake_author_sleep(
         ),
         gpus=bench.gpus,
     )
+    pacing = [
+        f"sweep `{la.name}`: {la.array} tasks, at most {la.concurrency or la.array} at a time"
+        for la in launches
+        if la.array > 1
+    ]
+    if pacing:
+        wake_text = f"{wake_text}\n\n" + "\n".join(pacing) + " (the contract's ceiling applies)."
     if extra_update:
         # a submitted park's gate/panel feedback leads; launch results follow
         wake_text = f"{extra_update}\n\n{wake_text}"
@@ -1016,6 +1035,7 @@ def _stage_syscall_launches(record: RunRecord) -> tuple:
             artifacts=tuple(str(a) for a in item.get("artifacts", [])),
             array=int(item.get("array") or 1),
             why=str(item.get("why") or ""),
+            concurrency=int(item.get("concurrency") or 0),
         )
         for item in _stage_launches(record)
     )
@@ -1044,7 +1064,9 @@ def _reconcile_launch_hours(
     used = float(stage.get("gpu_hours_used", 0.0))  # type: ignore[arg-type]
     if not gpus or stage.get("launch_hours_refunded"):
         return used
-    refund = _launch_refund(dispatch, launches, _stage_launch_job_ids(record), gpus)
+    refund = _launch_refund(
+        dispatch, launches, launch_task_ids(launches, _stage_launch_job_ids(record)), gpus
+    )
     if refund > 0:
         log.info("%s: refunding %.2f GPU-hours of unused launch walltime", record.run_id, refund)
         used = max(0.0, used - refund)
@@ -1710,6 +1732,7 @@ def resume_run(
                             artifacts=tuple(str(a) for a in item.get("artifacts", [])),
                             array=int(item.get("array") or 1),
                             why=str(item.get("why") or ""),
+                            concurrency=int(item.get("concurrency") or 0),
                         )
                         for item in _stage_launches(record)
                     ),

--- a/src/outerloop/brief.py
+++ b/src/outerloop/brief.py
@@ -392,7 +392,7 @@ def render(brief: SessionBrief) -> str:
             "inside your own session time — it costs no budget:",
             "",
             f"    python {_CHANNEL}/syscall launch --name <handle> "
-            '--minutes <N> [--array <K>] [--why "one line"] '
+            '--minutes <N> [--array <N>] [--concurrency <K>] [--why "one line"] '
             "--artifact <repo-relative file> -- <command>",
             f"    python {_CHANNEL}/syscall submit [--minutes <N>]",
             f"    python {_CHANNEL}/syscall siblings",
@@ -435,7 +435,9 @@ def render(brief: SessionBrief) -> str:
             "more, revise, or finish. `--array K` runs one command as K jobs "
             "(a sweep): each job sees SWEEP_INDEX=0..K-1 in its environment and "
             "returns its own result, with artifacts under "
-            f"{_CHANNEL}/results/<name>/<i>/; it counts as one launch. "
+            f"{_CHANNEL}/results/<name>/<i>/; it counts as one launch and one "
+            "cluster job, and `--concurrency K` runs at most K of its tasks at "
+            "once (the contract may cap K; the whole sweep runs otherwise). "
             "Budgets this run: "
             f"{brief.launch_budget} experiment launches, {brief.sleep_budget} "
             "sleeps (a `sleep` with nothing staged is a checkpoint that "

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
+import re
 import shlex
 import signal
 import subprocess
@@ -98,6 +99,9 @@ class JobSpec:
     # Slurm scheduling controls
     dependency: str = ""  # e.g. "afterany:12345" or "singleton"
     begin: str = ""  # e.g. "now+30" or an absolute "YYYY-MM-DDTHH:MM:SS"
+    # a job array: "0-15%4" runs tasks 0..15, at most 4 at a time; the queue
+    # holds one entry and squeue names its tasks `<id>_<k>`
+    array: str = ""
     extra: tuple[str, ...] = ()
 
     def to_argv(self) -> list[str]:
@@ -130,6 +134,8 @@ class JobSpec:
             argv.append(f"--dependency={self.dependency}")
         if self.begin:
             argv.append(f"--begin={self.begin}")
+        if self.array:
+            argv.append(f"--array={self.array}")
         argv.extend(self.extra)
         if self.command:
             argv.append(f"--wrap={self.command}")
@@ -183,6 +189,47 @@ def compute_from_env() -> SlurmCompute | LocalCompute:
     return LocalCompute() if local_mode() else SlurmCompute()
 
 
+_JOB_ID = re.compile(r"^\d+(_\d+)?$")  # a job, or one task of a job array (`<id>_<k>`)
+
+
+def _check_job_id(job_id: str) -> None:
+    if not _JOB_ID.match(job_id):
+        raise ValueError(f"not a job id: {job_id!r}")
+
+
+def array_indices(spec: str) -> list[int]:
+    """The task indices of an array spec: "0-15%4" -> 0..15 (the %K throttle
+    is the scheduler's concern); "" -> none."""
+    body = spec.split("%", 1)[0].strip()
+    if not body:
+        return []
+    lo, sep, hi = body.partition("-")
+    if not sep:
+        return [int(lo)] if lo.isdigit() else []
+    if not (lo.isdigit() and hi.isdigit()):
+        return []
+    return list(range(int(lo), int(hi) + 1))
+
+
+def combine_states(states: Sequence[str]) -> str:
+    """One state for a job array from its tasks' states: running while any
+    task runs, pending while any task waits, terminal only when every task
+    is — COMPLETED if all are, else the first other terminal state (FAILED,
+    TIMEOUT, CANCELLED...), so a sweep with one dead task reads as failed."""
+    if len(states) == 1:
+        return states[0]
+    for want in ("RUNNING", "COMPLETING"):
+        if any(s.startswith(want) for s in states):
+            return want
+    if any(is_pending(s) for s in states):
+        return "PENDING"
+    live = [s for s in states if not is_terminal(s)]
+    if live:
+        return live[0]
+    bad = [s for s in states if not s.startswith("COMPLETED")]
+    return bad[0] if bad else "COMPLETED"
+
+
 @dataclass
 class SlurmCompute:
     """The three verbs, plus afterany for wake jobs."""
@@ -204,8 +251,7 @@ class SlurmCompute:
     def status(self, job_id: str) -> str:
         """The job's Slurm state, or GONE when a *successful* query finds no
         record. Raises SlurmQueryError when the query itself fails."""
-        if not job_id.isdigit():
-            raise ValueError(f"not a job id: {job_id!r}")
+        _check_job_id(job_id)
         try:
             result = self.runner(
                 ["sacct", "-j", job_id, "--parsable2", "--noheader", "-X", "-o", "State"],
@@ -215,14 +261,14 @@ class SlurmCompute:
             raise SlurmQueryError(f"sacct did not run: {exc}") from exc
         if result.returncode != 0:
             raise SlurmQueryError(f"sacct failed ({result.returncode}): {result.stderr.strip()}")
-        state = result.stdout.strip().splitlines()[0].strip() if result.stdout.strip() else ""
-        return state if state else GONE
+        # a job array answers one line per task; the array's state is theirs combined
+        states = [ln.strip() for ln in result.stdout.splitlines() if ln.strip()]
+        return combine_states(states) if states else GONE
 
     def elapsed_seconds(self, job_id: str) -> int | None:
         """How long the job actually ran (sacct Elapsed), or None when sacct
         has no record. Raises SlurmQueryError when the query itself fails."""
-        if not job_id.isdigit():
-            raise ValueError(f"not a job id: {job_id!r}")
+        _check_job_id(job_id)
         try:
             result = self.runner(
                 ["sacct", "-j", job_id, "--parsable2", "--noheader", "-X", "-o", "Elapsed"],
@@ -239,8 +285,7 @@ class SlurmCompute:
         """Why a PENDING job is pending — Slurm's reason (`Dependency`,
         `DependencyNeverSatisfied`, `Priority`, ...), or "" when squeue no
         longer lists it. Raises SlurmQueryError when the query itself fails."""
-        if not job_id.isdigit():
-            raise ValueError(f"not a job id: {job_id!r}")
+        _check_job_id(job_id)
         try:
             result = self.runner(["squeue", "-j", job_id, "-h", "-o", "%r"], self.command_timeout_s)
         except (OSError, subprocess.TimeoutExpired) as exc:
@@ -254,8 +299,7 @@ class SlurmCompute:
         them, or "" when squeue no longer lists it. A site can MOVE a pending
         job off the partition it was submitted to (Torch does, under
         congestion); callers compare this with what they asked for."""
-        if not job_id.isdigit():
-            raise ValueError(f"not a job id: {job_id!r}")
+        _check_job_id(job_id)
         try:
             result = self.runner(["squeue", "-j", job_id, "-h", "-o", "%P"], self.command_timeout_s)
         except (OSError, subprocess.TimeoutExpired) as exc:
@@ -346,8 +390,7 @@ class SlurmCompute:
         """Cancel; idempotent (cancelling a finished job is not an error).
         False when scancel itself failed, so a caller that must know (the
         sweep's cancel-on-end) can try again; most callers are best-effort."""
-        if not job_id.isdigit():
-            raise ValueError(f"not a job id: {job_id!r}")
+        _check_job_id(job_id)
         result = self.runner(["scancel", job_id], self.command_timeout_s)
         if result.returncode != 0:
             log.warning("scancel %s: %s", job_id, result.stderr.strip())
@@ -417,6 +460,33 @@ class LocalCompute:
             if k in ("PATH", "HOME", "LANG", "TMPDIR", "SLURM_TMPDIR", "USER", "LOGNAME")
             or (k.startswith(("OUTERLOOP_", "REVIEW_HERMES_")) and not _secret_name(k))
         }
+        indices = array_indices(spec.array)
+        if indices:
+            # a job array runs its tasks in turn — there is no queue here to
+            # throttle; each task keeps its own state and output under
+            # `<id>_<k>`, and the array's own state is theirs combined
+            states = [
+                self._run_and_record(
+                    spec, argv, {**job_env, "SLURM_ARRAY_TASK_ID": str(i)}, f"{job_id}_{i}"
+                )
+                for i in indices
+            ]
+            state = combine_states(states)
+            self._record(spec, job_id, state, "")
+        else:
+            state = self._run_and_record(spec, argv, job_env, job_id)
+        state_dir = _local_state_dir()
+        where = (
+            f"; output in {state_dir / (job_id + '.out')}"
+            if state_dir and state != "COMPLETED"
+            else ""
+        )
+        log.info("ran %s locally as job %s: %s%s", spec.job_name, job_id, state, where)
+        return job_id
+
+    def _run_and_record(
+        self, spec: JobSpec, argv: list[str], job_env: dict[str, str], job_id: str
+    ) -> str:
         try:
             # the job runs in its OWN session (= process group), so the
             # walltime kill takes the whole tree — a job script waiting on
@@ -453,6 +523,10 @@ class LocalCompute:
                     "local job %s: an escaped child survived the walltime kill", spec.job_name
                 )
             state = "TIMEOUT"
+        self._record(spec, job_id, state, output)
+        return state
+
+    def _record(self, spec: JobSpec, job_id: str, state: str, output: str) -> None:
         state_dir = _local_state_dir()
         if state_dir is not None:
             try:
@@ -481,22 +555,14 @@ class LocalCompute:
                 log.warning("local job %s: state persist failed: %s", spec.job_name, exc)
         if spec.output and spec.output != "/dev/null":
             try:
-                with open(spec.output, "w") as fh:
+                with open(spec.output, "a" if "_" in job_id else "w") as fh:
                     fh.write(output)
             except OSError as exc:
                 log.warning("local job %s: output write failed: %s", spec.job_name, exc)
         self._states[job_id] = state
-        where = (
-            f"; output in {state_dir / (job_id + '.out')}"
-            if state_dir and state != "COMPLETED"
-            else ""
-        )
-        log.info("ran %s locally as job %s: %s%s", spec.job_name, job_id, state, where)
-        return job_id
 
     def status(self, job_id: str) -> str:
-        if not job_id.isdigit():
-            raise ValueError(f"not a job id: {job_id!r}")
+        _check_job_id(job_id)
         state = self._states.get(job_id, "")
         if state:
             return state
@@ -529,8 +595,7 @@ class LocalCompute:
         return ""
 
     def cancel(self, job_id: str) -> bool:
-        if not job_id.isdigit():
-            raise ValueError(f"not a job id: {job_id!r}")
+        _check_job_id(job_id)
         return True  # already terminal; cancelling a finished job is not an error
 
 

--- a/src/outerloop/contract.py
+++ b/src/outerloop/contract.py
@@ -272,6 +272,14 @@ class Budgets(_StrictModel):
     # (agent-01..agent-0N), so branches, ledger rows, and reports stay
     # distinct. runs_per_week and gpu_hours_per_run remain the spend guards.
     max_active_attempts: int | None = Field(default=None, ge=1)
+    # The pace ceiling for an author's sweeps, in GPUs: one launch may hold at
+    # most this many at once, so a sweep of N tasks runs
+    # max_concurrent_gpus // gpus of them at a time (`--array=0-N%K`). Lenient
+    # by design — not the cap divided by the agent count (agents rarely launch
+    # at the same moment, and an idle share is wasted GPU); on a 16-GPU cap 12
+    # lets one sweep use most of the machine while a sibling's job still gets
+    # in. Unset: the author's own pace, the whole array by default.
+    max_concurrent_gpus: int | None = Field(default=None, ge=1)
 
     @model_validator(mode="before")
     @classmethod

--- a/src/outerloop/dispatch.py
+++ b/src/outerloop/dispatch.py
@@ -289,8 +289,14 @@ def write_eval_job(
     artifacts: tuple[str, ...] = (),
     artifact_max_bytes: int = 0,
     gpus: int = 0,
+    array: int = 1,
 ) -> Path:
     """Write the orchestrator-authored job script for one dispatched eval.
+
+    `array` > 1 writes ONE script for a Slurm job array: each task derives its
+    own job dir `eval-<name>.<k>` from SLURM_ARRAY_TASK_ID (SWEEP_INDEX under a
+    local run) and sees the index as SWEEP_INDEX; the task dirs are created
+    and cleared here, the script lives under `eval-<name>/`.
 
     `gpus` > 0 adds `--nv` to the jail so the job's allocated GPUs (the
     JobSpec requests them) are visible inside the container; nothing else
@@ -318,13 +324,16 @@ def write_eval_job(
     """
     ev = run_dir / f"eval-{name}"
     ev.mkdir(parents=True, exist_ok=True)
-    # a resubmitted eval must never be read as its predecessor: every prior
-    # artifact — including a leftover extracted tree — goes before submission
-    for stale in ("exit-code", "stdout", "stderr", "setup.log", "submitted", "artifacts.log"):
-        (ev / stale).unlink(missing_ok=True)
-    shutil.rmtree(ev / "tree", ignore_errors=True)
-    shutil.rmtree(ev / "artifacts", ignore_errors=True)
-    (ev / "command.txt").write_text(command)
+    task_dirs = [run_dir / f"eval-{name}.{k}" for k in range(array)] if array > 1 else [ev]
+    for task_dir in task_dirs:
+        task_dir.mkdir(parents=True, exist_ok=True)
+        # a resubmitted eval must never be read as its predecessor: every prior
+        # artifact — including a leftover extracted tree — goes before submission
+        for stale in ("exit-code", "stdout", "stderr", "setup.log", "submitted", "artifacts.log"):
+            (task_dir / stale).unlink(missing_ok=True)
+        shutil.rmtree(task_dir / "tree", ignore_errors=True)
+        shutil.rmtree(task_dir / "artifacts", ignore_errors=True)
+        (task_dir / "command.txt").write_text(command)
     # extra_env matches the in-job evaluator's contract: managed keys (HOME,
     # UV_*, PATH...) are DROPPED, never allowed to override the isolation, and
     # keys must be shell-identifier shaped (they are exported unquoted).
@@ -338,10 +347,20 @@ def write_eval_job(
     # as the snapshot, injected as GIT_CONFIG_* env (robust to '=' in a driver
     # name, unlike -c) so a smudge filter cannot execute during checkout
     neutral = _filter_neutral_env(["git", "-C", str(repo_root), *SAFE_GIT_FLAGS], {})
+    if array > 1:
+        # the task picks its own job dir; under Slurm the index is the array
+        # task id, under a local run the caller exports SWEEP_INDEX
+        ev_lines = [
+            'TASK="${SLURM_ARRAY_TASK_ID:-${SWEEP_INDEX:-0}}"',
+            f'EV={shlex.quote(str(ev))}."$TASK"',
+            'export SWEEP_INDEX="$TASK" APPTAINERENV_SWEEP_INDEX="$TASK"',
+        ]
+    else:
+        ev_lines = [f"EV={shlex.quote(str(ev))}"]
     lines = [
         "#!/bin/sh",
         "set -u",
-        f"EV={shlex.quote(str(ev))}",
+        *ev_lines,
         f"REPO={shlex.quote(str(repo_root))}",
         # the extracted tree lives on NODE-LOCAL scratch, not the shared run
         # dir: it dies with the job (nothing to reap on the shared FS), and
@@ -487,6 +506,7 @@ def eval_job_spec(
     mem: str = "8G",
     gpus: int = 0,
     nice: int = 0,
+    array: str = "",
 ) -> JobSpec:
     """The JobSpec for one dispatched eval: the hint CLAMPED to our ceiling
     plus setup slack — a contract value above EVAL_JOB_MINUTES_CEILING must
@@ -514,6 +534,7 @@ def eval_job_spec(
         mem=mem,
         gpus=gpus,
         nice=nice,
+        array=array,
     )
 
 

--- a/src/outerloop/launchlog.py
+++ b/src/outerloop/launchlog.py
@@ -52,10 +52,13 @@ def append_submitted(
         for row in read_ledger(run_dir)
         if row.get("event") == "submitted"
     }
+    # one id per launch (a sweep is one Slurm job array), or one per task for
+    # a park recorded when arrays were separate jobs
+    per_launch = len(job_ids) == len(launches)
     rows: list[dict[str, Any]] = []
     k = 0
     for launch in launches:
-        n = len(launch_jobs(launch))
+        n = 1 if per_launch else len(launch_jobs(launch))
         ids = job_ids[k : k + n]
         k += n
         if (sleep, launch.name) in known:

--- a/src/outerloop/launchlog.py
+++ b/src/outerloop/launchlog.py
@@ -71,6 +71,7 @@ def append_submitted(
                 "why": launch.why,
                 "minutes": launch.minutes,
                 "array": launch.array,
+                "concurrency": launch.concurrency,
                 "job_ids": list(ids),
                 "at": at,
             }
@@ -166,5 +167,7 @@ def why_by_job(run_dir: Path) -> dict[str, dict[str, Any]]:
                 "name": row.get("name", ""),
                 "why": row.get("why", ""),
                 "sleep": row.get("sleep"),
+                "array": int(row.get("array") or 1),
+                "concurrency": int(row.get("concurrency") or 0),
             }
     return out

--- a/src/outerloop/orchestrator.py
+++ b/src/outerloop/orchestrator.py
@@ -46,6 +46,7 @@ from outerloop.rolespec import RoleSpec
 from outerloop.syscall import (
     SyscallError,
     SyscallRequest,
+    clamp_concurrency,
     evals_gpu_hours,
     launches_gpu_hours,
 )
@@ -1553,6 +1554,13 @@ def attempt_once(
                         run_seed=run_seed,
                     )
                 sha = snapshot()
+                # a sweep's pace is clamped to the contract's GPU ceiling
+                # before it is submitted or recorded; never refused
+                request = clamp_concurrency(
+                    request,
+                    gpus=bench.gpus,
+                    max_concurrent_gpus=contract.budgets.max_concurrent_gpus,
+                )
                 launch_afterany = launcher(sha, request)
                 raise RunParked(
                     phase="author-sleep",

--- a/src/outerloop/orchestrator.py
+++ b/src/outerloop/orchestrator.py
@@ -1510,6 +1510,12 @@ def attempt_once(
                 suite_gpus=suite_gpus,
                 main_evals=main_evals,
             )
+            # a sweep's pace is clamped to the contract's GPU ceiling here, once,
+            # before either path — an author-sleep launch or a submit's sibling
+            # launches — submits or records it; clamped, never refused
+            request = clamp_concurrency(
+                request, gpus=bench.gpus, max_concurrent_gpus=contract.budgets.max_concurrent_gpus
+            )
             if not problem:
                 if request.submit:
                     # a submit rides the measurement below on the SEALED tree —
@@ -1554,13 +1560,6 @@ def attempt_once(
                         run_seed=run_seed,
                     )
                 sha = snapshot()
-                # a sweep's pace is clamped to the contract's GPU ceiling
-                # before it is submitted or recorded; never refused
-                request = clamp_concurrency(
-                    request,
-                    gpus=bench.gpus,
-                    max_concurrent_gpus=contract.budgets.max_concurrent_gpus,
-                )
                 launch_afterany = launcher(sha, request)
                 raise RunParked(
                     phase="author-sleep",

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -132,6 +132,9 @@ class Launch:
     array: int = 1
     # the author's one-line reason; the queue view shows it to every agent
     why: str = ""
+    # a sweep's pace: at most this many tasks at once (0 = the whole array);
+    # the kernel clamps it to the contract's GPU ceiling (`clamp_concurrency`)
+    concurrency: int = 0
 
 
 @dataclass(frozen=True)
@@ -180,6 +183,50 @@ def launch_jobs(launch: Launch) -> tuple[tuple[str, dict[str, str]], ...]:
     if launch.array <= 1:
         return ((launch.name, {}),)
     return tuple((f"{launch.name}.{i}", {"SWEEP_INDEX": str(i)}) for i in range(launch.array))
+
+
+def array_spec(launch: Launch) -> str:
+    """The Slurm array spec for a sweep: tasks 0..N-1, at most `concurrency`
+    at a time (the whole array when unset). "" for a plain launch."""
+    if launch.array <= 1:
+        return ""
+    return f"0-{launch.array - 1}%{launch.concurrency or launch.array}"
+
+
+def clamp_concurrency(
+    request: SyscallRequest, *, gpus: int, max_concurrent_gpus: int | None
+) -> SyscallRequest:
+    """Apply the contract's ceiling to every sweep: the tasks one launch may
+    run at once is `max_concurrent_gpus // gpus` (a two-GPU task gets half the
+    tasks of a one-GPU task and the same share of the machine), never below
+    one; a request above it is clamped, never refused. No ceiling: the
+    author's pace stands, the whole array by default."""
+    if not max_concurrent_gpus:
+        return request
+    cap = max(1, max_concurrent_gpus // max(gpus, 1))
+    launches = tuple(
+        replace(la, concurrency=min(la.concurrency or la.array, cap)) if la.array > 1 else la
+        for la in request.launches
+    )
+    return replace(request, launches=launches)
+
+
+def launch_task_ids(launches: Iterable[Launch], job_ids: list[str]) -> list[str]:
+    """The per-task job ids of a park's launches, aligned with `launch_jobs`
+    order (what results, states and refunds are keyed by). A sweep is one
+    Slurm job whose tasks are `<id>_<k>`, so one id per launch expands; a park
+    recorded before arrays were single jobs already carries one id per task
+    and passes through. Anything else is an unknown mapping: no ids, so no
+    caller guesses."""
+    launches = list(launches)
+    if len(job_ids) == len(launches):
+        out: list[str] = []
+        for la, jid in zip(launches, job_ids, strict=True):
+            out.extend([f"{jid}_{k}" for k in range(la.array)] if la.array > 1 else [jid])
+        return out
+    if len(job_ids) == sum(max(la.array, 1) for la in launches):
+        return list(job_ids)
+    return []
 
 
 def _rel_path_ok(path: str) -> bool:
@@ -250,7 +297,7 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     for i, item in enumerate(raw_launches):
         if not isinstance(item, dict):
             raise SyscallError(f"launch #{i} must be an object")
-        bad = set(item) - {"name", "command", "minutes", "artifacts", "array", "why"}
+        bad = set(item) - {"name", "command", "minutes", "artifacts", "array", "why", "concurrency"}
         if bad:
             raise SyscallError(f"launch #{i}: unknown keys {sorted(bad)}")
         name = item.get("name")
@@ -272,6 +319,10 @@ def read_request(workspace: Path) -> SyscallRequest | None:
         if not isinstance(array, int) or isinstance(array, bool) or array < 1:
             raise SyscallError(f"launch {name}: array must be a positive integer")
         array = min(array, MAX_LAUNCH_ARRAY)
+        concurrency = item.get("concurrency", 0)
+        if not isinstance(concurrency, int) or isinstance(concurrency, bool) or concurrency < 0:
+            raise SyscallError(f"launch {name}: concurrency must be a non-negative integer")
+        concurrency = min(concurrency, array) if array > 1 else 0
         why = item.get("why", "")
         if not isinstance(why, str) or len(why) > MAX_WHY_CHARS:
             raise SyscallError(
@@ -297,6 +348,7 @@ def read_request(workspace: Path) -> SyscallRequest | None:
                 artifacts=tuple(arts),
                 array=array,
                 why=why,
+                concurrency=concurrency,
             )
         )
     # a sleep with no launches is legitimate: checkpoint-and-reschedule

--- a/src/outerloop/syscall_cli.py
+++ b/src/outerloop/syscall_cli.py
@@ -152,6 +152,10 @@ def cmd_launch(root: Path, args: argparse.Namespace) -> str:
     why = " ".join((args.why or "").split())
     if len(why) > MAX_WHY_CHARS:
         raise ToolError(f"--why must be at most {MAX_WHY_CHARS} chars")
+    concurrency = args.concurrency
+    if concurrency < 0:
+        raise ToolError("--concurrency must be a non-negative integer")
+    concurrency = min(concurrency, array) if array > 1 else 0
     if len(args.artifact) > MAX_ARTIFACTS:
         raise ToolError(f"at most {MAX_ARTIFACTS} --artifact paths")
     for a in args.artifact:
@@ -170,12 +174,18 @@ def cmd_launch(root: Path, args: argparse.Namespace) -> str:
             "artifacts": args.artifact,
             "array": array,
             **({"why": why} if why else {}),
+            **({"concurrency": concurrency} if concurrency else {}),
         }
     )
     _save_staged(root, staged)
     return (
         f"staged launch {args.name!r} ({minutes} min"
-        + (f" x {array} jobs, SWEEP_INDEX 0..{array - 1}" if array > 1 else "")
+        + (
+            f" x {array} tasks, SWEEP_INDEX 0..{array - 1}, "
+            f"at most {concurrency or array} at a time"
+            if array > 1
+            else ""
+        )
         + f"); {len(staged['launches'])} staged. "
         f"Add more, or `sleep` to run them. {_budget_line(root)}."
     )
@@ -306,6 +316,8 @@ def cmd_status(root: Path, _args: argparse.Namespace) -> str:
         for la in staged["launches"]:
             arts = (" -> " + ", ".join(la["artifacts"])) if la.get("artifacts") else ""
             width = f" x{la['array']}" if int(la.get("array") or 1) > 1 else ""
+            if width and la.get("concurrency"):
+                width += f" ({la['concurrency']} at a time)"
             lines.append(f"  - {la['name']} ({la['minutes']} min{width}): {la['command']}{arts}")
             if la.get("why"):
                 lines.append(f"      why: {la['why']}")
@@ -345,9 +357,15 @@ def build_parser() -> argparse.ArgumentParser:
         "--array",
         type=int,
         default=1,
-        help="fan out to N jobs of this command, each with SWEEP_INDEX=0..N-1 "
-        "and its own results/<name>/<i>/ (a sweep; counts as one launch, "
+        help="fan out to N tasks of this command, each with SWEEP_INDEX=0..N-1 "
+        "and its own results/<name>/<i>/ (a sweep: one launch, one cluster job, "
         "N times the GPU-hours)",
+    )
+    la.add_argument(
+        "--concurrency",
+        type=int,
+        default=0,
+        help="with --array: run at most K tasks at once (default: all; the contract may cap it)",
     )
     la.add_argument(
         "--artifact",
@@ -596,6 +614,8 @@ def cmd_queue(root: Path, args) -> str:
             if j.get("experiment")
             else str(j.get("kind") or j.get("name") or "job")[:64]
         )
+        if j.get("concurrency"):
+            what += f" (sweep, {int(j['concurrency'])} at a time)"
         state = str(j.get("state", ""))[:16]
         reason = str(j.get("reason", ""))[:40]
         if state == "PENDING" and reason and reason != "None":

--- a/src/outerloop/watcher.py
+++ b/src/outerloop/watcher.py
@@ -12,6 +12,7 @@ session exactly as it is without one."""
 from __future__ import annotations
 
 import logging
+import re
 import threading
 import time
 from collections.abc import Callable
@@ -32,6 +33,8 @@ POLL_S = 2.0
 # rewritten: a session cannot turn the watcher into a squeue loop
 QUERY_GAP_S = 5.0
 MAX_QUEUE_ROWS = 500
+# squeue names a pending array `<id>_[0-15%4]` and a running task `<id>_3`
+_ARRAY_THROTTLE = re.compile(r"_\[[^\]]*%(\d+)\]$")
 # the lane's node states move slowly; one sinfo a minute is plenty
 LANE_GAP_S = 60.0
 # a stopped watcher may still be inside a scheduler query (its own timeout,
@@ -146,11 +149,15 @@ class SessionWatcher:
             name = str(r.get("name") or "")
             prefix = f"{rid}-launch-" if rid else ""
             r["mine"] = bool(rid) and rid == ctx.run_id
+            job_id = str(r.get("id") or "")
+            throttle = _ARRAY_THROTTLE.search(job_id)
+            if throttle:
+                r["concurrency"] = int(throttle.group(1))
             if prefix and name.startswith(prefix):
                 r["experiment"] = name[len(prefix) :]
-                r["why"] = str(labels.get(str(r.get("id") or ""), {}).get("why", ""))[
-                    :MAX_WHY_CHARS
-                ]
+                # the ledger keys the array's id; squeue shows `<id>_<k>` or `<id>_[...]`
+                base = job_id.split("_", 1)[0]
+                r["why"] = str(labels.get(base, {}).get("why", ""))[:MAX_WHY_CHARS]
                 r["kind"] = "launch"
             else:
                 r["experiment"] = ""

--- a/src/outerloop/watcher.py
+++ b/src/outerloop/watcher.py
@@ -157,8 +157,14 @@ class SessionWatcher:
                 r["experiment"] = name[len(prefix) :]
                 # the ledger keys the array's id; squeue shows `<id>_<k>` or `<id>_[...]`
                 base = job_id.split("_", 1)[0]
-                r["why"] = str(labels.get(base, {}).get("why", ""))[:MAX_WHY_CHARS]
+                label = labels.get(base, {})
+                r["why"] = str(label.get("why", ""))[:MAX_WHY_CHARS]
                 r["kind"] = "launch"
+                # the pace: the pending range says it; once only running tasks
+                # are left, the ledger does (the whole array when unset)
+                array = int(label.get("array") or 1)
+                if "concurrency" not in r and array > 1:
+                    r["concurrency"] = int(label.get("concurrency") or array)
             else:
                 r["experiment"] = ""
                 r["why"] = ""

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -2352,9 +2352,10 @@ def test_resume_reparks_when_a_measure_is_pending(tmp_path, monkeypatch) -> None
 def test_author_sleep_live_array_launch_submits_one_job_per_index(
     tmp_path, target_repo_syscalls, monkeypatch
 ) -> None:
-    """`array: 2` is one launch that submits two jailed jobs, `<name>.0` and
-    `<name>.1`, each told its index through SWEEP_INDEX; the park waits on
-    both and the stage carries the width for re-parks and the wake."""
+    """`array: 2` is one launch and ONE job array: two task dirs, `<name>.0`
+    and `<name>.1`, one script whose task derives its dir and SWEEP_INDEX from
+    the array index; the park waits on the array id and the stage carries the
+    width for re-parks and the wake."""
     import json as json_mod
 
     outcome, _github = run_live(
@@ -2372,21 +2373,23 @@ def test_author_sleep_live_array_launch_submits_one_job_per_index(
             ),
         },
         values=[],
-        dispatch=_fake_dispatch(),
+        dispatch=(dispatch := _fake_dispatch()),
     )
     assert outcome.outcome == "parked"
     record = load_record(tmp_path / "state", "tsp-1")
-    assert record.stage["afterany"] == "afterany:1000:1001"
+    assert record.stage["afterany"] == "afterany:1000"  # one job for the whole sweep
+    sbatch = next(a for a in dispatch.compute.runner.seen if "--job-name=tsp-1-launch-sweep" in a)
+    assert "--array=0-1%2" in sbatch
     assert record.stage["syscall_launches"] == [
         {"name": "sweep", "minutes": 45, "artifacts": [], "array": 2}
     ]
     assert record.stage["launches_used"] == 1
     runs = tmp_path / "state" / "runs" / "tsp-1"
     for i in (0, 1):
-        ev = runs / f"eval-launch-sweep.{i}"
-        assert (ev / "command.txt").read_text() == "uv run probe.py"
-        scripts = " ".join(p.read_text() for p in ev.iterdir() if p.is_file())
-        assert f"SWEEP_INDEX={i}" in scripts
+        assert (runs / f"eval-launch-sweep.{i}" / "command.txt").read_text() == "uv run probe.py"
+    script = (runs / "eval-launch-sweep" / "job.sh").read_text()
+    assert 'TASK="${SLURM_ARRAY_TASK_ID:-${SWEEP_INDEX:-0}}"' in script
+    assert 'export SWEEP_INDEX="$TASK"' in script
 
 
 def test_resume_repark_of_a_submitted_park_keeps_the_submit_context(tmp_path, monkeypatch):

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -90,7 +90,13 @@ def test_park_run_appends_the_launch_ledger(tmp_path) -> None:
     entries = history(ledger_dir)
     assert [(e["name"], e["job_ids"]) for e in entries] == [("a", ["201"]), ("sw", ["202", "203"])]
     assert entries[0]["why"] == "probe a" and entries[0]["sleep"] == 1 and entries[0]["jobs"] == []
-    assert why_by_job(ledger_dir)["203"] == {"name": "sw", "why": "", "sleep": 1}
+    assert why_by_job(ledger_dir)["203"] == {
+        "name": "sw",
+        "why": "",
+        "sleep": 1,
+        "array": 2,
+        "concurrency": 0,
+    }
     assert load_record(tmp_path, "tsp-7").stage["syscall_launches"] == [
         {"name": "a", "minutes": 5, "artifacts": [], "why": "probe a"},
         {"name": "sw", "minutes": 5, "artifacts": [], "array": 2},

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -212,3 +212,31 @@ def test_lane_load_counts_nodes_by_state() -> None:
     with pytest.raises(SlurmQueryError):
         SlurmCompute(runner=FakeRunner([CommandResult(1, "", "down")])).lane_load("h200")
     assert LocalCompute.lane_load(None, "gpu") == {}  # type: ignore[arg-type]
+
+
+def test_job_arrays_have_a_spec_task_ids_and_a_combined_state() -> None:
+    from outerloop.compute import LocalCompute, array_indices, combine_states
+
+    spec = JobSpec(
+        job_name="s", account="", partition="", time_minutes=5, command="x", array="0-7%4"
+    )
+    assert "--array=0-7%4" in spec.to_argv()
+    assert array_indices("0-7%4") == list(range(8)) and array_indices("") == []
+    assert array_indices("3") == [3] and array_indices("x-y") == []
+    assert combine_states(["COMPLETED", "RUNNING", "PENDING"]) == "RUNNING"
+    assert combine_states(["COMPLETED", "PENDING"]) == "PENDING"
+    assert combine_states(["COMPLETED", "FAILED", "COMPLETED"]) == "FAILED"
+    assert combine_states(["COMPLETED", "COMPLETED"]) == "COMPLETED"
+    assert combine_states(["TIMEOUT"]) == "TIMEOUT"
+    # sacct answers one line per task for an array id: the state is theirs combined
+    runner = FakeRunner([CommandResult(0, "COMPLETED\nRUNNING\nPENDING\n", "")])
+    assert SlurmCompute(runner=runner).status("123") == "RUNNING"
+    # a task id `<id>_<k>` is a job id too; a squeue range is not
+    runner = FakeRunner([CommandResult(0, "COMPLETED\n", ""), CommandResult(0, "", "")])
+    c = SlurmCompute(runner=runner)
+    assert c.status("123_4") == "COMPLETED" and runner.seen[0][2] == "123_4"
+    assert c.cancel("123_4") is True
+    with pytest.raises(ValueError):
+        c.status("123_[0-3]")
+    with pytest.raises(ValueError):
+        LocalCompute().status("12a")

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -491,3 +491,33 @@ def test_snapshot_commit_is_the_bots(tmp_path: Path) -> None:
     snap = snapshot_tree(ws, base, author="outerloop-science[bot]")  # type: ignore[arg-type]
     ident = ws.git("log", "-1", "--format=%an <%ae>", snap.commit).strip()
     assert ident == "outerloop-science[bot] <outerloop-science[bot]@users.noreply.github.com>"
+
+
+def test_write_eval_job_array_writes_one_script_and_a_dir_per_task(tmp_path):
+    """A sweep is one job array: one script, whose task derives its job dir and
+    SWEEP_INDEX from the array index; the task dirs are created and cleared."""
+    run_dir = tmp_path / "run"
+    stale = run_dir / "eval-launch-sw.1"
+    stale.mkdir(parents=True)
+    (stale / "exit-code").write_text("0")
+    script = write_eval_job(
+        run_dir,
+        "launch-sw",
+        repo_root=tmp_path,
+        snapshot_sha="a" * 40,
+        command="true",
+        image="/i.sif",
+        array=3,
+    )
+    assert script == run_dir / "eval-launch-sw" / "job.sh"
+    for k in range(3):
+        assert (run_dir / f"eval-launch-sw.{k}" / "command.txt").read_text() == "true"
+    assert not (stale / "exit-code").exists()
+    text = script.read_text()
+    assert 'TASK="${SLURM_ARRAY_TASK_ID:-${SWEEP_INDEX:-0}}"' in text
+    assert f'EV={run_dir / "eval-launch-sw"}."$TASK"' in text
+    assert 'export SWEEP_INDEX="$TASK" APPTAINERENV_SWEEP_INDEX="$TASK"' in text
+    plain = write_eval_job(
+        run_dir, "launch-one", repo_root=tmp_path, snapshot_sha="a" * 40, command="true", image=""
+    )
+    assert "TASK=" not in plain.read_text() and "SWEEP_INDEX" not in plain.read_text()

--- a/tests/test_launchlog.py
+++ b/tests/test_launchlog.py
@@ -55,12 +55,14 @@ def test_history_joins_submits_with_their_ended_jobs(tmp_path: Path) -> None:
         ("sw.1", None, "TIMEOUT"),
     ]
     assert entries[2]["jobs"] == []  # not back yet
-    assert why_by_job(tmp_path) == {
-        "1": {"name": "a", "why": "probe a", "sleep": 1},
-        "2": {"name": "sw", "why": "sweep lr", "sleep": 1},
-        "3": {"name": "sw", "why": "sweep lr", "sleep": 1},
-        "4": {"name": "a", "why": "probe a", "sleep": 2},
+    labels = why_by_job(tmp_path)
+    assert {k: (v["name"], v["why"], v["sleep"]) for k, v in labels.items()} == {
+        "1": ("a", "probe a", 1),
+        "2": ("sw", "sweep lr", 1),
+        "3": ("sw", "sweep lr", 1),
+        "4": ("a", "probe a", 2),
     }
+    assert (labels["2"]["array"], labels["2"]["concurrency"]) == (2, 0)
 
 
 def test_ledger_tolerates_a_missing_file_and_a_torn_line(tmp_path: Path) -> None:

--- a/tests/test_launchlog.py
+++ b/tests/test_launchlog.py
@@ -96,3 +96,15 @@ def test_a_re_parked_sleep_keeps_its_first_records(tmp_path: Path) -> None:
     # the same name in the next sleep is a new launch
     append_submitted(tmp_path, sleep=2, launches=rebuilt, job_ids=["2"], at=30.0)
     assert [(e["sleep"], e["why"]) for e in history(tmp_path)] == [(1, "probe a"), (2, "")]
+
+
+def test_one_id_per_launch_is_the_arrays_id(tmp_path: Path) -> None:
+    """A sweep is one job array: the park records one id per launch, and the
+    queue view maps every task (`<id>_<k>`) back to it through the array id."""
+    launches = (
+        Launch(name="a", command="x", minutes=5, why="probe a"),
+        Launch(name="sw", command="y", minutes=7, array=4, why="sweep lr"),
+    )
+    append_submitted(tmp_path, sleep=1, launches=launches, job_ids=["10", "11"], at=1.0)
+    assert [e["job_ids"] for e in history(tmp_path)] == [["10"], ["11"]]
+    assert why_by_job(tmp_path)["11"]["why"] == "sweep lr"

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -324,3 +324,22 @@ def test_local_job_output_is_kept_beside_its_state(tmp_path: Path, monkeypatch) 
     out = tmp_path / "local_jobs" / f"{job_id}.out"
     assert out.read_text().strip() == "boom"
     assert out.stat().st_mode & 0o777 == 0o600  # a job may print a credential
+
+
+def test_array_runs_every_task_in_turn(tmp_path: Path) -> None:
+    """A local job array runs its tasks one after another, each with its
+    SLURM_ARRAY_TASK_ID; every task keeps its state under `<id>_<k>` and the
+    array's state is theirs combined."""
+    lc = LocalCompute()
+    log = tmp_path / "tasks"
+    script = tmp_path / "job.sh"
+    script.write_text(
+        f'#!/bin/sh\necho "$SLURM_ARRAY_TASK_ID" >> {log}\n[ "$SLURM_ARRAY_TASK_ID" != 1 ]\n'
+    )
+    spec = JobSpec(
+        job_name="t", account="", partition="", time_minutes=1, script=str(script), array="0-2%1"
+    )
+    job = lc.submit(spec)
+    assert log.read_text().split() == ["0", "1", "2"]
+    assert lc.status(job) == "FAILED"  # task 1 failed
+    assert lc.status(f"{job}_0") == "COMPLETED" and lc.status(f"{job}_1") == "FAILED"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -352,6 +352,39 @@ def test_submit_parks_the_dispatched_gate_with_the_submitted_marker(tmp_path: Pa
     assert sha == "cand1" and request.launches[0].name == "probe"
 
 
+def test_a_submits_sibling_sweep_is_clamped_too(tmp_path: Path) -> None:
+    """The ceiling applies before either path: a submit's sibling launches are
+    dispatched from the candidate park with the clamped pace."""
+    from outerloop.orchestrator import RunParked
+
+    contract = DEEP_CONTRACT.replace(
+        "budgets: {gpu_hours_per_run: 1, runs_per_week: 10}",
+        "budgets: {gpu_hours_per_run: 1, runs_per_week: 10, max_concurrent_gpus: 3}",
+    )
+    _write_syscall(
+        tmp_path, {"launches": [{"name": "s", "command": "x", "array": 8}], "submit": True}
+    )
+    launched: list = []
+    with pytest.raises(RunParked) as exc:
+        attempt_once(
+            CONFIG,
+            contract,
+            tmp_path,
+            FakeHarness(result=ok_session()),
+            ParkingMeasurer(park_on_call=1),
+            "base",
+            _bare_snapshot(),
+            ruler="r",
+            changed_paths=lambda: ["src/pilot/solvers/tsp.py"],
+            created="t",
+            launcher=_fake_launcher(launched),
+        )
+    assert exc.value.submitted
+    _sha, request = launched[0]
+    assert request.launches[0].concurrency == 3
+    assert exc.value.syscall is not None and exc.value.syscall.launches[0].concurrency == 3
+
+
 def test_dropped_bare_submit_does_not_buy_the_terminal_gate(tmp_path: Path) -> None:
     """The refuse-twice bypass: after two bare submits are refused, the
     dropped request must not be measured at finish — a metered run with no

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -287,6 +287,24 @@ def test_author_sleep_parks_on_a_sealed_snapshot(tmp_path: Path) -> None:
     assert sha == "cand1" and request.launches[0].name == "probe"
 
 
+def test_sweep_pace_is_clamped_to_the_contracts_gpu_ceiling(tmp_path: Path) -> None:
+    """A sweep's concurrency is clamped to `max_concurrent_gpus // gpus` before
+    the launcher sees it and before the park records it; never refused."""
+    from outerloop.orchestrator import RunParked
+
+    contract = DEEP_CONTRACT.replace(
+        "budgets: {gpu_hours_per_run: 1, runs_per_week: 10}",
+        "budgets: {gpu_hours_per_run: 1, runs_per_week: 10, max_concurrent_gpus: 3}",
+    )
+    _write_syscall(tmp_path, {"launches": [{"name": "s", "command": "x", "array": 8}]})
+    launched: list = []
+    with pytest.raises(RunParked) as exc:
+        run_climb(tmp_path, [], contract=contract, launcher=_fake_launcher(launched))
+    _sha, request = launched[0]
+    assert request.launches[0].concurrency == 3  # tsp has no gpus: the ceiling counts tasks
+    assert exc.value.syscall is not None and exc.value.syscall.launches[0].concurrency == 3
+
+
 def test_checkpoint_sleep_parks_with_no_dependency(tmp_path: Path) -> None:
     from outerloop.orchestrator import RunParked
 

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -1116,3 +1116,55 @@ def test_a_fifo_in_the_done_markers_place_never_blocks_the_kernel(tmp_path: Path
     t.join(timeout=5)
     assert not t.is_alive(), "marker_requested blocked on the FIFO"
     assert seen and seen[0] is not None  # the FIFO counts as no acknowledgement at all
+
+
+def test_sweep_pace_is_validated_clamped_and_expanded(tmp_path: Path) -> None:
+    from outerloop.syscall import (
+        Launch,
+        SyscallError,
+        SyscallRequest,
+        array_spec,
+        clamp_concurrency,
+        launch_task_ids,
+    )
+
+    write_req(
+        tmp_path,
+        {
+            "launches": [
+                {"name": "s", "command": "x", "array": 4, "concurrency": 9},
+                {"name": "p", "command": "y", "concurrency": 3},
+            ]
+        },
+    )
+    req = read_request(tmp_path)
+    assert req is not None
+    # clamped to the array; meaningless for a plain launch
+    assert [la.concurrency for la in req.launches] == [4, 0]
+    write_req(
+        tmp_path, {"launches": [{"name": "s", "command": "x", "array": 4, "concurrency": -1}]}
+    )
+    with pytest.raises(SyscallError, match="concurrency"):
+        read_request(tmp_path)
+    s8 = Launch(name="s", command="x", minutes=5, array=8)
+    assert array_spec(s8) == "0-7%8" and array_spec(Launch(name="p", command="y", minutes=5)) == ""
+    assert array_spec(Launch(name="s", command="x", minutes=5, array=8, concurrency=3)) == "0-7%3"
+    req = SyscallRequest(
+        launches=(
+            s8,
+            Launch(name="s2", command="x", minutes=5, array=8, concurrency=2),
+            Launch(name="p", command="y", minutes=5),
+        ),
+        note="",
+        submit=False,
+    )
+    clamped = clamp_concurrency(req, gpus=2, max_concurrent_gpus=12)  # 6 tasks of 2 GPUs
+    assert [la.concurrency for la in clamped.launches] == [6, 2, 0]
+    assert clamp_concurrency(req, gpus=2, max_concurrent_gpus=None) is req
+    assert clamp_concurrency(req, gpus=0, max_concurrent_gpus=1).launches[0].concurrency == 1
+    # one id per launch expands to the array's task ids; a legacy per-task list passes through
+    ids = launch_task_ids(req.launches, ["10", "11", "12"])
+    assert ids == [f"10_{k}" for k in range(8)] + [f"11_{k}" for k in range(8)] + ["12"]
+    legacy = [str(i) for i in range(1, 9)]
+    assert launch_task_ids((s8,), legacy) == legacy
+    assert launch_task_ids((s8,), ["1", "2"]) == []  # an unknown mapping is never guessed

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -9,6 +9,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 from outerloop.syscall import read_request, read_verdict
 from outerloop.syscall_cli import main
@@ -447,7 +448,7 @@ class _Kernel:
             time.sleep(0.05)
 
 
-_QUEUE = {
+_QUEUE: dict[str, Any] = {
     "at": 0,
     "error": "",
     "jobs": [
@@ -571,3 +572,36 @@ def test_history_renders_the_ledger(tmp_path: Path, capsys) -> None:
     with _Kernel(tmp_path, "history", {"at": 0, "history": []}):
         assert main(["history", "--wait", "5"], root=tmp_path) == 0
     assert "no launches yet" in capsys.readouterr().out
+
+
+def test_sweep_concurrency_is_staged_and_clamped_to_the_array(tmp_path: Path, capsys) -> None:
+    assert (
+        main(
+            ["launch", "--name", "s", "--array", "4", "--concurrency", "2", "--", "x"],
+            root=tmp_path,
+        )
+        == 0
+    )
+    assert "x 4 tasks, SWEEP_INDEX 0..3, at most 2 at a time" in capsys.readouterr().out
+    assert (
+        main(
+            ["launch", "--name", "t", "--array", "4", "--concurrency", "9", "--", "x"],
+            root=tmp_path,
+        )
+        == 0
+    )
+    assert "at most 4 at a time" in capsys.readouterr().out
+    assert main(["status"], root=tmp_path) == 0
+    assert "s (30 min x4 (2 at a time))" in capsys.readouterr().out
+    assert main(["launch", "--name", "u", "--concurrency", "-1", "--", "x"], root=tmp_path) == 2
+    capsys.readouterr()
+    assert main(["sleep"], root=tmp_path) == 0
+    req = read_request(tmp_path)
+    assert req is not None and [la.concurrency for la in req.launches] == [2, 4]
+
+
+def test_queue_shows_a_sweeps_pace(tmp_path: Path, capsys) -> None:
+    row = {**_QUEUE["jobs"][0], "id": "555_[0-7%4]", "concurrency": 4}
+    with _Kernel(tmp_path, "queue", {**_QUEUE, "jobs": [row]}):
+        assert main(["queue", "--wait", "5"], root=tmp_path) == 0
+    assert "launch lr (sweep, 4 at a time) — PENDING" in capsys.readouterr().out

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -240,3 +240,16 @@ def test_nothing_is_written_once_the_session_ended(tmp_path: Path) -> None:
     watcher.service()
     assert not (ws / ".outerloop" / "queue.json").exists()
     assert not (ws / ".outerloop" / "queue-done").exists()
+
+
+def test_array_rows_carry_the_launch_label_and_the_pace(tmp_path: Path) -> None:
+    """squeue names a pending array `<id>_[0-7%4]` and a running task `<id>_3`;
+    both map back to the ledger's array id, and the pace is read off the range."""
+    root, ws = _fleet(tmp_path)
+    rows = [_row("555_[0-7%4]", "r2-launch-lr"), _row("555_3", "r2-launch-lr", "RUNNING", "None")]
+    watcher = SessionWatcher(_ctx(root, ws, _Compute(rows)))
+    _ask(ws, "queue", 50.0)
+    watcher.service()
+    by_id = {j["id"]: j for j in _answered(ws, "queue")["jobs"]}
+    assert by_id["555_[0-7%4]"]["why"] == "try lr 3e-4" and by_id["555_[0-7%4]"]["concurrency"] == 4
+    assert by_id["555_3"]["why"] == "try lr 3e-4" and "concurrency" not in by_id["555_3"]

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -252,4 +252,19 @@ def test_array_rows_carry_the_launch_label_and_the_pace(tmp_path: Path) -> None:
     watcher.service()
     by_id = {j["id"]: j for j in _answered(ws, "queue")["jobs"]}
     assert by_id["555_[0-7%4]"]["why"] == "try lr 3e-4" and by_id["555_[0-7%4]"]["concurrency"] == 4
+    # a running task carries the pace from the ledger (the range is gone once
+    # only running tasks are left): this sweep recorded none, so the whole array
     assert by_id["555_3"]["why"] == "try lr 3e-4" and "concurrency" not in by_id["555_3"]
+    append_submitted(
+        run_dir(root, "r2"),
+        sleep=2,
+        launches=(Launch(name="wd", command="c", minutes=10, array=8, concurrency=4),),
+        job_ids=["777"],
+        at=6.0,
+    )
+    running = _Compute([_row("777_5", "r2-launch-wd", "RUNNING", "None")])
+    watcher = SessionWatcher(_ctx(root, ws, running))
+    _ask(ws, "queue", 60.0)
+    watcher.service()
+    row = _answered(ws, "queue")["jobs"][0]
+    assert row["concurrency"] == 4 and row["experiment"] == "wd"


### PR DESCRIPTION
Step 2b of the session-watcher design note (#316): **sweeps as throttled Slurm job arrays**, replacing the fan-out into N separate jobs.

- **One job per sweep.** `launch --array N` submits `--array=0-(N-1)%K`. The queue holds one entry that accrues priority as one job; Slurm runs at most K tasks at once; the wake's `afterany` on the array id covers every task. `write_eval_job(array=N)` writes one script whose task derives its job dir `eval-launch-<name>.<k>` and `SWEEP_INDEX` from `SLURM_ARRAY_TASK_ID` (or `SWEEP_INDEX` under a local run), and creates and clears the N task dirs. Result gathering by `<name>.<k>` is unchanged.
- **The author sets the pace, the contract caps it.** `launch --concurrency K` (default: the whole array). `budgets.max_concurrent_gpus` is a ceiling in GPUs: `clamp_concurrency` sets K to at most `ceiling // gpus` (a two-GPU task gets half the tasks of a one-GPU task and the same share of the machine), never below one, before the launcher submits and before the park records the request. Clamped, never refused; the wake text says each sweep's pace. Unset ceiling: the author's pace stands.
- **Task ids.** `<id>_<k>` is a job id (`_check_job_id`), so states, elapsed times and cancels work per task. `SlurmCompute.status` on an array id combines the per-task `sacct` lines (`combine_states`: running while any task runs, pending while any waits, terminal only when all are; COMPLETED only if all are). `launch_task_ids` expands one id per launch for `annotate_launch_states` and the GPU-hour refund; a park recorded before this change carries one id per task and passes through; an unknown mapping yields none rather than a guess.
- **Ledger and queue view.** The ledger keeps the array id per launch; the watcher maps `<id>_<k>` and the pending range `<id>_[0-15%4]` back to it and reads K off the range, and the tool renders "(sweep, K at a time)".
- **Local compute** runs an array's tasks in turn, each with `SLURM_ARRAY_TASK_ID` and its own persisted state; the array's state is theirs combined.
- Docs: contract knob row, design note status, CHANGELOG. Tests across compute, dispatch, local compute, the live author-sleep sweep, request parsing and the clamp, the orchestrator clamp, the watcher's array rows, the tool, the ledger.

Follow-up for the lab: set `budgets.max_concurrent_gpus: 12` in the gpt-speedrun contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
