### PR TITLE
Release 0.1.0.dev3: version bump, generalized docstring, PyPI/Python/license badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 # Outerloop
 
 [![ci](https://github.com/outerloop-science/outerloop/actions/workflows/ci.yml/badge.svg)](https://github.com/outerloop-science/outerloop/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/outerloop-science.svg)](https://pypi.org/project/outerloop-science/)
+[![Python](https://img.shields.io/pypi/pyversions/outerloop-science.svg)](https://pypi.org/project/outerloop-science/)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 **Autoresearch agents that improve your benchmark.**
 

--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -1,8 +1,8 @@
-"""Autonomous research agent that co-develops the lab's benchmark-bearing repos."""
+"""Outerloop: autonomous research agents that improve a benchmark on your own code."""
 
 import os
 
-__version__ = "0.1.0.dev2"
+__version__ = "0.1.0.dev3"
 
 
 def _bridge_legacy_env() -> None:


### PR DESCRIPTION
Cuts `0.1.0.dev3` (RELEASING.md). It carries the night's work: the seed cache (#330), the auto-update policy (#331), the maintenance scan (#334), `start`'s uv guard (#333), the toolchain bump (#335), and the test/dead-code cleanups (#336, #338).

- `__version__` `0.1.0.dev2` → `0.1.0.dev3`. `[Unreleased]` stays in place, as RELEASING.md says for a dev pre-release. dev3 is the next unused version on PyPI (dev0–dev2 are published).
- The package docstring dropped its lab-specific framing ("co-develops the lab's benchmark-bearing repos"); Outerloop runs on the adopter's own code, so the one-line description now matches the README.
- README badges: PyPI version, Python versions, Apache-2.0, beside the existing ci badge. The two PyPI badges resolve the moment dev3 publishes; kept to the few that tell a visitor something (published, supported Pythons, license) rather than a wall of shields.

After merge I tag `v0.1.0.dev3`, which the release workflow publishes to PyPI via Trusted Publishing, then a prerelease GitHub release and a fresh-venv install check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
