### PR TITLE
Docs: lab-member (non-owner) GitHub App onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
+- Install guide: a lab member who is not an org owner now has documented steps
+  for GitHub App auth — make the personal App public, request the install, an
+  org owner approves, then optionally transfer the App to the org — matching
+  what `init --github-app` prints on the personal-App fallback.
 - Docs: corrected stale `autoresearch` command and module paths left by the
   rename (onboarding, author-syscalls, architecture, role-cli), refreshed the
   architecture component map (`budget` → `limits`, `report` →

--- a/docs/install.md
+++ b/docs/install.md
@@ -228,6 +228,21 @@ declares Contents, Issues and Pull requests read-write and Metadata read,
 nothing else. If the install step was cut short, run
 `outerloop init --force --github-app` to finish and re-check it.
 
+**If you are a member, not an owner, of the organization.** Creating an App
+*owned by the org* needs org-owner rights, so init falls back to creating one
+under your personal account — and a personal App does not install on an org
+repo by default. You do not need an org-owned App or a shared key:
+
+1. In the App's settings, make it **public** (a private App installs only on
+   its owner's account, which is why the org repo is not offered).
+2. Request its installation on your repo; an **org owner approves** the request.
+3. Run `outerloop init --force --github-app` to record the installation.
+
+Your key never leaves your machine. To let the lab own the App centrally later,
+transfer it to the org from the App's Advanced settings — the same key keeps
+working, so nothing has to be recreated. init prints these steps itself when it
+detects the personal-App fallback.
+
 **A fine-grained PAT — the fallback.** For an org that already runs a machine
 user, or one where you cannot create Apps: pick `pat` (or pass `--pat-file`).
 Mint the token on the machine user with these settings:


### PR DESCRIPTION
Batch 5 (last of the mechanical/onboarding batch), adopting the lab-pattern (a) you approved.

Adds a documented path in the install guide for a lab member who is **not** an org owner — the case that blocked Amelia and is fixed in `init` by #351. The steps: make the personal App public, request the install, an org owner approves, then optionally transfer the App to the org for central ownership (the key keeps working, nothing is recreated). Mirrors what `init --github-app` now prints on the personal-App fallback.

Docs only; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
