### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-09-11
+
 ### Fixed
 
 - A GPU benchmark on local compute aborted at its first gate measure with "no GPU lane is configured". The measure placement now follows the launch placement's rule: local compute has no lanes, the job runs on the machine's own GPUs.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -13,5 +13,5 @@ authors:
 repository-code: "https://github.com/outerloop-science/outerloop"
 url: "https://outerloop.science"
 license: Apache-2.0
-version: 0.1.1
+version: 0.1.2
 date-released: "2026-09-11"

--- a/src/outerloop/__init__.py
+++ b/src/outerloop/__init__.py
@@ -2,7 +2,7 @@
 
 import os
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 
 
 def _bridge_legacy_env() -> None:


### PR DESCRIPTION
Patch release: local compute places a GPU measure without a lane (#364), folded from Unreleased. Version and citation bumped to 0.1.2.
