### PR TITLE
Local compute places a GPU measure without a lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- A GPU benchmark on local compute aborted at its first gate measure with "no GPU lane is configured". The measure placement now follows the launch placement's rule: local compute has no lanes, the job runs on the machine's own GPUs.
+
 ## [0.1.1] - 2026-09-11
 
 ### Fixed

--- a/src/outerloop/measure.py
+++ b/src/outerloop/measure.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from outerloop.compute import GONE, Compute, JobSpec, is_terminal
+from outerloop.compute import GONE, Compute, JobSpec, is_terminal, local_mode
 from outerloop.dispatch import (
     eval_job_spec,
     read_eval_result,
@@ -275,7 +275,9 @@ class DispatchedMeasurer:
     seed_cache: Path | None = None
 
     def _placement(self, m: Measure) -> tuple[str, str]:
-        if m.gpus <= 0:
+        # local compute has no lanes: the job is a subprocess on whatever GPUs
+        # the machine has (same rule as DispatchSettings.placement)
+        if m.gpus <= 0 or local_mode():
             return self.account, self.partition
         if not self.gpu_partition:
             raise ValueError(
@@ -492,8 +494,6 @@ class DispatchSettings:
         GPU job has no lane — a queue that can never run is worse than a
         loud refusal. Local compute has no lanes: jobs are subprocesses on
         whatever GPUs the machine has, so placement is empty by design."""
-        from outerloop.compute import local_mode
-
         if gpus <= 0 or local_mode():
             return self.account, self.partition
         if not self.gpu_partition:

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -399,6 +399,25 @@ def test_dispatch_settings_place_gpu_jobs_on_the_gpu_lane(tmp_path):
     assert own_account.placement(2) == ("gpu-acct", "h200")
 
 
+def test_local_compute_places_a_gpu_measure_without_a_lane(tmp_path, monkeypatch):
+    """Local compute has no lanes: a GPU measure is a subprocess on the machine's
+    own GPUs, so the gate's placement must not demand OUTERLOOP_GPU_PARTITION.
+    The launch placement already followed that rule; the measure placement did
+    not, and a GPU benchmark on a local box aborted at its first baseline."""
+    from outerloop.compute import LocalCompute
+    from outerloop.measure import DispatchSettings, Measure
+
+    settings = DispatchSettings(compute=LocalCompute(), image="", account="", partition="")
+    m = settings.measurer(tmp_path, repo_root=tmp_path, eval_minutes=15, run_tag="r")
+    gpu = Measure(name="baseline", tree_sha="a" * 40, command="x", metric="loss", gpus=1)
+    monkeypatch.delenv("OUTERLOOP_COMPUTE", raising=False)
+    with pytest.raises(ValueError, match="OUTERLOOP_GPU_PARTITION"):
+        m._placement(gpu)
+    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
+    assert m._placement(gpu) == ("", "")
+    assert settings.placement(1) == ("", "")  # the launch side, same rule
+
+
 def test_mixed_suite_places_each_measure_on_its_own_lane(tmp_path):
     """A suite gate measures siblings through the ONE measurer: a GPU
     sibling of a CPU benchmark (or vice versa) must land on its own lane with


### PR DESCRIPTION
## The bug

On local compute, a GPU benchmark aborts at its very first gate measure:

```
ValueError: measure baseline needs 1 GPU(s) but no GPU lane is configured (set OUTERLOOP_GPU_PARTITION)
```

Seen on cluster0 (`gpu-mlp-20260910-014302-agent-01`), a box with three GPUs and `OUTERLOOP_COMPUTE=local`. The benchmark never ran a single measure, let alone a launch.

## Cause

Local compute has no lanes by design: a job is a subprocess on whatever GPUs the machine has. `DispatchSettings.placement`, which places launches, already encodes that (`if gpus <= 0 or local_mode(): return ...`) and says so in its docstring. `DispatchedMeasurer._placement`, which places the gate's baseline and candidate measures, never got the same exemption and demanded a GPU lane unconditionally.

## Change

- `DispatchedMeasurer._placement` bypasses the lane requirement in local mode, the same rule as `DispatchSettings.placement`.
- `local_mode` is imported once at module level in `measure.py`; the sibling method's local import is gone.
- Test: with local compute, a GPU measure places without a lane, and still refuses without one on a scheduler.
- Changelog entry under Unreleased.

## Why it matters now

`gpu-mlp` is the only benchmark on the quickstart trial that launches and sleeps (`depth_k: 2`, `sleep_k: 4`). With this fix it can run on cluster0's real GPUs, which gives the first live exercise of the launch ledger path fixed in #362 on that fleet.
