### PR TITLE
Maintainer digest: date in the title, short summary up top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ Versions follow [SemVer](https://semver.org).
 ### Changed
 
 - The maintainer digest issue now carries the scan date in its title
-  (`Maintainer digest — YYYY-MM-DD`, refreshed each scan) so its freshness shows
-  in the issue list, and the scan's long verdict/rejected-findings text folds
-  into a collapsible block so the top of the issue stays a short summary
-  (title, advisory line, counts).
+  (`Maintainer digest — YYYY-MM-DD`), so its freshness shows in the issue list.
+  The scan's long verdict and rejected-findings text now folds into a
+  collapsible block, keeping the top of the issue a short summary (title,
+  advisory line, counts).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- The maintainer digest issue now carries the scan date in its title
+  (`Maintainer digest — YYYY-MM-DD`, refreshed each scan) so its freshness shows
+  in the issue list, and the scan's long verdict/rejected-findings text folds
+  into a collapsible block so the top of the issue stays a short summary
+  (title, advisory line, counts).
+
 ### Added
 
 - `outerloop upgrade`: one verb for a local install to move to the newest

--- a/docs/design/reviewer-infra.md
+++ b/docs/design/reviewer-infra.md
@@ -252,9 +252,9 @@ cron (weekly) or by hand. It fans out one read-only lens session per digest
 section (`maintain.MAINTENANCE_LENSES`, plus `general` for the whole
 checklist) over a checkout of the calling repository's default branch, merges
 the opinions with the same summarizer the wide review round uses, and posts
-ONE rolling issue ("Maintainer digest") whose body each scan replaces;
-earlier digests stay in the edit history, and a short comment per scan
-notifies watchers. The role is `roles.maintainer_spec`: the reviewer's tools
+ONE rolling issue (titled "Maintainer digest — <date>", the date of the digest
+it currently shows) whose body each scan replaces; earlier digests stay in the
+edit history, and a short comment per scan notifies watchers. The role is `roles.maintainer_spec`: the reviewer's tools
 and verdict shape (findings through the syscall tool, no scope), a larger
 budget because a tree is more to read than a diff. Items carry a section
 (`--category`), an effort and risk estimate, and a kind: `change` is

--- a/docs/install.md
+++ b/docs/install.md
@@ -105,8 +105,9 @@ always exits successfully so your PR stays green.
 
 The same reviewer, pointed at your whole repository once a week: dead code,
 duplicated logic, oversized modules, stale pins, slow tests, repeated work on
-the hot path, documentation drift. It writes one issue, "Maintainer digest",
-and replaces its body each scan. It changes no code and opens no work orders.
+the hot path, documentation drift. It writes one issue, titled "Maintainer
+digest — <date>" (the date of the digest it shows), and replaces its body each
+scan. It changes no code and opens no work orders.
 Add `.github/workflows/maintenance.yml` with the same secret as the reviewer:
 
 ```yaml

--- a/src/outerloop/github.py
+++ b/src/outerloop/github.py
@@ -768,15 +768,19 @@ class GitHubClient:
         )
         return int(data.get("number", 0)) if isinstance(data, dict) else 0
 
-    def update_issue(self, repo: str, number: int, body: str) -> None:
-        """Replace an issue's body (the rolling maintenance digest)."""
+    def update_issue(self, repo: str, number: int, body: str, *, title: str | None = None) -> None:
+        """Replace an issue's body (the rolling maintenance digest), and its
+        title when one is given (the digest carries the scan date there)."""
         if self.dry_run:
             log.info("[dry-run] update issue %s#%s (%d chars)", repo, number, len(body))
             return
+        payload: dict[str, str] = {"body": body}
+        if title is not None:
+            payload["title"] = title
         self._request(
             "PATCH",
             f"/repos/{urllib.parse.quote(repo)}/issues/{number}",
-            {"body": body},
+            payload,
         )
 
     def close_issue(self, repo: str, number: int) -> None:

--- a/src/outerloop/maintain.py
+++ b/src/outerloop/maintain.py
@@ -194,8 +194,10 @@ def _item(finding: Finding, repo: str, ref: str) -> str:
 
 
 def digest_title(today: str) -> str:
-    """The rolling issue's title, carrying the scan date so its freshness shows
-    in the issue list without opening it. Refreshed on every scan."""
+    """The rolling issue's title, carrying the date of the digest it shows so
+    its freshness reads from the issue list. A successful scan sets it to that
+    scan's date; a scan that could not run keeps the last good digest — and this
+    date — so a stalled scan reads as stale rather than falsely fresh."""
     return f"{DIGEST_TITLE} — {today}"
 
 

--- a/src/outerloop/maintain.py
+++ b/src/outerloop/maintain.py
@@ -193,6 +193,12 @@ def _item(finding: Finding, repo: str, ref: str) -> str:
     return f"- {label}**{summary}.** {detail} ([{where}]({link}); {finding.confidence})"
 
 
+def digest_title(today: str) -> str:
+    """The rolling issue's title, carrying the scan date so its freshness shows
+    in the issue list without opening it. Refreshed on every scan."""
+    return f"{DIGEST_TITLE} — {today}"
+
+
 def render_digest(
     result: ReviewResult,
     *,
@@ -221,7 +227,16 @@ def render_digest(
         "",
     ]
     if result.notes:
-        lines += [result.notes, ""]
+        # keep the top a short summary (title, advisory, counts); the scan's
+        # own verdict and its rejected-findings reasoning fold away below it
+        lines += [
+            "<details><summary>Scan verdict and rejected findings</summary>",
+            "",
+            result.notes,
+            "",
+            "</details>",
+            "",
+        ]
     by_section: dict[str, list[Finding]] = {}
     for f in findings:
         section = f.category if f.category in MAINTENANCE_LENSES else "other"

--- a/src/outerloop/maintain_post_cli.py
+++ b/src/outerloop/maintain_post_cli.py
@@ -18,7 +18,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from outerloop.github import EnvTokenProvider, GitHubClient
-from outerloop.maintain import DIGEST_TITLE, MARKER, render_digest, render_stub
+from outerloop.maintain import MARKER, digest_title, render_digest, render_stub
 from outerloop.posting import EXPECTED_FAILURES
 from outerloop.review import result_from_data
 
@@ -84,7 +84,7 @@ def post_digest(
                 str(envelope.get("detail", "")), repo=repo, ref=ref, today=today, who=who
             )
             if number is None:
-                client.create_issue(repo, DIGEST_TITLE, body)
+                client.create_issue(repo, digest_title(today), body)
             else:
                 client.comment(repo, number, body)
             return "skip-stub"
@@ -92,10 +92,10 @@ def post_digest(
         result = result_from_data(data if isinstance(data, dict) else {})
         body = render_digest(result, repo=repo, ref=ref, today=today, reviewed_by=who)
         if number is None:
-            number = client.create_issue(repo, DIGEST_TITLE, body)
+            number = client.create_issue(repo, digest_title(today), body)
             log.info("opened the digest issue %s#%s", repo, number)
             return "created"
-        client.update_issue(repo, number, body)
+        client.update_issue(repo, number, body, title=digest_title(today))
         # a body edit notifies nobody; the comment does
         client.comment(
             repo,

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -65,6 +65,23 @@ def test_create_pr_posts_body(provider: FileTokenProvider) -> None:
     }
 
 
+def test_update_issue_sets_the_title_only_when_given(provider: FileTokenProvider) -> None:
+    transport = FakeTransport([{}, {}])
+    client = GitHubClient(auth=provider, transport=transport)
+    client.update_issue("org/repo", 9, "new body", title="Maintainer digest — 2026-09-08")
+    req = transport.requests[0]
+    assert req.get_method() == "PATCH"
+    assert req.full_url == "https://api.github.com/repos/org/repo/issues/9"
+    assert isinstance(req.data, bytes)
+    assert json.loads(req.data.decode()) == {
+        "body": "new body",
+        "title": "Maintainer digest — 2026-09-08",
+    }
+    client.update_issue("org/repo", 9, "body only")  # no title → body only, title untouched
+    assert isinstance(transport.requests[1].data, bytes)
+    assert json.loads(transport.requests[1].data.decode()) == {"body": "body only"}
+
+
 def test_dry_run_mutations_touch_nothing(provider: FileTokenProvider) -> None:
     transport = FakeTransport([])
     client = GitHubClient(auth=provider, transport=transport, dry_run=True)

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -238,7 +238,7 @@ class _Client:
     def __init__(self, issues: list[dict[str, Any]] | None = None) -> None:
         self.issues = issues or []
         self.created: list[tuple[str, str]] = []
-        self.updated: list[tuple[int, str]] = []
+        self.updated: list[tuple[int, str, str | None]] = []
         self.comments: list[tuple[int, str]] = []
         self.asked_creator = ""
 

--- a/tests/test_maintain.py
+++ b/tests/test_maintain.py
@@ -17,6 +17,7 @@ from outerloop.maintain import (
     MAINTENANCE_LENSES,
     MARKER,
     build_maintenance_brief,
+    digest_title,
     lens_names,
     render_digest,
     render_stub,
@@ -104,7 +105,10 @@ def test_digest_groups_by_section_puts_decisions_first_and_links_the_lines() -> 
     assert body.startswith(MARKER + "\n")
     assert "o/r at `abcdef12` on 2026-09-08; scanned by `hermes/gpt-5.6-terra`" in body
     assert "4 items: 1 need a decision, 2 are mechanical, 1 are notes." in body
+    # the counts stay a short summary up top; the verdict folds away below them
     assert "Healthy overall." in body
+    assert "<details><summary>Scan verdict and rejected findings</summary>" in body
+    assert body.index("items: 1 need a decision") < body.index("Healthy overall.")
     pathways, docs, other = (
         body.index("### pathways"),
         body.index("### docs"),
@@ -118,6 +122,10 @@ def test_digest_groups_by_section_puts_decisions_first_and_links_the_lines() -> 
     assert "*Note.* **Stale &lt;b&gt;status&lt;/b&gt;.**" in body  # model text is escaped
     assert "`weird.py`" in body and "we`ird" not in body  # a backtick cannot close the span
     assert "Each scan replaces this body" in body
+
+
+def test_digest_title_carries_the_scan_date() -> None:
+    assert digest_title("2026-09-08") == "Maintainer digest — 2026-09-08"
 
 
 def test_stub_names_the_reason_and_who() -> None:
@@ -243,8 +251,8 @@ class _Client:
         self.created.append((title, body))
         return 42
 
-    def update_issue(self, repo: str, number: int, body: str) -> None:
-        self.updated.append((number, body))
+    def update_issue(self, repo: str, number: int, body: str, *, title: str | None = None) -> None:
+        self.updated.append((number, body, title))
 
     def comment(self, repo: str, number: int, body: str) -> None:
         self.comments.append((number, body))
@@ -277,7 +285,7 @@ def test_post_opens_the_digest_issue_when_there_is_none(tmp_path: Path) -> None:
     )
     assert out == "created"
     ((title, body),) = client.created
-    assert title == "Maintainer digest" and body.startswith(MARKER)
+    assert title == "Maintainer digest — 2026-09-08" and body.startswith(MARKER)
     assert "scanned by `terra`" in body and "### tests" in body
     assert client.updated == [] and client.comments == []
 
@@ -299,8 +307,9 @@ def test_post_rewrites_only_its_own_marker_issue_and_notifies(tmp_path: Path) ->
     )
     assert out == "updated" and client.created == []
     assert client.asked_creator == "github-actions[bot]"
-    ((number, body),) = client.updated
+    ((number, body, title),) = client.updated
     assert number == 9 and body.startswith(MARKER) and "scanned by `hermes/x`" in body
+    assert title == "Maintainer digest — 2026-09-08"  # the title refreshes its date on update
     ((cnumber, comment),) = client.comments
     assert cnumber == 9 and "Digest updated for `abcdef12` on 2026-09-08: 1 items." in comment
 


### PR DESCRIPTION
## What

Two small readability changes to the rolling maintainer digest issue (#337), per last night's request:

1. **Date in the title.** The issue title becomes `Maintainer digest — YYYY-MM-DD` so its freshness shows in the issue list without opening it. `GitHubClient.update_issue` gained an optional `title=` so the date refreshes on every scan, not only at creation.
2. **Short summary up top.** The scan's own verdict — including its long "Rejected: …" reasoning — folds into a collapsible `<details>` block, so the top of the issue stays scannable: title, the advisory line, and the counts.

## Notes

- `render_digest` folds `result.notes`; the counts line stays above it as the short summary.
- Tests: `digest_title` shape; the fold is present and the counts precede the verdict; `post_digest` passes the dated title on both create and update; `update_issue` puts `title` in the PATCH payload only when given.
- No behavior change to what the scan finds — purely how the digest issue is titled and laid out.
- Gate green (pytest, ruff, mypy, pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
