### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-09-11
+
 ### Fixed
 
 - Wakes never recorded a launch as ended. A nested `import time` in the wake function shadowed the module import, so the ledger step failed on every wake, and the failure was only logged to a stderr the scheduler discards. The PR's experiments table stayed empty and `history` showed every launch as not back. The nested imports are gone, the best-effort wrapper now logs the redacted traceback, and a wake writes its kernel log to `runs/<run>/kernel.log`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Versions follow [SemVer](https://semver.org).
 
 - The PyPI project page and the Python-version badge now read correctly: the package metadata lists the supported Python version (3.12) and the project's audience and topic. The README's Python badge is a static `3.12+` so it renders regardless of the release's metadata.
 
+### Deprecated
+
+- The `AUTORESEARCH_*` environment names and `.autoresearch` paths are still accepted. The 0.1.0 notes said they would go in 0.1.1; a bug-fix release should not also break a deployment's environment, so their removal moves to the next minor release.
+
 ## [0.1.0] - 2026-09-10
 
 The first release of Outerloop — autoresearch agents that improve your benchmark

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,9 @@ Agentic Learning AI Lab at NYU.
   codebase-health digest.
 
 The `AUTORESEARCH_*` environment names and `.autoresearch` paths from before the
-rename are still accepted in 0.1; they are removed in 0.1.1. The full history
-since the first pre-release follows.
+rename are still accepted in 0.1; they are removed in the next minor release
+(0.1.1 kept them, see its notes). The full history since the first pre-release
+follows.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Deprecated
 
-- The `AUTORESEARCH_*` environment names and `.autoresearch` paths are still accepted. The 0.1.0 notes said they would go in 0.1.1; a bug-fix release should not also break a deployment's environment, so their removal moves to the next minor release.
+- The `AUTORESEARCH_*` environment names and `.autoresearch` paths are still accepted. The 0.1.0 notes said they would go in 0.1.1; a bug-fix release should not also break a deployment's environment, so their removal moves to 0.2.0.
 
 ## [0.1.0] - 2026-09-10
 
@@ -57,9 +57,8 @@ Agentic Learning AI Lab at NYU.
   codebase-health digest.
 
 The `AUTORESEARCH_*` environment names and `.autoresearch` paths from before the
-rename are still accepted in 0.1; they are removed in the next minor release
-(0.1.1 kept them, see its notes). The full history since the first pre-release
-follows.
+rename are still accepted in 0.1; 0.1.1 kept them (see its notes) and 0.2.0
+removes them. The full history since the first pre-release follows.
 
 ### Changed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,5 +13,5 @@ authors:
 repository-code: "https://github.com/outerloop-science/outerloop"
 url: "https://outerloop.science"
 license: Apache-2.0
-version: 0.1.0
-date-released: "2026-09-10"
+version: 0.1.1
+date-released: "2026-09-11"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -8,8 +8,8 @@
 
 ## Cutting a release
 
-1. PR: bump `__version__` and move the `[Unreleased]` entries under the new
-   version. A dev or rc pre-release still bumps the version (PyPI never
+1. PR: bump `__version__`, set `CITATION.cff`'s `version` and `date-released`,
+   and move the `[Unreleased]` entries under the new version. A dev or rc pre-release still bumps the version (PyPI never
    accepts a version twice, so the next one is `.dev1`, `rc2`, ...) but leaves
    `[Unreleased]` in place until the final release.
 2. `git tag vX.Y.Z && git push origin vX.Y.Z`. The `release` workflow builds

--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 
 def _bridge_legacy_env() -> None:


### PR DESCRIPTION
Patch release: the wake's launch ledger fix (#362) and the PyPI metadata/badge fix (#361), folded from Unreleased. Version bumped to 0.1.1.
