### PR TITLE
Extract the shared session-timeout teardown in harness

### DIFF
--- a/src/outerloop/harness.py
+++ b/src/outerloop/harness.py
@@ -460,6 +460,24 @@ def _int(value: Any, default: int = 0) -> int:
         return default
 
 
+def _kill_and_drain(process: subprocess.Popen[str]) -> str:
+    """Kill a timed-out session's whole process group, then drain its pipe within
+    a bound so `run()` always returns — a descendant that left the group (setsid)
+    can hold the pipe open past the kill. Returns whatever stdout drained (may be
+    empty). Shared by every backend's timeout path; keep the sequence in one place
+    so the safety-sensitive termination cannot drift between them."""
+    with contextlib.suppress(ProcessLookupError, PermissionError):
+        os.killpg(process.pid, signal.SIGKILL)
+    try:
+        stdout, _ = process.communicate(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        stdout = ""
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            stdout, _ = process.communicate(timeout=5)
+    return stdout or ""
+
+
 @dataclass
 class ClaudeCodeHarness:
     """Headless Claude Code (`claude -p`): the JSON output carries cost,
@@ -625,17 +643,7 @@ class ClaudeCodeHarness:
         try:
             stdout, stderr = process.communicate(input=brief_text, timeout=self.timeout_s)
         except subprocess.TimeoutExpired:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(process.pid, signal.SIGKILL)
-            # Bounded drain: a descendant that left the process group (setsid)
-            # can hold the pipe open past the kill; run() must still return.
-            try:
-                stdout, _ = process.communicate(timeout=10)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                stdout = ""
-                with contextlib.suppress(subprocess.TimeoutExpired):
-                    stdout, _ = process.communicate(timeout=5)
+            stdout = _kill_and_drain(process)
             path = _write_private(
                 workspace.parent, transcript_stem, ".json", redact(stdout or "", (self.api_key,))
             )
@@ -1077,15 +1085,7 @@ class CodexHarness:
         try:
             stdout, stderr = process.communicate(input=brief_text, timeout=self.timeout_s)
         except subprocess.TimeoutExpired:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(process.pid, signal.SIGKILL)
-            try:
-                stdout, _ = process.communicate(timeout=10)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                stdout = ""
-                with contextlib.suppress(subprocess.TimeoutExpired):
-                    stdout, _ = process.communicate(timeout=5)
+            stdout = _kill_and_drain(process)
             path = _write_private(
                 workspace.parent, transcript_stem, ".jsonl", redact(stdout or "", (self.api_key,))
             )
@@ -1402,15 +1402,7 @@ class HermesHarness:
         try:
             stdout, _ = process.communicate(timeout=self.timeout_s)
         except subprocess.TimeoutExpired:
-            with contextlib.suppress(ProcessLookupError, PermissionError):
-                os.killpg(process.pid, signal.SIGKILL)
-            try:
-                stdout, _ = process.communicate(timeout=10)
-            except subprocess.TimeoutExpired:
-                process.kill()
-                stdout = ""
-                with contextlib.suppress(subprocess.TimeoutExpired):
-                    stdout, _ = process.communicate(timeout=5)
+            stdout = _kill_and_drain(process)
             path = _write_private(
                 workspace.parent, transcript_stem, ".log", redact(stdout or "", (self.api_key,))
             )


### PR DESCRIPTION
Dedup from maintainer digest #337 (batch 3).

The three backends (Claude/Codex/Hermes) each repeated the identical kill-process-group + bounded-drain sequence on their timeout path — only the transcript cleanup after it differed. Centralized as `_kill_and_drain(process)` so this safety-sensitive termination lives in one place and can't drift between backends.

- No behavior change; all three sites now call the helper.
- Existing timeout tests still pass, including `test_timeout_kills_the_whole_process_group`, which exercises the exact kill-and-drain path through the helper (the digest asked to "retain its tests").

Gate green (47 harness tests, ruff, mypy).

**Note on a sibling digest item I'm declining:** the same digest suggests unifying the `_rel_path_ok` validator across `syscall_cli.py` and `syscall.py`. That duplication is **intentional** — `syscall_cli.py` is standalone stdlib-only because it ships into the target sandbox where `outerloop` isn't installed, and the copies are pinned by parity tests (`test_artifact_path_check_matches_the_kernel`, documented in `role-cli.md`). Moving it to a shared module would break the standalone property, so it should stay duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
