### PR TITLE
The pull request carries the research: a required report at submit, and the run's experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- The pull request carries the research. `submit --report <file>` is required:
+  the author's write-up (hypothesis, what ran and what was measured, why it
+  should merge, what did not work) becomes the PR's research report, and the
+  panel reads it against the diff in place of the session's last message. An
+  experiments table follows, from the kernel's launch ledger: every job the
+  author launched this run, its reason, how it ended and how long it ran, and
+  the last line it printed. The measured table and the panel transcript follow.
 - Sweeps are Slurm job arrays. `launch --array N` submits one job,
   `--array=0-N%K`, and each task derives its job dir and `SWEEP_INDEX` from
   its array index. The queue holds one entry per sweep. `--concurrency K`

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -1790,6 +1790,9 @@ def resume_run(
                     ),
                     note=str(stage.get("syscall_note", "")),
                     submit=True,
+                    # the author's report rides every re-park: a suite fan-out
+                    # must not drop what the panel and the PR read
+                    report=str(stage.get("report", "")),
                 )
         old_afterany = str(record.stage.get("afterany", ""))
         made_progress = bool(parked.afterany) and parked.afterany != old_afterany

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -47,7 +47,7 @@ from outerloop.github import (
     git_identity,
 )
 from outerloop.harness import Harness, SessionResult, default_binary, redact
-from outerloop.launchlog import append_ended, append_submitted
+from outerloop.launchlog import append_ended, append_submitted, experiments_rows
 from outerloop.markers import has_marker
 from outerloop.measure import DispatchedMeasurer, DispatchSettings
 from outerloop.orchestrator import (
@@ -437,9 +437,14 @@ def _park_run(
         # it lands in the durable record, like every other persisted final_text
         # — a session that echoed a credential must not leave it in record.json.
         # Empty/zero for a baseline park (the session has not run yet).
-        "report": redact(parked.session.final_text, secrets)[:MAX_CLAIM_CHARS]
-        if parked.session
-        else "",
+        # the author's report at submit, else the session's last words (a park
+        # with no submit); either way what the wake's panel and the PR body read
+        "report": redact(
+            parked.syscall.report
+            if parked.syscall is not None and parked.syscall.report
+            else (parked.session.final_text if parked.session else ""),
+            secrets,
+        )[:MAX_CLAIM_CHARS],
         "session_cost_usd": parked.session.cost_usd if parked.session else 0.0,
         "session_turns": parked.session.num_turns if parked.session else 0,
     }
@@ -856,18 +861,20 @@ def _wake_author_sleep(
     # of a blank "job failure". The park's launch job ids align positionally
     # with the results (same launch/array order). Best-effort — the wake never
     # blocks on the scheduler query.
+    task_ids = launch_task_ids(launches, _stage_launch_job_ids(record))
     status_of = getattr(dispatch.compute, "status", None)
     if status_of is not None:
-        results = annotate_launch_states(
-            results, launch_task_ids(launches, _stage_launch_job_ids(record)), status_of
-        )
+        results = annotate_launch_states(results, task_ids, status_of)
     launches_used = int(record.stage.get("launches_used", 0))  # type: ignore[call-overload]
     sleeps_used = int(record.stage.get("sleeps_used", 0))  # type: ignore[call-overload]
+    elapsed = _launch_elapsed(dispatch, task_ids) if task_ids else None
     _best_effort(
         "launch ledger",
-        lambda: append_ended(run_dir, sleep=sleeps_used, results=results, at=time.time()),
+        lambda: append_ended(
+            run_dir, sleep=sleeps_used, results=results, at=time.time(), elapsed_seconds=elapsed
+        ),
     )
-    gpu_hours_used = _reconcile_launch_hours(record, dispatch, bench.gpus, launches)
+    gpu_hours_used = _reconcile_launch_hours(record, dispatch, bench.gpus, launches, elapsed)
     wake_text = render_wake(
         results,
         str(record.stage.get("syscall_note", "")),
@@ -1054,7 +1061,11 @@ def _stage_launch_job_ids(record: RunRecord) -> list[str]:
 
 
 def _reconcile_launch_hours(
-    record: RunRecord, dispatch: DispatchSettings, gpus: int, launches: tuple
+    record: RunRecord,
+    dispatch: DispatchSettings,
+    gpus: int,
+    launches: tuple,
+    elapsed: list[int | None] | None = None,
 ) -> float:
     """The run's GPU-hours after handing back the unused walltime of the
     park's launch jobs — once: the stage remembers the refund, so a wake
@@ -1065,7 +1076,7 @@ def _reconcile_launch_hours(
     if not gpus or stage.get("launch_hours_refunded"):
         return used
     refund = _launch_refund(
-        dispatch, launches, launch_task_ids(launches, _stage_launch_job_ids(record)), gpus
+        dispatch, launches, launch_task_ids(launches, _stage_launch_job_ids(record)), gpus, elapsed
     )
     if refund > 0:
         log.info("%s: refunding %.2f GPU-hours of unused launch walltime", record.run_id, refund)
@@ -1075,21 +1086,35 @@ def _reconcile_launch_hours(
     return used
 
 
+def _launch_elapsed(dispatch: DispatchSettings, job_ids: list[str]) -> list[int | None] | None:
+    """How long each launch job ran, from the compute, aligned with `job_ids`;
+    None when the compute cannot say (nothing is refunded or recorded on a
+    guess)."""
+    query = getattr(dispatch.compute, "elapsed_seconds", None)
+    if query is None or not job_ids:
+        return None
+    try:
+        return [query(jid) for jid in job_ids]
+    except Exception as exc:
+        log.warning("launch walltime unknown (%s: %s)", type(exc).__name__, exc)
+        return None
+
+
 def _launch_refund(
-    dispatch: DispatchSettings, launches: tuple, job_ids: list[str], gpus: int
+    dispatch: DispatchSettings,
+    launches: tuple,
+    job_ids: list[str],
+    gpus: int,
+    elapsed: list[int | None] | None = None,
 ) -> float:
     """The unused walltime of a park's launch jobs, in GPU-hours, or 0 when
     the compute cannot say how long they ran (nothing is refunded on a
-    guess)."""
+    guess). `elapsed` may be handed in when the caller already asked."""
     from outerloop.syscall import launch_hours_refund
 
-    query = getattr(dispatch.compute, "elapsed_seconds", None)
-    if query is None or not job_ids:
-        return 0.0
-    try:
-        elapsed = [query(jid) for jid in job_ids]
-    except Exception as exc:
-        log.warning("launch walltime unknown (%s: %s); nothing refunded", type(exc).__name__, exc)
+    if elapsed is None:
+        elapsed = _launch_elapsed(dispatch, job_ids)
+    if elapsed is None:
         return 0.0
     return launch_hours_refund(launches, elapsed, gpus=gpus)
 
@@ -2059,8 +2084,16 @@ def resume_run(
                     f"\n\nAgent: {config.agent_id}",
                 )
             ws.push(branch)
+            if record.stage.get("submitted"):
+                # the author's report at submit rides the stage: the PR shows it
+                # as the research report, over the ledger's experiments
+                result = dc_replace(result, submit_report=str(record.stage.get("report") or ""))
             body = pr_body(
-                result, config, redact_secrets=secrets, display_digits=bench.display_digits
+                result,
+                config,
+                redact_secrets=secrets,
+                display_digits=bench.display_digits,
+                experiments=experiments_rows(run_dir),
             )
             if issue_number:
                 body = f"Addresses #{issue_number}.\n\n{body}"
@@ -3006,7 +3039,11 @@ def live_attempt(
             ws.push(branch)
             pushed = True
             body = pr_body(
-                result, config, redact_secrets=secrets, display_digits=bench.display_digits
+                result,
+                config,
+                redact_secrets=secrets,
+                display_digits=bench.display_digits,
+                experiments=experiments_rows(run_dir),
             )
             if issue_number:
                 body = f"Addresses #{issue_number}.\n\n{body}"

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -942,6 +942,7 @@ def _wake_author_sleep(
             config.bot_login,
             _utc_date(now),
             exclude=LINE_MEMORY_PATHS if wake_line else (),
+            secrets=secrets,
         )
         if panel_lenses
         else None
@@ -1027,6 +1028,32 @@ def _stage_judged(record: RunRecord) -> tuple[str, AttemptResult] | None:
             candidate=num(j.get("candidate")),
             note=str(j.get("note") or ""),
         ),
+    )
+
+
+def _ledger_ended(
+    run_dir: Path,
+    record: RunRecord,
+    launches: tuple,
+    task_ids: list[str],
+    dispatch: DispatchSettings,
+    elapsed: list[int | None] | None,
+) -> None:
+    """Record a park's finished launches in the ledger from the run dir alone
+    (no delivery into a workspace), with the scheduler's state for jobs that
+    left no exit code."""
+    from outerloop.syscall import annotate_launch_states, read_results
+
+    results = read_results(run_dir, launches)
+    status_of = getattr(dispatch.compute, "status", None)
+    if status_of is not None:
+        results = annotate_launch_states(results, task_ids, status_of)
+    append_ended(
+        run_dir,
+        sleep=int(record.stage.get("sleeps_used", 0)),  # type: ignore[call-overload]
+        results=results,
+        at=time.time(),
+        elapsed_seconds=elapsed,
     )
 
 
@@ -1797,7 +1824,19 @@ def resume_run(
     # the park's sibling launches are done too: settle their charge before
     # any path — publish or hand back to the author — reads the budget
     if _stage_launches(record):
-        _reconcile_launch_hours(record, dispatch, bench.gpus, _stage_syscall_launches(record))
+        sibling_launches = _stage_syscall_launches(record)
+        sibling_ids = launch_task_ids(sibling_launches, _stage_launch_job_ids(record))
+        sibling_elapsed = _launch_elapsed(dispatch, sibling_ids) if sibling_ids else None
+        _reconcile_launch_hours(record, dispatch, bench.gpus, sibling_launches, sibling_elapsed)
+        # the ledger's ended records for the sibling launches, whether or not
+        # the author is woken: the PR's experiments table reads them (an
+        # author wake that follows records nothing twice)
+        _best_effort(
+            "launch ledger",
+            lambda: _ledger_ended(
+                run_dir, record, sibling_launches, sibling_ids, dispatch, sibling_elapsed
+            ),
+        )
 
     def _wake_author(
         extra_update: str, judged: tuple[str, AttemptResult] | None = None
@@ -2010,6 +2049,7 @@ def resume_run(
                         exclude=(
                             LINE_MEMORY_PATHS if _line_ref_for(bench, config.agent_id) else ()
                         ),
+                        secrets=secrets,
                     )(baseline, candidate, str(stage.get("report", "")))
                 except Exception as exc:
                     if isinstance(exc, GitError) and _is_git_tamper(exc):
@@ -2391,6 +2431,7 @@ def build_panel_runner(
     start_round: int = 0,
     exclude: tuple[str, ...] = (),
     claim_body: Callable[[float, float, str], str] | None = None,
+    secrets: tuple[str, ...] = (),
 ) -> Callable[[float, float, str], PanelVerdict]:
     """The git half of the pre-PR panel: prepare the two read-only checkouts
     and the synthetic claim, then hand off to `run_panel` (which owns no git).
@@ -2414,6 +2455,10 @@ def build_panel_runner(
     )
 
     def runner(baseline: float, candidate: float, report: str) -> PanelVerdict:
+        # the claim is author text (the report at submit, or the session's
+        # last words): redacted before any lens sees it, like the record and
+        # the PR body
+        report = redact(report, secrets)
         reads["n"] += 1
         panel_ws = run_dir / "panel"
         shutil.rmtree(panel_ws, ignore_errors=True)
@@ -2765,6 +2810,7 @@ def live_attempt(
                 config.bot_login,
                 created[:10],
                 exclude=LINE_MEMORY_PATHS if lines_active else (),
+                secrets=secrets,
             )
             if panel_lenses
             else None

--- a/src/outerloop/brief.py
+++ b/src/outerloop/brief.py
@@ -394,7 +394,7 @@ def render(brief: SessionBrief) -> str:
             f"    python {_CHANNEL}/syscall launch --name <handle> "
             '--minutes <N> [--array <N>] [--concurrency <K>] [--why "one line"] '
             "--artifact <repo-relative file> -- <command>",
-            f"    python {_CHANNEL}/syscall submit [--minutes <N>]",
+            f"    python {_CHANNEL}/syscall submit --report <file> [--minutes <N>]",
             f"    python {_CHANNEL}/syscall siblings",
             f"    python {_CHANNEL}/syscall queue",
             f"    python {_CHANNEL}/syscall history",
@@ -456,7 +456,14 @@ def render(brief: SessionBrief) -> str:
             "unvalidated submit wastes gate compute and spends a sleep on a "
             "guess.",
             "",
-            "When your candidate is READY, stage `submit` and then `sleep`: "
+            "A submit needs `--report <file>`: a short markdown write-up with "
+            "your hypothesis, what you ran and what it measured (`history` "
+            "lists your launches), why this should merge, and what did not "
+            "work. It becomes the pull request's research report, and the "
+            "panel reads it against the diff and your experiments — claim "
+            "only what the evidence shows.",
+            "",
+            "When your candidate is READY, stage `submit --report <file>` and then `sleep`: "
             "your tree is sealed, measured against the baseline, and read by "
             "the review panel. A clean pass is published as a PR directly; "
             "otherwise you wake with the gate result or the panel's findings "

--- a/src/outerloop/launchlog.py
+++ b/src/outerloop/launchlog.py
@@ -80,9 +80,15 @@ def append_submitted(
 
 
 def append_ended(
-    run_dir: Path, *, sleep: int, results: tuple[LaunchResult, ...], at: float
+    run_dir: Path,
+    *,
+    sleep: int,
+    results: tuple[LaunchResult, ...],
+    at: float,
+    elapsed_seconds: list[int | None] | None = None,
 ) -> None:
-    """One record per job that came back at the wake, keyed to its sleep."""
+    """One record per job that came back at the wake, keyed to its sleep, with
+    how long it ran when the compute could say (aligned with `results`)."""
     _append(
         run_dir,
         [
@@ -92,9 +98,14 @@ def append_ended(
                 "name": r.name,
                 "exit_code": r.exit_code,
                 "state": r.slurm_state,
+                "elapsed": (
+                    elapsed_seconds[i]
+                    if elapsed_seconds is not None and i < len(elapsed_seconds)
+                    else None
+                ),
                 "at": at,
             }
-            for r in results
+            for i, r in enumerate(results)
         ],
     )
 
@@ -133,6 +144,7 @@ def history(run_dir: Path) -> list[dict[str, Any]]:
             "why": row.get("why", ""),
             "minutes": row.get("minutes"),
             "array": row.get("array", 1),
+            "concurrency": row.get("concurrency", 0),
             "job_ids": list(row.get("job_ids") or []),
             "submitted_at": row.get("at"),
             "jobs": [],
@@ -149,10 +161,59 @@ def history(run_dir: Path) -> list[dict[str, Any]]:
                     "name": row.get("name"),
                     "exit_code": row.get("exit_code"),
                     "state": row.get("state", ""),
+                    "elapsed": row.get("elapsed"),
                     "ended_at": row.get("at"),
                 }
             )
     return list(entries.values())
+
+
+def _last_line(path: Path, cap: int = 160) -> str:
+    """The last non-empty line a job printed — its result line, as the wake
+    showed the author — or "" when there is none. Reads the tail only."""
+    try:
+        with path.open("rb") as fh:
+            fh.seek(0, 2)
+            size = fh.tell()
+            fh.seek(max(0, size - 8192))
+            tail = fh.read().decode("utf-8", "replace")
+    except OSError:
+        return ""
+    for line in reversed(tail.splitlines()):
+        text = " ".join(line.split())
+        if text:
+            return text[:cap]
+    return ""
+
+
+def experiments_rows(run_dir: Path) -> list[dict[str, Any]]:
+    """The pull request's experiments table: one row per job of every launch
+    this run — its sleep, name and why, how it ended and how long it ran, and
+    the last line it printed. A job not back yet says so."""
+    rows: list[dict[str, Any]] = []
+    for entry in history(run_dir):
+        ended = {str(j.get("name")): j for j in entry["jobs"]}
+        array = int(entry.get("array") or 1)
+        name = str(entry.get("name") or "")
+        jobs = [name] if array <= 1 else [f"{name}.{k}" for k in range(array)]
+        for job in jobs:
+            j = ended.get(job)
+            rows.append(
+                {
+                    "sleep": entry.get("sleep"),
+                    "launch": name,
+                    "why": str(entry.get("why") or ""),
+                    "array": array,
+                    "concurrency": int(entry.get("concurrency") or 0),
+                    "job": job,
+                    "back": j is not None,
+                    "exit_code": j.get("exit_code") if j else None,
+                    "state": str(j.get("state") or "") if j else "",
+                    "elapsed": j.get("elapsed") if j else None,
+                    "result": _last_line(run_dir / f"eval-launch-{job}" / "stdout"),
+                }
+            )
+    return rows
 
 
 def why_by_job(run_dir: Path) -> dict[str, dict[str, Any]]:

--- a/src/outerloop/launchlog.py
+++ b/src/outerloop/launchlog.py
@@ -88,7 +88,16 @@ def append_ended(
     elapsed_seconds: list[int | None] | None = None,
 ) -> None:
     """One record per job that came back at the wake, keyed to its sleep, with
-    how long it ran when the compute could say (aligned with `results`)."""
+    how long it ran when the compute could say (aligned with `results`) and
+    the last line it printed — captured now, because a later launch with the
+    same name overwrites the job dir. A job already recorded as ended under
+    this (sleep, name) is not written again: a submitted park's wake and the
+    author's wake may both see the same jobs."""
+    known = {
+        (int(row.get("sleep") or 0), str(row.get("name") or ""))
+        for row in read_ledger(run_dir)
+        if row.get("event") == "ended"
+    }
     _append(
         run_dir,
         [
@@ -103,11 +112,23 @@ def append_ended(
                     if elapsed_seconds is not None and i < len(elapsed_seconds)
                     else None
                 ),
+                "last_line": last_line(r.stdout_tail),
                 "at": at,
             }
             for i, r in enumerate(results)
+            if (sleep, r.name) not in known
         ],
     )
+
+
+def last_line(text: str, cap: int = 160) -> str:
+    """The last non-empty line of a job's output — its result line, as the
+    wake shows the author — on one line and bounded. "" when there is none."""
+    for line in reversed(text.splitlines()):
+        flat = " ".join(line.split())
+        if flat:
+            return flat[:cap]
+    return ""
 
 
 def read_ledger(run_dir: Path) -> list[dict[str, Any]]:
@@ -162,34 +183,18 @@ def history(run_dir: Path) -> list[dict[str, Any]]:
                     "exit_code": row.get("exit_code"),
                     "state": row.get("state", ""),
                     "elapsed": row.get("elapsed"),
+                    "last_line": str(row.get("last_line") or ""),
                     "ended_at": row.get("at"),
                 }
             )
     return list(entries.values())
 
 
-def _last_line(path: Path, cap: int = 160) -> str:
-    """The last non-empty line a job printed — its result line, as the wake
-    showed the author — or "" when there is none. Reads the tail only."""
-    try:
-        with path.open("rb") as fh:
-            fh.seek(0, 2)
-            size = fh.tell()
-            fh.seek(max(0, size - 8192))
-            tail = fh.read().decode("utf-8", "replace")
-    except OSError:
-        return ""
-    for line in reversed(tail.splitlines()):
-        text = " ".join(line.split())
-        if text:
-            return text[:cap]
-    return ""
-
-
 def experiments_rows(run_dir: Path) -> list[dict[str, Any]]:
     """The pull request's experiments table: one row per job of every launch
     this run — its sleep, name and why, how it ended and how long it ran, and
-    the last line it printed. A job not back yet says so."""
+    the last line it printed, all from the ledger (the job dir is overwritten
+    by a later launch of the same name). A job not back yet says so."""
     rows: list[dict[str, Any]] = []
     for entry in history(run_dir):
         ended = {str(j.get("name")): j for j in entry["jobs"]}
@@ -210,7 +215,7 @@ def experiments_rows(run_dir: Path) -> list[dict[str, Any]]:
                     "exit_code": j.get("exit_code") if j else None,
                     "state": str(j.get("state") or "") if j else "",
                     "elapsed": j.get("elapsed") if j else None,
-                    "result": _last_line(run_dir / f"eval-launch-{job}" / "stdout"),
+                    "result": str(j.get("last_line") or "") if j else "",
                 }
             )
     return rows

--- a/src/outerloop/orchestrator.py
+++ b/src/outerloop/orchestrator.py
@@ -475,6 +475,9 @@ class AttemptResult:
     candidate_sha: str = ""
     session: SessionResult | None = None
     note: str = ""
+    # the author's report at submit (SyscallRequest.report): the PR's research
+    # report and what the panel read; empty when the run never submitted one
+    submit_report: str = ""
     # the seed both measurements ran under (0 = benchmark has no seed_env):
     # recorded in the ledger row so the number is re-derivable
     run_seed: int = 0
@@ -1789,7 +1792,13 @@ def attempt_once(
             break
         # the panel reads the CREDITED claim: improvement + suite gate passed
         panel_reads += 1
-        verdict = panel_runner(baseline, candidate, session.final_text)
+        verdict = panel_runner(
+            baseline,
+            candidate,
+            # the author's report at submit is the claim the panel reads; the
+            # session's last words only when no submit carried one
+            submitted.report if submitted is not None and submitted.report else session.final_text,
+        )
         panel_sections.append(verdict.transcript)
         # only the FINAL read's degradation matters: an earlier outage that a
         # later clean read supersedes is history, not state
@@ -1821,6 +1830,7 @@ def attempt_once(
         suite=suite,
         suite_seed=suite_seed_ran,
         note=baseline_note,
+        submit_report=submitted.report if submitted is not None else "",
         panel_transcript="\n\n".join(panel_sections),
         panel_rounds=panel_reads,
         panel_blocking_open=panel_blocking_open,
@@ -1828,13 +1838,70 @@ def attempt_once(
     )
 
 
+MAX_EXPERIMENT_ROWS = 60
+
+
+def _cell(text: object, cap: int = 160) -> str:
+    """One markdown table cell: one line, pipes escaped, bounded."""
+    return " ".join(str(text).split()).replace("|", "\\|")[:cap]
+
+
+def _ended(row: dict[str, Any]) -> str:
+    if not row.get("back"):
+        return "not back"
+    code = row.get("exit_code")
+    how = f"exit {code}" if code is not None else (str(row.get("state") or "no exit code"))
+    secs = row.get("elapsed")
+    if isinstance(secs, int | float) and secs > 0:
+        h, m = divmod(int(secs) // 60, 60)
+        how += f", {h}h{m:02d}m" if h else f", {m}m"
+    return how
+
+
+def _experiments_section(rows: list[dict[str, Any]]) -> list[str]:
+    """The run's launches as the ledger recorded them: what ran, how each job
+    ended, what it printed last. Empty when the run launched nothing."""
+    if not rows:
+        return []
+    lines = [
+        "",
+        "## Experiments",
+        "",
+        f"{len(rows)} job(s) launched by the author this run, from the kernel's ledger; "
+        "the result column is the last line each job printed.",
+        "",
+        "| sleep | launch | why | job | ended | result |",
+        "| --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows[:MAX_EXPERIMENT_ROWS]:
+        pace = ""
+        if int(row.get("array") or 1) > 1:
+            k = int(row.get("concurrency") or 0) or int(row["array"])
+            pace = f" (x{row['array']}, {k} at a time)"
+        lines.append(
+            f"| {row.get('sleep', '')} | {_cell(row.get('launch', ''), 48)}{pace} | "
+            f"{_cell(row.get('why', ''), 120)} | {_cell(row.get('job', ''), 48)} | "
+            f"{_ended(row)} | {_cell(row.get('result', ''), 160)} |"
+        )
+    rest = rows[MAX_EXPERIMENT_ROWS:]
+    if rest:
+        ok = sum(1 for r in rest if r.get("back") and r.get("exit_code") == 0)
+        lines.append(
+            f"| | … {len(rest)} more job(s): {ok} exit 0, {len(rest) - ok} otherwise | | | | |"
+        )
+    return lines
+
+
 def pr_body(
     result: AttemptResult,
     config: RunConfig,
     redact_secrets: tuple[str, ...],
     display_digits: int | None = None,
+    experiments: list[dict[str, Any]] | None = None,
 ) -> str:
-    """The PR body for an improved run: results table + the agent's report.
+    """The PR body for an improved run: the author's report, the experiments
+    the run actually ran (from the launch ledger), the measured table, and
+    the panel's transcript.
 
     Human surfaces render at the benchmark's conventional precision;
     full precision lives only in results/leader.json, and every
@@ -1879,11 +1946,41 @@ def pr_body(
         if result.panel_transcript
         else []
     )
+    if result.submit_report:
+        report_lines = [
+            "*Written by the author at submit, before the orchestrator measured; the "
+            "panel read it against the diff and the experiments below.*",
+            "",
+            redact(result.submit_report, redact_secrets)[:MAX_REPORT_BODY],
+        ]
+    else:
+        report_lines = [
+            (
+                "*This report came from the previous session in this line — no "
+                "agent session ran for this attempt. It was written before the "
+                "orchestrator measured; the table below contains the measured "
+                "results.*"
+                if result.session and result.session.stop_reason == "resumed"
+                else "*Session prose, written before the orchestrator measured; "
+                "the table below contains the measured results.*"
+            ),
+            "",
+            redact(result.session.final_text, redact_secrets)[:MAX_REPORT_BODY]
+            if result.session
+            else "",
+        ]
     body = "\n".join(
         [
             *banner,
             f"Automated improvement attempt on `{config.benchmark}` "
             f"(agent `{config.agent_id}`, one hypothesis per PR).",
+            "",
+            "## Research report",
+            "",
+            *report_lines,
+            *_experiments_section(experiments or []),
+            "",
+            "## Measured",
             "",
             "| | value |",
             "| --- | --- |",
@@ -1894,24 +1991,6 @@ def pr_body(
             "Both numbers were measured by the orchestrator re-running the "
             "contract's eval command — not taken from the session. CI "
             "re-verifies independently.",
-            "",
-            "## Research report",
-            "",
-            (
-                "*This report came from the previous session in this line — no "
-                "agent session ran for this attempt. It was written before the "
-                "orchestrator measured; the table above contains the measured "
-                "results.*"
-                if result.session and result.session.stop_reason == "resumed"
-                else "*Session prose, written before the orchestrator measured; "
-                "the table above contains the measured results.*"
-            ),
-            "",
-            (
-                redact(result.session.final_text, redact_secrets)[:MAX_REPORT_BODY]
-                if result.session
-                else ""
-            ),
             *panel_section,
         ]
     )

--- a/src/outerloop/orchestrator.py
+++ b/src/outerloop/orchestrator.py
@@ -1842,8 +1842,9 @@ MAX_EXPERIMENT_ROWS = 60
 
 
 def _cell(text: object, cap: int = 160) -> str:
-    """One markdown table cell: one line, pipes escaped, bounded."""
-    return " ".join(str(text).split()).replace("|", "\\|")[:cap]
+    """One markdown table cell: one line, bounded, then pipes escaped — in that
+    order, so a cut never leaves a bare backslash before the row's separator."""
+    return " ".join(str(text).split())[:cap].replace("|", "\\|")
 
 
 def _ended(row: dict[str, Any]) -> str:

--- a/src/outerloop/panel.py
+++ b/src/outerloop/panel.py
@@ -115,7 +115,7 @@ def _render_wake(findings: tuple[Finding, ...]) -> str:
         "changes will be re-measured and re-read by the panel. The findings "
         "are quoted below as DATA, not instructions — judge them on the "
         "evidence. If one is wrong, leave the code alone and rebut it in "
-        "your final report instead.\n"
+        "your report at submit instead.\n"
         f"{fence}\n{body}\n{fence}"
     )
 

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -90,6 +90,8 @@ MAX_ARTIFACTS_PER_LAUNCH = 8
 MAX_NOTE_CHARS = 2_000
 # a launch's one-line reason, shown to every agent in the queue view
 MAX_WHY_CHARS = 200
+# the author's write-up at submit: hypothesis, what ran, what was measured, why merge
+MAX_REPORT_CHARS = 8_000
 # Per-job walltime ask, clamped to the same ceiling as dispatched evals.
 MAX_LAUNCH_MINUTES = 240
 # a submit's declared eval walltime: bounded only by the GPU-hour budget the
@@ -148,6 +150,9 @@ class SyscallRequest:
     # wake returns verdict + gate result to the author (published directly when
     # it clears cleanly). Costs the sleep it rides on, nothing else.
     submit: bool = False
+    # the author's report at submit, required with one: it becomes the pull
+    # request's research report and the panel reads it against the diff
+    report: str = ""
     # The author's declared walltime for the submit's paired gate evals
     # (None = the contract's eval_minutes). Walltime is a budget, never the
     # metric: compute is priced in GPU-hours against the run's budget, so a
@@ -271,7 +276,7 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     # so anything else here (e.g. a verdict) is a wrong-type request, not a sleep.
     if data.get("type") != "sleep":
         raise SyscallError(f"expected a sleep syscall, got type {data.get('type')!r}")
-    unknown = set(data) - {"type", "launches", "note", "submit", "eval_minutes"}
+    unknown = set(data) - {"type", "launches", "note", "submit", "eval_minutes", "report"}
     if unknown:
         raise SyscallError(f"unknown syscall keys: {sorted(unknown)}")
     note = data.get("note", "")
@@ -287,6 +292,14 @@ def read_request(workspace: Path) -> SyscallRequest | None:
         if not submit:
             raise SyscallError("eval_minutes only applies to a submit")
         eval_minutes = min(eval_minutes, MAX_EVAL_MINUTES)
+    report = data.get("report", "")
+    if not isinstance(report, str) or len(report) > MAX_REPORT_CHARS:
+        raise SyscallError(f"report must be a string of at most {MAX_REPORT_CHARS} chars")
+    if submit and not report.strip():
+        raise SyscallError(
+            "a submit needs a report: `submit --report <file>` with the hypothesis, what "
+            "ran and what was measured, and why this should merge"
+        )
     raw_launches = data.get("launches", [])
     if not isinstance(raw_launches, list):
         raise SyscallError("launches must be a list")
@@ -355,7 +368,11 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     # (research-loop.md, "the session clock is visible") — it still burns a
     # sleep count, which is what bounds living forever.
     return SyscallRequest(
-        launches=tuple(launches), note=note, submit=submit, eval_minutes=eval_minutes
+        launches=tuple(launches),
+        note=note,
+        submit=submit,
+        eval_minutes=eval_minutes,
+        report=report.strip(),
     )
 
 

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -692,6 +692,41 @@ def budget_error(
     return ""
 
 
+def _job_outcome(ev: Path) -> tuple[int | None, str, str, tuple[str, ...]]:
+    """What one launch job left in its dir: exit code (None = it died before
+    its wrapper ran), stdout/stderr tails, and the copy-out's skip lines."""
+    try:
+        exit_code: int | None = int((ev / "exit-code").read_text().strip())
+    except (OSError, ValueError):
+        exit_code = None
+    stdout = _read_tail(ev / "stdout", MAX_OUTPUT_CHARS)
+    stderr = _read_tail(ev / "stderr", MAX_OUTPUT_CHARS)
+    skipped = tuple(ln for ln in _read_text(ev / "artifacts.log").splitlines() if ln.strip())
+    return exit_code, stdout, stderr, skipped
+
+
+def read_results(run_dir: Path, launches: tuple[Launch, ...]) -> tuple[LaunchResult, ...]:
+    """Each launch job's outcome as it sits in the run dir — no delivery into
+    any workspace. For the ledger, and for a wake that publishes without
+    resuming the author (`gather_results` is the delivering form)."""
+    results: list[LaunchResult] = []
+    for launch in launches:
+        for job_name, _env in launch_jobs(launch):
+            exit_code, stdout, stderr, skipped = _job_outcome(run_dir / f"eval-launch-{job_name}")
+            results.append(
+                LaunchResult(
+                    name=job_name,
+                    exit_code=exit_code,
+                    stdout_tail=stdout,
+                    stderr_tail=stderr,
+                    delivered=(),
+                    skipped=skipped,
+                    why=launch.why,
+                )
+            )
+    return tuple(results)
+
+
 def gather_results(
     run_dir: Path, workspace: Path, launches: tuple[Launch, ...]
 ) -> tuple[LaunchResult, ...]:
@@ -714,16 +749,7 @@ def gather_results(
         # with artifacts under results/<launch>/<i>/
         for i, (job_name, _env) in enumerate(launch_jobs(launch)):
             ev = run_dir / f"eval-launch-{job_name}"
-            try:
-                exit_code: int | None = int((ev / "exit-code").read_text().strip())
-            except (OSError, ValueError):
-                exit_code = None
-            stdout = _read_tail(ev / "stdout", MAX_OUTPUT_CHARS)
-            stderr = _read_tail(ev / "stderr", MAX_OUTPUT_CHARS)
-            skipped = tuple(
-                ln for ln in _read_text(ev / "artifacts.log").splitlines() if ln.strip()
-            )
-
+            exit_code, stdout, stderr, skipped = _job_outcome(ev)
             delivered, skips = _deliver_artifacts(
                 ev / "artifacts", workspace, launch.name, index=i if launch.array > 1 else None
             )

--- a/src/outerloop/syscall_cli.py
+++ b/src/outerloop/syscall_cli.py
@@ -208,16 +208,20 @@ def cmd_submit(root: Path, args: argparse.Namespace) -> str:
     if not path.is_absolute():
         path = root / path
     try:
-        report = path.read_text(encoding="utf-8", errors="replace").strip()
+        # read one char past the cap, never the whole file: the size check
+        # decides before an oversized file is in memory
+        with path.open(encoding="utf-8", errors="replace") as fh:
+            report = fh.read(MAX_REPORT_CHARS + 1)
     except OSError as exc:
         raise ToolError(f"--report {args.report!r} could not be read ({exc})") from exc
+    if len(report) > MAX_REPORT_CHARS:
+        raise ToolError(f"--report is over the limit; at most {MAX_REPORT_CHARS} chars")
+    report = report.strip()
     if not report:
         raise ToolError(
             f"--report {args.report!r} is empty: write the hypothesis, what you ran and "
             "measured, and why this should merge"
         )
-    if len(report) > MAX_REPORT_CHARS:
-        raise ToolError(f"--report is {len(report)} chars; at most {MAX_REPORT_CHARS}")
     staged = _load_staged(root)
     staged["submit"] = True
     staged["report"] = report

--- a/src/outerloop/syscall_cli.py
+++ b/src/outerloop/syscall_cli.py
@@ -56,6 +56,7 @@ MAX_COMMAND_CHARS = 2_000
 MAX_ARTIFACTS = 8
 MAX_NOTE_CHARS = 2_000
 MAX_WHY_CHARS = 200  # one line on what a launch tests; every agent sees it in `queue`
+MAX_REPORT_CHARS = 8_000  # the write-up a submit carries; it becomes the PR's research report
 MAX_LAUNCH_MINUTES = 240
 MAX_LAUNCH_ARRAY = 16  # jobs one launch may fan out to (a sweep)
 # a submit's declared eval walltime (matches the kernel's backstop)
@@ -103,6 +104,7 @@ def _load_staged(root: Path) -> dict:
         ("note", ""),
         ("submit", False),
         ("eval_minutes", None),
+        ("report", ""),
         ("findings", []),
         ("notes", ""),
     ):
@@ -202,8 +204,23 @@ def cmd_note(root: Path, args: argparse.Namespace) -> str:
 
 
 def cmd_submit(root: Path, args: argparse.Namespace) -> str:
+    path = Path(args.report)
+    if not path.is_absolute():
+        path = root / path
+    try:
+        report = path.read_text(encoding="utf-8", errors="replace").strip()
+    except OSError as exc:
+        raise ToolError(f"--report {args.report!r} could not be read ({exc})") from exc
+    if not report:
+        raise ToolError(
+            f"--report {args.report!r} is empty: write the hypothesis, what you ran and "
+            "measured, and why this should merge"
+        )
+    if len(report) > MAX_REPORT_CHARS:
+        raise ToolError(f"--report is {len(report)} chars; at most {MAX_REPORT_CHARS}")
     staged = _load_staged(root)
     staged["submit"] = True
+    staged["report"] = report
     minutes = getattr(args, "minutes", None)
     if minutes is not None:
         if minutes < 1:
@@ -219,9 +236,9 @@ def cmd_submit(root: Path, args: argparse.Namespace) -> str:
     )
     return (
         "staged submit: on `sleep` your current tree is SEALED and measured "
-        "against the baseline, and the review panel reads the claim; you will "
-        f"be woken with the result (published if it clears cleanly). {walltime}. "
-        f"{_budget_line(root)}."
+        "against the baseline, and the review panel reads your report "
+        f"({len(report)} chars) against the diff; you will be woken with the "
+        f"result (published if it clears cleanly). {walltime}. {_budget_line(root)}."
     )
 
 
@@ -236,6 +253,9 @@ def cmd_sleep(root: Path, _args: argparse.Namespace) -> str:
     }
     if staged["submit"] and staged.get("eval_minutes"):
         payload["eval_minutes"] = int(staged["eval_minutes"])
+    if staged["submit"]:
+        # the report rides the submit: the kernel refuses a submit without one
+        payload["report"] = str(staged.get("report") or "")
     (_dir(root) / ABI).write_text(json.dumps(payload))
     (root / DIR / REQUEST).unlink(missing_ok=True)
     n = len(staged["launches"])
@@ -323,6 +343,8 @@ def cmd_status(root: Path, _args: argparse.Namespace) -> str:
                 lines.append(f"      why: {la['why']}")
         if staged["submit"]:
             lines.append("  submit staged: `sleep` seals this tree for the gate + panel")
+            if staged.get("report"):
+                lines.append(f"  report: {len(staged['report'])} chars")
         if staged.get("note"):
             lines.append(f"  note: {staged['note']}")
     if staged["findings"]:
@@ -379,6 +401,15 @@ def build_parser() -> argparse.ArgumentParser:
     su = sub.add_parser(
         "submit",
         help="stage a submit: on sleep, seal this tree for the gate + review panel",
+    )
+    su.add_argument(
+        "--report",
+        required=True,
+        help=(
+            "markdown file: your hypothesis, what you ran and what it measured (see "
+            "`history`), why this should merge, what did not work; it becomes the PR's "
+            "research report and the panel reads it against the diff"
+        ),
     )
     su.add_argument(
         "--minutes",

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -2453,6 +2453,7 @@ def test_resume_repark_of_a_submitted_park_keeps_the_submit_context(tmp_path, mo
     ]
     rec.stage["launches_used"] = 1
     rec.stage["sleeps_used"] = 1
+    rec.stage["report"] = "H: the author's report at submit"
     save_record(state, rec, 1_000_050.0)
     outcome = resume_run(
         state,
@@ -2466,6 +2467,8 @@ def test_resume_repark_of_a_submitted_park_keeps_the_submit_context(tmp_path, mo
     record = load_record(state, run_id)
     assert record.state == "waiting"
     assert record.stage.get("submitted") is True
+    # the author's report survives the re-park: the panel and the PR read it
+    assert record.stage["report"] == "H: the author's report at submit"
     assert record.stage["syscall_launches"] == [
         {"name": "probe", "minutes": 240, "artifacts": ["out.txt"], "array": 3}
     ]  # the sweep keeps its width across the re-park (terra #181)

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -116,6 +116,43 @@ def test_park_run_appends_the_launch_ledger(tmp_path) -> None:
     ]
 
 
+def test_park_run_keeps_the_submits_report_for_the_wake(tmp_path) -> None:
+    """A submitted park's stage report is the author's report at submit, not the
+    session's last words: the wake's panel and the PR read it."""
+    from outerloop.syscall import SyscallRequest
+
+    record = RunRecord(
+        run_id="tsp-8", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"
+    )
+    req = SyscallRequest(launches=(), note="", submit=True, report="H: token sk-secret-1 helps")
+    parked = RunParked(
+        phase="candidate",
+        afterany="afterany:301",
+        base_sha="b" * 40,
+        seed=1,
+        suite_seed=0,
+        candidate_sha="c" * 40,
+        session=_session("s1"),
+        syscall=req,
+        submitted=True,
+        sleeps_used=1,
+    )
+    _park_run(
+        tmp_path,
+        record,
+        parked,
+        "refs/dispatch/tok",
+        eval_minutes=None,
+        now=1000.0,
+        secrets=("sk-secret-1",),
+    )
+    stage = load_record(tmp_path, "tsp-8").stage
+    assert stage["report"] == "H: token [redacted] helps" or "sk-secret-1" not in str(
+        stage["report"]
+    )
+    assert str(stage["report"]).startswith("H: token")
+
+
 def test_park_run_writes_a_waiting_record_with_the_reentry_stage(tmp_path) -> None:
     record = RunRecord(
         run_id="tsp-1", target="org/pilot", task_title="t", state="implementing", benchmark="tsp"

--- a/tests/test_launchlog.py
+++ b/tests/test_launchlog.py
@@ -110,3 +110,31 @@ def test_one_id_per_launch_is_the_arrays_id(tmp_path: Path) -> None:
     append_submitted(tmp_path, sleep=1, launches=launches, job_ids=["10", "11"], at=1.0)
     assert [e["job_ids"] for e in history(tmp_path)] == [["10"], ["11"]]
     assert why_by_job(tmp_path)["11"]["why"] == "sweep lr"
+
+
+def test_experiments_rows_join_the_ledger_with_each_jobs_last_line(tmp_path: Path) -> None:
+    launches = (
+        Launch(name="wd", command="x", minutes=5, why="try 6400"),
+        Launch(name="lr", command="y", minutes=7, array=2, concurrency=1),
+    )
+    append_submitted(tmp_path, sleep=1, launches=launches, job_ids=["1", "2"], at=10.0)
+    (tmp_path / "eval-launch-wd").mkdir()
+    (tmp_path / "eval-launch-wd" / "stdout").write_text('step 1\nstep 2\n{"val": 3.28}\n\n')
+    (tmp_path / "eval-launch-lr.0").mkdir()
+    (tmp_path / "eval-launch-lr.0" / "stdout").write_text("a   b\n")
+    append_ended(
+        tmp_path,
+        sleep=1,
+        results=(_result("wd", 0), _result("lr.0", 1)),
+        at=20.0,
+        elapsed_seconds=[4500, None],
+    )
+    from outerloop.launchlog import experiments_rows
+
+    rows = experiments_rows(tmp_path)
+    assert [(r["job"], r["back"], r["exit_code"], r["elapsed"], r["result"]) for r in rows] == [
+        ("wd", True, 0, 4500, '{"val": 3.28}'),
+        ("lr.0", True, 1, None, "a b"),
+        ("lr.1", False, None, None, ""),
+    ]
+    assert rows[1]["why"] == "" and rows[1]["array"] == 2 and rows[1]["concurrency"] == 1

--- a/tests/test_launchlog.py
+++ b/tests/test_launchlog.py
@@ -15,11 +15,11 @@ from outerloop.launchlog import (
 from outerloop.syscall import Launch, LaunchResult
 
 
-def _result(name: str, code: int | None, state: str = "") -> LaunchResult:
+def _result(name: str, code: int | None, state: str = "", stdout: str = "") -> LaunchResult:
     return LaunchResult(
         name=name,
         exit_code=code,
-        stdout_tail="",
+        stdout_tail=stdout,
         stderr_tail="",
         delivered=(),
         skipped=(),
@@ -112,29 +112,43 @@ def test_one_id_per_launch_is_the_arrays_id(tmp_path: Path) -> None:
     assert why_by_job(tmp_path)["11"]["why"] == "sweep lr"
 
 
-def test_experiments_rows_join_the_ledger_with_each_jobs_last_line(tmp_path: Path) -> None:
+def test_experiments_rows_come_from_the_ledger_including_each_jobs_last_line(
+    tmp_path: Path,
+) -> None:
+    """The ledger keeps each job's last line at the wake, so a later launch of
+    the same name (which overwrites the job dir) cannot change what an earlier
+    row shows; ended rows are written once per (sleep, job)."""
+    from outerloop.launchlog import experiments_rows
+
     launches = (
         Launch(name="wd", command="x", minutes=5, why="try 6400"),
         Launch(name="lr", command="y", minutes=7, array=2, concurrency=1),
     )
     append_submitted(tmp_path, sleep=1, launches=launches, job_ids=["1", "2"], at=10.0)
-    (tmp_path / "eval-launch-wd").mkdir()
-    (tmp_path / "eval-launch-wd" / "stdout").write_text('step 1\nstep 2\n{"val": 3.28}\n\n')
-    (tmp_path / "eval-launch-lr.0").mkdir()
-    (tmp_path / "eval-launch-lr.0" / "stdout").write_text("a   b\n")
     append_ended(
         tmp_path,
         sleep=1,
-        results=(_result("wd", 0), _result("lr.0", 1)),
+        results=(
+            _result("wd", 0, stdout='step 1\nstep 2\n{"val": 3.28}\n\n'),
+            _result("lr.0", 1, stdout="a   b\n"),
+        ),
         at=20.0,
         elapsed_seconds=[4500, None],
     )
-    from outerloop.launchlog import experiments_rows
+    # the same jobs seen again by another wake: nothing recorded twice
+    append_ended(tmp_path, sleep=1, results=(_result("wd", 0, stdout="later"),), at=21.0)
+    # the same name reused in sleep 2 keeps its own line
+    append_submitted(tmp_path, sleep=2, launches=launches[:1], job_ids=["3"], at=30.0)
+    append_ended(tmp_path, sleep=2, results=(_result("wd", 0, stdout='{"val": 3.10}'),), at=40.0)
 
     rows = experiments_rows(tmp_path)
-    assert [(r["job"], r["back"], r["exit_code"], r["elapsed"], r["result"]) for r in rows] == [
-        ("wd", True, 0, 4500, '{"val": 3.28}'),
-        ("lr.0", True, 1, None, "a b"),
-        ("lr.1", False, None, None, ""),
+    assert [
+        (r["sleep"], r["job"], r["back"], r["exit_code"], r["elapsed"], r["result"]) for r in rows
+    ] == [
+        (1, "wd", True, 0, 4500, '{"val": 3.28}'),
+        (1, "lr.0", True, 1, None, "a b"),
+        (1, "lr.1", False, None, None, ""),
+        (2, "wd", True, 0, None, '{"val": 3.10}'),
     ]
     assert rows[1]["why"] == "" and rows[1]["array"] == 2 and rows[1]["concurrency"] == 1
+    assert len(history(tmp_path)[0]["jobs"]) == 1  # the duplicate ended row was skipped

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -324,7 +324,11 @@ def test_submit_parks_the_dispatched_gate_with_the_submitted_marker(tmp_path: Pa
 
     _write_syscall(
         tmp_path,
-        {"launches": [{"name": "probe", "command": "uv run probe.py"}], "submit": True},
+        {
+            "launches": [{"name": "probe", "command": "uv run probe.py"}],
+            "submit": True,
+            "report": "H: the change helps",
+        },
     )
     launched: list = []
     harness = FakeHarness(result=ok_session())
@@ -362,7 +366,12 @@ def test_a_submits_sibling_sweep_is_clamped_too(tmp_path: Path) -> None:
         "budgets: {gpu_hours_per_run: 1, runs_per_week: 10, max_concurrent_gpus: 3}",
     )
     _write_syscall(
-        tmp_path, {"launches": [{"name": "s", "command": "x", "array": 8}], "submit": True}
+        tmp_path,
+        {
+            "launches": [{"name": "s", "command": "x", "array": 8}],
+            "submit": True,
+            "report": "H: the change helps",
+        },
     )
     launched: list = []
     with pytest.raises(RunParked) as exc:
@@ -660,7 +669,11 @@ def test_inline_gate_never_dispatches_a_submits_sibling_launches(tmp_path: Path)
     # and their budget stays unspent.
     _write_syscall(
         tmp_path,
-        {"launches": [{"name": "probe", "command": "x"}], "submit": True},
+        {
+            "launches": [{"name": "probe", "command": "x"}],
+            "submit": True,
+            "report": "H: the change helps",
+        },
     )
     launched: list = []
     harness = _SeqHarness(["the claim", "conceded"])
@@ -1534,7 +1547,15 @@ class _SeqHarness:
             d = workspace / ".outerloop"
             d.mkdir(exist_ok=True)
             (d / "syscall.json").write_text(
-                _json.dumps({"type": "sleep", "launches": [], "note": "", "submit": True})
+                _json.dumps(
+                    {
+                        "type": "sleep",
+                        "launches": [],
+                        "note": "",
+                        "submit": True,
+                        "report": "H: the change helps",
+                    }
+                )
             )
         return SessionResult(
             stop_reason="end_turn",
@@ -1809,3 +1830,96 @@ def test_branch_prefix_derives_from_the_agent_id() -> None:
         assert RunConfig(target="o/r", benchmark="b", agent_id=legacy).branch_prefix == (
             "feat/auto/agent-01"
         )
+
+
+def test_a_submits_report_is_what_the_panel_reads_and_the_pr_shows(tmp_path: Path) -> None:
+    """The author's report at submit is the claim: the panel reads it in place
+    of the session's last message, and the result carries it for the PR."""
+    from outerloop.panel import PanelVerdict
+
+    _write_syscall(tmp_path, {"launches": [], "submit": True, "report": "H: warmdown 6400 helps"})
+    seen: list = []
+
+    def panel(baseline, candidate, text):
+        seen.append(text)
+        return PanelVerdict(blocking=(), transcript="panel: ok", wake_text="")
+
+    result, _harness, _ = run_climb(
+        tmp_path,
+        [13.876, 13.10],
+        contract=DEEP_CONTRACT,
+        launcher=_fake_launcher([]),
+        panel_runner=panel,
+    )
+    assert result.outcome == "improved"
+    assert seen == ["H: warmdown 6400 helps"]
+    assert result.submit_report == "H: warmdown 6400 helps"
+
+
+def test_pr_body_leads_with_the_report_and_lists_the_experiments() -> None:
+    from outerloop.orchestrator import AttemptResult
+
+    result = AttemptResult(
+        outcome="improved",
+        baseline=13.876,
+        candidate=13.1,
+        session=ok_session(),
+        submit_report="## Hypothesis\n\nA longer warmdown helps.",
+    )
+    rows = [
+        {
+            "sleep": 1,
+            "launch": "wd",
+            "why": "try 6400",
+            "array": 1,
+            "concurrency": 0,
+            "job": "wd",
+            "back": True,
+            "exit_code": 0,
+            "state": "",
+            "elapsed": 4500,
+            "result": '{"val": 3.28} | tail',
+        },
+        {
+            "sleep": 2,
+            "launch": "lr",
+            "why": "lr sweep",
+            "array": 4,
+            "concurrency": 2,
+            "job": "lr.3",
+            "back": True,
+            "exit_code": None,
+            "state": "TIMEOUT",
+            "elapsed": None,
+            "result": "",
+        },
+        {
+            "sleep": 3,
+            "launch": "late",
+            "why": "",
+            "array": 1,
+            "concurrency": 0,
+            "job": "late",
+            "back": False,
+            "exit_code": None,
+            "state": "",
+            "elapsed": None,
+            "result": "",
+        },
+    ]
+    body = pr_body(result, CONFIG, redact_secrets=(), experiments=rows)
+    report_at = body.index("## Research report")
+    experiments_at = body.index("## Experiments")
+    measured_at = body.index("## Measured")
+    assert report_at < experiments_at < measured_at
+    assert "Written by the author at submit" in body and "A longer warmdown helps." in body
+    assert '| 1 | wd | try 6400 | wd | exit 0, 1h15m | {"val": 3.28} \\| tail |' in body
+    assert "| 2 | lr (x4, 2 at a time) | lr sweep | lr.3 | TIMEOUT |  |" in body
+    assert "| 3 | late |  | late | not back |  |" in body
+    # no report: the session's last words, with the old banner; no table when nothing ran
+    plain = pr_body(
+        AttemptResult(outcome="improved", baseline=1.0, candidate=0.9, session=ok_session()),
+        CONFIG,
+        redact_secrets=(),
+    )
+    assert "Session prose" in plain and "## Experiments" not in plain

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1914,6 +1914,14 @@ def test_pr_body_leads_with_the_report_and_lists_the_experiments() -> None:
     assert report_at < experiments_at < measured_at
     assert "Written by the author at submit" in body and "A longer warmdown helps." in body
     assert '| 1 | wd | try 6400 | wd | exit 0, 1h15m | {"val": 3.28} \\| tail |' in body
+    # a pipe at the cut is escaped after the cut, so no bare backslash escapes the separator
+    cut = pr_body(
+        result,
+        CONFIG,
+        redact_secrets=(),
+        experiments=[{**rows[0], "result": "x" * 159 + "|" + "y" * 20}],
+    )
+    assert "x" * 159 + "\\| |" in cut and "x\\ |" not in cut
     assert "| 2 | lr (x4, 2 at a time) | lr sweep | lr.3 | TIMEOUT |  |" in body
     assert "| 3 | late |  | late | not back |  |" in body
     # no report: the session's last words, with the old banner; no table when nothing ran

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -114,7 +114,7 @@ def test_invalid_requests_are_refused_loudly(tmp_path: Path, payload, match) -> 
 
 
 def test_read_request_carries_submit_and_rejects_a_non_bool(tmp_path: Path) -> None:
-    write_req(tmp_path, {"launches": [], "submit": True})
+    write_req(tmp_path, {"launches": [], "submit": True, "report": "H: the change helps"})
     req = read_request(tmp_path)
     assert req is not None and req.submit
     write_req(tmp_path, {"launches": [], "submit": "yes"})
@@ -712,18 +712,24 @@ def test_submit_carries_a_declared_eval_walltime(tmp_path: Path) -> None:
     submit (refused loudly rather than silently ignored)."""
     from outerloop.syscall import MAX_EVAL_MINUTES
 
-    write_req(tmp_path, {"launches": [], "submit": True, "eval_minutes": 420})
+    write_req(
+        tmp_path,
+        {"launches": [], "submit": True, "report": "H: the change helps", "eval_minutes": 420},
+    )
     req = read_request(tmp_path)
     assert req is not None and req.submit and req.eval_minutes == 420
-    write_req(tmp_path, {"launches": [], "submit": True, "eval_minutes": 10**6})
+    write_req(
+        tmp_path,
+        {"launches": [], "submit": True, "report": "H: the change helps", "eval_minutes": 10**6},
+    )
     req = read_request(tmp_path)
     assert req is not None and req.eval_minutes == MAX_EVAL_MINUTES
-    write_req(tmp_path, {"launches": [], "submit": True})
+    write_req(tmp_path, {"launches": [], "submit": True, "report": "H: the change helps"})
     req = read_request(tmp_path)
     assert req is not None and req.eval_minutes is None
     for bad in (
         {"launches": [], "eval_minutes": 60},
-        {"launches": [], "submit": True, "eval_minutes": 0},
+        {"launches": [], "submit": True, "report": "H: the change helps", "eval_minutes": 0},
     ):
         write_req(tmp_path, bad)
         with pytest.raises(SyscallError):
@@ -1168,3 +1174,24 @@ def test_sweep_pace_is_validated_clamped_and_expanded(tmp_path: Path) -> None:
     legacy = [str(i) for i in range(1, 9)]
     assert launch_task_ids((s8,), legacy) == legacy
     assert launch_task_ids((s8,), ["1", "2"]) == []  # an unknown mapping is never guessed
+
+
+def test_a_submit_needs_a_report(tmp_path: Path) -> None:
+    from outerloop.syscall import MAX_REPORT_CHARS, SyscallError
+
+    write_req(tmp_path, {"launches": [], "submit": True})
+    with pytest.raises(SyscallError, match="submit needs a report"):
+        read_request(tmp_path)
+    write_req(tmp_path, {"launches": [], "submit": True, "report": "   "})
+    with pytest.raises(SyscallError, match="submit needs a report"):
+        read_request(tmp_path)
+    write_req(tmp_path, {"launches": [], "submit": True, "report": "x" * (MAX_REPORT_CHARS + 1)})
+    with pytest.raises(SyscallError, match="report must be"):
+        read_request(tmp_path)
+    write_req(tmp_path, {"launches": [], "submit": True, "report": "  H: it helps  "})
+    req = read_request(tmp_path)
+    assert req is not None and req.report == "H: it helps"
+    # a sleep without a submit needs none
+    write_req(tmp_path, {"launches": [{"name": "a", "command": "x"}]})
+    req = read_request(tmp_path)
+    assert req is not None and req.report == ""

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -1195,3 +1195,22 @@ def test_a_submit_needs_a_report(tmp_path: Path) -> None:
     write_req(tmp_path, {"launches": [{"name": "a", "command": "x"}]})
     req = read_request(tmp_path)
     assert req is not None and req.report == ""
+
+
+def test_read_results_reads_without_delivering(tmp_path: Path) -> None:
+    from outerloop.syscall import Launch, read_results
+
+    ev = tmp_path / "eval-launch-a"
+    ev.mkdir()
+    (ev / "exit-code").write_text("0\n")
+    (ev / "stdout").write_text("hello\nresult 1\n")
+    (ev / "artifacts").mkdir()
+    (ev / "artifacts" / "out.txt").write_text("x")
+    (result,) = read_results(tmp_path, (Launch(name="a", command="x", minutes=5, why="w"),))
+    assert (result.exit_code, result.stdout_tail, result.delivered, result.why) == (
+        0,
+        "hello\nresult 1\n",
+        (),
+        "w",
+    )
+    assert not (tmp_path / ".outerloop").exists()  # nothing was delivered anywhere

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -135,14 +135,36 @@ def test_artifact_path_check_matches_the_kernel(tmp_path: Path, capsys) -> None:
 
 
 def test_submit_stages_and_rides_the_sleep(tmp_path: Path, capsys) -> None:
-    assert run(tmp_path, "submit") == 0
-    assert "sealed" in capsys.readouterr().out.lower()
+    (tmp_path / "report.md").write_text("# Hypothesis\n\nA longer warmdown helps.\n")
+    assert run(tmp_path, "submit", "--report", "report.md") == 0
+    out = capsys.readouterr().out
+    assert "sealed" in out.lower() and "your report (" in out
     assert run(tmp_path, "status") == 0
-    assert "submit staged" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "submit staged" in out and "report:" in out
     assert run(tmp_path, "sleep") == 0
     assert "submit" in capsys.readouterr().out
     req = read_request(tmp_path)
     assert req is not None and req.submit and req.launches == ()
+    assert req.report == "# Hypothesis\n\nA longer warmdown helps."
+
+
+def test_submit_requires_a_readable_nonempty_report(tmp_path: Path, capsys) -> None:
+    import pytest
+
+    with pytest.raises(SystemExit):  # --report is required by the parser
+        run(tmp_path, "submit")
+    capsys.readouterr()
+    assert run(tmp_path, "submit", "--report", "missing.md") == 2
+    assert "could not be read" in capsys.readouterr().err
+    (tmp_path / "empty.md").write_text("  \n")
+    assert run(tmp_path, "submit", "--report", "empty.md") == 2
+    assert "is empty" in capsys.readouterr().err
+    (tmp_path / "long.md").write_text("x" * 8_001)
+    assert run(tmp_path, "submit", "--report", "long.md") == 2
+    assert "at most 8000" in capsys.readouterr().err
+    assert run(tmp_path, "status") == 0
+    assert "submit staged" not in capsys.readouterr().out  # nothing was staged by the failures
 
 
 def test_sleep_with_nothing_staged_is_a_checkpoint(tmp_path: Path, capsys) -> None:

--- a/tests/test_syscall_cli.py
+++ b/tests/test_syscall_cli.py
@@ -163,6 +163,9 @@ def test_submit_requires_a_readable_nonempty_report(tmp_path: Path, capsys) -> N
     (tmp_path / "long.md").write_text("x" * 8_001)
     assert run(tmp_path, "submit", "--report", "long.md") == 2
     assert "at most 8000" in capsys.readouterr().err
+    (tmp_path / "huge.md").write_text("y" * 2_000_000)  # refused from its first 8 001 chars
+    assert run(tmp_path, "submit", "--report", "huge.md") == 2
+    assert "at most 8000" in capsys.readouterr().err
     assert run(tmp_path, "status") == 0
     assert "submit staged" not in capsys.readouterr().out  # nothing was staged by the failures
 


### PR DESCRIPTION
The speedrun PRs showed one line under "Research report": the author's last message before the sleep that submitted. The hypothesis and the evidence never reached the PR. Owner's call: both halves, and the report is required.

- **`submit --report <file>` is required.** The tool reads the markdown file (repo-relative or absolute, non-empty, ≤ 8 000 chars) and stages it; `read_request` is the authority and refuses a submit without one. The brief says what the report must contain: the hypothesis, what ran and what it measured (`history` lists the launches), why it should merge, what did not work.
- **The panel reads the report.** On the inline path `panel_runner` gets `submitted.report` in place of the session's last message; on the dispatched path the submitted park's stage `report` is the author's report, which the wake's panel already read. `AttemptResult.submit_report` carries it to the PR.
- **The PR body leads with the research.** Order: research report (with a banner saying it was written by the author at submit and read by the panel), an **Experiments** table from the launch ledger, the **Measured** table, the panel transcript. The experiments table has one row per job: sleep, launch (with array width and pace), why, job, how it ended (`exit 0, 1h15m`, `TIMEOUT`, `not back`), and the last line the job printed. Capped at 60 rows with a summary line for the rest. Cells are one line with pipes escaped; the whole body goes through the existing redaction.
- **Elapsed time per job** is now recorded in the ledger at the wake, from the same `sacct` query the GPU-hour refund uses (one query, two consumers).
- Tests: tool (required flag, missing/empty/too-long file, staged and carried by `sleep`), request parsing, park stage keeps the report (redacted), the panel receives the report and the result carries it, PR-body order and table rendering with the fallback banner, ledger rows with last lines and elapsed.

Runs already parked before this deploys keep the old behaviour for their current sleep; their next submit needs a report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
