### PR TITLE
Fix the README Python badge; add package classifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Package metadata now declares trove classifiers (Python 3.12, audience, topic), so the PyPI project page and the Python-version badge read correctly. The README's Python badge is a static `3.12+` so it renders regardless of the release's metadata.
+
 ## [0.1.0] - 2026-09-10
 
 The first release of Outerloop — autoresearch agents that improve your benchmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Changed
 
-- Package metadata now declares trove classifiers (Python 3.12, audience, topic), so the PyPI project page and the Python-version badge read correctly. The README's Python badge is a static `3.12+` so it renders regardless of the release's metadata.
+- The PyPI project page and the Python-version badge now read correctly: the package metadata lists the supported Python version (3.12) and the project's audience and topic. The README's Python badge is a static `3.12+` so it renders regardless of the release's metadata.
 
 ## [0.1.0] - 2026-09-10
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![ci](https://github.com/outerloop-science/outerloop/actions/workflows/ci.yml/badge.svg)](https://github.com/outerloop-science/outerloop/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/outerloop-science.svg)](https://pypi.org/project/outerloop-science/)
-[![Python](https://img.shields.io/pypi/pyversions/outerloop-science.svg)](https://pypi.org/project/outerloop-science/)
+[![Python](https://img.shields.io/badge/python-3.12+-blue.svg)](https://pypi.org/project/outerloop-science/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
 **Autoresearch agents that improve your benchmark.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,13 @@ license = "Apache-2.0"
 license-files = ["LICENSE", "NOTICE"]
 requires-python = ">=3.12"
 authors = [{ name = "Agentic Learning AI Lab, New York University" }]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
 dependencies = [
     "cryptography>=42",  # GitHub App auth (RS256 JWTs), the recommended identity
     "pydantic>=2",


### PR DESCRIPTION
Fixes the two README-badge issues after the 0.1.0 launch.

- **Python badge showed "missing"** — the package declared **no trove classifiers**, and `pypi/pyversions` reads the `Programming Language :: Python ::` classifiers (not `requires-python`). Added classifiers (Python 3, 3.12; Science/Research audience; AI topic — **no** `License ::` classifier, which would conflict with the SPDX `license = "Apache-2.0"` field under PEP 639). They also improve the PyPI project page.
- Because 0.1.0's metadata is already published without classifiers, the *dynamic* badge can't render for it — so the README's Python badge is now a **static `3.12+`** that renders regardless. (The classifiers make the dynamic form work from the next release, if we ever switch back.)
- The **version badge showing "dev"** was just GitHub's image cache — shields.io already returns `v0.1.0`; merging this README change re-renders it.

Verified: the wheel still builds (hatchling) with the classifiers in `METADATA`, and `uv lock --check` is unaffected. Docs/metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
