### PR TITLE
Wake ledger: ended records were never written (nested import shadowed time)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- A wake never recorded its launches as ended: a nested `import time` in the wake function shadowed the module, so the ledger step raised inside a best-effort wrapper whose warning went to the scheduler's discarded stderr. The PR's experiments table stayed empty and `history` showed every launch as not back. The wrapper now logs the full (redacted) traceback, and a wake's kernel log persists at `runs/<run>/kernel.log`.
+
 ### Changed
 
 - The PyPI project page and the Python-version badge now read correctly: the package metadata lists the supported Python version (3.12) and the project's audience and topic. The README's Python badge is a static `3.12+` so it renders regardless of the release's metadata.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- A wake never recorded its launches as ended: a nested `import time` in the wake function shadowed the module, so the ledger step raised inside a best-effort wrapper whose warning went to the scheduler's discarded stderr. The PR's experiments table stayed empty and `history` showed every launch as not back. The wrapper now logs the full (redacted) traceback, and a wake's kernel log persists at `runs/<run>/kernel.log`.
+- Wakes never recorded a launch as ended. A nested `import time` in the wake function shadowed the module import, so the ledger step failed on every wake, and the failure was only logged to a stderr the scheduler discards. The PR's experiments table stayed empty and `history` showed every launch as not back. The nested imports are gone, the best-effort wrapper now logs the redacted traceback, and a wake writes its kernel log to `runs/<run>/kernel.log`.
 
 ### Changed
 

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -3433,11 +3433,22 @@ def main() -> int:
             )
         return value
 
+    def _run_id(value: str) -> str:
+        # the id names the run directory under runs/: one path segment, so a
+        # value cannot reach outside the run root before the record is read
+        # ("" is the default: a fresh climb, not a resume)
+        if value and not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.@-]{0,127}", value):
+            raise argparse.ArgumentTypeError(
+                f"run id {value!r} is not a run directory name (want [A-Za-z0-9][A-Za-z0-9_.@-]*)"
+            )
+        return value
+
     parser.add_argument("--agent-id", default="agent-01", type=_agent_id)
     parser.add_argument("--run-root", required=True, type=Path)
     parser.add_argument(
         "--resume",
         default="",
+        type=_run_id,
         metavar="RUN_ID",
         help="wake a parked dispatched run instead of starting a fresh climb",
     )

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -19,6 +19,7 @@ import os
 import re
 import shutil
 import time
+import traceback
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from dataclasses import replace as dc_replace
@@ -319,18 +320,35 @@ class AttemptOutcome:
     report_path: str = ""
 
 
+def _attach_run_log(directory: Path) -> None:
+    """Also write the kernel's log lines to `<run dir>/kernel.log`: the scheduler
+    discards a wake job's own stderr, so this is the only trace a swallowed
+    step leaves. Only for a run that exists — never a stray directory."""
+    if not directory.is_dir():
+        return
+    try:
+        handler = logging.FileHandler(directory / "kernel.log", encoding="utf-8")
+    except OSError as exc:
+        log.warning("run log unavailable: %s", exc)
+        return
+    handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+    logging.getLogger().addHandler(handler)
+
+
 def _best_effort(what: str, fn: Callable[[], object], secrets: tuple[str, ...] = ()) -> bool:
-    """One ending step; a failure is logged, never raised.
+    """One ending step; a failure is logged with its traceback, never raised.
 
     The terminal sequence (record, report, issue post) must degrade
     independently: a full disk must not block the GitHub post, and a network
-    failure must not block the record.
+    failure must not block the record. The traceback is the only trace a
+    swallowed step leaves, so it is logged whole (redacted).
     """
     try:
         fn()
         return True
     except Exception as exc:
-        log.warning("%s failed: %s", what, redact(f"{type(exc).__name__}: {exc}", secrets))
+        detail = "".join(traceback.format_exception(exc)).rstrip()
+        log.warning("%s failed: %s", what, redact(detail, secrets))
         return False
 
 
@@ -1025,8 +1043,6 @@ def _wake_author_sleep(
         # existing wake path decides). Keep the NEW park's snapshot ref; the OLD
         # sleep ref is superseded once the new park persists.
         kept_ref = next((s.ref for s in snapshots if s.commit == p.candidate_sha), "")
-        import time
-
         try:
             _park_run(
                 run_root,
@@ -3017,8 +3033,6 @@ def live_attempt(
                 # commit); record and keep that same ref, drop the rest. An
                 # author-sleep's snapshot is the tree the wake re-delivers.
                 kept_ref = next((s.ref for s in snapshots if s.commit == p.candidate_sha), "")
-            import time
-
             # anchor the deadline to the PARK (when the evals were submitted),
             # not the run's start `now` — a session lasting hours would otherwise
             # eat the queue budget and let the sweep cancel a still-queued eval.
@@ -3530,6 +3544,8 @@ def main() -> int:
     )
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+    if args.resume:
+        _attach_run_log(run_dir_of(args.run_root, args.resume))
     if not args.image and not args.uncontained:
         parser.error("--image is required (or pass --uncontained explicitly, dev only)")
     # NOTE: the codex author is validated on the EFFECTIVE author per path — the

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3304,6 +3304,81 @@ def test_author_sleep_wake_delivers_results_and_flows_to_a_candidate_park(
     assert str(record.stage["candidate_ref"]) in refs[0]
 
 
+def test_author_sleep_wake_records_each_launch_as_ended_in_the_ledger(
+    tmp_path, monkeypatch
+) -> None:
+    """The wake writes one `ended` record per launch job under the sleep that
+    submitted it, so `history` and the PR's experiments table see the job come
+    back. A nested `import time` once made this step raise inside its
+    best-effort wrapper on every wake: no ended record was ever written."""
+    from outerloop.launchlog import append_submitted, history, read_ledger
+    from outerloop.measure import MeasurementPending
+    from outerloop.roles import author_spec
+    from outerloop.syscall import Launch
+
+    state, run_id, _wsroot, _ = _write_parked_author_sleep(
+        tmp_path, monkeypatch, raise_exc=MeasurementPending(("701", "702"))
+    )
+    run_dir = state / "runs" / run_id
+    append_submitted(
+        run_dir,
+        sleep=1,
+        launches=(Launch(name="probe", command="uv run probe.py", minutes=45, why="tails"),),
+        job_ids=["501"],
+        at=1_000_000.0,
+    )
+    resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),
+        now=1_000_100.0,
+        harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "def solve(): return 'p'\n"}),
+        spec=author_spec(),
+    )
+    ended = [r for r in read_ledger(run_dir) if r["event"] == "ended"]
+    assert [(r["sleep"], r["name"], r["exit_code"], r["last_line"]) for r in ended] == [
+        (1, "probe", 0, "tail improvement: 0.7")
+    ]
+    (entry,) = history(run_dir)
+    assert entry["jobs"] and entry["jobs"][0]["exit_code"] == 0
+
+
+def test_best_effort_logs_the_traceback_of_a_swallowed_step(caplog) -> None:
+    import logging
+
+    from outerloop.attempt import _best_effort
+
+    def boom() -> None:
+        raise NameError("cannot access free variable 'time' (token hunter2)")
+
+    with caplog.at_level(logging.WARNING):
+        assert _best_effort("launch ledger", boom, secrets=("hunter2",)) is False
+    assert "launch ledger failed" in caplog.text
+    assert "Traceback" in caplog.text and "in boom" in caplog.text
+    assert "hunter2" not in caplog.text
+
+
+def test_attach_run_log_persists_kernel_lines_beside_the_run(tmp_path) -> None:
+    import logging
+
+    from outerloop.attempt import _attach_run_log, log
+
+    _attach_run_log(tmp_path / "runs" / "nope")  # no such run: nothing created
+    assert not (tmp_path / "runs").exists()
+    (tmp_path / "runs" / "r1").mkdir(parents=True)
+    _attach_run_log(tmp_path / "runs" / "r1")
+    try:
+        log.warning("launch ledger failed: NameError")
+    finally:
+        for h in list(logging.getLogger().handlers):
+            if isinstance(h, logging.FileHandler) and h.baseFilename.endswith("kernel.log"):
+                logging.getLogger().removeHandler(h)
+                h.close()
+    assert "launch ledger failed" in (tmp_path / "runs" / "r1" / "kernel.log").read_text()
+
+
 def test_author_sleep_wake_can_sleep_again(tmp_path, monkeypatch) -> None:
     # the woken author launches more work and sleeps again: a fresh author-sleep
     # park with the counts advanced.

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4280,6 +4280,26 @@ def test_cli_rejects_ref_shaping_agent_ids(capsys, monkeypatch) -> None:
         assert "cannot shape a git ref" in capsys.readouterr().err
 
 
+def test_resume_rejects_a_run_id_that_is_not_one_path_segment(
+    tmp_path, monkeypatch, capsys
+) -> None:
+    """`--resume` names the run directory under runs/. A traversal value is
+    refused by the parser, before the lease or the kernel log could be created
+    outside the run root."""
+    from outerloop.attempt import main as climb_main
+
+    (tmp_path / "elsewhere").mkdir()
+    for bad in ("../elsewhere", "a/b", ".."):
+        monkeypatch.setattr(
+            "sys.argv",
+            ["climb", "--resume", bad, "--run-root", str(tmp_path / "state"), "--image", "x.sif"],
+        )
+        with pytest.raises(SystemExit):
+            climb_main()
+        assert "is not a run directory name" in capsys.readouterr().err
+    assert not (tmp_path / "elsewhere" / "kernel.log").exists()
+
+
 def test_wake_refreshes_origin_refs(tmp_path, monkeypatch) -> None:
     """The clone's refs freeze at run start; a wake fetches origin so the
     resumed session reads current base and sibling refs locally."""


### PR DESCRIPTION
## The bug

Every run on Torch (6 runs, 25 launches, kernel versions #288 through #361) and Amelia's runs on cluster0 had a `launches.jsonl` with `submitted` records only and never an `ended` record. The PR experiments table read from the ledger was empty, and the author's `history` view reported every launch as "not back yet" on later wakes, even after it had read and acted on the results.

The author was not blind. The wake delivered job output and artifacts correctly (the sleep-2 transcript quotes the job's real last line, step 7104, and rejects the candidate for the right reason). Only the ledger and what is built on it were broken.

## Root cause

`_wake_author_sleep` had a nested `import time` inside its `except RunParked` block. A binding anywhere in a function body makes the name local to the whole function, so the ledger step's lambda

```python
lambda: append_ended(run_dir, sleep=sleeps_used, results=results, at=time.time(), ...)
```

dereferenced the not-yet-bound local and raised

```
NameError: cannot access free variable 'time' where it is not associated with a value in enclosing scope
```

on every wake. `_best_effort("launch ledger", ...)` swallowed it into a `log.warning`, and wake jobs run with stdout and stderr on `/dev/null`, so nothing was ever visible. `live_attempt` had the same nested import (harmless there today); both are removed in favour of the module import.

Captured by running the real `--resume` entrypoint against a scratch copy of a run with a neutered harness, stderr to a file. No test covered the ended side of the ledger, which is why this shipped.

## Changes

- Drop the two nested `import time` statements in `attempt.py`.
- `_best_effort` logs the full traceback (redacted), not just the exception type and message.
- On `--resume`, the kernel's log lines are also written to `runs/<run>/kernel.log`, so a wake's swallowed failures are readable after the fact. Only for a run directory that exists.
- Regression test `test_author_sleep_wake_records_each_launch_as_ended_in_the_ledger`: an author-sleep wake through `resume_run` must leave an `ended` record that `history` joins to its `submitted` record. Verified to fail on the mutant with the fleet's exact message.
- Tests for the traceback logging (redaction included) and the run log.
- CHANGELOG entry under Unreleased.

## After merge

Torch picks this up on the resident's next auto-update. Wakes already parked run their pinned flights, so the first `ended` records appear one park later per run. Existing runs' history is not backfilled here. cluster0 needs `outerloop upgrade` or a patch release. Follow-up design discussion (separate): the wake session should not carry the heavy work of the chain, and the kernel should self-heal unrecorded launches.
