### PR TITLE
Add `outerloop upgrade` for local installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Added
 
+- `outerloop upgrade`: one verb for a local install to move to the newest
+  release (`--pre` to track pre-releases), the local counterpart of the Slurm
+  resident tick's `OUTERLOOP_AUTO_UPDATE` policy. It runs `pip install --upgrade`,
+  reports the version change, and reminds you to restart the loop.
 - Base reintegration (docs/design/base-reintegration.md): when a research
   line's base moves while it sleeps, its wake fetches the fresh base and tells
   the agent to merge it and decide what to re-run — the same fetch-and-merge

--- a/docs/install.md
+++ b/docs/install.md
@@ -284,8 +284,10 @@ release tag at the next cadence (pre-releases included; the repo is public, so
 no credential is needed). `main` follows every merge and is meant for the
 kernel's own developers. Whatever moves the checkout, you or the policy, the
 environment is synced to the commit that is checked out, or the deploy rolls
-back to the last commit whose environment was installed. The local loop runs the installed package: upgrade it with
-`pip install -U outerloop-science` and start it again.
+back to the last commit whose environment was installed. The local loop runs
+the installed package, which has no such policy: run `outerloop upgrade` to move
+it to the newest release (add `--pre` to track pre-releases), then start it
+again. That is `pip install --upgrade outerloop-science` under one verb.
 
 Experiments run wherever your `compute` backend says. Slurm is the first
 backend; the interface is small (submit a job, poll for completion), so a CI

--- a/src/outerloop/cli.py
+++ b/src/outerloop/cli.py
@@ -499,6 +499,55 @@ def start(args: argparse.Namespace) -> int:
     return 0
 
 
+DIST = "outerloop-science"  # the PyPI distribution; imported as `outerloop`
+
+
+def _installed_version(python: str) -> str:
+    """The installed version of the distribution, read from a fresh interpreter
+    so it reflects what pip just wrote rather than this process's imported copy."""
+    proc = subprocess.run(
+        [python, "-c", f"import importlib.metadata as m; print(m.version({DIST!r}))"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.stdout.strip() or "unknown"
+
+
+def upgrade(args: argparse.Namespace) -> int:
+    """Upgrade the installed package in place, the local adopter's one verb.
+
+    On Slurm the resident tick self-updates through OUTERLOOP_AUTO_UPDATE; a local
+    install has no such loop, so this is the equivalent: `pip install --upgrade`,
+    then you restart the loop to pick the new code up. Pip already picks the newest
+    release and only falls back to a pre-release when that is all that is published;
+    --pre forces pre-releases even once a stable exists."""
+    cmd = [sys.executable, "-m", "pip", "install", "--upgrade", DIST]
+    if args.pre:
+        cmd.append("--pre")
+    if args.dry_run:
+        print(shlex.join(cmd))
+        return 0
+    before = _installed_version(sys.executable)
+    proc = subprocess.run(cmd, check=False)
+    if proc.returncode != 0:
+        print(
+            f"upgrade failed (pip exited {proc.returncode}). If this environment has no "
+            f"pip, upgrade through its installer instead, e.g. `uv pip install --upgrade {DIST}`.",
+            file=sys.stderr,
+        )
+        return proc.returncode
+    after = _installed_version(sys.executable)
+    if before == after:
+        print(f"already up to date: outerloop {after}.")
+    else:
+        print(
+            f"upgraded outerloop {before} -> {after}. Restart the loop to pick it up: "
+            f"stop the running tick, then `outerloop start`."
+        )
+    return 0
+
+
 def main(argv: list[str] | None = None) -> int:
     from outerloop import __version__
 
@@ -539,6 +588,17 @@ def main(argv: list[str] | None = None) -> int:
         help="guided setup: write ~/.config/outerloop/.env and the PAT file",
         add_help=False,
     )
+    up = sub.add_parser(
+        "upgrade",
+        help="upgrade the installed package, then restart the loop to pick it up",
+        description="Upgrade outerloop-science in this environment with pip. On Slurm the "
+        "resident tick self-updates through OUTERLOOP_AUTO_UPDATE; this is the equivalent "
+        "for a local install. Restart the loop afterwards to run the new code.",
+    )
+    up.add_argument(
+        "--pre", action="store_true", help="include pre-releases even once a stable exists"
+    )
+    up.add_argument("--dry-run", action="store_true", help="print the command and exit")
     argv = sys.argv[1:] if argv is None else list(argv)
     if argv[:1] == ["tick"]:
         # the tick entry owns its own parser; hand it the rest untouched
@@ -551,7 +611,10 @@ def main(argv: list[str] | None = None) -> int:
         from outerloop import init
 
         return init.main(argv[1:])
-    return start(parser.parse_args(argv))
+    args = parser.parse_args(argv)
+    if args.command == "upgrade":
+        return upgrade(args)
+    return start(args)
 
 
 if __name__ == "__main__":

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -780,3 +780,32 @@ def test_upgrade_surfaces_a_failed_pip_and_its_exit_code(
     monkeypatch.setattr(cli, "_installed_version", lambda _python: "0.1.0.dev3")
     assert main(["upgrade"]) == 3
     assert "upgrade failed (pip exited 3)" in capsys.readouterr().err
+
+
+def test_installed_version_reads_a_fresh_interpreter(monkeypatch: pytest.MonkeyPatch) -> None:
+    seen: list[list[str]] = []
+
+    def fake_run(argv: list[str], **kw: Any) -> Any:
+        import subprocess
+
+        seen.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="0.1.0.dev9\n", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    assert cli._installed_version("/usr/bin/python3") == "0.1.0.dev9"
+    # a fresh interpreter is what reflects a just-written upgrade, not this process
+    assert seen[0][0] == "/usr/bin/python3"
+    assert seen[0][1] == "-c"
+    assert "outerloop-science" in seen[0][2]
+
+
+def test_installed_version_is_unknown_when_the_lookup_says_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(argv: list[str], **kw: Any) -> Any:
+        import subprocess
+
+        return subprocess.CompletedProcess(argv, 1, stdout="", stderr="boom")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    assert cli._installed_version(sys.executable) == "unknown"

--- a/tests/test_start.py
+++ b/tests/test_start.py
@@ -710,3 +710,73 @@ def test_slurm_start_hands_the_installer_directory_to_the_resident_job(
     monkeypatch.chdir(home)
     assert main(["start", "--root", "/scratch/me/ar", "--account", "a", "--partition", "p"]) == 0
     assert pathlog.read_text().startswith("/h/.local/bin" + os.pathsep)
+
+
+# ---------------------------------------------------------------- upgrade
+
+
+def test_upgrade_dry_run_prints_the_pip_command(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli, "subprocess", pytest.fail)  # must not run pip
+    assert main(["upgrade", "--dry-run"]) == 0
+    out = capsys.readouterr().out
+    assert "-m pip install --upgrade outerloop-science" in out
+    assert "--pre" not in out
+
+
+def test_upgrade_pre_dry_run_adds_the_pre_flag(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(cli, "subprocess", pytest.fail)
+    assert main(["upgrade", "--pre", "--dry-run"]) == 0
+    assert "install --upgrade outerloop-science --pre" in capsys.readouterr().out
+
+
+def test_upgrade_runs_pip_and_reports_the_version_change(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    calls: list[list[str]] = []
+    versions = iter(["0.1.0.dev3", "0.1.0.dev4"])
+
+    def fake_run(argv: list[str], **kw: Any) -> Any:
+        import subprocess
+
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli, "_installed_version", lambda _python: next(versions))
+    assert main(["upgrade"]) == 0
+    assert calls[0][1:] == ["-m", "pip", "install", "--upgrade", "outerloop-science"]
+    out = capsys.readouterr().out
+    assert "0.1.0.dev3 -> 0.1.0.dev4" in out
+    assert "outerloop start" in out
+
+
+def test_upgrade_reports_when_already_current(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_run(argv: list[str], **kw: Any) -> Any:
+        import subprocess
+
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli, "_installed_version", lambda _python: "0.1.0.dev3")
+    assert main(["upgrade"]) == 0
+    assert "already up to date: outerloop 0.1.0.dev3" in capsys.readouterr().out
+
+
+def test_upgrade_surfaces_a_failed_pip_and_its_exit_code(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    def fake_run(argv: list[str], **kw: Any) -> Any:
+        import subprocess
+
+        return subprocess.CompletedProcess(argv, 3)
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+    monkeypatch.setattr(cli, "_installed_version", lambda _python: "0.1.0.dev3")
+    assert main(["upgrade"]) == 3
+    assert "upgrade failed (pip exited 3)" in capsys.readouterr().err


### PR DESCRIPTION
## What

`outerloop upgrade`: one verb for a local install to move to the newest release, the local counterpart of the Slurm resident tick's `OUTERLOOP_AUTO_UPDATE` policy.

- Runs `pip install --upgrade outerloop-science` in the current environment (`sys.executable -m pip`).
- Reports the version change (`old -> new`, read from a fresh interpreter so it reflects what pip just wrote), or says it is already current.
- Reminds you to restart the loop to pick up the new code.
- `--pre` forces pre-releases even once a stable exists; pip already falls back to a pre-release when that is all that is published (as today, only dev builds).
- `--dry-run` prints the command and exits.
- Surfaces a failed pip with its exit code and hints at `uv pip install --upgrade` for environments without pip.

## Why

A Slurm deployment self-updates through `OUTERLOOP_AUTO_UPDATE`; the local loop runs the installed package and had no equivalent, so an adopter had to remember the pip line. This is that one obvious verb.

## Notes

- `docs/install.md` "Updates" now points at the verb instead of the raw pip line.
- CHANGELOG updated under `[Unreleased]`.
- New tests in `tests/test_start.py` cover the dry-run command shape, `--pre`, the version-change and already-current reports, and a failed pip surfacing its exit code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
