### PR TITLE
Release 0.1.0.dev4

### DIFF
--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-__version__ = "0.1.0.dev3"
+__version__ = "0.1.0.dev4"
 
 
 def _bridge_legacy_env() -> None:


### PR DESCRIPTION
Cuts the `0.1.0.dev4` pre-release. Per RELEASING.md a dev pre-release just bumps `__version__` and leaves `[Unreleased]` in place (the changelog fold happens at the final 0.1.0).

Ships everything merged since dev3, including:
- Base reintegration (#346) and `outerloop upgrade` (#347)
- The digest cleanup batch (#350–#355)
- **Amelia's follow-up auto-merge fix (#357)** — the reason to cut this now

After merge: tag `v0.1.0.dev4` → the release workflow publishes to PyPI; verify a fresh-venv install; then deploy to Torch (auto) and cluster0 (`outerloop upgrade`) and watch a full climb before considering 0.1.0 stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
