### PR TITLE
A seed cache per target: warmed wheels-only by the tick, copied into every job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- A seed cache per target (docs/design/eval-cache.md): the tick warms one uv
+  cache from the target's lockfile on the tick host — wheels only, `--no-build`,
+  never the target's code — and every eval and launch job copies it into its
+  own scratch cache before `uv` runs, so a torch-sized dependency set is
+  downloaded once per lockfile instead of once per job. Jobs still build a
+  private environment and write nothing shared.
 - `docs/design/eval-cache.md`: why every eval downloads its dependencies today,
   and the two changes that stop it — a kernel-warmed seed cache each job
   copies, and a per-target image named in the contract (`environment.container`).

--- a/docs/design/eval-cache.md
+++ b/docs/design/eval-cache.md
@@ -40,6 +40,9 @@ the kernel, on a trusted host, and jobs only read it.
 
 ## Change 1: a kernel-warmed seed cache
 
+*Shipped: `evalcache.warm` on the tick, `write_eval_job(seed_cache=)` in every
+job, the seed under `<state root>/eval-cache/<target>`.*
+
 - **The kernel warms one cache per target**, `<state root>/eval-cache/<target>`
   on Torch and `~/.outerloop/eval-cache/<target>` in local mode, by running
   `uv sync --frozen --no-install-project --no-build` into a throwaway

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -37,6 +37,7 @@ from outerloop.dispatch import (
     should_dispatch,
     snapshot_tree,
 )
+from outerloop.evalcache import seed_dir
 from outerloop.github import (
     GitError,
     GitHubClient,
@@ -629,7 +630,6 @@ def _dispatch_settings(args: argparse.Namespace) -> DispatchSettings:
     fresh climb and the wake (a second constructor drifted once — terra
     #174: the wake dropped the GPU lane)."""
     from outerloop.compute import compute_from_env
-    from outerloop.evalcache import seed_dir
 
     target = getattr(args, "target", "") or ""
     return DispatchSettings(
@@ -651,6 +651,20 @@ def _dispatch_settings(args: argparse.Namespace) -> DispatchSettings:
 # per-GPU TRES share stays in the hundreds — so the order holds however long a
 # launch has waited. Other users' jobs and the group cap are untouched.
 LAUNCH_NICE = 5000
+
+
+def with_seed(dispatch: DispatchSettings, run_root: Path, target: str) -> DispatchSettings:
+    """These settings with the target's seed cache filled in from the record's
+    target when the CLI gave none (wake and follow-up jobs carry the run id,
+    not the target)."""
+    # tolerant of any settings object: a backend that knows no seed (or a
+    # test double) is left exactly as it is
+    if not target or getattr(dispatch, "seed_cache", "unknown") is not None:
+        return dispatch
+    try:
+        return dc_replace(dispatch, seed_cache=seed_dir(run_root, target))
+    except TypeError:
+        return dispatch
 
 
 def _make_launcher(
@@ -1622,6 +1636,7 @@ def resume_run(
     run_dir = run_root / "runs" / run_id
     workspace = run_dir / "ws"
     record = load_record(run_root, run_id)
+    dispatch = with_seed(dispatch, run_root, record.target)
     stage = record.stage
     # Push to the CANONICAL target URL, never the workspace's remote.origin.url:
     # the session could have rewritten that config to exfil the bot token / code

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -629,7 +629,9 @@ def _dispatch_settings(args: argparse.Namespace) -> DispatchSettings:
     fresh climb and the wake (a second constructor drifted once — terra
     #174: the wake dropped the GPU lane)."""
     from outerloop.compute import compute_from_env
+    from outerloop.evalcache import seed_dir
 
+    target = getattr(args, "target", "") or ""
     return DispatchSettings(
         compute=compute_from_env(),
         image=args.image,
@@ -637,6 +639,7 @@ def _dispatch_settings(args: argparse.Namespace) -> DispatchSettings:
         partition=args.partition,
         gpu_partition=getattr(args, "gpu_partition", ""),
         gpu_account=getattr(args, "gpu_account", ""),
+        seed_cache=seed_dir(Path(args.run_root), target) if target else None,
     )
 
 
@@ -682,6 +685,7 @@ def _make_launcher(
                     artifact_max_bytes=MAX_ARTIFACT_BYTES,
                     gpus=gpus,
                     array=launch.array,
+                    seed_cache=dispatch.seed_cache,
                 )
                 spec = eval_job_spec(
                     script,
@@ -2859,6 +2863,7 @@ def live_attempt(
                 run_tag=run_id,
                 # an inline gate shares the same target-wide baseline cache
                 baseline_cache=run_dir.parent / "baselines",
+                seed_cache=dispatch.seed_cache if dispatch is not None else None,
             )
         snapshots: list[Snapshot] = []
 

--- a/src/outerloop/dispatch.py
+++ b/src/outerloop/dispatch.py
@@ -290,8 +290,15 @@ def write_eval_job(
     artifact_max_bytes: int = 0,
     gpus: int = 0,
     array: int = 1,
+    seed_cache: Path | None = None,
 ) -> Path:
     """Write the orchestrator-authored job script for one dispatched eval.
+
+    `seed_cache` names the kernel-warmed seed for this target
+    (docs/design/eval-cache.md): the job copies its contents into its own
+    scratch cache before `uv` runs — a copy, never a bind or a hardlink, so the
+    job's cache is its own and the seed is never written; a missing seed or a
+    failed copy costs a download, never the eval.
 
     `array` > 1 writes ONE script for a Slurm job array: each task derives its
     own job dir `eval-<name>.<k>` from SLURM_ARRAY_TASK_ID (SWEEP_INDEX under a
@@ -388,6 +395,11 @@ def write_eval_job(
     ]
     for k, v in neutral.items():
         lines.append(f"export {k}={shlex.quote(v)}")
+    if seed_cache is not None:
+        q = shlex.quote(str(seed_cache))
+        lines.append(
+            f'if [ -d {q} ]; then cp -a {q}/. "$SCRATCH/cache"/ 2>> "$EV/setup.log" || true; fi'
+        )
     lines += [
         # Materialize the snapshot by CHECKOUT, not `git archive`: a checkout
         # reproduces content faithfully — INCLUDING .gitattributes — and does

--- a/src/outerloop/evalcache.py
+++ b/src/outerloop/evalcache.py
@@ -26,6 +26,25 @@ WARM_FILES = ("pyproject.toml", "uv.lock")
 # picked for it, and the tick host's uv fetches it when it has none
 EVAL_PYTHON = "3.12"
 WARM_TIMEOUT_S = 30 * 60
+# what uv needs to download wheels and nothing more: the tick host's
+# environment holds credentials (token providers, key paths) that an
+# uncontained download process has no business seeing
+WARM_ENV_KEYS = (
+    "PATH",
+    "HOME",
+    "LANG",
+    "LC_ALL",
+    "TMPDIR",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "no_proxy",
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "REQUESTS_CA_BUNDLE",
+)
 
 Runner = Callable[..., Any]
 
@@ -80,16 +99,23 @@ def warm(
     uv = uv or shutil.which("uv")
     if not uv:
         return "skipped: uv is not on the tick host's PATH"
-    seed.mkdir(parents=True, exist_ok=True)
+    # warm into a fresh directory beside the seed and swap it in whole: the
+    # seed then holds exactly this lockfile's wheels (nothing accumulates
+    # across lockfile changes), and a job copying mid-swap fails its
+    # best-effort copy rather than seeing a half-written cache
+    seed.parent.mkdir(parents=True, exist_ok=True)
+    fresh = seed.parent / f".{seed.name}.warm-{digest[:12]}"
+    shutil.rmtree(fresh, ignore_errors=True)
+    fresh.mkdir()
     with tempfile.TemporaryDirectory(prefix="outerloop-warm-") as tmp:
         for name, text in files.items():
             (Path(tmp) / name).write_text(text)
-        env = {
-            **os.environ,
-            "UV_CACHE_DIR": str(seed),
-            "UV_PROJECT_ENVIRONMENT": str(Path(tmp) / ".venv"),
-            "UV_LINK_MODE": "copy",
-        }
+        env = {k: os.environ[k] for k in WARM_ENV_KEYS if k in os.environ}
+        env.update(
+            UV_CACHE_DIR=str(fresh),
+            UV_PROJECT_ENVIRONMENT=str(Path(tmp) / ".venv"),
+            UV_LINK_MODE="copy",
+        )
         argv = [
             uv,
             "sync",
@@ -105,9 +131,17 @@ def warm(
                 argv, cwd=tmp, env=env, capture_output=True, text=True, timeout=WARM_TIMEOUT_S
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
+            shutil.rmtree(fresh, ignore_errors=True)
             return f"failed: {type(exc).__name__}: {exc}"
     if proc.returncode != 0:
+        shutil.rmtree(fresh, ignore_errors=True)
         tail = (proc.stderr or "").strip().splitlines()[-3:]
         return f"failed: uv sync exited {proc.returncode}: {' | '.join(tail)}"
-    marker.write_text(digest)
+    (fresh / LOCK_HASH).write_text(digest)
+    old = seed.parent / f".{seed.name}.old"
+    shutil.rmtree(old, ignore_errors=True)
+    if seed.exists():
+        os.replace(seed, old)
+    os.replace(fresh, seed)
+    shutil.rmtree(old, ignore_errors=True)
     return "warmed"

--- a/src/outerloop/evalcache.py
+++ b/src/outerloop/evalcache.py
@@ -1,0 +1,113 @@
+"""The seed cache: one uv cache per target, warmed by the kernel on the tick
+host and copied into each job's own scratch cache before `uv` runs there
+(docs/design/eval-cache.md). Jobs never write shared state: the warmer
+downloads and unpacks wheels only (`--no-build`, so no build backend of the
+target's ever runs here), and a job's copy is its own from the first byte."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+SEED_DIR = "eval-cache"
+LOCK_HASH = ".lockfile-sha256"
+# what uv sync needs to resolve a locked project without its sources
+WARM_FILES = ("pyproject.toml", "uv.lock")
+# the interpreter the eval jobs run under (the agent image's); wheels are
+# picked for it, and the tick host's uv fetches it when it has none
+EVAL_PYTHON = "3.12"
+WARM_TIMEOUT_S = 30 * 60
+
+Runner = Callable[..., Any]
+
+
+def seed_dir(root: Path, target: str) -> Path:
+    """Where a target's seed lives under the state root."""
+    return root / SEED_DIR / target.replace("/", "__")
+
+
+def lockfile_hash(files: dict[str, str]) -> str:
+    h = hashlib.sha256()
+    for name in sorted(files):
+        h.update(name.encode())
+        h.update(b"\0")
+        h.update(files[name].encode())
+        h.update(b"\0")
+    return h.hexdigest()
+
+
+def warm(
+    root: Path,
+    target: str,
+    github: Any,
+    ref: str,
+    *,
+    runner: Runner = subprocess.run,
+    uv: str | None = None,
+    python: str = EVAL_PYTHON,
+) -> str:
+    """Warm the target's seed from its lockfile at `ref`, when the lockfile
+    changed since the last warm. Fetches `pyproject.toml` and `uv.lock` only
+    (never the sources), and runs `uv sync --frozen --no-install-project
+    --no-build --all-extras` into a throwaway environment with the seed as
+    uv's cache. Returns one word on what happened, for the tick's report:
+    "warmed", "unchanged", or "skipped: ..." / "failed: ..." with the reason.
+    A failure leaves the seed as it was and the hash unrecorded, so the next
+    tick tries again."""
+    files: dict[str, str] = {}
+    for name in WARM_FILES:
+        text = github.get_file_content(target, name, ref)
+        if text is None:
+            return f"skipped: no {name} at {ref}"
+        files[name] = text
+    digest = lockfile_hash(files)
+    seed = seed_dir(root, target)
+    marker = seed / LOCK_HASH
+    try:
+        if marker.read_text().strip() == digest:
+            return "unchanged"
+    except OSError:
+        pass
+    uv = uv or shutil.which("uv")
+    if not uv:
+        return "skipped: uv is not on the tick host's PATH"
+    seed.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="outerloop-warm-") as tmp:
+        for name, text in files.items():
+            (Path(tmp) / name).write_text(text)
+        env = {
+            **os.environ,
+            "UV_CACHE_DIR": str(seed),
+            "UV_PROJECT_ENVIRONMENT": str(Path(tmp) / ".venv"),
+            "UV_LINK_MODE": "copy",
+        }
+        argv = [
+            uv,
+            "sync",
+            "--frozen",
+            "--no-install-project",
+            "--no-build",
+            "--all-extras",
+            "--python",
+            python,
+        ]
+        try:
+            proc = runner(
+                argv, cwd=tmp, env=env, capture_output=True, text=True, timeout=WARM_TIMEOUT_S
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            return f"failed: {type(exc).__name__}: {exc}"
+    if proc.returncode != 0:
+        tail = (proc.stderr or "").strip().splitlines()[-3:]
+        return f"failed: uv sync exited {proc.returncode}: {' | '.join(tail)}"
+    marker.write_text(digest)
+    return "warmed"

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -1565,6 +1565,12 @@ def _seal_and_measure(
     from outerloop.measure import MeasurementPending
 
     parent = ws.git("rev-parse", "HEAD").strip()
+    from outerloop.attempt import with_seed
+    from outerloop.runstate import load_record
+
+    # the follow-up CLI carries the run id, not the target: the seed comes
+    # from the record
+    dispatch = with_seed(dispatch, run_root, load_record(run_root, run_id).target)
     snap = snapshot_tree(
         ws, parent, exclude=LINE_MEMORY_PATHS if bench.lines else (), author=bot_login
     )

--- a/src/outerloop/measure.py
+++ b/src/outerloop/measure.py
@@ -271,6 +271,8 @@ class DispatchedMeasurer:
     # where a `baseline: cached` benchmark's base-tree measurements live
     # (target-wide); None = no cache, every gate measures its own baseline
     baseline_cache: Path | None = None
+    # the target's kernel-warmed seed cache, copied into each job (evalcache)
+    seed_cache: Path | None = None
 
     def _placement(self, m: Measure) -> tuple[str, str]:
         if m.gpus <= 0:
@@ -353,6 +355,7 @@ class DispatchedMeasurer:
             image=self.image,
             extra_env=m.env(),
             gpus=m.gpus,
+            seed_cache=self.seed_cache,
         )
         account, partition = self._placement(m)
         spec: JobSpec = eval_job_spec(
@@ -481,6 +484,8 @@ class DispatchSettings:
     # to launch such benchmarks); empty gpu_account = same account as CPU jobs.
     gpu_partition: str = ""
     gpu_account: str = ""
+    # the target's seed cache (evalcache.seed_dir), copied into every job
+    seed_cache: Path | None = None
 
     def placement(self, gpus: int) -> tuple[str, str]:
         """(account, partition) for a job needing `gpus` GPUs. Raises when a
@@ -520,4 +525,5 @@ class DispatchSettings:
             # target-wide, beside the run dirs: every attempt on one base
             # shares its cached baseline measurement (Benchmark.baseline)
             baseline_cache=run_dir.parent / "baselines",
+            seed_cache=self.seed_cache,
         )

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -1850,6 +1850,11 @@ def tick(
     # whether github/contract loaded this tick.
     if followup_spec is not None:
         service_syncs(root, followup_spec, now)
+    if github is not None and followup_spec is not None and followup_spec.target:
+        try:
+            service_eval_cache(root, github, followup_spec.target)
+        except Exception as exc:  # advisory: a cold cache costs a download, never a tick
+            log.warning("eval cache warm failed: %s: %s", type(exc).__name__, exc)
     if github is not None and followup_spec is not None:
         # expired flight snapshots die with their TTL, not with a human.
         # One home suffices: every lane's spec derives from followup_spec
@@ -1969,6 +1974,18 @@ def tick(
     # main / mark_tick_complete) — not here with the start-of-tick `now`, which
     # a tick longer than the window would leave stale.
     return report
+
+
+def service_eval_cache(root: Path, github: Any, target: str) -> str:
+    """Warm the target's seed cache from its default branch's lockfile
+    (docs/design/eval-cache.md). Cheap when nothing changed: two file reads
+    and a hash. Returns the warmer's one-word status."""
+    from outerloop.evalcache import warm
+
+    status = warm(root, target, github, github.default_branch(target))
+    if status != "unchanged":
+        log.info("eval cache for %s: %s", target, status)
+    return status
 
 
 def service_syncs(root: Path, spec: Any, now: float) -> None:

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -1850,7 +1850,8 @@ def tick(
     # whether github/contract loaded this tick.
     if followup_spec is not None:
         service_syncs(root, followup_spec, now)
-    if github is not None and followup_spec is not None and followup_spec.target:
+    # a dry run reports and writes nothing: no download, no seed
+    if github is not None and followup_spec is not None and followup_spec.target and not dry_run:
         try:
             service_eval_cache(root, github, followup_spec.target)
         except Exception as exc:  # advisory: a cold cache costs a download, never a tick

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -5083,3 +5083,17 @@ def test_is_git_tamper_classifies_object_store_damage_not_ordinary_failures() ->
     # ordinary git failures a wake should NOT treat as tamper
     assert not _is_git_tamper(GitError("git push failed: ! [rejected] (non-fast-forward)"))
     assert not _is_git_tamper(GitError("git fetch failed: could not resolve host"))
+
+
+def test_with_seed_fills_the_seed_from_the_records_target(tmp_path) -> None:
+    """Wake and follow-up jobs carry the run id, not the target: the seed cache
+    comes from the record, and an explicit setting is left alone."""
+    from outerloop.attempt import with_seed
+    from outerloop.evalcache import seed_dir
+
+    bare = _fake_dispatch()
+    assert bare.seed_cache is None
+    filled = with_seed(bare, tmp_path, "org/pilot")
+    assert filled.seed_cache == seed_dir(tmp_path, "org/pilot")
+    assert with_seed(filled, tmp_path, "other/repo").seed_cache == filled.seed_cache
+    assert with_seed(bare, tmp_path, "").seed_cache is None

--- a/tests/test_dispatch.py
+++ b/tests/test_dispatch.py
@@ -521,3 +521,34 @@ def test_write_eval_job_array_writes_one_script_and_a_dir_per_task(tmp_path):
         run_dir, "launch-one", repo_root=tmp_path, snapshot_sha="a" * 40, command="true", image=""
     )
     assert "TASK=" not in plain.read_text() and "SWEEP_INDEX" not in plain.read_text()
+
+
+def test_job_copies_the_seed_cache_into_its_own_before_uv_runs(tmp_path):
+    """The kernel-warmed seed is copied — never bound, never hardlinked — into
+    the job's scratch cache, best-effort, before uv runs; no seed, no line."""
+    run_dir = tmp_path / "run"
+    seed = tmp_path / "state" / "eval-cache" / "o__r"
+    script = write_eval_job(
+        run_dir,
+        "candidate",
+        repo_root=tmp_path,
+        snapshot_sha="a" * 40,
+        command="true",
+        image="/i.sif",
+        seed_cache=seed,
+    )
+    text = script.read_text()
+    line = next(ln for ln in text.splitlines() if "cp -a" in ln)
+    assert line == (
+        f'if [ -d {seed} ]; then cp -a {seed}/. "$SCRATCH/cache"/ 2>> "$EV/setup.log" || true; fi'
+    )
+    # after the scratch cache exists, before the venv is built
+    assert (
+        text.index('mkdir -p "$SCRATCH/cache"')
+        < text.index("cp -a")
+        < text.index("UV_PROJECT_ENVIRONMENT=")
+    )
+    plain = write_eval_job(
+        run_dir, "plain", repo_root=tmp_path, snapshot_sha="a" * 40, command="true", image="/i.sif"
+    )
+    assert "cp -a" not in plain.read_text()

--- a/tests/test_evalcache.py
+++ b/tests/test_evalcache.py
@@ -33,7 +33,10 @@ class _Runner:
 FILES = {"pyproject.toml": "[project]\nname='t'\n", "uv.lock": "version = 1\n"}
 
 
-def test_warm_runs_uv_with_the_seed_as_cache_and_no_build(tmp_path: Path) -> None:
+def test_warm_runs_uv_with_the_seed_as_cache_and_no_build(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_secret")
+    monkeypatch.setenv("OUTERLOOP_PAT_FILE", "/keys/pat")
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy:3128")
     gh, run = _GitHub(dict(FILES)), _Runner()
     assert warm(tmp_path, "o/r", gh, "main", runner=run, uv="/bin/uv") == "warmed"
     assert gh.asked == [("o/r", "pyproject.toml", "main"), ("o/r", "uv.lock", "main")]
@@ -45,10 +48,17 @@ def test_warm_runs_uv_with_the_seed_as_cache_and_no_build(tmp_path: Path) -> Non
     assert argv[argv.index("--python") + 1] == "3.12"
     seed = seed_dir(tmp_path, "o/r")
     assert seed == tmp_path / "eval-cache" / "o__r"
-    assert call["env"]["UV_CACHE_DIR"] == str(seed)
+    # warmed into a fresh directory beside the seed, then swapped in whole
+    assert call["env"]["UV_CACHE_DIR"] != str(seed)
+    assert call["env"]["UV_CACHE_DIR"].startswith(str(seed.parent / ".o__r.warm-"))
     assert call["env"]["UV_PROJECT_ENVIRONMENT"].startswith(call["cwd"])  # a throwaway env
     assert not Path(call["cwd"]).exists()  # the temp dir is gone
     assert (seed / LOCK_HASH).read_text() == lockfile_hash(FILES)
+    assert [p.name for p in seed.parent.iterdir()] == ["o__r"]  # no leftovers beside it
+    # the download process sees what it needs and no tick credential
+    env = call["env"]
+    assert env["HTTPS_PROXY"] == "http://proxy:3128" and "PATH" in env
+    assert "GITHUB_TOKEN" not in env and "OUTERLOOP_PAT_FILE" not in env
 
 
 def test_warm_is_a_no_op_until_the_lockfile_changes(tmp_path: Path) -> None:
@@ -56,9 +66,16 @@ def test_warm_is_a_no_op_until_the_lockfile_changes(tmp_path: Path) -> None:
     assert warm(tmp_path, "o/r", gh, "main", runner=run, uv="/bin/uv") == "warmed"
     assert warm(tmp_path, "o/r", gh, "main", runner=run, uv="/bin/uv") == "unchanged"
     assert len(run.calls) == 1
+    stale = seed_dir(tmp_path, "o/r") / "wheels-v1" / "old.whl"
+    stale.parent.mkdir()
+    stale.write_text("x")
     gh.files["uv.lock"] = "version = 2\n"
     assert warm(tmp_path, "o/r", gh, "main", runner=run, uv="/bin/uv") == "warmed"
     assert len(run.calls) == 2
+    # the seed is exactly the new lockfile's cache: nothing from before survives
+    assert not stale.exists()
+    changed = {**FILES, "uv.lock": "version = 2\n"}
+    assert (seed_dir(tmp_path, "o/r") / LOCK_HASH).read_text() == lockfile_hash(changed)
 
 
 def test_warm_skips_or_fails_loudly_and_records_nothing(tmp_path: Path, monkeypatch) -> None:
@@ -72,3 +89,4 @@ def test_warm_skips_or_fails_loudly_and_records_nothing(tmp_path: Path, monkeypa
     status = warm(tmp_path, "o/r", _GitHub(dict(FILES)), "main", runner=failing, uv="/bin/uv")
     assert status.startswith("failed: uv sync exited 2") and "resolution failed" in status
     assert not (seed_dir(tmp_path, "o/r") / LOCK_HASH).exists()  # the next tick tries again
+    assert not any(p.name.startswith(".o__r.warm-") for p in (tmp_path / "eval-cache").iterdir())

--- a/tests/test_evalcache.py
+++ b/tests/test_evalcache.py
@@ -1,0 +1,74 @@
+"""The seed cache: warmed by the kernel, wheels only, once per lockfile."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from outerloop.evalcache import LOCK_HASH, lockfile_hash, seed_dir, warm
+
+
+class _GitHub:
+    def __init__(self, files: dict[str, str | None]) -> None:
+        self.files = files
+        self.asked: list[tuple[str, str, str]] = []
+
+    def get_file_content(self, repo: str, path: str, ref: str) -> str | None:
+        self.asked.append((repo, path, ref))
+        return self.files.get(path)
+
+
+class _Runner:
+    def __init__(self, returncode: int = 0) -> None:
+        self.calls: list[dict] = []
+        self.returncode = returncode
+
+    def __call__(self, argv, **kw):
+        self.calls.append({"argv": argv, **kw})
+        return SimpleNamespace(
+            returncode=self.returncode, stdout="", stderr="boom\nresolution failed"
+        )
+
+
+FILES = {"pyproject.toml": "[project]\nname='t'\n", "uv.lock": "version = 1\n"}
+
+
+def test_warm_runs_uv_with_the_seed_as_cache_and_no_build(tmp_path: Path) -> None:
+    gh, run = _GitHub(dict(FILES)), _Runner()
+    assert warm(tmp_path, "o/r", gh, "main", runner=run, uv="/bin/uv") == "warmed"
+    assert gh.asked == [("o/r", "pyproject.toml", "main"), ("o/r", "uv.lock", "main")]
+    (call,) = run.calls
+    argv = call["argv"]
+    assert argv[:3] == ["/bin/uv", "sync", "--frozen"]
+    for flag in ("--no-install-project", "--no-build", "--all-extras"):
+        assert flag in argv  # wheels only: nothing of the target's ever runs on the tick host
+    assert argv[argv.index("--python") + 1] == "3.12"
+    seed = seed_dir(tmp_path, "o/r")
+    assert seed == tmp_path / "eval-cache" / "o__r"
+    assert call["env"]["UV_CACHE_DIR"] == str(seed)
+    assert call["env"]["UV_PROJECT_ENVIRONMENT"].startswith(call["cwd"])  # a throwaway env
+    assert not Path(call["cwd"]).exists()  # the temp dir is gone
+    assert (seed / LOCK_HASH).read_text() == lockfile_hash(FILES)
+
+
+def test_warm_is_a_no_op_until_the_lockfile_changes(tmp_path: Path) -> None:
+    gh, run = _GitHub(dict(FILES)), _Runner()
+    assert warm(tmp_path, "o/r", gh, "main", runner=run, uv="/bin/uv") == "warmed"
+    assert warm(tmp_path, "o/r", gh, "main", runner=run, uv="/bin/uv") == "unchanged"
+    assert len(run.calls) == 1
+    gh.files["uv.lock"] = "version = 2\n"
+    assert warm(tmp_path, "o/r", gh, "main", runner=run, uv="/bin/uv") == "warmed"
+    assert len(run.calls) == 2
+
+
+def test_warm_skips_or_fails_loudly_and_records_nothing(tmp_path: Path, monkeypatch) -> None:
+    run = _Runner()
+    status = warm(tmp_path, "o/r", _GitHub({"pyproject.toml": "x"}), "main", runner=run)
+    assert status.startswith("skipped: no uv.lock") and run.calls == []
+    monkeypatch.setattr("outerloop.evalcache.shutil.which", lambda name: None)
+    status = warm(tmp_path, "o/r", _GitHub(dict(FILES)), "main", runner=run)
+    assert status.startswith("skipped: uv is not") and run.calls == []
+    failing = _Runner(returncode=2)
+    status = warm(tmp_path, "o/r", _GitHub(dict(FILES)), "main", runner=failing, uv="/bin/uv")
+    assert status.startswith("failed: uv sync exited 2") and "resolution failed" in status
+    assert not (seed_dir(tmp_path, "o/r") / LOCK_HASH).exists()  # the next tick tries again

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -4457,3 +4457,22 @@ def test_cancel_on_end_cancels_an_ended_runs_pending_launches(tmp_path: Path) ->
     assert (
         slurm.cancelled == ["7"] and "launches_cancelled" not in load_record(tmp_path, "r7").stage
     )
+
+
+def test_eval_cache_service_warms_from_the_default_branch(tmp_path: Path, monkeypatch) -> None:
+    from outerloop import tick as tick_mod
+
+    seen: list = []
+
+    def fake_warm(root, target, github, ref, **kw):
+        seen.append((root, target, ref))
+        return "warmed"
+
+    monkeypatch.setattr("outerloop.evalcache.warm", fake_warm)
+
+    class G:
+        def default_branch(self, repo):
+            return "trunk"
+
+    assert tick_mod.service_eval_cache(tmp_path, G(), "org/repo") == "warmed"
+    assert seen == [(tmp_path, "org/repo", "trunk")]

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -4476,3 +4476,48 @@ def test_eval_cache_service_warms_from_the_default_branch(tmp_path: Path, monkey
 
     assert tick_mod.service_eval_cache(tmp_path, G(), "org/repo") == "warmed"
     assert seen == [(tmp_path, "org/repo", "trunk")]
+
+
+def test_a_tick_warms_the_targets_seed_cache(tmp_path: Path, monkeypatch) -> None:
+    """The scheduled tick itself, not just the service: with a GitHub client and
+    a target, one tick warms the seed from the default branch."""
+    from outerloop.tick import FollowupSpec, tick
+
+    seen: list = []
+
+    def fake_warm(root, target, gh, ref, **kw):
+        seen.append((target, ref))
+        return "warmed"
+
+    monkeypatch.setattr("outerloop.evalcache.warm", fake_warm)
+
+    class G:
+        def default_branch(self, repo):
+            return "main"
+
+        def get_file_content(self, repo, path, ref):
+            return None  # no contract: the launch lanes stop after the gate
+
+    spec = FollowupSpec(
+        target="org/pilot",
+        account="a",
+        partition="p",
+        run_root=tmp_path,
+        image="img.sif",
+        home=tmp_path,
+    )
+
+    def runner(argv, timeout_s):
+        if argv[0] == "squeue":
+            return CommandResult(0, "", "")
+        raise AssertionError("no slurm calls expected")
+
+    tick(
+        tmp_path,
+        SlurmCompute(runner=runner),
+        RecordingDispatcher(),
+        now=NOW,
+        github=G(),
+        followup_spec=spec,
+    )
+    assert seen == [("org/pilot", "main")]


### PR DESCRIPTION
Step 1 of the eval-cache design note (#328): a **seed cache per target**, so a torch-sized dependency set is downloaded once per lockfile instead of once per job.

- **The tick warms it** (`evalcache.warm`, run by `service_eval_cache` once per cycle): fetches `pyproject.toml` and `uv.lock` from the target's default branch through the GitHub client (never the sources), and runs `uv sync --frozen --no-install-project --no-build --all-extras` into a throwaway environment with `<state root>/eval-cache/<target>` as uv's cache. `--no-build` is the trust line: wheels are downloaded and unpacked, no build backend of the target's ever runs on the tick host; a lockfile that needs a build is reported and its jobs install as today. Re-warms only when the lockfile hash changes; a failure records nothing so the next tick retries.
- **Every job copies the seed into its own cache** before `uv` runs: one line in the job script (`cp -a seed/. "$SCRATCH/cache"/`, best-effort, after the scratch dirs exist and before the venv is built). A copy, never a bind or hardlinks; the jail and the private environment are unchanged, and jobs still write nothing shared.
- Plumbing: `DispatchSettings.seed_cache` (set from the attempt's `--run-root` and `--target`), `DispatchedMeasurer.seed_cache`, the launcher and the inline measurer pass it. Local mode is the same code.
- Tests: the warmer's argv, env and temp dir; unchanged-lockfile no-op and re-warm on change; skip and failure paths record nothing; the job-script line and its position; the tick service.

Not in this PR: the in-image seed and the `environment.container` knob (step 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
