### PR TITLE
start stops when uv is nowhere, and finds the installer's directory when it is only there

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- `outerloop start` stops with a clear message when `uv` is not on PATH, instead
+  of starting a loop whose every run ends unmeasured; when the binary is only in
+  the uv installer's default directory, that directory is added to the loop's
+  PATH.
 - The follow-up's note on a re-measured change says the change is not pushed
   yet and that GitHub still shows the previous head (conflict included) until
   the number lands; the old wording read as if the merge were already on the

--- a/docs/install.md
+++ b/docs/install.md
@@ -237,7 +237,8 @@ that can reach GitHub and your LLM provider works.
   job — no daemon and no inbound SSH, which matters when your cluster requires
   2FA.
 - **A VM or workstation**: `outerloop start` runs the local loop in the
-  foreground. Ctrl-C stops it; its saved records let it continue the work when
+  foreground. It needs `uv` on PATH and stops with a message when it is not.
+  Ctrl-C stops it; its saved records let it continue the work when
   you start it again. On a headless machine start it under `nohup` or in a
   tmux window, or as a user service.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -237,7 +237,8 @@ that can reach GitHub and your LLM provider works.
   job — no daemon and no inbound SSH, which matters when your cluster requires
   2FA.
 - **A VM or workstation**: `outerloop start` runs the local loop in the
-  foreground. It needs `uv` on PATH and stops with a message when it is not.
+  foreground. It needs `uv` on PATH or in its installer's directory, and stops
+  with a message when it is in neither.
   Ctrl-C stops it; its saved records let it continue the work when
   you start it again. On a headless machine start it under `nohup` or in a
   tmux window, or as a user service.

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -339,6 +339,25 @@ def _exec(cmd: list[str], env: dict[str, str]) -> int:
     return 1  # unreachable; keeps the signature honest for tests that stub this
 
 
+# where the uv installer puts the binary before the shell's PATH knows it
+UV_FALLBACK_DIRS = (".local/bin", ".cargo/bin")
+
+
+def find_uv() -> tuple[str, str]:
+    """(uv's path, the directory to prepend to PATH): the directory is "" when
+    uv is already on PATH, both are "" when it is nowhere. Every evaluation and
+    launch runs through `uv run` with the PATH start hands over, so a missing
+    uv is caught here, not in a run that ends unmeasured."""
+    found = shutil.which("uv")
+    if found:
+        return found, ""
+    for rel in UV_FALLBACK_DIRS:
+        candidate = Path.home() / rel / "uv"
+        if os.access(candidate, os.X_OK):
+            return str(candidate), str(candidate.parent)
+    return "", ""
+
+
 HARNESS_BIN_KEYS = ("OUTERLOOP_CLAUDE_BIN", "OUTERLOOP_CODEX_BIN")
 
 
@@ -388,10 +407,22 @@ def start(args: argparse.Namespace) -> int:
     if args.dry_run:
         print(shlex.join(cmd))
         return 0
+    uv, uv_dir = find_uv()
+    if not uv:
+        print(
+            "outerloop start: uv is not on PATH. Evaluations and launches run through "
+            "`uv run`; install it (https://docs.astral.sh/uv/) or add its directory to "
+            "PATH, then start again.",
+            file=sys.stderr,
+        )
+        return 2
+    path_env = {"PATH": uv_dir + os.pathsep + os.environ.get("PATH", "")} if uv_dir else {}
+    if uv_dir:
+        print(f"uv found at {uv}; {uv_dir} is added to the loop's PATH", file=sys.stderr)
     if plan.mode == "local":
         # the loop has no deploy step, so the author knobs the chain would
         # export from .env each tick are exported here once; the shell wins
-        env = dict(os.environ)
+        env = {**os.environ, **path_env}
         for key, value in values.items():
             if key in TICK_ENV_KEYS:
                 env.setdefault(key, value)
@@ -427,7 +458,7 @@ def start(args: argparse.Namespace) -> int:
         return 0
     # sbatch --export=ALL carries these to the resident job from the environment
     # we hand it here (so a comma in a value never breaks a --export delimiter).
-    submit_env = {**os.environ, **plan.export_env()}
+    submit_env = {**os.environ, **path_env, **plan.export_env()}
     proc = subprocess.run(cmd, capture_output=True, text=True, env=submit_env)
     if proc.returncode != 0:
         print(

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -353,7 +353,9 @@ def find_uv() -> tuple[str, str]:
         return found, ""
     for rel in UV_FALLBACK_DIRS:
         candidate = Path.home() / rel / "uv"
-        if os.access(candidate, os.X_OK):
+        # a regular executable file, as `which` would accept: a directory of
+        # that name is searchable, not runnable
+        if candidate.is_file() and os.access(candidate, os.X_OK):
             return str(candidate), str(candidate.parent)
     return "", ""
 

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -653,6 +653,9 @@ def test_find_uv_takes_path_first_then_the_installer_directory(
     assert cli.find_uv() == ("", "")  # nowhere
     installed = tmp_path / ".local" / "bin" / "uv"
     installed.parent.mkdir(parents=True)
+    installed.mkdir()  # a searchable DIRECTORY of that name is not uv
+    assert cli.find_uv() == ("", "")
+    installed.rmdir()
     installed.write_text("#!/bin/sh\n")
     installed.chmod(0o755)
     assert cli.find_uv() == (str(installed), str(installed.parent))
@@ -689,3 +692,21 @@ def test_start_adds_the_installer_directory_to_the_loops_path(
     env = seen["env"]
     assert isinstance(env, dict)
     assert env["PATH"].startswith("/h/.local/bin" + os.pathsep)
+
+
+def test_slurm_start_hands_the_installer_directory_to_the_resident_job(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The resident job inherits start's environment through --export=ALL, so
+    the fallback directory must reach sbatch's PATH, not only the local loop."""
+    home = checkout(clean_env)
+    bin_dir = clean_env / "bin"
+    bin_dir.mkdir()
+    pathlog = clean_env / "sbatch.path"
+    shim(bin_dir, "sbatch", f'printf "%s" "$PATH" > {pathlog}\necho "4242;torch"\n')
+    shim(bin_dir, "squeue", "exit 0\n")
+    monkeypatch.setenv("PATH", f"{bin_dir}:{os.environ['PATH']}")
+    monkeypatch.setattr(cli, "find_uv", lambda: ("/h/.local/bin/uv", "/h/.local/bin"))
+    monkeypatch.chdir(home)
+    assert main(["start", "--root", "/scratch/me/ar", "--account", "a", "--partition", "p"]) == 0
+    assert pathlog.read_text().startswith("/h/.local/bin" + os.pathsep)

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -325,6 +325,7 @@ def clean_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     for key in (*START_KEYS, *TICK_ENV_KEYS, "OUTERLOOP_HOME"):
         monkeypatch.delenv(key, raising=False)
     monkeypatch.setattr(cli, "ENV_FILE", tmp_path / "absent.env")
+    monkeypatch.setattr(cli, "find_uv", lambda: ("/usr/bin/uv", ""))
     return tmp_path
 
 
@@ -637,3 +638,54 @@ def test_start_refuses_a_missing_recorded_harness_binary(
     monkeypatch.setenv("OUTERLOOP_AUTHOR_BACKEND", "codex")
     assert main(["start"]) == 2
     assert "state root" in capsys.readouterr().err  # past the binary check
+
+
+# ---------------------------------------------------------------- uv
+
+
+def test_find_uv_takes_path_first_then_the_installer_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(cli.shutil, "which", lambda name: "/opt/bin/uv")
+    assert cli.find_uv() == ("/opt/bin/uv", "")
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    assert cli.find_uv() == ("", "")  # nowhere
+    installed = tmp_path / ".local" / "bin" / "uv"
+    installed.parent.mkdir(parents=True)
+    installed.write_text("#!/bin/sh\n")
+    installed.chmod(0o755)
+    assert cli.find_uv() == (str(installed), str(installed.parent))
+
+
+def test_start_stops_when_uv_is_nowhere(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A loop without uv marks every run unmeasured; start says so and stops.
+    The dry run still prints the command."""
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli, "find_uv", lambda: ("", ""))
+    monkeypatch.setattr(cli, "_exec", lambda cmd, env: pytest.fail("must not exec"))
+    monkeypatch.chdir(checkout(clean_env))
+    assert main(["start", "--root", str(clean_env / "s")]) == 2
+    assert "uv is not on PATH" in capsys.readouterr().err
+    assert main(["start", "--dry-run", "--root", str(clean_env / "s")]) == 0
+
+
+def test_start_adds_the_installer_directory_to_the_loops_path(
+    clean_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(cli.shutil, "which", lambda name: None)
+    monkeypatch.setattr(cli, "find_uv", lambda: ("/h/.local/bin/uv", "/h/.local/bin"))
+    seen: dict[str, object] = {}
+
+    def fake_exec(cmd: list[str], env: dict[str, str]) -> int:
+        seen["env"] = env
+        return 0
+
+    monkeypatch.setattr(cli, "_exec", fake_exec)
+    monkeypatch.chdir(checkout(clean_env))
+    assert main(["start", "--root", str(clean_env / "s")]) == 0
+    env = seen["env"]
+    assert isinstance(env, dict)
+    assert env["PATH"].startswith("/h/.local/bin" + os.pathsep)


### PR DESCRIPTION
## What

`outerloop start` checks for `uv` once, before either mode submits or execs:

- nowhere on PATH and not in the uv installer's default directories (`~/.local/bin`, `~/.cargo/bin`): a message naming the fix and exit 2;
- only in an installer directory: that directory is prepended to the PATH the loop (or the resident job, via `--export=ALL`) inherits, and start says so;
- on PATH: nothing changes.

`--dry-run` still prints the command.

## Why

Every evaluation and launch runs through `uv run` with the PATH start hands over. A loop started from a shell without uv on PATH ran fine and marked every run unmeasured (cluster0, 2026-09-07, the loop was started over ssh with a PATH that lacked `~/.local/bin`). Failing at start is the honest place.

## Tests

`find_uv` prefers PATH, then the installer directory, else nothing; start stops with the message and never execs when uv is nowhere while the dry run still prints; the installer directory lands at the front of the loop's PATH. The `clean_env` fixture pins `find_uv` so the existing start tests do not depend on the runner's uv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
