### PR TITLE
Every climb ends through one terminal, fresh or resumed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
+- A resumed session's improvement was lost on local compute: the gate answers inline there instead of parking a candidate, and the author-sleep wake only knew how to end a run, so "improved" became an aborted ending with no PR (cluster0, two runs). Every climb now ends through one terminal, fresh or resumed: report, line notebook, then the PR or the ending record, and the issue note.
 - A research line lost its snapshot when the author's session reset its branch to main: the seal parented on main, the push was refused, and the run left no notebook entry (#368). The kernel now records the line head itself and the line only moves forward from that record. Memory files a reset dropped from the tree come back at the seal; files the session deleted on the line stay deleted.
 - Intake dropped an issue from a private org member without a word: the App's token sees such an author as CONTRIBUTOR, and only OWNER/MEMBER/COLLABORATOR qualified. Every skipped issue is now logged with its reason, a maintainer's `outerloop:task` label vouches for an issue regardless of association, and new Apps request members read so private members read as MEMBER.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Versions follow [SemVer](https://semver.org).
 
 ### Fixed
 
-- A resumed session's improvement was lost on local compute: the gate answers inline there instead of parking a candidate, and the author-sleep wake only knew how to end a run, so "improved" became an aborted ending with no PR (cluster0, two runs). Every climb now ends through one terminal, fresh or resumed: report, line notebook, then the PR or the ending record, and the issue note.
+- On local compute an author-sleep wake could lose an improvement: the gate answers inline there, and the wake only knew how to end a run, so the result became an aborted ending with no PR (cluster0, three runs). Fresh and resumed climbs now share one terminal: the report, the line notebook, a PR or an ending record, and the issue note. A wake that opened its PR but died before recording it reconciles to that PR instead of opening a second, and a park's snapshot is released only once the run has left waiting.
 - A research line lost its snapshot when the author's session reset its branch to main: the seal parented on main, the push was refused, and the run left no notebook entry (#368). The kernel now records the line head itself and the line only moves forward from that record. Memory files a reset dropped from the tree come back at the seal; files the session deleted on the line stay deleted.
 - Intake dropped an issue from a private org member without a word: the App's token sees such an author as CONTRIBUTOR, and only OWNER/MEMBER/COLLABORATOR qualified. Every skipped issue is now logged with its reason, a maintainer's `outerloop:task` label vouches for an issue regardless of association, and new Apps request members read so private members read as MEMBER.
 

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -838,8 +838,17 @@ def _wake_author_sleep(
             line_ref=_line_ref_for(bench, config.agent_id),
             date=_utc_date(now),
         )
-        for ref in drop_refs:
-            drop_snapshot(ws, Snapshot(commit="", tree="", ref=ref))
+        # the park's snapshot is released only once the run has left WAITING:
+        # a terminal whose record failed to save stays recoverable by a re-wake
+        try:
+            still_waiting = load_record(run_root, run_id).state == WAITING
+        except Exception:
+            still_waiting = True
+        if still_waiting:
+            log.warning("run %s: terminal record unsaved; the sleep snapshot is kept", run_id)
+        else:
+            for ref in drop_refs:
+                drop_snapshot(ws, Snapshot(commit="", tree="", ref=ref))
         return outcome
 
     # The wake NEEDS the author harness (it resumes the session). Fail as a
@@ -2769,75 +2778,101 @@ def _finish_attempt(
                 raise EvalError("improved result missing measurements or the sealed sha")
             bench = next(b for b in contract.benchmarks if b.name == config.benchmark)
             baseline, candidate = result.baseline, result.candidate
-            # FORCE-checkout: the workspace still holds the session's dirty
-            # tree. The snapshot commit is anchored by the new branch (the
-            # dropped dispatch ref left it unreferenced; nothing pruned it in
-            # this process). clean -fd drops post-snapshot cruft so the
-            # pushed tree is exactly candidate_sha plus the ledger commit.
-            ws.git("checkout", "-f", "-B", branch, result.candidate_sha)
-            ws.git("clean", "-fd")
-            entries = update_leader(
-                load_leader(workspace),
-                benchmark=bench.name,
-                metric=bench.metric,
-                direction=bench.direction,
-                baseline=baseline,
-                candidate=candidate,
-                run_id=run_id,
-                date=date,
-                run_seed=result.run_seed,
-            )
-            write_progress(
-                workspace,
-                entries,
-                config.target,
-                digits={b.name: b.display_digits for b in contract.benchmarks if b.display_digits},
-            )
-            # Stage ONLY the ledger files on top of the sealed candidate —
-            # never `git add -A`, which would sweep in anything a session or
-            # eval left behind (same rule as the wake publish).
-            ws.git("add", "--", *PROGRESS_PATHS)
-            staged = ws.staged_paths()
-            extra = [p for p in staged if p not in PROGRESS_PATHS]
-            if extra:
-                raise WorkspaceDrift(f"publish would stage non-ledger paths: {extra[:10]}")
-            if staged:
-                ws.git(
-                    *git_identity(config.bot_login),
-                    "commit",
-                    "-m",
-                    f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
-                    f"\n\nAgent: {config.agent_id}",
+            # IDEMPOTENCY: a wake may have opened the PR and died before
+            # recording it (the run stays WAITING and is woken again). If a PR
+            # is already open for this head->base, reconcile to it — never
+            # re-push (non-fast-forward) or open a duplicate; a lookup failure
+            # just falls through to the normal publish.
+            existing: dict[str, object] | None = None
+            try:
+                existing = github.find_open_pull_for_head(config.target, branch, base_branch)
+            except Exception as exc:
+                log.warning(
+                    "idempotency PR lookup failed for %s: %s",
+                    run_id,
+                    redact(f"{type(exc).__name__}: {exc}", secrets),
                 )
-            ws.push(branch)
-            pushed = True
-            body = pr_body(
-                result,
-                config,
-                redact_secrets=secrets,
-                display_digits=bench.display_digits,
-                experiments=experiments_rows(run_dir),
-            )
-            if issue_number:
-                body = f"Addresses #{issue_number}.\n\n{body}"
-            pr_url = github.create_pull(
-                config.target,
-                # short precision in the title; full precision lives in the
-                # PR body table and the ledger
-                title=f"[agent] {config.benchmark}: {_title_pair(baseline, candidate)}",
-                head=branch,
-                base=base_branch,
-                body=body,
+            if existing:
+                pr_url = str(existing.get("html_url", ""))
+                draft = bool(existing.get("draft"))
+                log.info("run %s: PR %s already open; reconciling the record", run_id, pr_url)
+                # the workspace goes on the branch a later follow-up expects
+                ws.git("checkout", "-f", "-B", branch, result.candidate_sha)
+            else:
                 # blocking findings open at the panel, or a degraded final
                 # read: visible, plainly not merge-ready
-                draft=result.panel_blocking_open or result.panel_degraded,
-            )
+                draft = result.panel_blocking_open or result.panel_degraded
+                # FORCE-checkout: the workspace still holds the session's dirty
+                # tree. The snapshot commit is anchored by the new branch (the
+                # dropped dispatch ref left it unreferenced; nothing pruned it in
+                # this process). clean -fd drops post-snapshot cruft so the
+                # pushed tree is exactly candidate_sha plus the ledger commit.
+                ws.git("checkout", "-f", "-B", branch, result.candidate_sha)
+                ws.git("clean", "-fd")
+                entries = update_leader(
+                    load_leader(workspace),
+                    benchmark=bench.name,
+                    metric=bench.metric,
+                    direction=bench.direction,
+                    baseline=baseline,
+                    candidate=candidate,
+                    run_id=run_id,
+                    date=date,
+                    run_seed=result.run_seed,
+                )
+                write_progress(
+                    workspace,
+                    entries,
+                    config.target,
+                    digits={
+                        b.name: b.display_digits for b in contract.benchmarks if b.display_digits
+                    },
+                )
+                # Stage ONLY the ledger files on top of the sealed candidate —
+                # never `git add -A`, which would sweep in anything a session or
+                # eval left behind (same rule as the wake publish).
+                ws.git("add", "--", *PROGRESS_PATHS)
+                staged = ws.staged_paths()
+                extra = [p for p in staged if p not in PROGRESS_PATHS]
+                if extra:
+                    raise WorkspaceDrift(f"publish would stage non-ledger paths: {extra[:10]}")
+                if staged:
+                    ws.git(
+                        *git_identity(config.bot_login),
+                        "commit",
+                        "-m",
+                        f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
+                        f"\n\nAgent: {config.agent_id}",
+                    )
+                ws.push(branch)
+                pushed = True
+                body = pr_body(
+                    result,
+                    config,
+                    redact_secrets=secrets,
+                    display_digits=bench.display_digits,
+                    experiments=experiments_rows(run_dir),
+                )
+                if issue_number:
+                    body = f"Addresses #{issue_number}.\n\n{body}"
+                pr_url = github.create_pull(
+                    config.target,
+                    # short precision in the title; full precision lives in the
+                    # PR body table and the ledger
+                    title=f"[agent] {config.benchmark}: {_title_pair(baseline, candidate)}",
+                    head=branch,
+                    base=base_branch,
+                    body=body,
+                    # blocking findings open at the panel, or a degraded final
+                    # read: visible, plainly not merge-ready
+                    draft=draft,
+                )
             # Arm auto-merge, best-effort, and ONLY when branch protection
             # requires a human review — the guard keeps bot-never-merges
             # enforced in code, not in per-repo config. Never arm a draft,
             # and never arm a claim whose base has moved (_arm_unless_base_moved).
             pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
-            if pr_number.isdigit() and not (result.panel_blocking_open or result.panel_degraded):
+            if pr_number.isdigit() and not draft:
                 _arm_unless_base_moved(
                     github,
                     ws,

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -819,6 +819,11 @@ def _wake_author_sleep(
     def _end(result: AttemptResult, drop_refs: list[str]) -> AttemptOutcome:
         # the terminal every climb takes (report, notebook, PR or ending
         # record, issue note); then this park's snapshot is released
+        if record.stage.get("submitted") and not result.submit_report:
+            # the author's report at submit rides the stage: a session woken
+            # with its gate result that ends without submitting again still
+            # shows that report on the PR (same rule as the candidate wake)
+            result = dc_replace(result, submit_report=str(record.stage.get("report") or ""))
         outcome = _finish_attempt(
             result=result,
             ws=ws,

--- a/src/outerloop/attempt.py
+++ b/src/outerloop/attempt.py
@@ -817,48 +817,30 @@ def _wake_author_sleep(
     )
 
     def _end(result: AttemptResult, drop_refs: list[str]) -> AttemptOutcome:
-        # a terminal from the resumed climb: report, ending record, issue note —
-        # the same ending shape every other terminal takes. The line notebook
-        # records it first, while the tree is still the session's final tree.
-        _push_line_snapshot(
-            ws,
-            _line_ref_for(bench, config.agent_id),
-            run_id,
-            result.outcome,
-            secrets,
-            bot_login=config.bot_login,
+        # the terminal every climb takes (report, notebook, PR or ending
+        # record, issue note); then this park's snapshot is released
+        outcome = _finish_attempt(
+            result=result,
+            ws=ws,
+            workspace=workspace,
+            run_root=run_root,
+            run_dir=run_dir,
+            run_id=run_id,
+            record=record,
+            config=config,
+            contract=contract,
+            github=github,
+            now=now,
+            secrets=secrets,
+            base_branch=base_branch,
+            base_sha=base_sha,
+            issue_number=issue_number,
+            line_ref=_line_ref_for(bench, config.agent_id),
+            date=_utc_date(now),
         )
         for ref in drop_refs:
             drop_snapshot(ws, Snapshot(commit="", tree="", ref=ref))
-        report_path = run_dir / "report.md"
-        _best_effort(
-            "run report",
-            lambda: report_path.write_text(result.report(config, redact_secrets=secrets)),
-            secrets,
-        )
-        ending = _ENDINGS_BY_OUTCOME.get(result.outcome, ABORTED)
-        final = _clear_stage(
-            RunRecord(
-                **{
-                    **record.__dict__,
-                    "state": ENDED,
-                    "ending": ending,
-                    "ending_note": redact(result.note, secrets),
-                }
-            )
-        )
-        _best_effort("final record", lambda: save_record(run_root, final, now), secrets)
-        _post_issue_finished(
-            github,
-            config.target,
-            issue_number,
-            run_id,
-            result.outcome,
-            "",
-            redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
-            secrets,
-        )
-        return AttemptOutcome(run_id=run_id, outcome=result.outcome, report_path=str(report_path))
+        return outcome
 
     # The wake NEEDS the author harness (it resumes the session). Fail as a
     # named ending, not a crash: the run cannot proceed and re-waking will not
@@ -1069,9 +1051,10 @@ def _wake_author_sleep(
                 continue
             drop_snapshot(ws, snap)
 
-    # a terminal from the resumed session (session-error/-outage/-budget,
-    # scope-violation, eval-error; a dispatched gate never returns improved
-    # inline): end the run and release the sleep snapshot.
+    # a terminal from the resumed session: a session ending, a negative
+    # verdict, or an inline gate verdict on a synchronous backend (a
+    # dispatched gate parks a candidate instead). Same terminal as a fresh
+    # climb's; then the sleep snapshot is released.
     return _end(result, drop_refs=[sleep_ref])
 
 
@@ -2724,6 +2707,242 @@ def build_panel_runner(
     return runner
 
 
+def _finish_attempt(
+    *,
+    result: AttemptResult,
+    ws: Workspace,
+    workspace: Path,
+    run_root: Path,
+    run_dir: Path,
+    run_id: str,
+    record: RunRecord,
+    config: RunConfig,
+    contract: Contract,
+    github: GitHubClient,
+    now: float,
+    secrets: tuple[str, ...],
+    base_branch: str,
+    base_sha: str,
+    issue_number: int,
+    line_ref: str,
+    date: str,
+) -> AttemptOutcome:
+    """A climb's terminal, the same whether the session was fresh or resumed
+    from a park: the report, the line notebook, then a PR for an improved
+    result (the sealed candidate, never the live tree) or an ending record
+    for anything else, and the issue note. On a synchronous backend the gate
+    answers inline instead of parking a candidate, so a resumed session's
+    improvement reaches this path too (a wake that only knew how to END lost
+    two improved runs on cluster0, 2026-09-12). `base_sha` is the tree the
+    run started on (the auto-merge arm checks the base has not moved past
+    it); `date` is the ledger row's date."""
+    if result.outcome == "improved" and not result.measured_paths:
+        # a zero-change "improvement" is metric noise, not progress — never a
+        # PR (same rule as the wake publish)
+        result = dc_replace(result, outcome="no-improvement", note="no code change; metric noise")
+
+    report = result.report(config, redact_secrets=secrets)
+    report_path = run_dir / "report.md"
+    wrote_report = _best_effort("run report", lambda: report_path.write_text(report), secrets)
+
+    # Research lines: seal the notebook NOW, while the tree is still the
+    # session's final tree — the publish below force-checkouts the sealed
+    # candidate and cleans untracked files, which would drop the agent's
+    # memory (it is excluded from measurable seals by design). The label is
+    # the GATE outcome, correct at this moment; a publish failure appends a
+    # publish-error snapshot at the tail.
+    _push_line_snapshot(ws, line_ref, run_id, result.outcome, secrets, bot_login=config.bot_login)
+
+    pr_url = ""
+    outcome_name = result.outcome
+    branch = ""
+    pushed = False
+    if result.outcome == "improved":
+        try:
+            # Publish the SEALED candidate sha — never the live tree, which
+            # may have drifted since the snapshot (eval caches, stray writes);
+            # the sha is exactly the measured, scope-checked content. A base
+            # branch that moved during the climb is NOT merged and re-measured
+            # here: a stale PR is review's to handle (research-loop.md).
+            branch = f"{config.branch_prefix}/{run_id}"
+            if result.baseline is None or result.candidate is None or not result.candidate_sha:
+                raise EvalError("improved result missing measurements or the sealed sha")
+            bench = next(b for b in contract.benchmarks if b.name == config.benchmark)
+            baseline, candidate = result.baseline, result.candidate
+            # FORCE-checkout: the workspace still holds the session's dirty
+            # tree. The snapshot commit is anchored by the new branch (the
+            # dropped dispatch ref left it unreferenced; nothing pruned it in
+            # this process). clean -fd drops post-snapshot cruft so the
+            # pushed tree is exactly candidate_sha plus the ledger commit.
+            ws.git("checkout", "-f", "-B", branch, result.candidate_sha)
+            ws.git("clean", "-fd")
+            entries = update_leader(
+                load_leader(workspace),
+                benchmark=bench.name,
+                metric=bench.metric,
+                direction=bench.direction,
+                baseline=baseline,
+                candidate=candidate,
+                run_id=run_id,
+                date=date,
+                run_seed=result.run_seed,
+            )
+            write_progress(
+                workspace,
+                entries,
+                config.target,
+                digits={b.name: b.display_digits for b in contract.benchmarks if b.display_digits},
+            )
+            # Stage ONLY the ledger files on top of the sealed candidate —
+            # never `git add -A`, which would sweep in anything a session or
+            # eval left behind (same rule as the wake publish).
+            ws.git("add", "--", *PROGRESS_PATHS)
+            staged = ws.staged_paths()
+            extra = [p for p in staged if p not in PROGRESS_PATHS]
+            if extra:
+                raise WorkspaceDrift(f"publish would stage non-ledger paths: {extra[:10]}")
+            if staged:
+                ws.git(
+                    *git_identity(config.bot_login),
+                    "commit",
+                    "-m",
+                    f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
+                    f"\n\nAgent: {config.agent_id}",
+                )
+            ws.push(branch)
+            pushed = True
+            body = pr_body(
+                result,
+                config,
+                redact_secrets=secrets,
+                display_digits=bench.display_digits,
+                experiments=experiments_rows(run_dir),
+            )
+            if issue_number:
+                body = f"Addresses #{issue_number}.\n\n{body}"
+            pr_url = github.create_pull(
+                config.target,
+                # short precision in the title; full precision lives in the
+                # PR body table and the ledger
+                title=f"[agent] {config.benchmark}: {_title_pair(baseline, candidate)}",
+                head=branch,
+                base=base_branch,
+                body=body,
+                # blocking findings open at the panel, or a degraded final
+                # read: visible, plainly not merge-ready
+                draft=result.panel_blocking_open or result.panel_degraded,
+            )
+            # Arm auto-merge, best-effort, and ONLY when branch protection
+            # requires a human review — the guard keeps bot-never-merges
+            # enforced in code, not in per-repo config. Never arm a draft,
+            # and never arm a claim whose base has moved (_arm_unless_base_moved).
+            pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
+            if pr_number.isdigit() and not (result.panel_blocking_open or result.panel_degraded):
+                _arm_unless_base_moved(
+                    github,
+                    ws,
+                    config.target,
+                    pr_number,
+                    base_branch,
+                    base_sha,
+                    secrets,
+                    merge_mode=getattr(contract, "merge", "manual"),
+                    panel_ran=result.panel_rounds > 0,
+                )
+            final = RunRecord(
+                **{
+                    **record.__dict__,
+                    "state": IN_REVIEW,
+                    "pr_url": pr_url,
+                    "auto_blessed_head": _blessed_head(ws, result, contract),
+                    "resume_session_id": result.session.session_id if result.session else "",
+                    "ending_note": pr_url,
+                }
+            )
+        except Exception as exc:
+            log.warning(
+                "publish failed for %s: %s",
+                run_id,
+                redact(f"{type(exc).__name__}: {exc}", secrets),
+            )
+            # Never delete the remote branch: an exception from create_pull
+            # does not prove no PR exists (a 422-already-exists or a timeout
+            # after a successful POST both land here), and deleting the ref
+            # would close such a PR and discard the only pushed copy. Leave
+            # it and record it; a sweeper can reap confirmed orphans later.
+            outcome_name = "publish-error"
+            final = RunRecord(
+                **{
+                    **record.__dict__,
+                    "state": ENDED,
+                    "ending": ABORTED,
+                    "ending_note": (
+                        (f"branch left on remote: {branch}; " if pushed else "")
+                        + redact(f"{type(exc).__name__}: {exc}", secrets)[:480]
+                    ),
+                }
+            )
+    else:
+        if result.outcome == "session-outage":
+            _best_effort(
+                "outage stamp",
+                lambda: stamp_outage(run_root, redact(result.note, secrets)[:300], now),
+                secrets,
+            )
+        final = RunRecord(
+            **{
+                **record.__dict__,
+                "state": ENDED,
+                "ending": _ENDINGS_BY_OUTCOME[result.outcome],
+                "ending_note": redact(result.note, secrets),
+            }
+        )
+    # a resumed run's park bookkeeping never rides into review or an ending
+    final = _clear_stage(final)
+    if not _best_effort("final record", lambda: save_record(run_root, final, now), secrets):
+        # The on-disk record still says `implementing`, so automated
+        # follow-up servicing will not track this run — and if a PR was
+        # opened, its humans are the only ones who can act. Say so WHERE
+        # they are looking: GitHub is the one store still writable when the
+        # local disk is gone.
+        pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1] if pr_url else ""
+        if pr_number.isdigit():
+            _best_effort(
+                "pr state warning",
+                lambda: github.comment(
+                    config.target,
+                    int(pr_number),
+                    f"State record for run `{run_id}` could not be saved; "
+                    f"automated follow-up servicing is offline for this run. "
+                    f"A maintainer owns any follow-ups on this PR.",
+                ),
+                secrets,
+            )
+    if issue_number:
+        _post_issue_finished(
+            github,
+            config.target,
+            issue_number,
+            run_id,
+            outcome_name,
+            pr_url,
+            redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
+            secrets,
+        )
+    if outcome_name != result.outcome:
+        # the publish failed after the gate credited the tree: the improved
+        # snapshot above stands (the measurement was real); append the
+        # publish-error marker so the notebook records how the run ended
+        _push_line_snapshot(ws, line_ref, run_id, outcome_name, secrets, bot_login=config.bot_login)
+    log.info("run %s: %s %s", run_id, outcome_name, pr_url)
+    return AttemptOutcome(
+        run_id=run_id,
+        outcome=outcome_name,
+        pr_url=pr_url,
+        report_path=str(report_path) if wrote_report else "",
+    )
+
+
 def live_attempt(
     config: RunConfig,
     run_root: Path,
@@ -3206,208 +3425,24 @@ def live_attempt(
             report_path=str(report_path) if wrote else "",
         )
 
-    if result.outcome == "improved" and not result.measured_paths:
-        # a zero-change "improvement" is metric noise, not progress — never a
-        # PR (same rule as the wake publish)
-        result = dc_replace(result, outcome="no-improvement", note="no code change; metric noise")
-
-    report = result.report(config, redact_secrets=secrets)
-    report_path = run_dir / "report.md"
-    wrote_report = _best_effort("run report", lambda: report_path.write_text(report), secrets)
-
-    # Research lines: seal the notebook NOW, while the tree is still the
-    # session's final tree — the publish below force-checkouts the sealed
-    # candidate and cleans untracked files, which would drop the agent's
-    # memory (it is excluded from measurable seals by design). The label is
-    # the GATE outcome, correct at this moment; a publish failure appends a
-    # publish-error snapshot at the tail.
-    _push_line_snapshot(ws, line_ref, run_id, result.outcome, secrets, bot_login=config.bot_login)
-
-    pr_url = ""
-    outcome_name = result.outcome
-    branch = ""
-    pushed = False
-    if result.outcome == "improved":
-        try:
-            # Publish the SEALED candidate sha — never the live tree, which
-            # may have drifted since the snapshot (eval caches, stray writes);
-            # the sha is exactly the measured, scope-checked content. A base
-            # branch that moved during the climb is NOT merged and re-measured
-            # here: a stale PR is review's to handle (research-loop.md).
-            branch = f"{config.branch_prefix}/{run_id}"
-            if result.baseline is None or result.candidate is None or not result.candidate_sha:
-                raise EvalError("improved result missing measurements or the sealed sha")
-            bench = next(b for b in contract.benchmarks if b.name == config.benchmark)
-            baseline, candidate = result.baseline, result.candidate
-            # FORCE-checkout: the workspace still holds the session's dirty
-            # tree. The snapshot commit is anchored by the new branch (the
-            # dropped dispatch ref left it unreferenced; nothing pruned it in
-            # this process). clean -fd drops post-snapshot cruft so the
-            # pushed tree is exactly candidate_sha plus the ledger commit.
-            ws.git("checkout", "-f", "-B", branch, result.candidate_sha)
-            ws.git("clean", "-fd")
-            entries = update_leader(
-                load_leader(workspace),
-                benchmark=bench.name,
-                metric=bench.metric,
-                direction=bench.direction,
-                baseline=baseline,
-                candidate=candidate,
-                run_id=run_id,
-                date=created[:10],
-                run_seed=result.run_seed,
-            )
-            write_progress(
-                workspace,
-                entries,
-                config.target,
-                digits={b.name: b.display_digits for b in contract.benchmarks if b.display_digits},
-            )
-            # Stage ONLY the ledger files on top of the sealed candidate —
-            # never `git add -A`, which would sweep in anything a session or
-            # eval left behind (same rule as the wake publish).
-            ws.git("add", "--", *PROGRESS_PATHS)
-            staged = ws.staged_paths()
-            extra = [p for p in staged if p not in PROGRESS_PATHS]
-            if extra:
-                raise WorkspaceDrift(f"publish would stage non-ledger paths: {extra[:10]}")
-            if staged:
-                ws.git(
-                    *git_identity(config.bot_login),
-                    "commit",
-                    "-m",
-                    f"agent: improve {config.benchmark} ({_title_pair(baseline, candidate)})"
-                    f"\n\nAgent: {config.agent_id}",
-                )
-            ws.push(branch)
-            pushed = True
-            body = pr_body(
-                result,
-                config,
-                redact_secrets=secrets,
-                display_digits=bench.display_digits,
-                experiments=experiments_rows(run_dir),
-            )
-            if issue_number:
-                body = f"Addresses #{issue_number}.\n\n{body}"
-            pr_url = github.create_pull(
-                config.target,
-                # short precision in the title; full precision lives in the
-                # PR body table and the ledger
-                title=f"[agent] {config.benchmark}: {_title_pair(baseline, candidate)}",
-                head=branch,
-                base=base_branch,
-                body=body,
-                # blocking findings open at the panel, or a degraded final
-                # read: visible, plainly not merge-ready
-                draft=result.panel_blocking_open or result.panel_degraded,
-            )
-            # Arm auto-merge, best-effort, and ONLY when branch protection
-            # requires a human review — the guard keeps bot-never-merges
-            # enforced in code, not in per-repo config. Never arm a draft,
-            # and never arm a claim whose base has moved (_arm_unless_base_moved).
-            pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1]
-            if pr_number.isdigit() and not (result.panel_blocking_open or result.panel_degraded):
-                _arm_unless_base_moved(
-                    github,
-                    ws,
-                    config.target,
-                    pr_number,
-                    base_branch,
-                    pre_session_sha,
-                    secrets,
-                    merge_mode=getattr(contract, "merge", "manual"),
-                    panel_ran=result.panel_rounds > 0,
-                )
-            final = RunRecord(
-                **{
-                    **record.__dict__,
-                    "state": IN_REVIEW,
-                    "pr_url": pr_url,
-                    "auto_blessed_head": _blessed_head(ws, result, contract),
-                    "resume_session_id": result.session.session_id if result.session else "",
-                    "ending_note": pr_url,
-                }
-            )
-        except Exception as exc:
-            log.warning(
-                "publish failed for %s: %s",
-                run_id,
-                redact(f"{type(exc).__name__}: {exc}", secrets),
-            )
-            # Never delete the remote branch: an exception from create_pull
-            # does not prove no PR exists (a 422-already-exists or a timeout
-            # after a successful POST both land here), and deleting the ref
-            # would close such a PR and discard the only pushed copy. Leave
-            # it and record it; a sweeper can reap confirmed orphans later.
-            outcome_name = "publish-error"
-            final = RunRecord(
-                **{
-                    **record.__dict__,
-                    "state": ENDED,
-                    "ending": ABORTED,
-                    "ending_note": (
-                        (f"branch left on remote: {branch}; " if pushed else "")
-                        + redact(f"{type(exc).__name__}: {exc}", secrets)[:480]
-                    ),
-                }
-            )
-    else:
-        if result.outcome == "session-outage":
-            _best_effort(
-                "outage stamp",
-                lambda: stamp_outage(run_root, redact(result.note, secrets)[:300], now),
-                secrets,
-            )
-        final = RunRecord(
-            **{
-                **record.__dict__,
-                "state": ENDED,
-                "ending": _ENDINGS_BY_OUTCOME[result.outcome],
-                "ending_note": redact(result.note, secrets),
-            }
-        )
-    if not _best_effort("final record", lambda: save_record(run_root, final, now), secrets):
-        # The on-disk record still says `implementing`, so automated
-        # follow-up servicing will not track this run — and if a PR was
-        # opened, its humans are the only ones who can act. Say so WHERE
-        # they are looking: GitHub is the one store still writable when the
-        # local disk is gone.
-        pr_number = pr_url.rstrip("/").rsplit("/", 1)[-1] if pr_url else ""
-        if pr_number.isdigit():
-            _best_effort(
-                "pr state warning",
-                lambda: github.comment(
-                    config.target,
-                    int(pr_number),
-                    f"State record for run `{run_id}` could not be saved; "
-                    f"automated follow-up servicing is offline for this run. "
-                    f"A maintainer owns any follow-ups on this PR.",
-                ),
-                secrets,
-            )
-    if issue_number:
-        _post_issue_finished(
-            github,
-            config.target,
-            issue_number,
-            run_id,
-            outcome_name,
-            pr_url,
-            redact(result.report(config, redact_secrets=secrets), secrets)[:8000],
-            secrets,
-        )
-    if outcome_name != result.outcome:
-        # the publish failed after the gate credited the tree: the improved
-        # snapshot above stands (the measurement was real); append the
-        # publish-error marker so the notebook records how the run ended
-        _push_line_snapshot(ws, line_ref, run_id, outcome_name, secrets, bot_login=config.bot_login)
-    log.info("run %s: %s %s", run_id, outcome_name, pr_url)
-    return AttemptOutcome(
+    return _finish_attempt(
+        result=result,
+        ws=ws,
+        workspace=workspace,
+        run_root=run_root,
+        run_dir=run_dir,
         run_id=run_id,
-        outcome=outcome_name,
-        pr_url=pr_url,
-        report_path=str(report_path) if wrote_report else "",
+        record=record,
+        config=config,
+        contract=contract,
+        github=github,
+        now=now,
+        secrets=secrets,
+        base_branch=base_branch,
+        base_sha=pre_session_sha,
+        issue_number=issue_number,
+        line_ref=line_ref,
+        date=created[:10],
     )
 
 

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3301,7 +3301,9 @@ def test_resume_improved_reconciles_to_an_existing_pr(tmp_path, monkeypatch) -> 
 # --- the author-sleep wake (research-loop-buildout.md Phase A, part 2) ---
 
 
-def _write_parked_author_sleep(tmp_path, monkeypatch, *, raise_exc=None, run_id="tsp-9"):
+def _write_parked_author_sleep(
+    tmp_path, monkeypatch, *, raise_exc=None, run_id="tsp-9", values=None
+):
     """An author-sleep-parked run on disk in the REAL park state: the session's
     tree persisted as the author left it (uncommitted edits over base), the
     sleep snapshot sealed under its ref, launch job outputs in the run dir, and
@@ -3326,6 +3328,10 @@ def _write_parked_author_sleep(tmp_path, monkeypatch, *, raise_exc=None, run_id=
     (wsroot / "src" / "pilot" / "solvers" / "tsp.py").write_text("def solve(): return 'wip'\n")
     ws = Workspace(root=wsroot)
     snap = snapshot_tree(ws, base_sha)  # the sealed sleep tree
+    # a bare 'origin' so an improved wake can push its branch
+    bare = tmp_path / f"origin-{run_id}.git"
+    _git(tmp_path, "clone", "-q", "--bare", str(wsroot), str(bare))
+    _git(wsroot, "remote", "add", "origin", str(bare))
     # the finished launch's job outputs, as the job script leaves them
     ev = state / "runs" / run_id / "eval-launch-probe"
     (ev / "artifacts").mkdir(parents=True)
@@ -3358,8 +3364,11 @@ def _write_parked_author_sleep(tmp_path, monkeypatch, *, raise_exc=None, run_id=
         },
     )
     save_record(state, record, 1_000_000.0)
-    fake = _FakeMeasurer(values={}, raise_exc=raise_exc)
+    fake = _FakeMeasurer(values=values or {}, raise_exc=raise_exc)
     monkeypatch.setattr(DispatchSettings, "measurer", lambda self, *a, **k: fake)
+    # the wake pushes to the canonical target URL (never the ws git config);
+    # point that at this run's local bare so an improved wake can push
+    monkeypatch.setattr("outerloop.attempt.target_clone_url", lambda target: str(bare))
     return state, run_id, wsroot, json_mod
 
 
@@ -3413,6 +3422,43 @@ def test_author_sleep_wake_delivers_results_and_flows_to_a_candidate_park(
     refs = [r for r in _git(wsroot, "for-each-ref", "refs/dispatch/").splitlines() if r]
     assert len(refs) == 1
     assert str(record.stage["candidate_ref"]) in refs[0]
+
+
+def test_author_sleep_wake_publishes_an_inline_improvement(tmp_path, monkeypatch) -> None:
+    """On a synchronous backend the gate answers inline instead of parking a
+    candidate: the woken session's improvement becomes a PR through the same
+    terminal a fresh climb takes (cluster0, 2026-09-12: two improved wakes
+    ended `aborted` with no PR)."""
+    from outerloop.roles import author_spec
+
+    state, run_id, wsroot, _ = _write_parked_author_sleep(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    github = CommentingGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),
+        now=1_000_100.0,
+        harness=ScriptedHarness(
+            edits={"src/pilot/solvers/tsp.py": "def solve(): return 'polished'\n"}
+        ),
+        spec=author_spec(),
+    )
+    assert outcome.outcome == "improved" and outcome.pr_url.endswith("/pull/1")
+    record = load_record(state, run_id)
+    assert record.state == "in-review" and record.pr_url == outcome.pr_url
+    assert not record.stage.get("phase")  # the park's bookkeeping is gone
+    pr = github.prs[0]
+    assert pr["head"] == f"feat/auto/agent-01/{run_id}" and pr["base"] == "main"
+    bare = tmp_path / f"origin-{run_id}.git"
+    assert "def solve(): return 'polished'" in _git(
+        bare, "show", f"feat/auto/agent-01/{run_id}:src/pilot/solvers/tsp.py"
+    )
+    # the sleep snapshot is released; nothing else lingers under the dispatch refs
+    assert _git(wsroot, "for-each-ref", "refs/dispatch/").strip() == ""
 
 
 def test_author_sleep_wake_records_each_launch_as_ended_in_the_ledger(

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3302,7 +3302,7 @@ def test_resume_improved_reconciles_to_an_existing_pr(tmp_path, monkeypatch) -> 
 
 
 def _write_parked_author_sleep(
-    tmp_path, monkeypatch, *, raise_exc=None, run_id="tsp-9", values=None
+    tmp_path, monkeypatch, *, raise_exc=None, run_id="tsp-9", values=None, submitted=False
 ):
     """An author-sleep-parked run on disk in the REAL park state: the session's
     tree persisted as the author left it (uncommitted edits over base), the
@@ -3361,6 +3361,7 @@ def _write_parked_author_sleep(
             "syscall_note": "compare against the sweep",
             "launches_used": 1,
             "sleeps_used": 1,
+            **({"submitted": True, "report": "the author's submit report"} if submitted else {}),
         },
     )
     save_record(state, record, 1_000_000.0)
@@ -3459,6 +3460,31 @@ def test_author_sleep_wake_publishes_an_inline_improvement(tmp_path, monkeypatch
     )
     # the sleep snapshot is released; nothing else lingers under the dispatch refs
     assert _git(wsroot, "for-each-ref", "refs/dispatch/").strip() == ""
+
+
+def test_author_sleep_wake_keeps_the_submit_report_on_the_pr(tmp_path, monkeypatch) -> None:
+    """A submitted park woken with its gate result whose session ends without
+    submitting again still shows the author's submit report on the PR."""
+    from outerloop.roles import author_spec
+
+    state, run_id, _, _ = _write_parked_author_sleep(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}, submitted=True
+    )
+    github = CommentingGitHub()
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),
+        now=1_000_100.0,
+        harness=ScriptedHarness(
+            edits={"src/pilot/solvers/tsp.py": "def solve(): return 'polished'\n"}
+        ),
+        spec=author_spec(),
+    )
+    assert outcome.outcome == "improved"
+    assert "the author's submit report" in github.prs[0]["body"]
 
 
 def test_author_sleep_wake_reconciles_an_already_open_pr(tmp_path, monkeypatch) -> None:

--- a/tests/test_attempt.py
+++ b/tests/test_attempt.py
@@ -3461,6 +3461,70 @@ def test_author_sleep_wake_publishes_an_inline_improvement(tmp_path, monkeypatch
     assert _git(wsroot, "for-each-ref", "refs/dispatch/").strip() == ""
 
 
+def test_author_sleep_wake_reconciles_an_already_open_pr(tmp_path, monkeypatch) -> None:
+    """A wake that opened its PR and died before recording it is woken again:
+    the terminal finds the open PR for its head and reconciles to it, never
+    re-pushing or opening a second."""
+    from outerloop.roles import author_spec
+
+    state, run_id, _, _ = _write_parked_author_sleep(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 12.0}
+    )
+    github = CommentingGitHub(existing_pr="https://github.com/org/pilot/pull/7")
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=github,  # type: ignore[arg-type]
+        bot_auth=NoAuth(),
+        now=1_000_100.0,
+        harness=ScriptedHarness(
+            edits={"src/pilot/solvers/tsp.py": "def solve(): return 'polished'\n"}
+        ),
+        spec=author_spec(),
+    )
+    assert outcome.outcome == "improved" and outcome.pr_url.endswith("/pull/7")
+    assert github.prs == []  # no duplicate
+    record = load_record(state, run_id)
+    assert record.state == "in-review" and record.pr_url.endswith("/pull/7")
+
+
+def test_author_sleep_wake_keeps_its_snapshot_when_the_terminal_record_fails(
+    tmp_path, monkeypatch
+) -> None:
+    """A terminal whose record cannot be saved leaves the run WAITING; the
+    sleep snapshot must survive with it, or nothing could ever wake it."""
+    import outerloop.attempt as attempt_mod
+    from outerloop.roles import author_spec
+
+    state, run_id, wsroot, _ = _write_parked_author_sleep(
+        tmp_path, monkeypatch, values={"baseline": 13.0, "candidate": 13.0}
+    )
+    refs_before = _git(wsroot, "for-each-ref", "refs/dispatch/").strip()
+    assert refs_before
+    real_save = attempt_mod.save_record
+
+    def failing_save(root, record, now):
+        if record.state in ("ended", "in-review"):
+            raise OSError("disk gone")
+        return real_save(root, record, now)
+
+    monkeypatch.setattr(attempt_mod, "save_record", failing_save)
+    outcome = resume_run(
+        state,
+        run_id,
+        dispatch=_fake_dispatch(),
+        github=CommentingGitHub(),  # type: ignore[arg-type]
+        bot_auth=NoAuth(),
+        now=1_000_100.0,
+        harness=ScriptedHarness(edits={"src/pilot/solvers/tsp.py": "def solve(): return 1\n"}),
+        spec=author_spec(),
+    )
+    assert outcome.outcome == "no-improvement"
+    assert load_record(state, run_id).state == "waiting"  # unsaved terminal
+    assert _git(wsroot, "for-each-ref", "refs/dispatch/").strip() == refs_before
+
+
 def test_author_sleep_wake_records_each_launch_as_ended_in_the_ledger(
     tmp_path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## What was wrong

On cluster0 two gpu-mlp runs woke from an author sleep, submitted, passed the gate as improved, and then ended `aborted` with no PR (runs 103748 and 162148 on quickstart-trial #11; the second improved test MSE from 1.07e-4 to 6.6e-6). The author-sleep wake's terminal, `_end`, mapped the outcome through `_ENDINGS_BY_OUTCOME`, which has no entry for `improved`, and defaulted to `ABORTED`. The comment on that path said a dispatched gate never returns improved inline. On Slurm that is true: the gate parks a candidate and a later wake decides it through the candidate path, which publishes. On local compute the measurer is synchronous, so the gate answers inline, and the wake had no publish path at all.

A fresh climb on local compute already handled the inline verdict: `live_attempt`'s tail commits the sealed candidate, folds in the ledger, pushes, opens the PR, records in-review, and posts the issue note. The wake was a second copy of the terminal that lacked the improved branch.

## One terminal

- `live_attempt`'s tail is now `_finish_attempt`, a module-level function: report, line notebook, then the PR for an improved result (the sealed candidate, never the live tree) or the ending record for anything else, the outage stamp, the pr-state warning, and the issue note.
- `_wake_author_sleep`'s `_end` calls it and then releases the park's snapshot. The wake now also gets the session-outage stamp and the strict ending map the fresh climb had.
- `_clear_stage` is applied inside the shared terminal, so a resumed run's park bookkeeping never rides into review or an ending; for a fresh climb it is a no-op.

No behaviour change on Slurm: the dispatched gate still parks a candidate, and the candidate wake path is untouched.

## Tests

- New: `test_author_sleep_wake_publishes_an_inline_improvement` parks an author-sleep run on a synchronous measurer, resumes it with a code edit, and asserts a PR opens from the run's branch against main, the record goes in-review with the park's stage cleared, the pushed branch carries the edit, and the sleep snapshot is released. The parked-author-sleep helper gained a bare origin and the canonical-URL patch the candidate helper already had.
- All existing fresh-climb and wake tests unchanged and green (the shared function is the same code moved). Full gate: ruff, format, mypy, 1389 tests.

## Fleet

cluster0 runs main by commit for the first round; this lands there before any release. Torch is unaffected in behaviour.

Changelog under Unreleased.
