### PR TITLE
Release 0.1.0 — held for validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-09-09
+## [0.1.0] - 2026-09-10
 
 The first release of Outerloop — autoresearch agents that improve your benchmark
 on your own code, your keys, and your compute. Built and used daily by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ Versions follow [SemVer](https://semver.org).
 
 ## [0.1.0] - 2026-09-09
 
+The first release of Outerloop — autoresearch agents that improve your benchmark
+on your own code, your keys, and your compute. Built and used daily by the
+Agentic Learning AI Lab at NYU.
+
+### Highlights
+
+- **The loop.** An agent proposes a change, runs the experiment on your cluster,
+  measures it against the base tree at the same seed, and opens a pull request
+  only when the benchmark actually improves. Every attempt gets a short report,
+  negative results included.
+- **Verification first.** Outerloop re-measures every claim against the
+  repository's contract — it never trusts a number the agent reports — and a
+  reviewer panel reads the change and the claim before a pull request stands.
+- **Your guardrails apply.** Agents cannot touch the benchmark, the budgets, or
+  your CI; your branch protection and required checks apply to them as to any
+  contributor. A pull request waits for a human by default; a repo can also let
+  clean ones merge themselves.
+- **Runs where you do.** Slurm or a single GPU machine, behind one compute seam.
+  Sessions run in a scrubbed sandbox, and your model key and bot credentials
+  never leave the job.
+- **Onboarding in a few commands.** `outerloop init` writes the config and sets
+  up auth (a per-adopter GitHub App, or a token), `outerloop start` runs the
+  loop, and `outerloop upgrade` moves a local install to the newest release. The
+  container image is pulled, not built.
+- **Contracts and the board.** A repo declares its benchmark, scope, and budgets
+  in `.outerloop.yaml`; the climb board publishes every attempt and its outcome,
+  and the ledger keeps the honest record — refusals and negatives included.
+- **Research lines and depth.** Each agent works its own line and reintegrates
+  the moving base; a run hibernates through long experiments and wakes to read
+  its results.
+- **Advisory review and a weekly digest.** The reviewer posts structured,
+  advisory findings on every pull request, and a weekly maintainer scan files a
+  codebase-health digest.
+
+The `AUTORESEARCH_*` environment names and `.autoresearch` paths from before the
+rename are still accepted in 0.1; they are removed in 0.1.1. The full history
+since the first pre-release follows.
+
 ### Changed
 
 - Install guide: a lab member who is not an org owner now has documented steps

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-09-09
+
 ### Changed
 
 - Install guide: a lab member who is not an org owner now has documented steps

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,9 +9,6 @@ abstract: >-
   and your repositories.
 type: software
 authors:
-  - family-names: Ren
-    given-names: Mengye
-    affiliation: New York University
   - name: "Agentic Learning AI Lab, New York University"
 repository-code: "https://github.com/outerloop-science/outerloop"
 url: "https://outerloop.science"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,20 @@
+cff-version: 1.2.0
+message: "If you use Outerloop in your research, please cite it."
+title: Outerloop
+abstract: >-
+  Outerloop runs AI agents on your own research code: an agent proposes a
+  change, runs the experiment on your cluster, and opens a pull request only when
+  your benchmark improves. Every claim is re-measured against the repository's
+  contract, every attempt is recorded, and it runs on your keys, your compute,
+  and your repositories.
+type: software
+authors:
+  - family-names: Ren
+    given-names: Mengye
+    affiliation: New York University
+  - name: "Agentic Learning AI Lab, New York University"
+repository-code: "https://github.com/outerloop-science/outerloop"
+url: "https://outerloop.science"
+license: Apache-2.0
+version: 0.1.0
+date-released: "2026-09-09"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -14,4 +14,4 @@ repository-code: "https://github.com/outerloop-science/outerloop"
 url: "https://outerloop.science"
 license: Apache-2.0
 version: 0.1.0
-date-released: "2026-09-09"
+date-released: "2026-09-10"

--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-__version__ = "0.1.0.dev4"
+__version__ = "0.1.0"
 
 
 def _bridge_legacy_env() -> None:


### PR DESCRIPTION
The first stable release. Content is approved; this is **held (draft) pending one live validation** — a clean follow-up re-measure on dev4 that confirms the auto-merge fix (#357) works in the wild. A manufactured full onboarding or full climb is not required: cluster0 (now on dev4) and Amelia are the live adopter tests.

## What this does

- Bumps `__version__` to `0.1.0`.
- Folds `[Unreleased]` into `[0.1.0]`, opening with a plain-prose intro and a **Highlights** section; the full dev0→dev4 history is preserved below it.
- Adds `CITATION.cff` (author: Agentic Learning AI Lab, New York University).
- The `AUTORESEARCH_*` environment names and `.autoresearch` paths stay for 0.1; they drop at 0.1.1.

## Explicitly not in 0.1.0 (deferred, staying open)

- #122 egress hardening — defense-in-depth; the fork-PR `head.repo` guard is already in place.
- #292 macOS containment.

## To cut it (when the validation lands + go)

Finalize the release date (`2026-09-09` if we cut today) → merge → tag `v0.1.0` → the release workflow publishes to PyPI → verify a fresh-venv install → `gh release create v0.1.0` (**not** `--prerelease`) → deploy to Torch (auto) and cluster0 (`outerloop upgrade`) → announce (Discord via webhook; X/Bluesky human-written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
