### PR TITLE
Base reintegration stage 1: re-pin a line on wake when main moved, with a change digest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- Base reintegration, stage 1 (docs/design/base-reintegration.md): a research
+  line that has drifted behind sibling merges is re-pinned onto the current
+  base at each wake, not only at run start. When `origin/<base_branch>` has
+  advanced past the line's pinned base, the wake merges it in, re-pins the base
+  to the merge, and leads the wake text with a short digest — the record move
+  plus a one-line summary of each sibling commit, never full diffs. It is a
+  strict no-op when the base has not moved, applies only to line runs, triggers
+  no eval (the agent re-measures a kept change through its normal launch), and
+  leaves a conflicting merge in the working tree for the agent to resolve.
 - A weekly maintenance digest (`maintenance-agent.yml`, reusable; the kernel's
   own caller is `maintenance.yml`): read-only lens sessions scan a repository's
   default branch for dead pathways, duplicated logic, oversized modules, stale

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -65,7 +65,9 @@ from outerloop.orchestrator import (
 from outerloop.panel import PanelLens, PanelVerdict, run_panel
 from outerloop.paths import CONFIG_DIR
 from outerloop.progress import (
+    LEADER_FILE,
     PROGRESS_PATHS,
+    LeaderEntry,
     load_leader,
     update_leader,
     write_progress,
@@ -949,6 +951,19 @@ def _wake_author_sleep(
     snapshots: list[Snapshot] = []
     wake_line = _line_ref_for(bench, config.agent_id)
 
+    # Base reintegration stage 1: a line that has drifted behind sibling merges
+    # is re-pinned onto the current base HERE, at the wake seam (never mid-
+    # experiment), before the base_sha-paired snapshot/changed_paths/panel are
+    # built below. Only line runs; a strict no-op when the base has not moved.
+    # A clean merge advances base_sha to the merge and leads the wake with a
+    # digest; a conflict is left in the tree for the agent, base_sha unchanged.
+    reint = _reintegrate_line_base(
+        ws, wake_line, base_branch, base_sha, config.benchmark, config.bot_login, secrets
+    )
+    if reint is not None:
+        base_sha = reint.new_base_sha
+        wake_text = f"{reint.digest}\n\n{wake_text}"
+
     def snapshot() -> str:
         snap = snapshot_tree(
             ws, base_sha, exclude=LINE_MEMORY_PATHS if wake_line else (), author=config.bot_login
@@ -1466,6 +1481,180 @@ def _checkout_line(
         # pushed: the conflict is session work, not line state.
         ws.push(line)
     return line
+
+
+# Base reintegration stage 1 (docs/design/base-reintegration.md): a line that
+# merged main only at run start drifts behind sibling merges over a multi-day
+# depth run. Each wake re-pins the line onto the current base when — and only
+# when — a sibling actually landed something.
+_DIGEST_MAX_SIBLINGS = 12
+_DIGEST_SUBJECT_CHARS = 120
+
+
+@dataclass(frozen=True)
+class _Reintegration:
+    """The outcome of re-pinning a line's base at wake. `new_base_sha` is the
+    merged line head after a clean merge, or the UNCHANGED base after a
+    conflict — the base advances only when the merge actually applied.
+    `conflicted` says the merge was left in the working tree for the agent to
+    resolve; `digest` leads the wake text (the record move plus a one-line
+    summary of each sibling change)."""
+
+    new_base_sha: str
+    conflicted: bool
+    digest: str
+
+
+def _leader_best_at(ws: Workspace, sha: str, benchmark: str) -> LeaderEntry | None:
+    """The leaderboard entry for `benchmark` in results/leader.json AT a commit
+    `sha`, read straight from git (never the working tree). None when the file
+    or the entry is absent or unparsable — best-effort, like load_leader."""
+    try:
+        raw = json.loads(ws.git("show", f"{sha}:{LEADER_FILE}"))
+    except Exception:
+        return None
+    item = raw.get(benchmark) if isinstance(raw, dict) else None
+    if not isinstance(item, dict):
+        return None
+    known = {k: v for k, v in item.items() if k in LeaderEntry.__dataclass_fields__}
+    try:
+        return LeaderEntry(**known)
+    except TypeError:
+        return None
+
+
+def _reintegration_digest(
+    ws: Workspace,
+    base_branch: str,
+    old_base_sha: str,
+    new_main: str,
+    benchmark: str,
+    conflicted: bool,
+    secrets: tuple[str, ...],
+) -> str:
+    """The wake digest: what moved on the base, not a diff. The best-metric
+    move for this benchmark (results/leader.json, old base vs new head) plus a
+    one-line summary of each sibling commit that landed since. Decision 3
+    (tell, don't force): it surfaces the change; the agent pivots or pushes on
+    its own — the kernel never abandons the line."""
+    if conflicted:
+        lines = [
+            f"Base moved: `origin/{base_branch}` advanced since you last ran, but "
+            "merging it into your line CONFLICTS. Resolving the conflicts left in "
+            "your working tree is your first task before you continue."
+        ]
+    else:
+        lines = [
+            f"Base moved: `origin/{base_branch}` advanced since you last ran; I "
+            "merged it into your line and re-pinned your base to the merge. Decide "
+            "what to re-run — a result you keep is re-measured through a normal "
+            "launch, and results that do not depend on what changed still hold."
+        ]
+    before = _leader_best_at(ws, old_base_sha, benchmark)
+    after = _leader_best_at(ws, new_main, benchmark)
+    if after is not None and before is not None and after.best != before.best:
+        better = after.best < before.best if after.direction == "min" else after.best > before.best
+        lines.append(
+            f"- record on {benchmark}: {before.best:g} -> {after.best:g} "
+            f"({after.direction}; {'better' if better else 'worse'}), run {after.best_run}"
+        )
+    elif after is not None and before is None:
+        lines.append(
+            f"- record on {benchmark}: now {after.best:g} ({after.direction}), run {after.best_run}"
+        )
+    try:
+        subjects = [
+            ln.strip()
+            for ln in ws.git(
+                "log", "--no-merges", "--format=%h %s", f"{old_base_sha}..{new_main}"
+            ).splitlines()
+            if ln.strip()
+        ]
+    except Exception:
+        subjects = []
+    for entry in subjects[:_DIGEST_MAX_SIBLINGS]:
+        lines.append(f"- {entry[:_DIGEST_SUBJECT_CHARS]}")
+    if len(subjects) > _DIGEST_MAX_SIBLINGS:
+        lines.append(f"- (+{len(subjects) - _DIGEST_MAX_SIBLINGS} more)")
+    return redact("\n".join(lines), secrets)
+
+
+def _reintegrate_line_base(
+    ws: Workspace,
+    wake_line: str,
+    base_branch: str,
+    base_sha: str,
+    benchmark: str,
+    bot_login: str,
+    secrets: tuple[str, ...],
+) -> _Reintegration | None:
+    """Stage 1 of base reintegration (docs/design/base-reintegration.md): when
+    a research LINE wakes and `origin/<base_branch>` has advanced past the
+    pinned base, merge the base into the line, re-pin the base to the merge,
+    and return a digest for the wake text. A strict no-op — returns None,
+    changes nothing — for a non-line run (`wake_line` empty) or when the base
+    has not moved. Git + text only: it never triggers an eval (decision 5 —
+    the agent re-measures a kept change through its normal launch path).
+
+    A conflicting merge is left in the working tree for the AGENT to resolve
+    (the kernel never resolves content, mirroring the run-start conflict-as-
+    first-task behavior), and the base stays pinned until a clean merge
+    applies. Best-effort: any unexpected git failure restores the pre-call
+    tree and returns None, so the wake proceeds exactly as it does today."""
+    if not wake_line:
+        return None
+    base_ref = f"refs/remotes/origin/{base_branch}"
+    # Detect movement the way the base-sync wake does (followup.py): fetch the
+    # canonical remote, then ask whether the fresh base head is already
+    # contained in the pinned base. For a line, base_sha is the line tip that
+    # merged the base in at run start, so an unmoved base is its ancestor and
+    # this is a strict no-op. The fetch also refreshes refs/remotes/origin/*,
+    # which the wake's changed_paths pairs against.
+    try:
+        ws.fetch_origin()
+        new_main = ws.git("rev-parse", base_ref).strip()
+        merge_base = ws.git("merge-base", new_main, base_sha).strip()
+    except Exception as exc:
+        log.warning("base reintegration: movement check failed (%s); skipping", type(exc).__name__)
+        return None
+    if merge_base == new_main:
+        return None  # the fresh base head is already in the line: nothing moved
+    # Commit the session's accumulated tree so the merge runs on a clean tree
+    # (a dirty overlapping tree makes `git merge` abort wholesale) and the work
+    # is preserved on the line — then merge the fresh base in, exactly like the
+    # run-start merge (_checkout_line).
+    try:
+        ws.git("add", "-A")
+        if ws.git("diff", "--cached", "--name-only").strip():
+            ws.git(
+                *git_identity(bot_login),
+                "commit",
+                "-q",
+                "-m",
+                "line: session work in progress before base reintegration",
+            )
+    except Exception as exc:
+        log.warning("base reintegration: staging the session tree failed (%s)", type(exc).__name__)
+        _best_effort("reintegration reset", lambda: ws.git("reset", "-q", base_sha), secrets)
+        return None
+    try:
+        ws.git(*git_identity(bot_login), "merge", "--no-edit", base_ref)
+    except GitError:
+        if ws.git("diff", "--name-only", "--diff-filter=U").strip():
+            # a real content conflict: the agent resolves it, never the kernel;
+            # the base stays pinned — it advances only on a clean merge.
+            digest = _reintegration_digest(
+                ws, base_branch, base_sha, new_main, benchmark, True, secrets
+            )
+            return _Reintegration(new_base_sha=base_sha, conflicted=True, digest=digest)
+        # not a content conflict: undo the half-merge and the WIP commit, and
+        # skip — the wake proceeds against the unchanged base.
+        _best_effort("reintegration merge abort", lambda: ws.git("merge", "--abort"), secrets)
+        _best_effort("reintegration reset", lambda: ws.git("reset", "-q", base_sha), secrets)
+        return None
+    new_base = ws.git("rev-parse", "HEAD").strip()
+    digest = _reintegration_digest(ws, base_branch, base_sha, new_main, benchmark, False, secrets)
+    return _Reintegration(new_base_sha=new_base, conflicted=False, digest=digest)
 
 
 def _paths_changed_from_base(

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import json
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -3801,6 +3802,140 @@ def test_checkout_line_rejects_a_ref_shaping_agent_id(tmp_path: Path, target_rep
     ws = _line_ws(tmp_path, target_repo)
     with pytest.raises(ValueError, match="cannot shape a line ref"):
         _checkout_line(ws, ws.root, "../evil", "main")
+
+
+# Base reintegration stage 1 (docs/design/base-reintegration.md): a line is
+# re-pinned onto the current base at each wake, but only when a sibling moved.
+
+
+def _leader_json(best: float, run: str) -> str:
+    return json.dumps(
+        {
+            "tsp": {
+                "benchmark": "tsp",
+                "metric": "mean_tour_length",
+                "direction": "min",
+                "baseline": 8192.0,
+                "best": best,
+                "best_run": run,
+                "updated": "2026-09-05",
+            }
+        }
+    )
+
+
+def _advance_main_in(tmp_path: Path, bare: Path, subdir: str, files: dict[str, str]) -> None:
+    """Like _advance_main, but into a named work dir so a test can move main
+    more than once."""
+    work = tmp_path / subdir
+    _git(tmp_path, "clone", "-q", str(bare), str(work))
+    for rel, content in files.items():
+        path = work / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "add", "-A")
+    _git(work, "-c", "user.name=t", "-c", "user.email=t@t", "commit", "-qm", "main moves")
+    _git(work, "push", "-q", "origin", "main")
+
+
+def test_reintegrate_line_base_is_a_no_op_when_the_base_did_not_move(
+    tmp_path: Path, target_repo
+) -> None:
+    from outerloop.attempt import _checkout_line, _reintegrate_line_base
+
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    base_sha = ws.git("rev-parse", "HEAD").strip()
+    tsp = ws.root / "src" / "pilot" / "solvers" / "tsp.py"
+    tsp.write_text("def solve(): return 2\n")  # the session's dirty tree
+
+    reint = _reintegrate_line_base(ws, "agents/agent-07", "main", base_sha, "tsp", "bot", ())
+
+    assert reint is None  # strict no-op: no merge, no digest
+    assert ws.git("rev-parse", "HEAD").strip() == base_sha  # base unchanged
+    assert tsp.read_text() == "def solve(): return 2\n"  # dirty tree untouched
+    assert ws.git("status", "--porcelain").strip() != ""  # nothing was committed
+
+
+def test_reintegrate_line_base_repins_and_digests_when_main_moved(
+    tmp_path: Path, target_repo
+) -> None:
+    from outerloop.attempt import _checkout_line, _reintegrate_line_base
+
+    _advance_main_in(
+        tmp_path, target_repo, "main-a", {"results/leader.json": _leader_json(8192.0, "tsp-3")}
+    )
+    _push_line(tmp_path, target_repo, {"docs/line-note.md": "belief\n"})
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    base_sha = ws.git("rev-parse", "HEAD").strip()
+    tsp = ws.root / "src" / "pilot" / "solvers" / "tsp.py"
+    tsp.write_text("def solve(): return 3\n")  # the session's accumulated work
+    # a sibling lands a change and moves the record
+    _advance_main_in(
+        tmp_path,
+        target_repo,
+        "main-b",
+        {
+            "docs/warmdown.md": "warmdown to 4352\n",
+            "results/leader.json": _leader_json(7808.0, "tsp-10"),
+        },
+    )
+
+    reint = _reintegrate_line_base(
+        ws, "agents/agent-07", "main", base_sha, "tsp", "outerloop-science[bot]", ()
+    )
+
+    assert reint is not None and not reint.conflicted
+    new_head = ws.git("rev-parse", "HEAD").strip()
+    assert reint.new_base_sha == new_head != base_sha  # re-pinned to the merge
+    # the base merged in, the line's work and the session's edit all survive
+    assert (ws.root / "docs" / "warmdown.md").read_text() == "warmdown to 4352\n"
+    assert (ws.root / "docs" / "line-note.md").read_text() == "belief\n"
+    assert tsp.read_text() == "def solve(): return 3\n"
+    # the digest names the record move and summarizes the sibling change
+    assert "8192" in reint.digest and "7808" in reint.digest
+    assert "better" in reint.digest and "tsp" in reint.digest
+    assert "main moves" in reint.digest  # the sibling commit subject, not a diff
+
+
+def test_reintegrate_line_base_surfaces_a_conflict_to_the_agent(
+    tmp_path: Path, target_repo
+) -> None:
+    from outerloop.attempt import _checkout_line, _reintegrate_line_base
+
+    _push_line(tmp_path, target_repo, {"docs/roadmap.md": "# line roadmap\n"})
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    base_sha = ws.git("rev-parse", "HEAD").strip()
+    # the session edits the same file the sibling is about to change
+    (ws.root / "docs" / "roadmap.md").write_text("# agent roadmap edit\n")
+    _advance_main(tmp_path, target_repo, {"docs/roadmap.md": "# main roadmap\n"})
+
+    reint = _reintegrate_line_base(ws, "agents/agent-07", "main", base_sha, "tsp", "bot", ())
+
+    assert reint is not None and reint.conflicted
+    assert reint.new_base_sha == base_sha  # the base stays pinned on a conflict
+    assert "conflict" in reint.digest.lower()  # the digest says so
+    # the kernel did NOT resolve: the conflict is left in the working tree
+    assert "docs/roadmap.md" in ws.git("diff", "--name-only", "--diff-filter=U")
+
+
+def test_reintegrate_line_base_skips_a_non_line_run(tmp_path: Path, target_repo) -> None:
+    from outerloop.attempt import _reintegrate_line_base
+
+    ws = _line_ws(tmp_path, target_repo)  # checked out on main, not a line
+    base_sha = ws.git("rev-parse", "HEAD").strip()
+    tsp = ws.root / "src" / "pilot" / "solvers" / "tsp.py"
+    tsp.write_text("def solve(): return 9\n")
+    _advance_main(tmp_path, target_repo, {"docs/news.md": "moved\n"})  # main DID move
+
+    reint = _reintegrate_line_base(ws, "", "main", base_sha, "tsp", "bot", ())
+
+    assert reint is None  # non-line: bypassed entirely, never even fetched
+    assert ws.git("rev-parse", "HEAD").strip() == base_sha
+    assert tsp.read_text() == "def solve(): return 9\n"  # dirty tree untouched
+    assert not (ws.root / "docs" / "news.md").exists()  # main's move not pulled in
 
 
 @pytest.fixture


### PR DESCRIPTION
Stage 1 of the design in `docs/design/base-reintegration.md` (the five owner decisions; #341). Implements decisions 1, 2, 3, 5. Stage 2 (the post-terminal reconcile, decision 4) is a separate PR.

## What

When a research line wakes and `origin/<base_branch>` has advanced past its pinned base, the kernel now merges the base into the line, re-pins the base to the merge, and prepends a short digest to the wake text. Today a line merges main only at run start, so a multi-day depth run drifts behind sibling merges — which is how gpt-speedrun PR #12 opened against a base superseded three days earlier and needed a human to unstack it.

- **Only when main moved** (decision 1): fetch + merge-base check; if the fresh base head is already in the line, strict no-op — no merge, no digest, no base change. Non-line runs return before the fetch.
- **The digest** (decisions 2, 3): the leaderboard best move (`results/leader.json`, old base vs new head) plus one line per sibling commit subject, capped, never diffs; neutral "decide what to re-run" wording. It tells; it never abandons the line.
- **No eager re-measure** (decision 5): git and text only. The agent re-measures a kept change through its normal launch path.
- **Conflicts stay with the agent**: a conflicting merge is left in the working tree and the base stays pinned, mirroring the run-start conflict-as-first-task behavior; the kernel never resolves content. Any unexpected git failure restores the pre-call tree and the wake proceeds exactly as today.

The re-pinned base threads into `attempt_once` and thence `RunParked.base_sha`, so the measurement pairing follows the re-pin — the same two-base model the wake path already uses (snapshot parents on base; changed_paths pairs on `origin/<base>`).

## Tests

No-op when the base did not move; re-pin plus digest when main moved; a conflict surfaced to the agent (base stays pinned); a non-line run unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)