### PR TITLE
Lanes are the backend's word; dispatch always exists; sessions see no GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Whether jobs need a lane is now the compute backend's word (`has_lanes`): the measurer, the launcher, and the tick's GPU preflight ask it instead of testing for local mode. The dispatch settings always exist (a backend always does), so local compute arms the author's `launch`/`sleep` syscalls for benchmarks with `depth_k`, and a local wake no longer needs a container image. A `--image` path that is not a file is refused at the command line instead of silently degrading the run to inline evaluation.
+- Author sessions see no GPU on any backend (`CUDA_VISIBLE_DEVICES` is empty): experiments that need one go through `launch`, so they are recorded in the ledger and metered against the GPU budget. Contained sessions already had none.
+
 ## [0.1.2] - 2026-09-11
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Versions follow [SemVer](https://semver.org).
 ### Changed
 
 - Whether jobs need a lane is now the compute backend's word (`has_lanes`): the measurer, the launcher, and the tick's GPU preflight ask it instead of testing for local mode. The dispatch settings always exist (a backend always does), so local compute arms the author's `launch`/`sleep` syscalls for benchmarks with `depth_k`, and a local wake no longer needs a container image. A `--image` path that is not a file is refused at the command line instead of silently degrading the run to inline evaluation.
-- Author sessions see no GPU on any backend (`CUDA_VISIBLE_DEVICES` is empty): experiments that need one go through `launch`, so they are recorded in the ledger and metered against the GPU budget. Contained sessions already had none.
+- Author sessions start with no GPU visible on any backend (`CUDA_VISIBLE_DEVICES` is empty), so experiments that need one go through `launch`, where they are recorded in the ledger and metered against the GPU budget. This is the bare session's default; a contained session has no GPU device at all, which is the enforcement.
 
 ## [0.1.2] - 2026-09-11
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -351,10 +351,12 @@ sandbox, evaluations run bare in a throwaway tree under an allowlisted
 environment, both on your machine with your keys, and the loop says so once
 at start. Local compute has no lanes, so GPU benchmarks need no
 `OUTERLOOP_GPU_PARTITION`: evaluations and the author's launches run on the
-machine's own GPUs. The author's session itself sees no GPU on any backend
-(`CUDA_VISIBLE_DEVICES` is empty): an experiment that needs one goes through
-`launch`, where it is recorded in the run's ledger and metered against
-`gpu_hours_per_run`. The verification panel is off in this mode unless you set
+machine's own GPUs. The author's session itself starts with no GPU visible on
+any backend (`CUDA_VISIBLE_DEVICES` is empty), so an experiment that needs one
+goes through `launch`, where it is recorded in the run's ledger and metered
+against `gpu_hours_per_run`. Uncontained, that is a default the session could
+reset; contained, the session has no GPU device at all, which is one more
+reason to run with the image. The verification panel is off in this mode unless you set
 `OUTERLOOP_PANEL_UNCONTAINED=1`, because an uncontained judge holds a shell
 next to its own key file; a pull request opened without a panel says so. A
 Codex author needs the image in every mode. Contained local mode needs

--- a/docs/install.md
+++ b/docs/install.md
@@ -349,7 +349,12 @@ the walltime the tick requests for the climb and author-sleep wake jobs it sizes
 `OUTERLOOP_COMPUTE=local` still runs. Sessions run under the harness's own
 sandbox, evaluations run bare in a throwaway tree under an allowlisted
 environment, both on your machine with your keys, and the loop says so once
-at start. The verification panel is off in this mode unless you set
+at start. Local compute has no lanes, so GPU benchmarks need no
+`OUTERLOOP_GPU_PARTITION`: evaluations and the author's launches run on the
+machine's own GPUs. The author's session itself sees no GPU on any backend
+(`CUDA_VISIBLE_DEVICES` is empty): an experiment that needs one goes through
+`launch`, where it is recorded in the run's ledger and metered against
+`gpu_hours_per_run`. The verification panel is off in this mode unless you set
 `OUTERLOOP_PANEL_UNCONTAINED=1`, because an uncontained judge holds a shell
 next to its own key file; a pull request opened without a panel says so. A
 Codex author needs the image in every mode. Contained local mode needs

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -35,6 +35,7 @@ from outerloop.dispatch import (
     Snapshot,
     afterany_ids,
     drop_snapshot,
+    image_file_arg,
     should_dispatch,
     snapshot_tree,
 )
@@ -3443,13 +3444,6 @@ def main() -> int:
             )
         return value
 
-    def _image_file(value: str) -> str:
-        # a container image is a file on this machine; a wrong path fails here,
-        # loudly, instead of silently degrading the run to inline evals
-        if value and not Path(value).is_file():
-            raise argparse.ArgumentTypeError(f"--image {value!r} is not a file")
-        return value
-
     parser.add_argument("--agent-id", default="agent-01", type=_agent_id)
     parser.add_argument("--run-root", required=True, type=Path)
     parser.add_argument(
@@ -3469,7 +3463,7 @@ def main() -> int:
     parser.add_argument(
         "--image",
         default=os.environ.get("OUTERLOOP_IMAGE", ""),
-        type=_image_file,
+        type=image_file_arg,
         help="apptainer image for session+eval",
     )
     parser.add_argument("--account", default=os.environ.get("OUTERLOOP_ACCOUNT", ""))

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -2889,8 +2889,8 @@ def live_attempt(
                     f"(benchmark `{config.benchmark}`). A report will follow here.",
                 )
 
-        # Expensive benchmarks measure as dispatched cluster jobs; cheap ones
-        # (and any run with no cluster coordinates) measure inline. The choice
+        # Expensive benchmarks measure as dispatched jobs; cheap ones measure
+        # inline (so does a library caller that passes no dispatch). The choice
         # is the benchmark's eval-time hint against the in-job runway, decided
         # ONCE here so the baseline setup, the measurer, and the park deadline
         # all agree on it.
@@ -2900,11 +2900,11 @@ def live_attempt(
         wants_dispatch = should_dispatch(eval_minutes)
         dispatched = dispatch is not None and wants_dispatch
         if wants_dispatch and dispatch is None:
-            # a benchmark asked to be dispatched but no cluster coordinates
-            # reached us — never silently: name it, then measure inline
+            # a benchmark asked to be dispatched but the caller passed no
+            # dispatch settings — never silently: name it, then measure inline
             log.warning(
-                "benchmark %s wants dispatched eval (eval_minutes=%s) but no cluster "
-                "coordinates (image/account/partition) are set; measuring inline",
+                "benchmark %s wants dispatched eval (eval_minutes=%s) but no dispatch "
+                "settings were given; measuring inline",
                 config.benchmark,
                 eval_minutes,
             )
@@ -3443,6 +3443,13 @@ def main() -> int:
             )
         return value
 
+    def _image_file(value: str) -> str:
+        # a container image is a file on this machine; a wrong path fails here,
+        # loudly, instead of silently degrading the run to inline evals
+        if value and not Path(value).is_file():
+            raise argparse.ArgumentTypeError(f"--image {value!r} is not a file")
+        return value
+
     parser.add_argument("--agent-id", default="agent-01", type=_agent_id)
     parser.add_argument("--run-root", required=True, type=Path)
     parser.add_argument(
@@ -3462,6 +3469,7 @@ def main() -> int:
     parser.add_argument(
         "--image",
         default=os.environ.get("OUTERLOOP_IMAGE", ""),
+        type=_image_file,
         help="apptainer image for session+eval",
     )
     parser.add_argument("--account", default=os.environ.get("OUTERLOOP_ACCOUNT", ""))
@@ -3572,12 +3580,6 @@ def main() -> int:
     # and re-enter the decision. The wake job the WakeDispatcher submits runs
     # exactly this.
     if args.resume:
-        if not (args.image and Path(args.image).is_file()):
-            parser.error(
-                "--resume needs --image to rebuild the dispatched measurer "
-                "(account and partition are optional: empty ones use Slurm's "
-                "defaults, and local compute has no placement)"
-            )
         from outerloop.runstate import load_record
 
         # a wake that is not the lease holder is a straggler (a replacement was
@@ -3741,13 +3743,10 @@ def main() -> int:
     except ValueError as exc:
         parser.error(str(exc))
 
-    # Dispatched measurement needs a real image file to bind against; without
-    # one the climb measures inline. Account and partition are optional: empty
-    # ones use Slurm's defaults (the tick sets them on the climb job's env from
-    # the chain's), and local compute has no placement.
-    dispatch: DispatchSettings | None = None
-    if args.image and Path(args.image).is_file():
-        dispatch = _dispatch_settings(args)
+    # The compute backend always exists (Slurm, or local); containment was
+    # settled by --image/--uncontained above. Account and partition are
+    # optional: empty ones use the backend's defaults.
+    dispatch = _dispatch_settings(args)
     try:
         try:
             outcome = live_attempt(

--- a/src/outerloop/compute.py
+++ b/src/outerloop/compute.py
@@ -26,7 +26,7 @@ import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Protocol
+from typing import ClassVar, Protocol
 
 log = logging.getLogger(__name__)
 
@@ -166,6 +166,10 @@ class Compute(Protocol):
     """The verbs every compute backend implements. Callers (the measurer, the
     launcher, the wake dispatcher) depend on this, never on a backend."""
 
+    # Whether jobs are placed on named lanes (accounts/partitions). A backend
+    # without lanes runs every job on the default placement, GPUs included.
+    has_lanes: ClassVar[bool]
+
     def submit(self, spec: JobSpec) -> str: ...
     def status(self, job_id: str) -> str: ...
     def pending_reason(self, job_id: str) -> str: ...
@@ -235,6 +239,8 @@ def combine_states(states: Sequence[str]) -> str:
 @dataclass
 class SlurmCompute:
     """The three verbs, plus afterany for wake jobs."""
+
+    has_lanes: ClassVar[bool] = True
 
     runner: Runner = field(default=_subprocess_runner)
     command_timeout_s: int = 60
@@ -423,6 +429,8 @@ class LocalCompute:
     allocation, for deployments with no cluster at all, and for tests. It runs
     the identical job scripts the cluster runs (fresh checkout of the sealed
     sha, results to the job dir); only WHERE they run differs."""
+
+    has_lanes: ClassVar[bool] = False
 
     _states: dict[str, str] = field(default_factory=dict)
     _seq: int = 0

--- a/src/outerloop/dispatch.py
+++ b/src/outerloop/dispatch.py
@@ -23,6 +23,7 @@ its own code-side ceiling; under the in-job threshold nothing here runs.
 
 from __future__ import annotations
 
+import argparse
 import contextlib
 import json
 import logging
@@ -75,6 +76,15 @@ def effective_eval_minutes(eval_minutes: int | None) -> int:
     if eval_minutes is None:
         return 0
     return max(1, min(int(eval_minutes), EVAL_JOB_MINUTES_CEILING))
+
+
+def image_file_arg(value: str) -> str:
+    """argparse type for --image on every entry point: a container image is a
+    file on this machine, so a wrong path fails at the parser instead of
+    silently degrading the run to inline evaluation. "" (no image) passes."""
+    if value and not Path(value).is_file():
+        raise argparse.ArgumentTypeError(f"--image {value!r} is not a file")
+    return value
 
 
 def should_dispatch(eval_minutes: int | None) -> bool:

--- a/src/outerloop/followup.py
+++ b/src/outerloop/followup.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
 
 from outerloop.brief import render_review_wake
 from outerloop.contract import CONTRACT_NAME, contract_in_tree, contract_text_in_tree, load_contract
+from outerloop.dispatch import image_file_arg
 from outerloop.github import (
     GitError,
     GitHubClient,
@@ -1976,7 +1977,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(description="Service one in-review run.")
     parser.add_argument("--run-root", required=True, type=Path)
     parser.add_argument("--run-id", required=True)
-    parser.add_argument("--image", default="")
+    parser.add_argument("--image", default="", type=image_file_arg)
     parser.add_argument("--uncontained", action="store_true")
     parser.add_argument("--claude-bin", default=default_binary("claude"))
     parser.add_argument(
@@ -2056,10 +2057,10 @@ def main() -> int:
     )
     from outerloop.panel import panel_read_minutes
 
-    # cluster coordinates (the climb's own resolver, the climb's own rule):
-    # a real image dispatches evals, a GPU benchmark's to the GPU lane; with
-    # no image, evals run inline. Account and partition are optional (#300).
-    dispatch = _dispatch_settings(args) if (args.image and Path(args.image).is_file()) else None
+    # the climb's own resolver, the climb's own rule: the compute backend
+    # always exists, so a revision's evals dispatch and meter the same way a
+    # climb's do. Account and partition are optional (#300).
+    dispatch = _dispatch_settings(args)
 
     # a follow-up services ONE run: reproduce THAT run's author (the persisted
     # (backend, model) PAIR), not the current fleet default, so a codex-authored

--- a/src/outerloop/harness.py
+++ b/src/outerloop/harness.py
@@ -99,9 +99,11 @@ def session_env(api_key: str, key_variable: str, home: Path) -> dict[str, str]:
     env = {name: os.environ[name] for name in SESSION_ENV_ALLOWLIST if name in os.environ}
     env["HOME"] = str(home)
     env[key_variable] = api_key
-    # the session reasons; experiments that need a GPU go through `launch`, so
-    # they are recorded and metered. A contained session has no GPU anyway
-    # (no --nv); this makes the bare session match it.
+    # The session reasons; experiments that need a GPU go through `launch`,
+    # where they are recorded and metered. This is the DEFAULT a bare session
+    # starts with, not an enforcement: a host process can reset the variable.
+    # Containment is what enforces it (a contained session runs without --nv
+    # and has no GPU device at all); this makes the bare default match.
     env["CUDA_VISIBLE_DEVICES"] = ""
     return env
 

--- a/src/outerloop/harness.py
+++ b/src/outerloop/harness.py
@@ -99,6 +99,10 @@ def session_env(api_key: str, key_variable: str, home: Path) -> dict[str, str]:
     env = {name: os.environ[name] for name in SESSION_ENV_ALLOWLIST if name in os.environ}
     env["HOME"] = str(home)
     env[key_variable] = api_key
+    # the session reasons; experiments that need a GPU go through `launch`, so
+    # they are recorded and metered. A contained session has no GPU anyway
+    # (no --nv); this makes the bare session match it.
+    env["CUDA_VISIBLE_DEVICES"] = ""
     return env
 
 

--- a/src/outerloop/measure.py
+++ b/src/outerloop/measure.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from outerloop.compute import GONE, Compute, JobSpec, is_terminal, local_mode
+from outerloop.compute import GONE, Compute, JobSpec, is_terminal
 from outerloop.dispatch import (
     eval_job_spec,
     read_eval_result,
@@ -275,9 +275,7 @@ class DispatchedMeasurer:
     seed_cache: Path | None = None
 
     def _placement(self, m: Measure) -> tuple[str, str]:
-        # local compute has no lanes: the job is a subprocess on whatever GPUs
-        # the machine has (same rule as DispatchSettings.placement)
-        if m.gpus <= 0 or local_mode():
+        if m.gpus <= 0 or not self.compute.has_lanes:
             return self.account, self.partition
         if not self.gpu_partition:
             raise ValueError(
@@ -492,9 +490,9 @@ class DispatchSettings:
     def placement(self, gpus: int) -> tuple[str, str]:
         """(account, partition) for a job needing `gpus` GPUs. Raises when a
         GPU job has no lane — a queue that can never run is worse than a
-        loud refusal. Local compute has no lanes: jobs are subprocesses on
-        whatever GPUs the machine has, so placement is empty by design."""
-        if gpus <= 0 or local_mode():
+        loud refusal. A backend without lanes (local compute) runs every job,
+        GPUs included, on the default placement."""
+        if gpus <= 0 or not self.compute.has_lanes:
             return self.account, self.partition
         if not self.gpu_partition:
             raise ValueError(

--- a/src/outerloop/steward.py
+++ b/src/outerloop/steward.py
@@ -36,6 +36,7 @@ from outerloop.attempt import (
     arm_sigterm_containment,
 )
 from outerloop.contract import Contract, contract_text_in_tree, load_contract
+from outerloop.dispatch import image_file_arg
 from outerloop.github import (
     GitHubClient,
     TokenProvider,
@@ -761,7 +762,9 @@ def main() -> int:
     parser.add_argument("--target", required=True)
     parser.add_argument("--benchmark", required=True)
     parser.add_argument("--run-root", required=True, type=Path)
-    parser.add_argument("--image", default="", help="apptainer image for session+validation")
+    parser.add_argument(
+        "--image", default="", type=image_file_arg, help="apptainer image for session+validation"
+    )
     parser.add_argument(
         "--uncontained",
         action="store_true",

--- a/src/outerloop/tick.py
+++ b/src/outerloop/tick.py
@@ -205,6 +205,7 @@ class FollowupSpec:
     # the tick environment, so it is never threaded through argv
     github_app_file: str = ""
     target: str = ""  # the repo the intake pass scans for requested-lane issues
+    has_lanes: bool = True  # the compute backend's: False = every job on the default placement
     # the STEWARD'S OWN key (role separation): the steward lane stays off
     # until the operator provisions it
     steward_key_file: str = ""
@@ -291,9 +292,9 @@ def _gpu_lane_error(contract: Any, benchmark: str, spec: FollowupSpec) -> str:
     evals would queue into jobs that can never run (the climb would then
     park forever on a phantom eval). ANY GPU benchmark in the contract
     counts, not just the climbed one: the suite gate measures siblings.
-    Local compute has no lanes — jobs run on whatever GPUs the machine
-    has — so the check is waived there."""
-    if spec.gpu_partition or local_mode():
+    A backend without lanes (local compute) runs GPU jobs on the default
+    placement, so the check does not apply."""
+    if spec.gpu_partition or not spec.has_lanes:
         return ""
     gpu_benches = [
         b.name for b in getattr(contract, "benchmarks", []) if int(getattr(b, "gpus", 0) or 0)
@@ -3259,6 +3260,7 @@ def _followup_spec_from_env(root: Path) -> tuple[Any, FollowupSpec | None]:
                 gpu_partition=os.environ.get("OUTERLOOP_GPU_PARTITION", ""),
                 gpu_account=os.environ.get("OUTERLOOP_GPU_ACCOUNT", ""),
                 max_job_minutes=_max_job_minutes_from_env(),
+                has_lanes=compute_from_env().has_lanes,
             )
             return github, followup_spec
         except Exception as exc:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -2707,6 +2707,77 @@ def test_resume_cli_releases_the_lease_on_exit(tmp_path, monkeypatch) -> None:
     assert not (run_dir(tmp_path, run_id) / "lease.json").exists()  # released
 
 
+@pytest.mark.parametrize("compute_env", ["local", None])
+def test_resume_cli_needs_no_image_when_uncontained(tmp_path, monkeypatch, compute_env) -> None:
+    """A wake rebuilds its dispatch settings from the backend, not from an image
+    file: `--uncontained` is enough on every backend. Local wakes used to be
+    refused for lacking an image, so a local park could never wake."""
+    from outerloop.attempt import AttemptOutcome, main
+    from outerloop.compute import LocalCompute, SlurmCompute
+    from outerloop.runstate import acquire_lease
+
+    run_id = "tsp-wake"
+    (tmp_path / "runs" / run_id).mkdir(parents=True)
+    (tmp_path / "pat").write_text("ghp_x\n")
+    (tmp_path / "pat").chmod(0o600)
+    assert acquire_lease(tmp_path, run_id, "wake-job:1", "1", 1_000.0)
+    monkeypatch.setenv("SLURM_JOB_ID", "1")  # this process IS the wake job that holds it
+    if compute_env:
+        monkeypatch.setenv("OUTERLOOP_COMPUTE", compute_env)
+    else:
+        monkeypatch.delenv("OUTERLOOP_COMPUTE", raising=False)
+    seen: dict = {}
+
+    def fake_resume(*a, **k):
+        seen.update(k)
+        return AttemptOutcome(run_id=run_id, outcome="parked")
+
+    monkeypatch.setattr(climb_mod, "arm_sigterm_containment", lambda: None)
+    monkeypatch.setattr(climb_mod, "resume_run", fake_resume)
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "climb",
+            "--resume",
+            run_id,
+            "--run-root",
+            str(tmp_path),
+            "--uncontained",
+            "--pat-file",
+            str(tmp_path / "pat"),
+            "--panel",
+            "",
+        ],
+    )
+    assert main() == 0
+    expected = LocalCompute if compute_env else SlurmCompute
+    assert isinstance(seen["dispatch"].compute, expected)
+
+
+def test_cli_refuses_an_image_that_is_not_a_file(tmp_path, monkeypatch, capsys) -> None:
+    """A wrong image path fails at the command line instead of silently
+    degrading the run to inline evaluation."""
+    from outerloop.attempt import main as climb_main
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "climb",
+            "--target",
+            "o/r",
+            "--benchmark",
+            "b",
+            "--run-root",
+            str(tmp_path),
+            "--image",
+            str(tmp_path / "missing.sif"),
+        ],
+    )
+    with pytest.raises(SystemExit):
+        climb_main()
+    assert "is not a file" in capsys.readouterr().err
+
+
 def test_resume_reports_terminal_back_to_the_requesting_issue(tmp_path, monkeypatch) -> None:
     # an issue-requested dispatched run must post its outcome back on wake, or
     # the issue stays claimed forever. Improved -> comment with the PR link +

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -240,3 +240,11 @@ def test_job_arrays_have_a_spec_task_ids_and_a_combined_state() -> None:
         c.status("123_[0-3]")
     with pytest.raises(ValueError):
         LocalCompute().status("12a")
+
+
+def test_backends_say_whether_jobs_need_lanes() -> None:
+    """The one property every placement asks instead of testing for local mode."""
+    from outerloop.compute import CommandResult, LocalCompute, SlurmCompute
+
+    assert SlurmCompute(runner=lambda argv, timeout_s: CommandResult(0, "", "")).has_lanes is True
+    assert LocalCompute().has_lanes is False

--- a/tests/test_followup.py
+++ b/tests/test_followup.py
@@ -3126,3 +3126,39 @@ def test_a_resume_that_died_after_its_push_completes_on_the_next_follow_up(
     assert load_record(root, "tsp-r1").followup_stage == {}
     assert _origin_head(bare) == landed  # nothing re-pushed
     assert _git(ws, "for-each-ref", "refs/dispatch/").strip() == ""
+
+
+def test_followup_cli_dispatches_uncontained_and_refuses_a_missing_image(
+    tmp_path, monkeypatch, capsys
+):
+    """A follow-up's revision evals dispatch and meter like a climb's: with
+    --uncontained the CLI builds the dispatch settings (they come from the
+    backend, not from an image file), and a --image path that is not a file is
+    refused by the parser. Before this, an uncontained follow-up left dispatch
+    None and a GPU revision evaluated inline on an unmetered host GPU."""
+    import sys
+
+    import pytest
+
+    import outerloop.attempt as attempt_mod
+    import outerloop.followup as followup_mod
+
+    class _Stop(BaseException):
+        pass
+
+    seen: dict = {}
+
+    def fake_dispatch_settings(args):
+        seen["args"] = args
+        raise _Stop
+
+    monkeypatch.setattr(attempt_mod, "_dispatch_settings", fake_dispatch_settings)
+    base = ["followup", "--run-root", str(tmp_path), "--run-id", "r1", "--bot-login", "bot[bot]"]
+    monkeypatch.setattr(sys, "argv", [*base, "--uncontained"])
+    with pytest.raises(_Stop):
+        followup_mod.main()
+    assert seen["args"].image == "" and seen["args"].uncontained is True
+    monkeypatch.setattr(sys, "argv", [*base, "--image", str(tmp_path / "missing.sif")])
+    with pytest.raises(SystemExit):
+        followup_mod.main()
+    assert "is not a file" in capsys.readouterr().err

--- a/tests/test_harness.py
+++ b/tests/test_harness.py
@@ -75,6 +75,7 @@ def test_session_env_is_scrubbed(tmp_path: Path, monkeypatch) -> None:
     assert "aws_SECRET" not in seen
     assert "ANTHROPIC_API_KEY=sk-test-123" in seen
     assert "PATH=" in seen
+    assert "CUDA_VISIBLE_DEVICES=" in seen  # the session sees no GPU
 
 
 def test_home_is_redirected_per_session(tmp_path: Path) -> None:
@@ -98,8 +99,20 @@ def test_home_is_redirected_per_session(tmp_path: Path) -> None:
 
 def test_session_env_allowlist_is_exhaustive(tmp_path: Path) -> None:
     env = session_env("key", "ANTHROPIC_API_KEY", home=tmp_path)
-    assert set(env) <= set(SESSION_ENV_ALLOWLIST) | {"ANTHROPIC_API_KEY", "HOME"}
+    assert set(env) <= set(SESSION_ENV_ALLOWLIST) | {
+        "ANTHROPIC_API_KEY",
+        "HOME",
+        "CUDA_VISIBLE_DEVICES",
+    }
     assert env["HOME"] == str(tmp_path)
+
+
+def test_sessions_see_no_gpu(tmp_path: Path, monkeypatch) -> None:
+    """The session reasons; GPU work goes through `launch`, where it is recorded
+    and metered. A host that exposes GPUs to the loop must not expose them to
+    the session, on any backend."""
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "0,1")
+    assert session_env("key", "ANTHROPIC_API_KEY", home=tmp_path)["CUDA_VISIBLE_DEVICES"] == ""
 
 
 def test_argv_carries_the_controls(tmp_path: Path) -> None:

--- a/tests/test_local_compute.py
+++ b/tests/test_local_compute.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
+from typing import ClassVar
 
 import pytest
 
@@ -183,6 +184,8 @@ def test_job_terminal_without_a_result_fails_instead_of_parking(tmp_path: Path) 
     run_dir.mkdir()
 
     class _DeadCompute:
+        has_lanes: ClassVar[bool] = True
+
         def submit(self, spec) -> str:
             return "123"  # "ran", but wrote nothing (killed at the walltime)
 
@@ -279,39 +282,59 @@ def test_terminal_states_survive_across_instances(tmp_path, monkeypatch) -> None
     assert poller.status(job_id) == GONE  # no root -> memory-only, as before
 
 
-def test_gpu_contracts_pass_the_lane_check_under_local_mode(monkeypatch) -> None:
-    """Local compute has no lanes: a contract with GPU benchmarks must not be
-    rejected for a missing OUTERLOOP_GPU_PARTITION (terra #223)."""
+def test_gpu_contracts_pass_the_lane_check_on_a_backend_without_lanes() -> None:
+    """A backend without lanes (local compute) runs GPU jobs on the default
+    placement, so a contract with GPU benchmarks needs no OUTERLOOP_GPU_PARTITION
+    there; a backend with lanes still refuses loudly (terra #223)."""
     from types import SimpleNamespace
 
     from outerloop.tick import FollowupSpec, _gpu_lane_error
 
-    spec = FollowupSpec(
-        account="", partition="", run_root=Path("/tmp/x"), image="", home=Path("/tmp/x")
-    )
     contract = SimpleNamespace(benchmarks=[SimpleNamespace(name="speedrun", gpus=1)])
-    assert "no GPU lane" in _gpu_lane_error(contract, "speedrun", spec)
-    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
-    assert _gpu_lane_error(contract, "speedrun", spec) == ""
+
+    def spec(has_lanes: bool) -> FollowupSpec:
+        return FollowupSpec(
+            account="",
+            partition="",
+            run_root=Path("/tmp/x"),
+            image="",
+            home=Path("/tmp/x"),
+            has_lanes=has_lanes,
+        )
+
+    assert "no GPU lane" in _gpu_lane_error(contract, "speedrun", spec(True))
+    assert _gpu_lane_error(contract, "speedrun", spec(False)) == ""
 
 
-def test_local_mode_places_gpu_measures_without_a_lane(monkeypatch) -> None:
-    """DispatchSettings.placement must not raise for a GPU measure under
-    local mode (terra #223 r7: the lane waiver admitted GPU contracts that
-    then failed at placement) — local jobs run on the machine's own GPUs."""
-    from outerloop.compute import LocalCompute
-    from outerloop.measure import DispatchSettings
-
-    settings = DispatchSettings(
-        compute=LocalCompute(), image="", account="", partition="", gpu_partition=""
-    )
-    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
-    assert settings.placement(1) == ("", "")
-    monkeypatch.delenv("OUTERLOOP_COMPUTE")
+def test_a_backend_without_lanes_places_gpu_launches_and_measures() -> None:
+    """Both placements ask the backend: LocalCompute has no lanes, so a GPU job
+    places on the default; SlurmCompute without a GPU lane refuses loudly
+    (terra #223 r7; the measure placement once lacked the rule and a GPU
+    benchmark on a local box aborted at its first baseline)."""
     import pytest
 
+    from outerloop.compute import CommandResult, LocalCompute, SlurmCompute
+    from outerloop.measure import DispatchSettings, Measure
+
+    gpu = Measure(name="baseline", tree_sha="a" * 40, command="x", metric="loss", gpus=1)
+    local = DispatchSettings(compute=LocalCompute(), image="", account="", partition="")
+    assert local.placement(1) == ("", "")
+    measurer = local.measurer(
+        Path("/tmp/x"), repo_root=Path("/tmp/x"), eval_minutes=15, run_tag="r"
+    )
+    assert measurer._placement(gpu) == ("", "")
+    slurm = DispatchSettings(
+        compute=SlurmCompute(runner=lambda argv, timeout_s: CommandResult(0, "", "")),
+        image="",
+        account="",
+        partition="",
+    )
     with pytest.raises(ValueError, match="no GPU lane"):
-        settings.placement(1)  # slurm mode still refuses loudly
+        slurm.placement(1)
+    with pytest.raises(ValueError, match="no GPU lane"):
+        slurm.measurer(
+            Path("/tmp/x"), repo_root=Path("/tmp/x"), eval_minutes=15, run_tag="r"
+        )._placement(gpu)
 
 
 def test_local_job_output_is_kept_beside_its_state(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -399,25 +399,6 @@ def test_dispatch_settings_place_gpu_jobs_on_the_gpu_lane(tmp_path):
     assert own_account.placement(2) == ("gpu-acct", "h200")
 
 
-def test_local_compute_places_a_gpu_measure_without_a_lane(tmp_path, monkeypatch):
-    """Local compute has no lanes: a GPU measure is a subprocess on the machine's
-    own GPUs, so the gate's placement must not demand OUTERLOOP_GPU_PARTITION.
-    The launch placement already followed that rule; the measure placement did
-    not, and a GPU benchmark on a local box aborted at its first baseline."""
-    from outerloop.compute import LocalCompute
-    from outerloop.measure import DispatchSettings, Measure
-
-    settings = DispatchSettings(compute=LocalCompute(), image="", account="", partition="")
-    m = settings.measurer(tmp_path, repo_root=tmp_path, eval_minutes=15, run_tag="r")
-    gpu = Measure(name="baseline", tree_sha="a" * 40, command="x", metric="loss", gpus=1)
-    monkeypatch.delenv("OUTERLOOP_COMPUTE", raising=False)
-    with pytest.raises(ValueError, match="OUTERLOOP_GPU_PARTITION"):
-        m._placement(gpu)
-    monkeypatch.setenv("OUTERLOOP_COMPUTE", "local")
-    assert m._placement(gpu) == ("", "")
-    assert settings.placement(1) == ("", "")  # the launch side, same rule
-
-
 def test_mixed_suite_places_each_measure_on_its_own_lane(tmp_path):
     """A suite gate measures siblings through the ONE measurer: a GPU
     sibling of a CPU benchmark (or vice versa) must land on its own lane with

--- a/tests/test_tick.py
+++ b/tests/test_tick.py
@@ -3633,13 +3633,16 @@ def test_followup_spec_needs_no_account_or_partition(monkeypatch: Any, tmp_path:
     assert spec.account == "" and spec.partition == ""
 
 
-def test_resume_gate_needs_only_the_image(monkeypatch: Any, tmp_path: Path, capsys: Any) -> None:
+def test_resume_gate_needs_only_the_containment_choice(
+    monkeypatch: Any, tmp_path: Path, capsys: Any
+) -> None:
     """The resume gate accepts empty account/partition under
     OUTERLOOP_COMPUTE=local (terra #223: locally dispatched wakes died at
     the parser) and on Slurm (#300: the cluster's defaults apply). Proof of
     admission: the CLI proceeds far enough to complain about the missing
-    parked run, not about the placement. Only the image is required: without
-    it the same argv trips the gate."""
+    parked run, not about the placement. The dispatch settings come from the
+    backend, so the only thing the parser insists on is the containment
+    choice: an image that exists, or --uncontained."""
     import sys
 
     import pytest
@@ -3679,26 +3682,30 @@ def test_resume_gate_needs_only_the_image(monkeypatch: Any, tmp_path: Path, caps
         attempt_mod.main()
     assert "needs --image" not in capsys.readouterr().err
 
-    # the image is the one thing the gate needs
-    # a path that is not a file: past the parser's own --image check, but not
-    # the gate
+    # an image path that is not a file is refused by the parser itself
     missing = str(tmp_path / "missing.sif")
     monkeypatch.setattr(sys, "argv", [(missing if a == str(image) else a) for a in argv])
     with pytest.raises(SystemExit):
         attempt_mod.main()
-    assert "needs --image" in capsys.readouterr().err
+    assert "is not a file" in capsys.readouterr().err
+    # --uncontained instead of an image: admitted the same way
+    monkeypatch.setattr(
+        sys, "argv", [a for a in argv if a not in ("--image", str(image))] + ["--uncontained"]
+    )
+    with pytest.raises(FileNotFoundError, match=r"state\.json"):
+        attempt_mod.main()
 
 
 def test_fresh_climb_dispatches_without_account_or_partition(
     monkeypatch: Any, tmp_path: Path
 ) -> None:
-    """The fresh climb's dispatch gate needs only the image (#300): with no
-    --account and no --partition the measurer is still dispatched and the
-    settings carry the empty placement (JobSpec then omits both flags, Slurm
-    applies its defaults); a set account passes through; without an image the
-    climb measures inline (dispatch=None). main() is halted right past the
-    gate with a BaseException, which the run's `except Exception`
-    containment does not swallow."""
+    """The fresh climb always builds its dispatch settings (#300): with no
+    --account and no --partition the settings carry the empty placement
+    (JobSpec then omits both flags, Slurm applies its defaults); a set account
+    passes through; --uncontained without an image dispatches the same way;
+    an image path that is not a file is refused by the parser. main() is
+    halted right past the gate with a BaseException, which the run's
+    `except Exception` containment does not swallow."""
     import sys
 
     import pytest
@@ -3760,14 +3767,19 @@ def test_fresh_climb_dispatches_without_account_or_partition(
         attempt_mod.main()
     assert seen.pop("dispatch_args") == ("acct", "")
 
-    # no image: measured inline
-    # a path that is not a file: past the parser's own --image check, but not
-    # the gate
-    missing = str(tmp_path / "missing.sif")
-    monkeypatch.setattr(sys, "argv", [(missing if a == str(image) else a) for a in argv])
+    # --uncontained, no image: dispatched all the same (the backend decides)
+    monkeypatch.setattr(
+        sys, "argv", [a for a in argv if a not in ("--image", str(image))] + ["--uncontained"]
+    )
     with pytest.raises(_Stop):
         attempt_mod.main()
-    assert seen == {"live_dispatch": None}
+    assert seen.pop("dispatch_args") == ("", "")
+    # an image path that is not a file is refused by the parser
+    missing = str(tmp_path / "missing.sif")
+    monkeypatch.setattr(sys, "argv", [(missing if a == str(image) else a) for a in argv])
+    with pytest.raises(SystemExit):
+        attempt_mod.main()
+    assert seen == {}
 
 
 def test_local_jobs_inherit_the_config_env(tmp_path: Path, monkeypatch: Any) -> None:


### PR DESCRIPTION
## What was wrong

On cluster0 (local compute, three GPUs, no container image) the gpu-mlp run from quickstart-trial #7 improved test MSE 25x, but it never used `launch` or `sleep`: the syscall tool was never installed. `main()` built the dispatch settings only when `--image` named an existing file, and author syscalls arm only when a dispatch exists. So a local run had no launch tool, its experiments ran inline in `/tmp` on GPUs the session could see, nothing reached the ledger, and about 4000 GPU-seconds went unmetered. The same image check on `--resume` meant a local park could never have woken anyway.

This was the fourth and fifth place where "local mode" was special-cased. `DispatchSettings.placement`, `DispatchedMeasurer._placement` (#364), and the tick's GPU-lane preflight each tested `local_mode()`; the two `main()` guards tested for the image file instead. Each was a separate conditional branch on the same idea.

## One rule instead of five branches

- **The backend says whether jobs need lanes.** `Compute.has_lanes` is a class attribute on the protocol: `SlurmCompute` True, `LocalCompute` False. Both placements and the tick preflight ask it. `FollowupSpec` carries it (`has_lanes`, from the backend at construction). No placement code reads the environment anymore.
- **Dispatch settings always exist.** A compute backend always does. `main()` builds `_dispatch_settings(args)` unconditionally for fresh climbs and wakes; containment is already settled by the universal `--image` / `--uncontained` requirement. The `--resume needs --image` guard is gone: a wake needs the containment choice, not an image file.
- **A wrong image path fails loudly.** `--image` is validated at argument parsing (must be a file) instead of silently degrading the run to inline evaluation.
- **Sessions see no GPU, on every backend.** `session_env` sets `CUDA_VISIBLE_DEVICES=""` for all harnesses (Claude, Codex, Hermes share it). The session reasons; experiments that need a GPU go through `launch`, where they are recorded and metered. Contained sessions already had no GPU (no `--nv`); this makes the bare session match. Launch jobs are unaffected: their environment comes from the loop, not the session.

## Tests

- `has_lanes` on both backends; placements and the preflight tested with backend objects, no environment monkeypatching (the two env-based local-mode tests are rewritten).
- CLI: `--resume --uncontained` is admitted on local and Slurm and hands `resume_run` a dispatch with the right backend; a non-file `--image` is refused with "is not a file"; the fresh-climb gate test now covers `--uncontained` dispatching and the loud image check.
- `session_env` carries an empty `CUDA_VISIBLE_DEVICES` even when the host sets one; the Claude harness test asserts it reached the process.
- Full gate green: ruff, format, mypy, 1380 tests.

## Behaviour on each fleet

- **Torch (Slurm, contained):** unchanged placement and dispatch; the session already ran in a CPU job without `--nv`, so the empty `CUDA_VISIBLE_DEVICES` changes nothing observable.
- **cluster0 (local, currently uncontained):** GPU benchmarks now arm `launch`/`sleep`, wakes are admitted, launches run on the machine's GPUs, the session does not. First-round test runs from this branch's commit installed into the adopter venv, before any release.

Docs: `docs/install.md` local-mode paragraph. Changelog under Unreleased.
