### PR TITLE
Line seal parents on the kernel's record of the line head, not the checked-out branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- A research line's snapshot was lost when the author's session reset its branch to main: the seal parented on wherever the checked-out branch pointed, the push was refused as a non-fast-forward, and the winning run left no notebook entry (gpt-speedrun agent-02, #368). The kernel now keeps its own record of the line head in the workspace refs; the line only moves forward from it (a session's commits count, a reset does not), and the line's memory files a reset dropped from the tree come back at the seal.
+- A research line lost its snapshot when the author's session reset its branch to main: the seal parented on main, the push was refused, and the run left no notebook entry (#368). The kernel now records the line head itself and the line only moves forward from that record. Memory files a reset dropped from the tree come back at the seal; files the session deleted on the line stay deleted.
 - Intake dropped an issue from a private org member without a word: the App's token sees such an author as CONTRIBUTOR, and only OWNER/MEMBER/COLLABORATOR qualified. Every skipped issue is now logged with its reason, a maintainer's `outerloop:task` label vouches for an issue regardless of association, and new Apps request members read so private members read as MEMBER.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- A research line's snapshot was lost when the author's session reset its branch to main: the seal parented on wherever the checked-out branch pointed, the push was refused as a non-fast-forward, and the winning run left no notebook entry (gpt-speedrun agent-02, #368). The kernel now keeps its own record of the line head in the workspace refs; the line only moves forward from it (a session's commits count, a reset does not), and the line's memory files a reset dropped from the tree come back at the seal.
 - Intake dropped an issue from a private org member without a word: the App's token sees such an author as CONTRIBUTOR, and only OWNER/MEMBER/COLLABORATOR qualified. Every skipped issue is now logged with its reason, a maintainer's `outerloop:task` label vouches for an issue regardless of association, and new Apps request members read so private members read as MEMBER.
 
 ### Changed

--- a/docs/design/research-lines.md
+++ b/docs/design/research-lines.md
@@ -99,7 +99,12 @@ v1).
 - **Branch resets**: an agent may deliberately reset its line to main; the
   kernel performs it as `--force-with-lease` on the agent's OWN branch only
   (the only non-fast-forward ever allowed), recorded in the run report.
-  Nothing may force-push any other ref.
+  Nothing may force-push any other ref. A session's own `git reset` in its
+  workspace is not that: the kernel keeps its own record of the line head
+  (`refs/outerloop/line`), the seal parents on it, and memory files the
+  reset dropped from the tree come back (a file the session deleted while
+  its branch still sat on the line stays deleted). The line's content
+  follows the session; its history only moves forward.
 - **Instruction-file isolation**: an agent branch is an AUTHOR-WRITTEN tree.
   Checking one out inherits the same sanitization as any untrusted tree
   (the CLAUDE.md/hooks instruction-smuggling class): harness-instruction

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -1411,26 +1411,47 @@ def _restore_line_memory(ws: Workspace, parent: str, seen: str) -> None:
             ws.git("checkout", parent, "--", file)
 
 
+def _rev(ws: Workspace, ref: str) -> str:
+    """The commit `ref` names, or "" when it does not exist."""
+    try:
+        return ws.git("rev-parse", "--verify", "-q", f"{ref}^{{commit}}").strip()
+    except Exception:
+        return ""
+
+
+def _is_ancestor(ws: Workspace, older: str, newer: str) -> bool:
+    try:
+        ws.git("merge-base", "--is-ancestor", older, newer)  # raises when not
+        return True
+    except Exception:
+        return False
+
+
 def _line_head(ws: Workspace, line_ref: str, branch: str) -> str:
-    """The commit the seal parents on. The line only moves forward from the
-    kernel's record: a session that COMMITTED on the line advanced the branch
-    past it (those commits count), one that reset the branch onto main moved
-    it off the line (the record wins, #368). No record — a park that predates
-    it — means the branch is the line."""
-    try:
-        record = ws.git("rev-parse", "--verify", "-q", LINE_HEAD_REF).strip()
-    except Exception:
+    """The commit the seal parents on: the line's head as the kernel knows it,
+    not wherever the session left the checked-out branch (#368). The kernel's
+    record (`LINE_HEAD_REF`, written at checkout and after each push) is the
+    head while it sits on the line, an ancestor or descendant of the remote
+    line head; a record the session removed or moved off the line yields to
+    the remote-tracking ref, which the session cannot move without push
+    rights; the branch itself is the fallback for a line with no remote yet.
+    A branch that DESCENDS from that head is the head (the session committed
+    on the line); one that moved off it (a reset onto main) is not."""
+    remote = _rev(ws, f"refs/remotes/origin/{line_ref}")
+    record = _rev(ws, LINE_HEAD_REF)
+    if record and remote and record != remote:
+        if not (_is_ancestor(ws, record, remote) or _is_ancestor(ws, remote, record)):
+            log.info(
+                "line %s: the kernel's record is off the line; using the remote head", line_ref
+            )
+            record = ""
+    head = record or remote or branch
+    if head == branch:
         return branch
-    if record == branch:
-        return branch
-    try:
-        ws.git("merge-base", "--is-ancestor", record, branch)  # raises when not
-    except Exception:
-        log.info(
-            "line %s: the session moved the branch off the line; sealing on the record", line_ref
-        )
-        return record
-    return branch
+    if _is_ancestor(ws, head, branch):
+        return branch  # the session's own commits on the line
+    log.info("line %s: the session moved the branch off the line; sealing on the record", line_ref)
+    return head
 
 
 def _push_line_snapshot(

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -1383,12 +1383,13 @@ def _line_base_advanced(ws: Workspace, base_branch: str, base_sha: str) -> str:
 
 def _restore_line_memory(ws: Workspace, parent: str, seen: str) -> None:
     """Put back the line's memory files a session's reset to main took from
-    the tree. File by file, judged against the session's branch (`seen`): a
-    file the session wrote or deleted stands; any other memory file on the
-    line comes back. So a topic file the session never saw (its branch was
-    reset onto main) returns beside whatever it wrote since, a file the
-    session deleted on the line stays deleted, and main's stale copy of a
-    memory path never replaces the line's."""
+    the tree. File by file, judged against the commit the session's tree was
+    checked out from (`seen`, its HEAD): a file the session wrote or deleted
+    stands; any other memory file on the line comes back. So a topic file the
+    session never saw (it reset onto main, or checked main out) returns
+    beside whatever it wrote since, a file the session deleted on the line
+    stays deleted, and main's stale copy of a memory path never replaces the
+    line's."""
 
     def blob(rev: str, file: str) -> str:
         try:
@@ -1475,7 +1476,8 @@ def _push_line_snapshot(
     def _seal_and_push() -> None:
         # raises if the session altered .git (every ws.git call checks) —
         # _best_effort turns that into a logged skip
-        branch = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()  # what the session saw
+        branch = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
+        seen = ws.git("rev-parse", "HEAD").strip()  # what the session's tree was checked out from
         local = _line_head(ws, line_ref, branch)
         last_exc: Exception | None = None
         # the line commit this workspace's untouched files currently match:
@@ -1501,7 +1503,7 @@ def _push_line_snapshot(
                     fork = parent = remote
             except Exception as exc:
                 log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
-            _restore_line_memory(ws, parent, seen=branch)
+            _restore_line_memory(ws, parent, seen=seen)
             memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
             snap = snapshot_tree(ws, parent, force=memory, author=bot_login)
             try:

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -1439,12 +1439,11 @@ def _line_head(ws: Workspace, line_ref: str, branch: str) -> str:
     on the line); one that moved off it (a reset onto main) is not."""
     remote = _rev(ws, f"refs/remotes/origin/{line_ref}")
     record = _rev(ws, LINE_HEAD_REF)
-    if record and remote and record != remote:
-        if not (_is_ancestor(ws, record, remote) or _is_ancestor(ws, remote, record)):
-            log.info(
-                "line %s: the kernel's record is off the line; using the remote head", line_ref
-            )
-            record = ""
+    on_line = not record or not remote or record == remote
+    on_line = on_line or _is_ancestor(ws, record, remote) or _is_ancestor(ws, remote, record)
+    if not on_line:
+        log.info("line %s: the kernel's record is off the line; using the remote head", line_ref)
+        record = ""
     head = record or remote or branch
     if head == branch:
         return branch

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -1301,6 +1301,10 @@ def _reset_instruction_files(ws: Workspace, workspace: Path, base_ref: str) -> N
 # every MEASURABLE seal and from changed-path accounting — never a scope
 # violation, never claimable work, never part of a main-PR candidate.
 LINE_MEMORY_PATHS = ("AGENT_MEMORY.md", "agent_memory")
+# The kernel's own record of the line head, kept in the workspace's refs: a
+# session's `git reset`/`checkout` moves only the checked-out branch, never
+# this ref, so a seal parents on the line the kernel last sealed (#368).
+LINE_HEAD_REF = "refs/outerloop/line"
 
 
 def _is_line_memory(path: str) -> bool:
@@ -1377,6 +1381,42 @@ def _line_base_advanced(ws: Workspace, base_branch: str, base_sha: str) -> str:
         return ""
 
 
+def _restore_line_memory(ws: Workspace, parent: str) -> None:
+    """Put back the line's memory files a session's reset to main dropped from
+    the tree: they live on the line, and the seal must carry them forward."""
+    for path in LINE_MEMORY_PATHS:
+        if (Path(ws.root) / path).exists():
+            continue
+        try:
+            ws.git("cat-file", "-e", f"{parent}:{path}")
+        except Exception:
+            continue  # not on the line either
+        ws.git("checkout", parent, "--", path)
+
+
+def _line_head(ws: Workspace, line_ref: str) -> str:
+    """The commit the seal parents on. The line only moves forward from the
+    kernel's record: a session that COMMITTED on the line advanced the branch
+    past it (those commits count), one that reset the branch onto main moved
+    it off the line (the record wins, #368). No record — a park that predates
+    it — means the branch is the line."""
+    branch = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
+    try:
+        record = ws.git("rev-parse", "--verify", "-q", LINE_HEAD_REF).strip()
+    except Exception:
+        return branch
+    if record == branch:
+        return branch
+    try:
+        ws.git("merge-base", "--is-ancestor", record, branch)  # raises when not
+    except Exception:
+        log.info(
+            "line %s: the session moved the branch off the line; sealing on the record", line_ref
+        )
+        return record
+    return branch
+
+
 def _push_line_snapshot(
     ws: Workspace,
     line_ref: str,
@@ -1397,11 +1437,9 @@ def _push_line_snapshot(
         return
 
     def _seal_and_push() -> None:
-        # raises if the ref is absent (e.g. a park that predates the line
-        # feature) or the session altered .git (every ws.git call checks) —
-        # _best_effort turns either into a logged skip
-        local = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
-        memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
+        # raises if the session altered .git (every ws.git call checks) —
+        # _best_effort turns that into a logged skip
+        local = _line_head(ws, line_ref)
         last_exc: Exception | None = None
         # the line commit this workspace's untouched files currently match:
         # the local ref at first, then each remote head reconciled into it
@@ -1426,6 +1464,8 @@ def _push_line_snapshot(
                     fork = parent = remote
             except Exception as exc:
                 log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
+            _restore_line_memory(ws, parent)
+            memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
             snap = snapshot_tree(ws, parent, force=memory, author=bot_login)
             try:
                 # seal only when the tree moved past the parent; the PUSH runs
@@ -1446,6 +1486,7 @@ def _push_line_snapshot(
                 ws.git("update-ref", f"refs/heads/{line_ref}", sealed)
                 try:
                     ws.push(line_ref)
+                    ws.git("update-ref", LINE_HEAD_REF, sealed)  # the record follows the push
                     return
                 except Exception as exc:
                     # another run pushed between our fetch and this push:
@@ -1512,6 +1553,7 @@ def _checkout_line(
     if not ws.git("branch", "--list", "-r", f"origin/{line}").strip():
         ws.git("checkout", "-q", "-B", line, base_ref)
         ws.push(line)  # the line is durable from its first run
+        ws.git("update-ref", LINE_HEAD_REF, ws.git("rev-parse", f"refs/heads/{line}").strip())
         return line
     ws.git("checkout", "-q", "-B", line, f"origin/{line}")
     conflicted = False
@@ -1546,6 +1588,7 @@ def _checkout_line(
         # a sealed sha, never invent a commit). A conflicted merge is not
         # pushed: the conflict is session work, not line state.
         ws.push(line)
+    ws.git("update-ref", LINE_HEAD_REF, ws.git("rev-parse", f"refs/heads/{line}").strip())
     return line
 
 

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -1381,26 +1381,31 @@ def _line_base_advanced(ws: Workspace, base_branch: str, base_sha: str) -> str:
         return ""
 
 
-def _restore_line_memory(ws: Workspace, parent: str) -> None:
+def _restore_line_memory(ws: Workspace, parent: str, seen: str) -> None:
     """Put back the line's memory files a session's reset to main dropped from
-    the tree: they live on the line, and the seal must carry them forward."""
+    the tree. File by file: one missing from the tree is a deletion only when
+    the session's branch (`seen`) had it, so a file the session deleted on the
+    line stays deleted, and a topic file the session never saw (its branch
+    was reset onto main) comes back beside whatever it wrote since."""
     for path in LINE_MEMORY_PATHS:
-        if (Path(ws.root) / path).exists():
-            continue
-        try:
-            ws.git("cat-file", "-e", f"{parent}:{path}")
-        except Exception:
-            continue  # not on the line either
-        ws.git("checkout", parent, "--", path)
+        files = ws.git("ls-tree", "-r", "-z", "--name-only", parent, "--", path).split("\0")
+        for file in filter(None, files):
+            if (Path(ws.root) / file).exists():
+                continue
+            try:
+                ws.git("cat-file", "-e", f"{seen}:{file}")
+                continue  # the session had it and removed it
+            except Exception:
+                pass
+            ws.git("checkout", parent, "--", file)
 
 
-def _line_head(ws: Workspace, line_ref: str) -> str:
+def _line_head(ws: Workspace, line_ref: str, branch: str) -> str:
     """The commit the seal parents on. The line only moves forward from the
     kernel's record: a session that COMMITTED on the line advanced the branch
     past it (those commits count), one that reset the branch onto main moved
     it off the line (the record wins, #368). No record — a park that predates
     it — means the branch is the line."""
-    branch = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()
     try:
         record = ws.git("rev-parse", "--verify", "-q", LINE_HEAD_REF).strip()
     except Exception:
@@ -1439,7 +1444,8 @@ def _push_line_snapshot(
     def _seal_and_push() -> None:
         # raises if the session altered .git (every ws.git call checks) —
         # _best_effort turns that into a logged skip
-        local = _line_head(ws, line_ref)
+        branch = ws.git("rev-parse", f"refs/heads/{line_ref}").strip()  # what the session saw
+        local = _line_head(ws, line_ref, branch)
         last_exc: Exception | None = None
         # the line commit this workspace's untouched files currently match:
         # the local ref at first, then each remote head reconciled into it
@@ -1464,7 +1470,7 @@ def _push_line_snapshot(
                     fork = parent = remote
             except Exception as exc:
                 log.info("line %s: sealing on the local ref (%s)", line_ref, type(exc).__name__)
-            _restore_line_memory(ws, parent)
+            _restore_line_memory(ws, parent, seen=branch)
             memory = tuple(p for p in LINE_MEMORY_PATHS if (Path(ws.root) / p).exists())
             snap = snapshot_tree(ws, parent, force=memory, author=bot_login)
             try:

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -1382,21 +1382,32 @@ def _line_base_advanced(ws: Workspace, base_branch: str, base_sha: str) -> str:
 
 
 def _restore_line_memory(ws: Workspace, parent: str, seen: str) -> None:
-    """Put back the line's memory files a session's reset to main dropped from
-    the tree. File by file: one missing from the tree is a deletion only when
-    the session's branch (`seen`) had it, so a file the session deleted on the
-    line stays deleted, and a topic file the session never saw (its branch
-    was reset onto main) comes back beside whatever it wrote since."""
+    """Put back the line's memory files a session's reset to main took from
+    the tree. File by file, judged against the session's branch (`seen`): a
+    file the session wrote or deleted stands; any other memory file on the
+    line comes back. So a topic file the session never saw (its branch was
+    reset onto main) returns beside whatever it wrote since, a file the
+    session deleted on the line stays deleted, and main's stale copy of a
+    memory path never replaces the line's."""
+
+    def blob(rev: str, file: str) -> str:
+        try:
+            return ws.git("rev-parse", "--verify", "-q", f"{rev}:{file}").strip()
+        except Exception:
+            return ""  # absent
+
     for path in LINE_MEMORY_PATHS:
         files = ws.git("ls-tree", "-r", "-z", "--name-only", parent, "--", path).split("\0")
         for file in filter(None, files):
+            in_seen = blob(seen, file)
             if (Path(ws.root) / file).exists():
-                continue
-            try:
-                ws.git("cat-file", "-e", f"{seen}:{file}")
-                continue  # the session had it and removed it
-            except Exception:
-                pass
+                in_tree = ws.git("hash-object", "--", file).strip()
+                if in_tree != in_seen:
+                    continue  # the session wrote it
+                if in_tree == blob(parent, file):
+                    continue  # already the line's
+            elif in_seen:
+                continue  # the session deleted it
             ws.git("checkout", parent, "--", file)
 
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4073,6 +4073,34 @@ def test_line_seal_parents_on_the_kernels_head_not_the_checked_out_branch(
     assert ws.git("rev-parse", LINE_HEAD_REF).strip() == tip  # the record follows the push
 
 
+def test_line_seal_survives_a_session_removing_or_moving_the_kernels_record(
+    tmp_path: Path, target_repo
+) -> None:
+    """The record lives in the session's writable .git. Deleted, the seal
+    falls back to the remote line head; retargeted off the line, likewise.
+    Either way a reset onto main still seals on the line with its memory."""
+    from outerloop.attempt import LINE_HEAD_REF, _checkout_line, _push_line_snapshot
+
+    _push_line(tmp_path, target_repo, {"AGENT_MEMORY.md": "remember the pivot\n"})
+    line_tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
+    for tamper in ("delete", "retarget"):
+        ws = _line_ws(tmp_path / tamper, target_repo)
+        _checkout_line(ws, ws.root, "agent-07", "main")
+        if tamper == "delete":
+            ws.git("update-ref", "-d", LINE_HEAD_REF)
+        else:
+            ws.git("update-ref", LINE_HEAD_REF, ws.git("rev-parse", "origin/main").strip())
+        ws.git("reset", "-q", "--hard", "origin/main")
+        (ws.root / "docs" / "belief.md").write_text(f"after the reset ({tamper})\n")
+        _push_line_snapshot(ws, "agents/agent-07", f"tsp-{tamper}", "improved")
+        tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
+        assert _git(target_repo, "rev-parse", f"{tip}^").strip() == line_tip, tamper
+        assert _git(target_repo, "show", "agents/agent-07:AGENT_MEMORY.md") == (
+            "remember the pivot\n"
+        )
+        line_tip = tip
+
+
 def test_line_seal_prefers_the_lines_memory_over_mains_stale_copy(
     tmp_path: Path, target_repo
 ) -> None:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4036,6 +4036,34 @@ def test_push_line_snapshot_chains_sequential_terminals(tmp_path: Path, target_r
     assert _git(target_repo, "show", "agents/agent-07:docs/belief.md") == "second\n"
 
 
+def test_line_seal_parents_on_the_kernels_head_not_the_checked_out_branch(
+    tmp_path: Path, target_repo
+) -> None:
+    """A session that runs `git reset --hard origin/main` moves the checked-out
+    line branch onto main's history and drops the line's memory file from the
+    tree (gpt-speedrun agent-02, 2026-09-12; #368). The seal parents on the
+    kernel's own record of the line head, so the push is still a fast-forward
+    on the line, and the memory file comes back from that head."""
+    from outerloop.attempt import LINE_HEAD_REF, _checkout_line, _push_line_snapshot
+
+    _push_line(tmp_path, target_repo, {"AGENT_MEMORY.md": "remember the pivot\n"})
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    line_tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
+    assert ws.git("rev-parse", LINE_HEAD_REF).strip() == line_tip
+    # the session's reset: the branch now points at main, the memory is gone from the tree
+    ws.git("reset", "-q", "--hard", "origin/main")
+    assert ws.git("rev-parse", "refs/heads/agents/agent-07").strip() != line_tip
+    assert not (ws.root / "AGENT_MEMORY.md").exists()
+    (ws.root / "docs" / "belief.md").write_text("after the reset\n")
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "improved")
+    tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
+    assert _git(target_repo, "rev-parse", f"{tip}^").strip() == line_tip  # on the line, not main
+    assert _git(target_repo, "show", "agents/agent-07:AGENT_MEMORY.md") == "remember the pivot\n"
+    assert _git(target_repo, "show", "agents/agent-07:docs/belief.md") == "after the reset\n"
+    assert ws.git("rev-parse", LINE_HEAD_REF).strip() == tip  # the record follows the push
+
+
 def test_push_line_snapshot_is_best_effort(tmp_path: Path, target_repo) -> None:
     from outerloop.attempt import _push_line_snapshot
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4073,6 +4073,27 @@ def test_line_seal_parents_on_the_kernels_head_not_the_checked_out_branch(
     assert ws.git("rev-parse", LINE_HEAD_REF).strip() == tip  # the record follows the push
 
 
+def test_line_seal_prefers_the_lines_memory_over_mains_stale_copy(
+    tmp_path: Path, target_repo
+) -> None:
+    """When main itself tracks a memory path (a human committed one), a reset
+    leaves main's older copy in the tree; the seal still carries the line's,
+    since the session did not write that copy."""
+    from outerloop.attempt import _checkout_line, _push_line_snapshot
+
+    _advance_main(tmp_path, target_repo, {"AGENT_MEMORY.md": "main's stale copy\n"})
+    _push_line(tmp_path, target_repo, {"AGENT_MEMORY.md": "the line's newer memory\n"})
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    ws.git("reset", "-q", "--hard", "origin/main")
+    assert (ws.root / "AGENT_MEMORY.md").read_text() == "main's stale copy\n"
+    (ws.root / "docs" / "belief.md").write_text("after the reset\n")
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "improved")
+    assert (
+        _git(target_repo, "show", "agents/agent-07:AGENT_MEMORY.md") == "the line's newer memory\n"
+    )
+
+
 def test_line_seal_keeps_a_memory_deletion_the_session_made_on_the_line(
     tmp_path: Path, target_repo
 ) -> None:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4046,7 +4046,11 @@ def test_line_seal_parents_on_the_kernels_head_not_the_checked_out_branch(
     on the line, and the memory file comes back from that head."""
     from outerloop.attempt import LINE_HEAD_REF, _checkout_line, _push_line_snapshot
 
-    _push_line(tmp_path, target_repo, {"AGENT_MEMORY.md": "remember the pivot\n"})
+    _push_line(
+        tmp_path,
+        target_repo,
+        {"AGENT_MEMORY.md": "remember the pivot\n", "agent_memory/lr.md": "lr 0.08 wins\n"},
+    )
     ws = _line_ws(tmp_path, target_repo)
     _checkout_line(ws, ws.root, "agent-07", "main")
     line_tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
@@ -4056,12 +4060,40 @@ def test_line_seal_parents_on_the_kernels_head_not_the_checked_out_branch(
     assert ws.git("rev-parse", "refs/heads/agents/agent-07").strip() != line_tip
     assert not (ws.root / "AGENT_MEMORY.md").exists()
     (ws.root / "docs" / "belief.md").write_text("after the reset\n")
+    # ...and it starts a fresh topic file in the (recreated) memory directory
+    (ws.root / "agent_memory").mkdir()
+    (ws.root / "agent_memory" / "wd.md").write_text("wd 0.01\n")
     _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "improved")
     tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
     assert _git(target_repo, "rev-parse", f"{tip}^").strip() == line_tip  # on the line, not main
     assert _git(target_repo, "show", "agents/agent-07:AGENT_MEMORY.md") == "remember the pivot\n"
+    assert _git(target_repo, "show", "agents/agent-07:agent_memory/lr.md") == "lr 0.08 wins\n"
+    assert _git(target_repo, "show", "agents/agent-07:agent_memory/wd.md") == "wd 0.01\n"
     assert _git(target_repo, "show", "agents/agent-07:docs/belief.md") == "after the reset\n"
     assert ws.git("rev-parse", LINE_HEAD_REF).strip() == tip  # the record follows the push
+
+
+def test_line_seal_keeps_a_memory_deletion_the_session_made_on_the_line(
+    tmp_path: Path, target_repo
+) -> None:
+    """A missing memory file is a deletion when the session's branch had it:
+    the restore is for files a reset took away, not for ones the agent chose
+    to drop."""
+    from outerloop.attempt import _checkout_line, _push_line_snapshot
+
+    _push_line(
+        tmp_path,
+        target_repo,
+        {"AGENT_MEMORY.md": "stale\n", "agent_memory/lr.md": "lr 0.08 wins\n"},
+    )
+    ws = _line_ws(tmp_path, target_repo)
+    _checkout_line(ws, ws.root, "agent-07", "main")
+    (ws.root / "agent_memory" / "lr.md").unlink()  # the agent retires a topic
+    (ws.root / "AGENT_MEMORY.md").write_text("fresh\n")
+    _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "no-improvement")
+    tree = _git(target_repo, "ls-tree", "-r", "--name-only", "agents/agent-07")
+    assert "agent_memory/lr.md" not in tree
+    assert _git(target_repo, "show", "agents/agent-07:AGENT_MEMORY.md") == "fresh\n"
 
 
 def test_push_line_snapshot_is_best_effort(tmp_path: Path, target_repo) -> None:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -4078,19 +4078,25 @@ def test_line_seal_survives_a_session_removing_or_moving_the_kernels_record(
 ) -> None:
     """The record lives in the session's writable .git. Deleted, the seal
     falls back to the remote line head; retargeted off the line, likewise.
-    Either way a reset onto main still seals on the line with its memory."""
+    A session that checks main out (HEAD off the line, the branch untouched)
+    is judged by what its tree came from. In every case the seal lands on
+    the line with its memory."""
     from outerloop.attempt import LINE_HEAD_REF, _checkout_line, _push_line_snapshot
 
     _push_line(tmp_path, target_repo, {"AGENT_MEMORY.md": "remember the pivot\n"})
     line_tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
-    for tamper in ("delete", "retarget"):
+    for tamper in ("delete", "retarget", "checkout"):
         ws = _line_ws(tmp_path / tamper, target_repo)
         _checkout_line(ws, ws.root, "agent-07", "main")
         if tamper == "delete":
             ws.git("update-ref", "-d", LINE_HEAD_REF)
-        else:
+        elif tamper == "retarget":
             ws.git("update-ref", LINE_HEAD_REF, ws.git("rev-parse", "origin/main").strip())
-        ws.git("reset", "-q", "--hard", "origin/main")
+        if tamper == "checkout":
+            ws.git("checkout", "-q", "main")  # HEAD leaves the line; the branch stays put
+        else:
+            ws.git("reset", "-q", "--hard", "origin/main")
+        assert not (ws.root / "AGENT_MEMORY.md").exists()
         (ws.root / "docs" / "belief.md").write_text(f"after the reset ({tamper})\n")
         _push_line_snapshot(ws, "agents/agent-07", f"tsp-{tamper}", "improved")
         tip = _git(target_repo, "rev-parse", "agents/agent-07").strip()
@@ -4113,7 +4119,7 @@ def test_line_seal_prefers_the_lines_memory_over_mains_stale_copy(
     _push_line(tmp_path, target_repo, {"AGENT_MEMORY.md": "the line's newer memory\n"})
     ws = _line_ws(tmp_path, target_repo)
     _checkout_line(ws, ws.root, "agent-07", "main")
-    ws.git("reset", "-q", "--hard", "origin/main")
+    ws.git("checkout", "-q", "--detach", "origin/main")  # the line branch itself is untouched
     assert (ws.root / "AGENT_MEMORY.md").read_text() == "main's stale copy\n"
     (ws.root / "docs" / "belief.md").write_text("after the reset\n")
     _push_line_snapshot(ws, "agents/agent-07", "tsp-9", "improved")


### PR DESCRIPTION
Fixes #368.

## What was wrong

gpt-speedrun agent-02's winning run left no notebook entry. Its author session ran `git reset --hard origin/main` inside the workspace, which moved the checked-out `agents/agent-02` branch onto main's history and dropped `AGENT_MEMORY.md` from the tree. The seal then parented on wherever the branch pointed (main), the push was refused as a non-fast-forward on the line, and the three retries all re-sealed on the same wrong parent. The run's result was published on main, but the line, and the agent's persistent memory with it, did not move.

The line branch in the workspace is the session's to check out; it is not a safe record of where the line is.

## The fix

- **The kernel keeps its own record of the line head** in `refs/outerloop/line`, written at `_checkout_line` and after every successful push. The session cannot move it with branch operations.
- **The line only moves forward from that record.** `_line_head` picks the seal's parent: the branch when it descends from the record (a session that committed on the line, as `test_push_line_snapshot_publishes_session_commits` covers), the record when the branch moved off the line (a reset, a checkout of something else). No record, a park that predates it, means the branch is the line as before.
- **A reset does not lose the memory.** Before the seal, `_restore_line_memory` puts back any `LINE_MEMORY_PATHS` file that is absent from the tree but present on the parent, so the snapshot carries the agent's memory forward. A session that deliberately deletes its memory file still can: the restore only fills a missing file, and the memory paths are the only ones it touches.

Mengye's requirement: a session that resets and pulls main must not throw away its own persistent memory. The snapshot now parents on the line and carries the memory, whatever the session did to the branch.

## Tests

- New: `test_line_seal_parents_on_the_kernels_head_not_the_checked_out_branch` reproduces the incident (reset onto main, memory gone from the tree, an edit after) and asserts the pushed seal parents on the old line tip, carries both the memory and the edit, and that the record follows the push.
- Existing line tests unchanged and green, including the session-commit case that a naive "always use the record" would have broken.
- Full gate: ruff, format, mypy, 1385 tests.

Changelog under Unreleased.
