### PR TITLE
init --github-app: guide a non-owner when the App lands under a personal account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ Versions follow [SemVer](https://semver.org).
 ### Fixed
 
 - `outerloop init --github-app` no longer dead-ends a non-owner of an
-  organization: creating an org-owned App needs org-owner rights, so GitHub
+  organization. Creating an org-owned App needs org-owner rights, so GitHub
   makes a personal App that will not install on the org repo by default. init
   now detects that the App landed under a different account and prints the path
-  that works (make the App public, request the install, an org owner approves,
-  rerun `init --force --github-app`; optionally transfer the App to the org),
-  and the install-failure help names the same steps.
+  that works — make it public, request the install, have an org owner approve
+  it, then rerun `init --force --github-app` (and optionally transfer the App to
+  the org). The install-failure help names the same steps.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- `outerloop init --github-app` no longer dead-ends a non-owner of an
+  organization: creating an org-owned App needs org-owner rights, so GitHub
+  makes a personal App that will not install on the org repo by default. init
+  now detects that the App landed under a different account and prints the path
+  that works (make the App public, request the install, an org owner approves,
+  rerun `init --force --github-app`; optionally transfer the App to the org),
+  and the install-failure help names the same steps.
+
 ### Added
 
 - `outerloop upgrade`: one verb for a local install to move to the newest

--- a/src/outerloop/init.py
+++ b/src/outerloop/init.py
@@ -367,6 +367,26 @@ def _owner_type(owner: str) -> str:
         return ""
 
 
+def _app_owner_mismatch_note(conversion: dict[str, Any], expected_owner: str, target: str) -> str:
+    """When the App landed under a different account than intended — GitHub's
+    fallback when someone who is not an org owner tries to create an org-owned
+    App — explain the path that still works, since a personal App does not
+    install on an org repo by default. Empty when the App landed as intended."""
+    actual = str((conversion.get("owner") or {}).get("login", "")).strip()
+    if not actual or actual.casefold() == expected_owner.casefold():
+        return ""
+    org = target.split("/")[0]
+    return (
+        f"  note: the App was created under '{actual}', not '{expected_owner}'. Creating an\n"
+        f"  App owned by an organization needs org-owner rights, so GitHub made a personal\n"
+        f"  one — which will not install on {target} by default. To use it there anyway:\n"
+        f"  make the App public (its Settings > 'Make public'), request its installation on\n"
+        f"  {target}, and have an owner of {org} approve it; then rerun\n"
+        f"  `outerloop init --force --github-app`. For lab ownership, you can later transfer\n"
+        f"  the App to {org} from its Advanced settings — the key keeps working."
+    )
+
+
 def _app_failure(answers: InitAnswers, slug: str, problem: str) -> int:
     """The App cannot write the target: say so, keep the credentials, and point
     at the fix and the re-check. Never `start` — the check just failed."""
@@ -376,7 +396,9 @@ def _app_failure(answers: InitAnswers, slug: str, problem: str) -> int:
         f"  https://github.com/apps/{slug}/installations/new (or the App's page under\n"
         "  Settings > Installations > Configure) install it on that repository and accept\n"
         "  contents, issues and pull-request write access, then run\n"
-        "  `outerloop init --force --github-app` to re-check with these credentials.",
+        "  `outerloop init --force --github-app` to re-check with these credentials.\n"
+        "  If the App is under your personal account and the repository belongs to an\n"
+        "  organization, make the App public first and have an org owner approve the install.",
         file=sys.stderr,
     )
     return 1
@@ -449,6 +471,9 @@ def _github_app_setup(
     pem_path, app_json = appmanifest.save_app_creds(conversion, CONFIG_DIR)
     repo = answers.target.split("/", 1)[-1]
     print(f"  created App '{conversion['slug']}'; credentials in {app_json} and {pem_path} (0600)")
+    mismatch = _app_owner_mismatch_note(conversion, owner, answers.target)
+    if mismatch:
+        print(mismatch, file=sys.stderr)
     print()
     print(f"Step 2 of 3: install the App on {answers.target}.")
     print(f"  Open {appmanifest.install_url(conversion)}")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -289,6 +289,14 @@ def test_app_owner_mismatch_note_fires_only_on_a_fallback() -> None:
     assert init._app_owner_mismatch_note({}, org, target) == ""
 
 
+def test_app_failure_names_the_make_public_and_owner_approval_path(capsys) -> None:
+    rc = init._app_failure(InitAnswers(compute="local", target="the-lab/forecast"), "s", "no write")
+    assert rc == 1  # the check failed, so init keeps the creds and never says start
+    err = capsys.readouterr().err
+    assert "cannot write the-lab/forecast" in err
+    assert "make the App public" in err and "org owner approve" in err
+
+
 def test_github_app_warns_when_it_lands_under_a_different_account(
     tmp_path: Path, monkeypatch, capsys
 ) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -276,6 +276,44 @@ def test_github_app_run_asks_only_for_the_organization(tmp_path: Path, monkeypat
     assert asked == [init.ORG_PROMPT]
 
 
+def test_app_owner_mismatch_note_fires_only_on_a_fallback() -> None:
+    org, target = "agentic-learning-ai-lab", "agentic-learning-ai-lab/autoresearch-forecast"
+    # non-owner fallback: App landed under a personal account, not the org
+    note = init._app_owner_mismatch_note({"owner": {"login": "amelia"}}, org, target)
+    assert "'amelia'" in note and f"'{org}'" in note
+    assert "Make public" in note or "make the App public" in note
+    assert "approve" in note and "--force" in note
+    # landed where intended (org owner, or a personal target): no note
+    assert init._app_owner_mismatch_note({"owner": {"login": org}}, org, target) == ""
+    assert init._app_owner_mismatch_note({"owner": {"login": "Amelia"}}, "amelia", "amelia/r") == ""
+    assert init._app_owner_mismatch_note({}, org, target) == ""
+
+
+def test_github_app_warns_when_it_lands_under_a_different_account(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """A non-owner org member gets a personal App; init must say so and name the
+    make-public + owner-approval path rather than silently dead-ending (#349)."""
+    from outerloop import appmanifest
+
+    monkeypatch.setattr(init, "_ask", lambda *a, **k: "")
+    monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(init, "_owner_type", lambda owner: "Organization")
+    monkeypatch.setattr(appmanifest, "request_manifest_code", lambda *a, **k: "c")
+    monkeypatch.setattr(
+        appmanifest,
+        "convert_manifest",
+        lambda code, **k: {"id": 1, "slug": "s", "pem": "p", "owner": {"login": "amelia"}},
+    )
+    monkeypatch.setattr(appmanifest, "capture_installation_id", lambda *a, **k: 0)
+    monkeypatch.setattr("builtins.input", lambda *a: "")
+    rc = init.main(["--github-app", "--compute", "local", "--target", "the-lab/forecast"])
+    assert rc == 1  # not installed, so it still exits 1 and keeps the creds
+    err = capsys.readouterr().err
+    assert "was created under 'amelia', not 'the-lab'" in err
+    assert "make the App public" in err and "approve" in err
+
+
 def test_main_yes_rejects_an_unknown_author_backend(tmp_path: Path, monkeypatch, capsys) -> None:
     monkeypatch.setattr(init, "CONFIG_DIR", tmp_path)
     rc = init.main(["--yes", "--compute", "local", "--target", "o/r", "--author-backend", "hermes"])


### PR DESCRIPTION
Closes #349.

## What

`outerloop init --github-app` dead-ended a lab member who is **not an org owner**: creating a GitHub App *owned by the org* needs org-owner rights, so GitHub makes a **personal** App, which won't install on the org repo by default — and the wizard left them stuck at the install step with no guidance. (First hit by a student onboarding to a lab repo.)

## Fix

init now compares the created App's owner (`conversion.owner.login`) to the intended one. On the personal fallback it prints the path that actually works, with no key hand-off and no org-owned App:

1. make the App **public** (a private App only installs on its owner's account),
2. request its install on the org repo,
3. an **org owner approves** it,
4. rerun `outerloop init --force --github-app`,

plus the option to **transfer the App to the org** later for lab ownership (the key keeps working). The install-failure help (`_app_failure`) gained the same make-public + owner-approval note, so the guidance is there on either path.

No behavior change for an actual org owner (the App lands under the org, owners match, no note) or for a personal-account target.

## Tests

- `_app_owner_mismatch_note`: fires only on a real fallback (different login), silent when owners match (case-insensitively) or the owner is absent.
- Flow test: a `--github-app` run whose conversion lands under a different account prints "was created under '…', not '…'" plus the make-public/approve steps.

Gate green (pytest, ruff, mypy over src+tests, pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
