### PR TITLE
A report-less submit is a refusal wake; wakes refresh the session's tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- A submit without a report is refused with a wake the author can act on, not
+  a dead run, and a wake rewrites the session's tool from the running kernel,
+  so a session that started before a deploy has today's verbs and flags.
 - The pull request carries the research. `submit --report <file>` is required:
   the author's write-up (hypothesis, what ran and what was measured, why it
   should merge, what did not work) becomes the PR's research report, and the

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -99,6 +99,7 @@ from outerloop.syscall import (
 )
 from outerloop.syscall import ensure_excluded as syscall_excluded
 from outerloop.syscall import install_tool as syscall_install_tool
+from outerloop.syscall import refresh_tool as syscall_refresh_tool
 from outerloop.syscall import write_budget as syscall_write_budget
 from outerloop.syscall import write_siblings as syscall_write_siblings
 from outerloop.verifier import MAX_CLAIM_CHARS
@@ -897,6 +898,9 @@ def _wake_author_sleep(
     if extra_update:
         # a submitted park's gate/panel feedback leads; launch results follow
         wake_text = f"{extra_update}\n\n{wake_text}"
+    # the tool the session invokes comes from THIS kernel: a session that
+    # started under an older one gets today's verbs and flags at its wake
+    _best_effort("tool refresh", lambda: syscall_refresh_tool(workspace))
     _best_effort(
         "budget refresh",
         lambda: write_budget(

--- a/src/outerloop/orchestrator.py
+++ b/src/outerloop/orchestrator.py
@@ -50,6 +50,7 @@ from outerloop.syscall import (
     clamp_concurrency,
     evals_gpu_hours,
     launches_gpu_hours,
+    refresh_tool,
 )
 from outerloop.syscall import budget_error as syscall_budget_error
 from outerloop.syscall import read_request as read_syscall_request
@@ -1377,6 +1378,10 @@ def attempt_once(
         """Resume the author session with `prompt`: None on success (session
         advanced), else the terminal AttemptResult for the failed resume."""
         nonlocal session
+        # the tool the author is about to use is this kernel's, whatever the
+        # session started with (a wake refreshed it too; this covers a refusal)
+        with contextlib.suppress(Exception):
+            refresh_tool(workspace)
         with _watched():
             wake_result = run_role(
                 spec, harness, prompt, workspace, resume_session_id=session.session_id
@@ -1464,7 +1469,9 @@ def attempt_once(
                     gpus=bench.gpus,
                 ):
                     main_evals = 1
-            if request.submit and failed_gate is not None:
+            # a report-less resubmit never rides the failed-gate fast path: it
+            # falls through to the refusal below like any other missing report
+            if request.submit and request.report and failed_gate is not None:
                 # a resubmit of the tree the gate already turned down: nothing
                 # to budget or charge — the verdict is reused below (the sleep
                 # still counts, so unchanged resubmits stay bounded). An eval

--- a/src/outerloop/orchestrator.py
+++ b/src/outerloop/orchestrator.py
@@ -44,6 +44,7 @@ from outerloop.role_runner import run_role
 from outerloop.roles import author_spec
 from outerloop.rolespec import RoleSpec
 from outerloop.syscall import (
+    MISSING_REPORT,
     SyscallError,
     SyscallRequest,
     clamp_concurrency,
@@ -1513,6 +1514,11 @@ def attempt_once(
                 suite_gpus=suite_gpus,
                 main_evals=main_evals,
             )
+            if not problem and request.submit and not request.report:
+                # a refusal the author can act on, never a dead run: a session
+                # that started under an older tool learns the flag here (the wake
+                # refreshed its tool) and resubmits with the report
+                problem = MISSING_REPORT
             # a sweep's pace is clamped to the contract's GPU ceiling here, once,
             # before either path — an author-sleep launch or a submit's sibling
             # launches — submits or records it; clamped, never refused

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -622,9 +622,10 @@ def refresh_tool(workspace: Path) -> None:
             st = None
         if st is not None and stat.S_ISDIR(st.st_mode):
             # a directory planted in the tool's place: rename cannot replace
-            # it; the channel fd was opened O_NOFOLLOW, so this path is the
-            # real directory and nothing else
-            shutil.rmtree(workspace / channel_dir(workspace) / "syscall")
+            # it. Removed RELATIVE TO THE CHANNEL FD, never by path — a path
+            # would be re-resolved, and a channel swapped for a symlink in
+            # between would send the removal outside the workspace
+            shutil.rmtree("syscall", dir_fd=dirfd)
         _write_channel(dirfd, "syscall", source, mode=0o755)
     finally:
         os.close(dirfd)

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -295,11 +295,6 @@ def read_request(workspace: Path) -> SyscallRequest | None:
     report = data.get("report", "")
     if not isinstance(report, str) or len(report) > MAX_REPORT_CHARS:
         raise SyscallError(f"report must be a string of at most {MAX_REPORT_CHARS} chars")
-    if submit and not report.strip():
-        raise SyscallError(
-            "a submit needs a report: `submit --report <file>` with the hypothesis, what "
-            "ran and what was measured, and why this should merge"
-        )
     raw_launches = data.get("launches", [])
     if not isinstance(raw_launches, list):
         raise SyscallError("launches must be a list")
@@ -598,6 +593,30 @@ def install_tool(workspace: Path) -> None:
     tool = channel / "syscall"
     tool.write_text(source)
     tool.chmod(0o755)
+
+
+MISSING_REPORT = (
+    "a submit needs a report. Write your hypothesis, what you ran and what it measured, "
+    "why this should merge and what did not work to a markdown file, stage "
+    "`submit --report <file>`, and sleep again."
+)
+
+
+def refresh_tool(workspace: Path) -> None:
+    """Rewrite the installed tool from this kernel's source at a wake, so a
+    session that started under an older kernel gets the current verbs and
+    flags. Only the tool file changes — the channel and everything in it
+    stay — and it is written with a marker's care (a fresh O_EXCL inode,
+    renamed into place), so a `syscall` the session replaced with a symlink
+    is never written through."""
+    from outerloop import syscall_cli
+
+    source = Path(syscall_cli.__file__).read_bytes()
+    dirfd = _channel_fd(workspace)
+    try:
+        _write_channel(dirfd, "syscall", source, mode=0o755)
+    finally:
+        os.close(dirfd)
 
 
 def write_budget(
@@ -1055,14 +1074,14 @@ def _read_done(dirfd: int, name: str = SYNC_DONE) -> float:
         os.close(fd)
 
 
-def _write_channel(dirfd: int, name: str, data: bytes) -> None:
+def _write_channel(dirfd: int, name: str, data: bytes, mode: int = 0o644) -> None:
     """Write `data` to `name` in the channel: a fresh O_EXCL temp inode with an
     unguessable name, then an atomic rename — all relative to the O_NOFOLLOW
     channel fd. Never opens (and O_TRUNCs) an existing inode, so a session
     that hard-links a victim file to the temp name gets a failure instead of a
     truncation; never writes through a planted symlink; never utime()s."""
     tmp = f".{name}.{os.urandom(8).hex()}"
-    fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, 0o644, dir_fd=dirfd)
+    fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, mode, dir_fd=dirfd)
     try:
         view = memoryview(data)
         while view:

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -609,11 +609,22 @@ def refresh_tool(workspace: Path) -> None:
     stay — and it is written with a marker's care (a fresh O_EXCL inode,
     renamed into place), so a `syscall` the session replaced with a symlink
     is never written through."""
+    import shutil
+
     from outerloop import syscall_cli
 
     source = Path(syscall_cli.__file__).read_bytes()
     dirfd = _channel_fd(workspace)
     try:
+        try:
+            st = os.stat("syscall", dir_fd=dirfd, follow_symlinks=False)
+        except FileNotFoundError:
+            st = None
+        if st is not None and stat.S_ISDIR(st.st_mode):
+            # a directory planted in the tool's place: rename cannot replace
+            # it; the channel fd was opened O_NOFOLLOW, so this path is the
+            # real directory and nothing else
+            shutil.rmtree(workspace / channel_dir(workspace) / "syscall")
         _write_channel(dirfd, "syscall", source, mode=0o755)
     finally:
         os.close(dirfd)

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -1095,6 +1095,8 @@ def _write_channel(dirfd: int, name: str, data: bytes, mode: int = 0o644) -> Non
     tmp = f".{name}.{os.urandom(8).hex()}"
     fd = os.open(tmp, os.O_CREAT | os.O_EXCL | os.O_WRONLY | os.O_NOFOLLOW, mode, dir_fd=dirfd)
     try:
+        # the open's mode is filtered by the umask; the tool must stay executable
+        os.fchmod(fd, mode)
         view = memoryview(data)
         while view:
             written = os.write(fd, view)

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1931,3 +1931,16 @@ def test_pr_body_leads_with_the_report_and_lists_the_experiments() -> None:
         redact_secrets=(),
     )
     assert "Session prose" in plain and "## Experiments" not in plain
+
+
+def test_a_submit_without_a_report_is_refused_not_fatal(tmp_path: Path) -> None:
+    """A session under an older tool (no --report flag) submits without a report:
+    the author is woken with the refusal and the flag to use, the run goes on."""
+    _write_syscall(tmp_path, {"launches": [], "submit": True})
+    result, harness, _ = run_climb(
+        tmp_path, [13.876, 13.10], contract=DEEP_CONTRACT, launcher=_fake_launcher([])
+    )
+    assert result.outcome == "improved"  # the run went on after the refusal
+    refusal_text, _ws, resumed = harness.calls[1]
+    assert "REFUSED" in refusal_text and "submit --report <file>" in refusal_text
+    assert resumed == "s1"

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1944,3 +1944,24 @@ def test_a_submit_without_a_report_is_refused_not_fatal(tmp_path: Path) -> None:
     refusal_text, _ws, resumed = harness.calls[1]
     assert "REFUSED" in refusal_text and "submit --report <file>" in refusal_text
     assert resumed == "s1"
+
+
+def test_a_report_less_resubmit_of_a_judged_tree_is_refused_too(tmp_path: Path) -> None:
+    """The failed-gate fast path (same tree the gate already judged) never
+    carries a submit past the report check."""
+    from outerloop.orchestrator import AttemptResult
+
+    _write_syscall(tmp_path, {"launches": [], "submit": True})
+    judged = ("cand1", AttemptResult(outcome="no-improvement", baseline=13.876, candidate=13.9))
+    result, harness, _ = run_climb(
+        tmp_path,
+        [13.876, 13.10],
+        contract=DEEP_CONTRACT,
+        launcher=_fake_launcher([]),
+        judged=judged,
+    )
+    refusal_text, _ws, resumed = harness.calls[1]
+    assert "REFUSED" in refusal_text and "submit --report <file>" in refusal_text
+    assert resumed == "s1"
+    # the run went on: with no new request the judged negative stands, never a dead run
+    assert result.outcome == "no-improvement"

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -1179,12 +1179,14 @@ def test_sweep_pace_is_validated_clamped_and_expanded(tmp_path: Path) -> None:
 def test_a_submit_needs_a_report(tmp_path: Path) -> None:
     from outerloop.syscall import MAX_REPORT_CHARS, SyscallError
 
+    # a submit without a report reads fine — the orchestrator REFUSES it with a
+    # wake the author can act on, never a dead run (an older tool has no flag)
     write_req(tmp_path, {"launches": [], "submit": True})
-    with pytest.raises(SyscallError, match="submit needs a report"):
-        read_request(tmp_path)
+    req = read_request(tmp_path)
+    assert req is not None and req.submit and req.report == ""
     write_req(tmp_path, {"launches": [], "submit": True, "report": "   "})
-    with pytest.raises(SyscallError, match="submit needs a report"):
-        read_request(tmp_path)
+    req = read_request(tmp_path)
+    assert req is not None and req.report == ""
     write_req(tmp_path, {"launches": [], "submit": True, "report": "x" * (MAX_REPORT_CHARS + 1)})
     with pytest.raises(SyscallError, match="report must be"):
         read_request(tmp_path)
@@ -1214,3 +1216,22 @@ def test_read_results_reads_without_delivering(tmp_path: Path) -> None:
         "w",
     )
     assert not (tmp_path / ".outerloop").exists()  # nothing was delivered anywhere
+
+
+def test_refresh_tool_rewrites_only_the_tool_and_never_through_a_symlink(tmp_path: Path) -> None:
+    from outerloop.syscall import install_tool, refresh_tool
+
+    install_tool(tmp_path)
+    channel = tmp_path / ".outerloop"
+    (channel / "budget.json").write_text("{}")
+    tool = channel / "syscall"
+    tool.write_text("# stale tool\n")
+    refresh_tool(tmp_path)
+    assert "def main(" in tool.read_text() and (tool.stat().st_mode & 0o111)
+    assert (channel / "budget.json").exists()  # the channel is untouched
+    victim = tmp_path / "victim"
+    victim.write_text("keep")
+    tool.unlink()
+    tool.symlink_to(victim)
+    refresh_tool(tmp_path)
+    assert victim.read_text() == "keep" and "def main(" in tool.read_text()

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -1226,8 +1226,14 @@ def test_refresh_tool_rewrites_only_the_tool_and_never_through_a_symlink(tmp_pat
     (channel / "budget.json").write_text("{}")
     tool = channel / "syscall"
     tool.write_text("# stale tool\n")
-    refresh_tool(tmp_path)
-    assert "def main(" in tool.read_text() and (tool.stat().st_mode & 0o111)
+    import os
+
+    before = os.umask(0o177)  # an execute-masking umask must not strip the tool's x bits
+    try:
+        refresh_tool(tmp_path)
+    finally:
+        os.umask(before)
+    assert "def main(" in tool.read_text() and (tool.stat().st_mode & 0o111) == 0o111
     assert (channel / "budget.json").exists()  # the channel is untouched
     victim = tmp_path / "victim"
     victim.write_text("keep")

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -1235,3 +1235,9 @@ def test_refresh_tool_rewrites_only_the_tool_and_never_through_a_symlink(tmp_pat
     tool.symlink_to(victim)
     refresh_tool(tmp_path)
     assert victim.read_text() == "keep" and "def main(" in tool.read_text()
+    # a directory planted in the tool's place is replaced by the tool
+    tool.unlink()
+    tool.mkdir()
+    (tool / "junk").write_text("x")
+    refresh_tool(tmp_path)
+    assert tool.is_file() and "def main(" in tool.read_text()

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -1235,7 +1235,12 @@ def test_refresh_tool_rewrites_only_the_tool_and_never_through_a_symlink(tmp_pat
     tool.symlink_to(victim)
     refresh_tool(tmp_path)
     assert victim.read_text() == "keep" and "def main(" in tool.read_text()
-    # a directory planted in the tool's place is replaced by the tool
+    # a directory planted in the tool's place is replaced by the tool, removed
+    # relative to the channel fd (no path re-resolution a swapped symlink
+    # could redirect)
+    import shutil
+
+    assert shutil.rmtree.avoids_symlink_attacks
     tool.unlink()
     tool.mkdir()
     (tool / "junk").write_text("x")


### PR DESCRIPTION
Follow-up to #325 before Torch picks it up. Runs parked right now started under the previous kernel and carry the old tool, whose `sleep` writes no report. Under #325 as merged, their next submit would hit `read_request`'s check and end the run as a session-error.

- The missing report is now a **refusal wake** (`MISSING_REPORT`), checked in `attempt_once` next to the budget check: the author is told to write the report and stage `submit --report <file>`, and the run goes on. `read_request` keeps validating the field's type and size.
- **Wakes refresh the tool.** `refresh_tool` rewrites `.outerloop/syscall` from the running kernel's `syscall_cli.py` at every author wake, tool file only (the channel and its contents stay), written like a marker so a `syscall` the session replaced with a symlink is never written through. A session that started before a deploy gets today's verbs and flags on its next turn.
- Tests: the refusal path resumes the session with the flag named; refresh rewrites the tool, leaves the channel alone, and refuses a symlink.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
