### PR TITLE
CI & reusable workflows: bump Actions to current majors (checkout v7, setup-uv v10, upload v7, download v8)

### DIFF
--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -164,7 +164,7 @@ jobs:
       # An empty ssh-key is ignored by actions/checkout (token auth is enough
       # for a public or same-repo reviewer); a private reviewer repo needs it.
       - name: Check out the reviewer
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.reviewer_repo }}
           ref: ${{ inputs.reviewer_ref }}
@@ -172,12 +172,12 @@ jobs:
           path: .autoresearch
           persist-credentials: false
       - name: Check out the PR head (read-only; never executed)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ env.PR_NUMBER }}/head
           path: pr-head
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -288,7 +288,7 @@ jobs:
         # not `success()`: a session step that died AFTER emitting must still
         # deliver its findings (or its skip-stub) to the posting job
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: review-findings-${{ inputs.opinion_id || inputs.backend }}-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}/findings.json
@@ -311,14 +311,14 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Check out the reviewer
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.reviewer_repo }}
           ref: ${{ inputs.reviewer_ref }}
           ssh-key: ${{ secrets.checkout_ssh_key }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -330,7 +330,7 @@ jobs:
         # caller's PR stays green; the job is continue-on-error at job
         # level). Observed live 2026-08-15: errored terra sessions posted
         # nothing and read as quiet clean days.
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: review-findings-${{ inputs.opinion_id || inputs.backend }}-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}

--- a/.github/workflows/advisory-review-agent.yml
+++ b/.github/workflows/advisory-review-agent.yml
@@ -177,7 +177,7 @@ jobs:
           ref: refs/pull/${{ env.PR_NUMBER }}/head
           path: pr-head
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -318,7 +318,7 @@ jobs:
           ssh-key: ${{ secrets.checkout_ssh_key }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock

--- a/.github/workflows/advisory-review-summarize.yml
+++ b/.github/workflows/advisory-review-summarize.yml
@@ -103,7 +103,7 @@ jobs:
           ssh-key: ${{ secrets.checkout_ssh_key }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -231,7 +231,7 @@ jobs:
           ssh-key: ${{ secrets.checkout_ssh_key }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock

--- a/.github/workflows/advisory-review-summarize.yml
+++ b/.github/workflows/advisory-review-summarize.yml
@@ -96,14 +96,14 @@ jobs:
       HERMES_SHA: f80f453ae0679347e38abc917c7f94f717bf96c5
     steps:
       - name: Check out the reviewer
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.reviewer_repo }}
           ref: ${{ inputs.reviewer_ref }}
           ssh-key: ${{ secrets.checkout_ssh_key }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -168,7 +168,7 @@ jobs:
         # NO required-download here: the summarizer CLI itself turns "no
         # envelopes" into a visible skip-stub, so a died-before-emitting lens
         # set still surfaces on the PR rather than failing into silence.
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: review-findings-lens-*-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}/opinions
@@ -204,7 +204,7 @@ jobs:
           fi
       - name: Upload merged findings
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: review-findings-summary-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}/findings.json
@@ -224,20 +224,20 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Check out the reviewer
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.reviewer_repo }}
           ref: ${{ inputs.reviewer_ref }}
           ssh-key: ${{ secrets.checkout_ssh_key }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
       - name: Download merged findings
         id: findings
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: review-findings-summary-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: eWaterCycle/setup-apptainer@v2
       - name: Build
         run: sudo -E apptainer build --force agent-py312.sif containers/agent-py312.def

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           # Full history: gitleaks scans it (this repo handles credentials).
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
       - run: uv sync --locked

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,11 +20,11 @@ jobs:
   ci:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history: gitleaks scans it (this repo handles credentials).
           fetch-depth: 0
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
       - run: uv sync --locked

--- a/.github/workflows/maintenance-agent.yml
+++ b/.github/workflows/maintenance-agent.yml
@@ -100,19 +100,19 @@ jobs:
       HERMES_SHA: f80f453ae0679347e38abc917c7f94f717bf96c5
     steps:
       - name: Check out the kernel
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.reviewer_repo }}
           ref: ${{ inputs.reviewer_ref }}
           path: .autoresearch
           persist-credentials: false
       - name: Check out the tree to scan (the default branch's resolved commit)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.resolve.outputs.sha }}
           path: tree
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -195,7 +195,7 @@ jobs:
           fi
       - name: Upload findings
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: maintenance-findings-lens-${{ matrix.lens }}-${{ github.run_id }}
           path: ${{ runner.temp }}/findings.json
@@ -217,13 +217,13 @@ jobs:
       HERMES_SHA: f80f453ae0679347e38abc917c7f94f717bf96c5
     steps:
       - name: Check out the kernel
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.reviewer_repo }}
           ref: ${{ inputs.reviewer_ref }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -276,7 +276,7 @@ jobs:
               ;;
           esac
       - name: Download lens opinions
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: maintenance-findings-lens-*-${{ github.run_id }}
           path: ${{ runner.temp }}/opinions
@@ -311,7 +311,7 @@ jobs:
           fi
       - name: Upload the merged digest
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: maintenance-findings-summary-${{ github.run_id }}
           path: ${{ runner.temp }}/findings.json
@@ -330,19 +330,19 @@ jobs:
       issues: write
     steps:
       - name: Check out the kernel
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.reviewer_repo }}
           ref: ${{ inputs.reviewer_ref }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
       - name: Download the merged digest
         id: findings
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: maintenance-findings-summary-${{ github.run_id }}
           path: ${{ runner.temp }}

--- a/.github/workflows/maintenance-agent.yml
+++ b/.github/workflows/maintenance-agent.yml
@@ -112,7 +112,7 @@ jobs:
           ref: ${{ needs.resolve.outputs.sha }}
           path: tree
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -223,7 +223,7 @@ jobs:
           ref: ${{ inputs.reviewer_ref }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock
@@ -336,7 +336,7 @@ jobs:
           ref: ${{ inputs.reviewer_ref }}
           path: .autoresearch
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
       - run: uv build
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v6
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v10
       - run: uv build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
@@ -33,7 +33,7 @@ jobs:
     permissions:
       id-token: write # mint the OIDC token Trusted Publishing exchanges
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -60,7 +60,7 @@ jobs:
           ref: refs/pull/${{ inputs.pr_number }}/head
           path: pr-head
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock

--- a/.github/workflows/review-agent.yml
+++ b/.github/workflows/review-agent.yml
@@ -50,17 +50,17 @@ jobs:
       BACKEND: ${{ inputs.backend }}
     steps:
       - name: Check out the reviewer
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           path: .autoresearch
           persist-credentials: false
       - name: Check out the PR head (read-only; never executed)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ inputs.pr_number }}/head
           path: pr-head
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: .autoresearch/uv.lock

--- a/.github/workflows/verify-agent.yml
+++ b/.github/workflows/verify-agent.yml
@@ -141,7 +141,7 @@ jobs:
           ref: ${{ github.event.pull_request.base.ref }}
           path: base
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: kernel/uv.lock
@@ -218,7 +218,7 @@ jobs:
           ssh-key: ${{ secrets.checkout_ssh_key }}
           path: kernel
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.1
         with:
           enable-cache: true
           cache-dependency-glob: kernel/uv.lock

--- a/.github/workflows/verify-agent.yml
+++ b/.github/workflows/verify-agent.yml
@@ -120,7 +120,7 @@ jobs:
       # force-owns (recreates) before the session; a colliding checkout there
       # would be destroyed.
       - name: Check out the verifier
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.verifier_repo }}
           ref: ${{ inputs.verifier_ref }}
@@ -128,7 +128,7 @@ jobs:
           path: kernel
           persist-credentials: false
       - name: Check out the PR head (the change under review)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: refs/pull/${{ env.PR_NUMBER }}/head
           path: pr-head
@@ -136,12 +136,12 @@ jobs:
       # The base tree carries the TRUSTED contract and ruler — the brief
       # directs all ruler reads here, never at the PR head.
       - name: Check out the base branch (trusted contract + ruler)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.ref }}
           path: base
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: kernel/uv.lock
@@ -183,7 +183,7 @@ jobs:
       - name: Upload the verdict
         # not success(): a session that died AFTER emitting must still deliver
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: verify-verdict-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}/verdict.json
@@ -211,14 +211,14 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Check out the verifier
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: ${{ inputs.verifier_repo }}
           ref: ${{ inputs.verifier_ref }}
           ssh-key: ${{ secrets.checkout_ssh_key }}
           path: kernel
           persist-credentials: false
-      - uses: astral-sh/setup-uv@v6
+      - uses: astral-sh/setup-uv@v10
         with:
           enable-cache: true
           cache-dependency-glob: kernel/uv.lock
@@ -227,7 +227,7 @@ jobs:
         # NO continue-on-error: every session outcome uploads an envelope, so a
         # missing artifact means the session died before emitting — fail this
         # job visibly (the caller's PR stays green; job is continue-on-error).
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: verify-verdict-${{ env.PR_NUMBER }}
           path: ${{ runner.temp }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -649,6 +649,11 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- CI and reusable-workflow Actions bumped to current majors: actions/checkout
+  v7, astral-sh/setup-uv v10, upload-artifact v7, download-artifact v8. The
+  single-name artifact downloads stay flat and the pattern download reads
+  recursively, so the review split is unaffected; the node24 runtime is on the
+  hosted runners.
 - Helpers shared across kernel modules are public in their owning module:
   `brief.code_fence`, `brief.cap`, `attempt.target_clone_url`,
   `attempt.stage_launch_job_ids`, `orchestrator.metric_from_output`,


### PR DESCRIPTION
Digest #332, the mechanical part. Bumps the four pinned actions to their current majors across every workflow.

The one behaviour to watch is download-artifact (v4 → v8). It is safe here: the post jobs download a **single named** artifact into `runner.temp`, which stays flat, so `runner.temp/findings.json` still resolves; the summarizer's **pattern** download reads `**/findings.json` recursively, so a per-artifact subdirectory is fine. node24 (required by checkout v5+) is on the hosted runners.

Because these reusable workflows run from `@main`, a break only shows after merge — so this merges then gets a **canary review** on a throwaway PR immediately, and I revert if the review does not post. Held for a watched window on purpose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)