### PR TITLE
Intake: every skip is logged, a task label vouches, new Apps read members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versions follow [SemVer](https://semver.org).
 
 ## [Unreleased]
 
+### Fixed
+
+- Intake dropped an issue from a private org member without a word: the App's token sees such an author as CONTRIBUTOR, and only OWNER/MEMBER/COLLABORATOR qualified. Every skipped issue is now logged with its reason, a maintainer's `outerloop:task` label vouches for an issue regardless of association, and new Apps request members read so private members read as MEMBER.
+
 ### Changed
 
 - The brief's launch section says that a launch runs a sealed snapshot of the working tree and is scope-checked like the final tree, so experiment scripts must live under the contract's allowed paths.

--- a/docs/install.md
+++ b/docs/install.md
@@ -224,7 +224,8 @@ manifest flow:
 The bot login is `<slug>[bot]`; init records it as `OUTERLOOP_BOT_LOGIN`.
 Tokens are minted from the key an hour at a time and scoped to the installed
 repos; the App takes no seat and needs no collaborator grant. The manifest
-declares Contents, Issues and Pull requests read-write and Metadata read,
+declares Contents, Issues and Pull requests read-write, Metadata read and
+Members read (so a private org member's issue reads as MEMBER, not CONTRIBUTOR),
 nothing else. If the install step was cut short, run
 `outerloop init --force --github-app` to finish and re-check it.
 

--- a/src/outerloop/appmanifest.py
+++ b/src/outerloop/appmanifest.py
@@ -47,6 +47,9 @@ SETUP_URL = os.environ.get("OUTERLOOP_SETUP_URL") or "https://setup.outerloop.sc
 DEFAULT_PERMISSIONS = {
     "contents": "write",
     "issues": "write",
+    # so the App sees a private org member's issue as MEMBER, not CONTRIBUTOR
+    # (intake qualifies issues by author association)
+    "members": "read",
     "metadata": "read",
     "pull_requests": "write",
 }

--- a/src/outerloop/intake.py
+++ b/src/outerloop/intake.py
@@ -48,13 +48,28 @@ def infer_benchmark(text: str, contract: Contract) -> str:
     return named[0] if len(named) == 1 else ""
 
 
+def issue_labels(issue: dict) -> set[str]:
+    """The issue's label names, casefolded."""
+    return {
+        str(label.get("name", "")).casefold()
+        for label in issue.get("labels", [])
+        if isinstance(label, dict)
+    }
+
+
 def qualifying_issue(issue: dict, bot_login: str) -> bool:
+    """An issue is a work order when a maintainer vouches for it: by writing it
+    (an OWNER, MEMBER or COLLABORATOR author) or by labelling it `task` (only
+    triage rights can set a label). The label matters because the kernel
+    lists issues with the App's token, and an App without the members
+    permission sees a private org member as CONTRIBUTOR."""
     author = str((issue.get("user") or {}).get("login", ""))
     if is_own_login(author, bot_login):
         return False  # the kernel's own issues (research log, alarms) are never orders
-    if str(issue.get("author_association", "")) not in QUALIFYING_ASSOCIATIONS:
+    if not str(issue.get("title") or "").strip():
         return False
-    return bool(str(issue.get("title") or "").strip())
+    vouched = str(issue.get("author_association", "")) in QUALIFYING_ASSOCIATIONS
+    return vouched or has_label(issue_labels(issue), "task")
 
 
 def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTask | None:
@@ -68,16 +83,20 @@ def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTa
         return None
     issues = sorted(github.list_open_issues(repo), key=lambda i: i.get("number", 0))
     for issue in issues:
-        labels = {
-            str(label.get("name", "")).casefold()
-            for label in issue.get("labels", [])
-            if isinstance(label, dict)
-        }
-        if has_label(labels, "steward"):
+        number = int(issue["number"])
+        if has_label(issue_labels(issue), "steward"):
             continue  # the steward lane's, never the solver's
         if not qualifying_issue(issue, bot_login):
+            # every skip says why: a silent one cost a day of "why is my
+            # issue not picked up" on a private org member's issue
+            log.info(
+                "issue #%s skipped: by %s as %s (needs %s, or the task label)",
+                number,
+                (issue.get("user") or {}).get("login", ""),
+                issue.get("author_association", ""),
+                "/".join(QUALIFYING_ASSOCIATIONS),
+            )
             continue
-        number = int(issue["number"])
         claimed = False
         attempts = 0
         for c in github.list_comments(repo, number):
@@ -91,7 +110,8 @@ def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTa
             if has_marker(body, "claim-released"):
                 claimed = False
         if claimed:
-            continue  # already claimed by a run
+            log.info("issue #%s skipped: claimed by a run", number)
+            continue
         if attempts >= MAX_INTAKE_ATTEMPTS:
             log.info("issue #%s burned %d claim attempts; needs a human look", number, attempts)
             continue

--- a/src/outerloop/intake.py
+++ b/src/outerloop/intake.py
@@ -57,19 +57,31 @@ def issue_labels(issue: dict) -> set[str]:
     }
 
 
-def qualifying_issue(issue: dict, bot_login: str) -> bool:
-    """An issue is a work order when a maintainer vouches for it: by writing it
-    (an OWNER, MEMBER or COLLABORATOR author) or by labelling it `task` (only
-    triage rights can set a label). The label matters because the kernel
-    lists issues with the App's token, and an App without the members
-    permission sees a private org member as CONTRIBUTOR."""
+def disqualification(issue: dict, bot_login: str, *, vouching_label: str | None = None) -> str:
+    """Why this issue is not a work order, or "" when it is. A maintainer
+    vouches for an issue by writing it (an OWNER, MEMBER or COLLABORATOR
+    author) or, on a lane that accepts one, by setting the lane's label (only
+    triage rights can). The label matters because the kernel lists issues with
+    the App's token, and an App without the members permission sees a private
+    org member as CONTRIBUTOR. The reason is what the skip log says."""
     author = str((issue.get("user") or {}).get("login", ""))
     if is_own_login(author, bot_login):
-        return False  # the kernel's own issues (research log, alarms) are never orders
+        return "the kernel's own issue"  # research log, alarms: never orders
     if not str(issue.get("title") or "").strip():
-        return False
-    vouched = str(issue.get("author_association", "")) in QUALIFYING_ASSOCIATIONS
-    return vouched or has_label(issue_labels(issue), "task")
+        return "no title"
+    association = str(issue.get("author_association", ""))
+    if association in QUALIFYING_ASSOCIATIONS:
+        return ""
+    if vouching_label and has_label(issue_labels(issue), vouching_label):
+        return ""
+    wanted = "/".join(QUALIFYING_ASSOCIATIONS)
+    if vouching_label:
+        wanted += f", or the {vouching_label} label"
+    return f"by {author} as {association or 'unknown'} (needs {wanted})"
+
+
+def qualifying_issue(issue: dict, bot_login: str, *, vouching_label: str | None = None) -> bool:
+    return not disqualification(issue, bot_login, vouching_label=vouching_label)
 
 
 def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTask | None:
@@ -84,18 +96,13 @@ def pick_issue(github, repo: str, contract: Contract, bot_login: str) -> IssueTa
     issues = sorted(github.list_open_issues(repo), key=lambda i: i.get("number", 0))
     for issue in issues:
         number = int(issue["number"])
+        # every skip says why: a silent one cost a day of "why is my issue
+        # not picked up" on a private org member's issue
         if has_label(issue_labels(issue), "steward"):
-            continue  # the steward lane's, never the solver's
-        if not qualifying_issue(issue, bot_login):
-            # every skip says why: a silent one cost a day of "why is my
-            # issue not picked up" on a private org member's issue
-            log.info(
-                "issue #%s skipped: by %s as %s (needs %s, or the task label)",
-                number,
-                (issue.get("user") or {}).get("login", ""),
-                issue.get("author_association", ""),
-                "/".join(QUALIFYING_ASSOCIATIONS),
-            )
+            log.info("issue #%s skipped: a steward work order", number)
+            continue
+        if reason := disqualification(issue, bot_login, vouching_label="task"):
+            log.info("issue #%s skipped: %s", number, reason)
             continue
         claimed = False
         attempts = 0

--- a/src/outerloop/steward.py
+++ b/src/outerloop/steward.py
@@ -50,6 +50,7 @@ from outerloop.intake import (
     RELEASE_MARKER,
     IssueTask,
     infer_benchmark,
+    issue_labels,
     qualifying_issue,
 )
 from outerloop.markers import has_label, has_marker, marker
@@ -243,13 +244,9 @@ def pick_steward_issue(
         return None
     issues = sorted(github.list_open_issues(repo), key=lambda i: i.get("number", 0))
     for issue in issues:
-        labels = {
-            str(label.get("name", "")).casefold()
-            for label in issue.get("labels", [])
-            if isinstance(label, dict)
-        }
-        if not has_label(labels, "steward"):
+        if not has_label(issue_labels(issue), "steward"):
             continue
+        # author standing only: no label vouches for the privileged lane
         if not qualifying_issue(issue, bot_login):
             continue
         number = int(issue["number"])
@@ -327,11 +324,7 @@ def release_orphaned_claims(
     for issue in github.list_open_issues(repo):
         if released >= limit:
             break
-        labels = {
-            str(label.get("name", "")).casefold()
-            for label in issue.get("labels", [])
-            if isinstance(label, dict)
-        }
+        labels = issue_labels(issue)
         if not has_label(labels, "steward"):
             continue
         number = int(issue.get("number", 0))

--- a/tests/test_appmanifest.py
+++ b/tests/test_appmanifest.py
@@ -36,6 +36,7 @@ def test_build_manifest_declares_least_privilege() -> None:
     assert m["default_permissions"] == {
         "contents": "write",
         "issues": "write",
+        "members": "read",  # a private org member's issue reads as MEMBER, not CONTRIBUTOR
         "metadata": "read",
         "pull_requests": "write",
     }

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -172,3 +172,24 @@ roadmap: docs/roadmap.md
             return []
 
     assert pick_issue(G(), "org/pilot", contract, "agentic-learning-bot") is None
+
+
+def test_task_label_vouches_for_an_issue_and_every_skip_says_why(caplog) -> None:
+    """The App lists issues with its own token; without the members permission
+    a private org member reads as CONTRIBUTOR and the issue was dropped with no
+    log line (quickstart-trial #7, 2026-09-11). A maintainer's `outerloop:task`
+    label now vouches for an issue regardless of association, and a skipped
+    issue is logged with its reason."""
+    import logging
+
+    unlabelled = issue(7, "reach: make each step count", assoc="CONTRIBUTOR")
+    labelled = {
+        **issue(8, "reach: try a wider trunk", assoc="CONTRIBUTOR"),
+        "labels": [{"name": "outerloop:task"}],
+    }
+    assert not qualifying_issue(unlabelled, "bot")
+    assert qualifying_issue(labelled, "bot")
+    with caplog.at_level(logging.INFO):
+        task = pick_issue(G([unlabelled, labelled]), "org/pilot", CONTRACT, "bot")
+    assert task is not None and task.number == 8
+    assert "issue #7 skipped: by renmengye as CONTRIBUTOR" in caplog.text

--- a/tests/test_intake.py
+++ b/tests/test_intake.py
@@ -187,9 +187,18 @@ def test_task_label_vouches_for_an_issue_and_every_skip_says_why(caplog) -> None
         **issue(8, "reach: try a wider trunk", assoc="CONTRIBUTOR"),
         "labels": [{"name": "outerloop:task"}],
     }
-    assert not qualifying_issue(unlabelled, "bot")
-    assert qualifying_issue(labelled, "bot")
+    assert not qualifying_issue(unlabelled, "bot", vouching_label="task")
+    assert qualifying_issue(labelled, "bot", vouching_label="task")
+    # no lane label: author standing only, which is the steward lane's rule
+    assert not qualifying_issue(labelled, "bot")
+    own = issue(6, "reach: research log", author="bot")
+    steward = {**issue(5, "reach: fix the ruler"), "labels": [{"name": "outerloop:steward"}]}
     with caplog.at_level(logging.INFO):
-        task = pick_issue(G([unlabelled, labelled]), "org/pilot", CONTRACT, "bot")
+        task = pick_issue(G([steward, own, unlabelled, labelled]), "org/pilot", CONTRACT, "bot")
     assert task is not None and task.number == 8
-    assert "issue #7 skipped: by renmengye as CONTRIBUTOR" in caplog.text
+    assert "issue #5 skipped: a steward work order" in caplog.text
+    assert "issue #6 skipped: the kernel's own issue" in caplog.text
+    assert (
+        "issue #7 skipped: by renmengye as CONTRIBUTOR (needs OWNER/MEMBER/COLLABORATOR, "
+        "or the task label)" in caplog.text
+    )


### PR DESCRIPTION
## What happened

quickstart-trial #7 sat unclaimed for a day with a free slot and no log line. The kernel lists issues with the App's installation token; the App had no `members` permission, the author's org membership was private, so the issue read as `author_association=CONTRIBUTOR` and `qualifying_issue` (OWNER/MEMBER/COLLABORATOR) dropped it on a silent `continue`. Verified by listing the issues through the kernel's own App auth on cluster0. Same class as "students aren't org owners".

## Changes

- `pick_issue` logs every skipped issue with its reason (author, association seen, or "claimed by a run").
- `qualifying_issue`: a maintainer vouches for an issue by writing it (association) **or** by labelling it `outerloop:task`. Labels are already the control surface and only triage rights can set one, so this is not a loophole.
- `DEFAULT_PERMISSIONS` in the App manifest adds `members: read`, so Apps created by `outerloop init --github-app` see a private member as MEMBER. Existing Apps are unaffected: `init` only checks write on contents/issues/pull_requests. docs/install.md names the permission and why.
- Tests: label vouches, unlabelled CONTRIBUTOR is skipped and the skip is logged; manifest permissions.

## Not changed

Existing Apps keep their permissions; an owner grants members-read in the App settings if they want association-based qualification for private members, or uses the label.