### PR TITLE
Maintenance scan: an architecture lens for abstraction simplifications and extension points

### DIFF
--- a/.github/workflows/maintenance-agent.yml
+++ b/.github/workflows/maintenance-agent.yml
@@ -41,7 +41,7 @@ on:
           JSON array of lens names to fan out (general = the whole checklist;
           the library is outerloop.maintain.MAINTENANCE_LENSES)
         type: string
-        default: '["general", "pathways", "duplication", "structure", "upgrades", "tests", "performance", "docs"]'
+        default: '["general", "pathways", "duplication", "structure", "upgrades", "tests", "performance", "docs", "architecture"]'
       reviewer_repo:
         description: The kernel repository to run the scan code from
         type: string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -649,6 +649,9 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- The maintenance scan gains an `architecture` lens: it proposes abstraction
+  simplifications and missing extension points (a new backend, benchmark, or
+  role should need zero kernel change), as decision-kind digest items.
 - Helpers shared across kernel modules are public in their owning module:
   `brief.code_fence`, `brief.cap`, `attempt.target_clone_url`,
   `attempt.stage_launch_job_ids`, `orchestrator.metric_from_output`,

--- a/src/outerloop/maintain.py
+++ b/src/outerloop/maintain.py
@@ -92,8 +92,9 @@ MAINTENANCE_LENSES: dict[str, str] = {
         "that a new backend, benchmark, or role should need zero kernel "
         "change, where an extension point is missing so adding one today "
         "forces a kernel edit. Name the files and propose the merge or the "
-        "seam; mark these decisions — a refactor of a load-bearing "
-        "abstraction is the maintainer's call, not a mechanical change."
+        "seam; mark these decisions — a refactor of an abstraction many "
+        "parts of the system depend on is the maintainer's call, not a "
+        "mechanical change."
     ),
 }
 

--- a/src/outerloop/maintain.py
+++ b/src/outerloop/maintain.py
@@ -85,6 +85,16 @@ MAINTENANCE_LENSES: dict[str, str] = {
         "whose status no longer matches the code, knobs and flags the docs "
         "never name, wording that disagrees between two documents."
     ),
+    "architecture": (
+        "LENS — abstraction and extensibility, forward-looking rather than "
+        "cleanup: where two abstractions could be unified or a layer dropped "
+        "so the system is simpler to reason about; and, holding the principle "
+        "that a new backend, benchmark, or role should need zero kernel "
+        "change, where an extension point is missing so adding one today "
+        "forces a kernel edit. Name the files and propose the merge or the "
+        "seam; mark these decisions — a refactor of a load-bearing "
+        "abstraction is the maintainer's call, not a mechanical change."
+    ),
 }
 
 SYSTEM_PROMPT = (

--- a/src/outerloop/review_summarize_cli.py
+++ b/src/outerloop/review_summarize_cli.py
@@ -30,7 +30,7 @@ from outerloop.roles import summarizer_spec
 
 log = logging.getLogger(__name__)
 
-MAX_OPINIONS = 8  # artifacts are workflow-authored, but cap the read anyway
+MAX_OPINIONS = 12  # the maintenance scan fans out 9 lenses; cap the read, generously
 
 
 def _load_envelopes(root: Path, repo: str, number: int) -> list[dict]:

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -428,6 +428,7 @@ def test_workflows_keep_the_write_token_out_of_the_session_jobs() -> None:
     triggers = agent.get("on", agent.get(True))
     default = json.loads(triggers["workflow_call"]["inputs"]["lenses"]["default"])
     assert lens_names(default) == default and "general" in default
+    assert "architecture" in default  # the weekly scan must keep running it
     caller = yaml.safe_load((ROOT / ".github/workflows/maintenance.yml").read_text())
     events = caller.get("on", caller.get(True))
     assert "schedule" in events and "workflow_dispatch" in events

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -48,6 +48,8 @@ def test_brief_focuses_one_lens_or_covers_all_and_refuses_unknown_ones() -> None
     assert "Today's date: 2026-09-08" in general and "Repository: o/r at abc123" in general
     with pytest.raises(ValueError, match="unknown maintenance lens"):
         build_maintenance_brief("o/r", "abc123", lens="vibes")
+    assert "architecture" in MAINTENANCE_LENSES
+    assert "extension point" in build_maintenance_brief("o/r", "abc123", lens="architecture")
     assert lens_names(["general", "docs"]) == ["general", "docs"]
     with pytest.raises(ValueError, match="unknown maintenance lens"):
         lens_names(["docs", "vibes"])


### PR DESCRIPTION
Adds one lens to the weekly maintenance scan (docs/design/reviewer-infra.md), the forward-looking one you asked for: not just "this module is big" but "these two abstractions could be one" and "adding a new backend/benchmark/role here forces a kernel edit — the seam is missing." It uses the kernel's own principle that a new backend, benchmark, or role should need zero kernel change. Findings are decision-kind (a load-bearing refactor is the maintainer's call), and the lens is added to the reusable workflow's default set so the kernel's own weekly scan runs it. Tests assert the lens exists and shapes the brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)