### PR TITLE
The wake tells an older session what is new in its tool; local loop is foreground, say so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- A wake that replaced an older session's tool tells the author what is new
+  (`--report`, `--why`, `--concurrency`, `queue`, `history`). The install guide
+  says the local loop runs in the foreground and how to keep it up headless.
 - A submit without a report is refused with a wake the author can act on, not
   a dead run, and a wake rewrites the session's tool from the running kernel,
   so a session that started before a deploy has today's verbs and flags.

--- a/docs/install.md
+++ b/docs/install.md
@@ -237,8 +237,9 @@ that can reach GitHub and your LLM provider works.
   job — no daemon and no inbound SSH, which matters when your cluster requires
   2FA.
 - **A VM or workstation**: `outerloop start` runs the local loop in the
-  foreground (Ctrl-C stops it, the records resume it); on a headless machine
-  start it under `nohup` or in a tmux window, or as a user service.
+  foreground. Ctrl-C stops it; its saved records let it continue the work when
+  you start it again. On a headless machine start it under `nohup` or in a
+  tmux window, or as a user service.
 
 Experiments run wherever your `compute` backend says. Slurm is the first
 backend; the interface is small (submit a job, poll for completion), so a CI

--- a/docs/install.md
+++ b/docs/install.md
@@ -236,7 +236,9 @@ that can reach GitHub and your LLM provider works.
 - **Slurm cluster**: the tick can live in the queue as a self-resubmitting
   job — no daemon and no inbound SSH, which matters when your cluster requires
   2FA.
-- **A VM or workstation**: run it on a timer.
+- **A VM or workstation**: `outerloop start` runs the local loop in the
+  foreground (Ctrl-C stops it, the records resume it); on a headless machine
+  start it under `nohup` or in a tmux window, or as a user service.
 
 Experiments run wherever your `compute` backend says. Slurm is the first
 backend; the interface is small (submit a job, poll for completion), so a CI

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -93,6 +93,7 @@ from outerloop.runstate import (
 from outerloop.syscall import (
     CHANNEL_DIR_NAMES,
     MAX_ARTIFACT_BYTES,
+    TOOL_UPDATE_NOTE,
     SyscallRequest,
     channel_dir,
     launch_task_ids,
@@ -876,6 +877,14 @@ def _wake_author_sleep(
         ),
     )
     gpu_hours_used = _reconcile_launch_hours(record, dispatch, bench.gpus, launches, elapsed)
+    # the tool the session invokes comes from THIS kernel: a session that
+    # started under an older one gets today's verbs and flags at its wake, and
+    # is told what is new
+    tool_changed = False
+    try:
+        tool_changed = syscall_refresh_tool(workspace)
+    except Exception as exc:
+        log.warning("tool refresh failed: %s", redact(f"{type(exc).__name__}: {exc}", secrets))
     wake_text = render_wake(
         results,
         str(record.stage.get("syscall_note", "")),
@@ -895,12 +904,11 @@ def _wake_author_sleep(
     ]
     if pacing:
         wake_text = f"{wake_text}\n\n" + "\n".join(pacing) + " (the contract's ceiling applies)."
+    if tool_changed:
+        wake_text = f"{wake_text}\n\n{TOOL_UPDATE_NOTE}"
     if extra_update:
         # a submitted park's gate/panel feedback leads; launch results follow
         wake_text = f"{extra_update}\n\n{wake_text}"
-    # the tool the session invokes comes from THIS kernel: a session that
-    # started under an older one gets today's verbs and flags at its wake
-    _best_effort("tool refresh", lambda: syscall_refresh_tool(workspace))
     _best_effort(
         "budget refresh",
         lambda: write_budget(

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -93,10 +93,10 @@ from outerloop.runstate import (
 from outerloop.syscall import (
     CHANNEL_DIR_NAMES,
     MAX_ARTIFACT_BYTES,
-    TOOL_UPDATE_NOTE,
     SyscallRequest,
     channel_dir,
     launch_task_ids,
+    tool_update_note,
 )
 from outerloop.syscall import ensure_excluded as syscall_excluded
 from outerloop.syscall import install_tool as syscall_install_tool
@@ -905,7 +905,7 @@ def _wake_author_sleep(
     if pacing:
         wake_text = f"{wake_text}\n\n" + "\n".join(pacing) + " (the contract's ceiling applies)."
     if tool_changed:
-        wake_text = f"{wake_text}\n\n{TOOL_UPDATE_NOTE}"
+        wake_text = f"{wake_text}\n\n{tool_update_note(channel_dir(workspace))}"
     if extra_update:
         # a submitted park's gate/panel feedback leads; launch results follow
         wake_text = f"{extra_update}\n\n{wake_text}"

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -602,13 +602,25 @@ MISSING_REPORT = (
 )
 
 
-def refresh_tool(workspace: Path) -> None:
+TOOL_UPDATE_NOTE = (
+    "Your syscall tool was updated with this kernel. New since your session started: "
+    "`submit` requires `--report <file>` — your write-up (hypothesis, what ran and what "
+    "it measured, why this should merge, what did not work), which becomes the pull "
+    "request's research report and which the panel reads; `launch` takes `--why "
+    '"one line"` and, with `--array`, `--concurrency K`; `queue` shows the cluster '
+    "queue (every agent's jobs) and `history` your launches this run. "
+    "`python .outerloop/syscall <verb> --help` has the details."
+)
+
+
+def refresh_tool(workspace: Path) -> bool:
     """Rewrite the installed tool from this kernel's source at a wake, so a
     session that started under an older kernel gets the current verbs and
     flags. Only the tool file changes — the channel and everything in it
     stay — and it is written with a marker's care (a fresh O_EXCL inode,
     renamed into place), so a `syscall` the session replaced with a symlink
-    is never written through."""
+    is never written through. Returns whether the tool changed, so the wake
+    can tell the author what is new."""
     import shutil
 
     from outerloop import syscall_cli
@@ -620,6 +632,13 @@ def refresh_tool(workspace: Path) -> None:
             st = os.stat("syscall", dir_fd=dirfd, follow_symlinks=False)
         except FileNotFoundError:
             st = None
+        if st is not None and stat.S_ISREG(st.st_mode) and st.st_size == len(source):
+            fd = os.open("syscall", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dirfd)
+            try:
+                if os.read(fd, len(source) + 1) == source:
+                    return False  # already this kernel's tool
+            finally:
+                os.close(fd)
         if st is not None and stat.S_ISDIR(st.st_mode):
             # a directory planted in the tool's place: rename cannot replace
             # it. Removed RELATIVE TO THE CHANNEL FD, never by path — a path
@@ -627,6 +646,7 @@ def refresh_tool(workspace: Path) -> None:
             # between would send the removal outside the workspace
             shutil.rmtree("syscall", dir_fd=dirfd)
         _write_channel(dirfd, "syscall", source, mode=0o755)
+        return True
     finally:
         os.close(dirfd)
 

--- a/src/outerloop/syscall.py
+++ b/src/outerloop/syscall.py
@@ -602,15 +602,18 @@ MISSING_REPORT = (
 )
 
 
-TOOL_UPDATE_NOTE = (
-    "Your syscall tool was updated with this kernel. New since your session started: "
-    "`submit` requires `--report <file>` — your write-up (hypothesis, what ran and what "
-    "it measured, why this should merge, what did not work), which becomes the pull "
-    "request's research report and which the panel reads; `launch` takes `--why "
-    '"one line"` and, with `--array`, `--concurrency K`; `queue` shows the cluster '
-    "queue (every agent's jobs) and `history` your launches this run. "
-    "`python .outerloop/syscall <verb> --help` has the details."
-)
+def tool_update_note(channel: str) -> str:
+    """What a session that started under an older kernel is told at a wake
+    whose tool refresh replaced its tool; `channel` is this workspace's channel
+    dir name (a resumed legacy session still has `.autoresearch`)."""
+    return (
+        "Your syscall tool was updated. `submit` now requires `--report <file>`. The "
+        "report explains your hypothesis, what you ran and measured, why this should "
+        "merge, and what did not work; it becomes the pull request's research report "
+        "and the panel reads it. `launch` accepts `--why` and, with `--array`, "
+        "`--concurrency K`. `queue` shows every agent's jobs; `history` shows your "
+        f"launches this run. `python {channel}/syscall <verb> --help` has the details."
+    )
 
 
 def refresh_tool(workspace: Path) -> bool:
@@ -632,13 +635,25 @@ def refresh_tool(workspace: Path) -> bool:
             st = os.stat("syscall", dir_fd=dirfd, follow_symlinks=False)
         except FileNotFoundError:
             st = None
+        current: bytes | None = None
         if st is not None and stat.S_ISREG(st.st_mode) and st.st_size == len(source):
-            fd = os.open("syscall", os.O_RDONLY | os.O_NOFOLLOW, dir_fd=dirfd)
+            # compare through a non-blocking open checked after the fact: a FIFO
+            # swapped in since the stat returns at once instead of waiting for a
+            # writer, and anything unreadable (mode 000) simply gets rewritten
             try:
-                if os.read(fd, len(source) + 1) == source:
-                    return False  # already this kernel's tool
-            finally:
-                os.close(fd)
+                fd = os.open("syscall", os.O_RDONLY | os.O_NOFOLLOW | os.O_NONBLOCK, dir_fd=dirfd)
+            except OSError:
+                fd = -1
+            if fd >= 0:
+                try:
+                    if stat.S_ISREG(os.fstat(fd).st_mode):
+                        current = os.read(fd, len(source) + 1)
+                except OSError:
+                    current = None
+                finally:
+                    os.close(fd)
+        if current == source:
+            return False  # already this kernel's tool, readable as it should be
         if st is not None and stat.S_ISDIR(st.st_mode):
             # a directory planted in the tool's place: rename cannot replace
             # it. Removed RELATIVE TO THE CHANNEL FD, never by path — a path

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -1253,5 +1253,27 @@ def test_refresh_tool_rewrites_only_the_tool_and_never_through_a_symlink(tmp_pat
     tool.unlink()
     tool.mkdir()
     (tool / "junk").write_text("x")
-    refresh_tool(tmp_path)
+    assert refresh_tool(tmp_path) is True
     assert tool.is_file() and "def main(" in tool.read_text()
+    # the same bytes made unreadable (mode 000) are replaced, not left as a
+    # tool the session cannot run
+    tool.chmod(0)
+    assert refresh_tool(tmp_path) is True
+    assert (tool.stat().st_mode & 0o777) == 0o755 and "def main(" in tool.read_text()
+    # a FIFO in the tool's place never blocks the wake: the comparison opens
+    # non-blocking and checks what it opened, then the tool is rewritten
+    import threading
+
+    tool.unlink()
+    os.mkfifo(tool)
+    seen: list[bool] = []
+    t = threading.Thread(target=lambda: seen.append(refresh_tool(tmp_path)), daemon=True)
+    t.start()
+    t.join(timeout=5)
+    assert not t.is_alive(), "refresh_tool blocked on a FIFO"
+    assert seen == [True] and tool.is_file() and "def main(" in tool.read_text()
+    # the notice names this workspace's channel, legacy name included
+    from outerloop.syscall import tool_update_note
+
+    assert "python .autoresearch/syscall <verb> --help" in tool_update_note(".autoresearch")
+    assert "`--report <file>`" in tool_update_note(".outerloop")

--- a/tests/test_syscall.py
+++ b/tests/test_syscall.py
@@ -1225,6 +1225,9 @@ def test_refresh_tool_rewrites_only_the_tool_and_never_through_a_symlink(tmp_pat
     channel = tmp_path / ".outerloop"
     (channel / "budget.json").write_text("{}")
     tool = channel / "syscall"
+    assert refresh_tool(tmp_path) is False  # already this kernel's tool: nothing to tell
+    tool.write_text("# stale tool\n")
+    assert refresh_tool(tmp_path) is True  # an older tool was replaced: the wake says what is new
     tool.write_text("# stale tool\n")
     import os
 


### PR DESCRIPTION
Follow-up to #326. A session that started under an older kernel gets today's tool at its wake, but nothing told it what changed; it would discover `--report` only on refusal.

- `refresh_tool` now returns whether the tool changed (byte comparison through the channel fd; an unchanged tool is not rewritten), and the wake text gains one paragraph when it did: `--report` required at submit and what the report is for, `--why` and `--concurrency` on launch, `queue` and `history`.
- Install guide: `outerloop start` runs the local loop in the foreground by design; the guide now says so and how to keep it up on a headless machine (learned on cluster0 today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
