### PR TITLE
Design pass: the run lifecycle, its states, messages, and what the kernel decides

### DIFF
--- a/docs/design/lifecycle.md
+++ b/docs/design/lifecycle.md
@@ -1,0 +1,274 @@
+# The run lifecycle: states, messages, and what the kernel decides
+
+**Status: design pass (2026-09-12), for review before code.** A re-read of the
+whole lifecycle against one rule, from Mengye: benchmark verification and
+launching jobs are rigid; everything else is the author deciding, through
+tool calls. It absorbs Phase C of `research-loop-buildout.md` and supersedes
+the follow-up sections of `roles.md` and `orchestrator-verify.md`. Built from
+three inventories of the code as of main `8944625` (states and transitions,
+inbound messages and syscalls, standing design rulings); the numbers in
+brackets refer to the kernel-decision list in the first inventory, kept in
+the PR that carries this note.
+
+## The rule
+
+The kernel owns two things because nobody else can be trusted with them:
+
+- **The gate.** The credited number is the kernel's paired measurement of a
+  sealed tree on the fixed benchmark under a private seed, with scope checked
+  on the diff and the suite re-measured when shared paths moved. The author
+  never sees the seed, never edits the ledger, and cannot make a number.
+- **Launching.** Jobs run outside the sandbox under the kernel's containment,
+  on the lane the contract names, metered in counts and GPU-hours, always
+  queued, cancelled when the run ends.
+
+Around those sit invariants that are not science and are not the author's to
+change: who may send a message and who may merge, isolation of the session,
+crash-proof liveness, a report on every ending, the line notebook sealed at
+every terminal. Everything else is judgment, and judgment belongs to the
+author: what to run, what a result means, whether to answer a reviewer with an
+experiment or a sentence, when to submit, when to stop. Where the kernel makes
+such a call today, that call goes.
+
+## What exists
+
+Five states, one of them dead. `implementing` (a session runs), `waiting`
+(parked on jobs), `in-review` (a PR is open), `concluding` (declared, never
+written), `ended` with six endings. A run parks in three shapes: an
+author-sleep park (the author launched and slept), a candidate park (the
+gate's measures are jobs) and a submitted park (a candidate park the author
+asked for). Each shape has its own wake path with its own decisions.
+
+A run in review does not park. The tick services it on a separate pipeline of
+two thousand lines that reads new comments, resumes the session with a fixed
+prompt, and then decides for it: an in-scope edit is re-measured as the PR's
+new candidate; a number inside the floor leaves the ledger row alone; the row
+is folded into the sealed commit and pushed; a moved base has a ladder of
+sync, conflict, withheld and superseded; a pushed change gets a panel re-read
+with its own revision cap; the steward repeats most of this under another key.
+Reviewers who asked for an ablation got the ablation pushed as the PR head, or
+nothing when the push step failed.
+
+The inventory counts fifty-six places where the kernel decides something
+about the science or a reviewer's intent. About half are the gate, the meter,
+authorization and merge authority, and stay. The rest cluster in five places:
+
+| Cluster | Examples | Inventory |
+| --- | --- | --- |
+| review time | re-measure any edit; the base-sync ladder; six withhold wordings; "worse than before, stated plainly"; abandon when the head moved; the panel re-read cap | 25–37 |
+| submit policy | a submit is refused until a launch has returned results; a metered finish without a submit is scored no-improvement, panel only; a submit needs a report | 7, 49, 50 |
+| the finish | blocking findings at a plain finish open a draft; a degraded panel drafts; never arm when the base moved | 13–18 |
+| base moves | the kernel re-pins the base and instructs the agent to merge; conflict and behind prompts written by the kernel | 26, 54 |
+| the outer loop | an issue must name exactly one benchmark; which benchmark to climb next; the steward's mission text | 39, 42, 43 |
+
+Messages reach a session by five channels: the brief at start, the launch
+wake text, an `extra_update` that leads a submitted park's wake, the panel's
+wake text, and the follow-up prompt with its four preambles. Twelve syscalls
+exist. A session has no verb that posts anything to GitHub. A comment cannot
+reach a session parked on jobs. A follow-up session has no syscalls at all.
+Advisory panel findings never reach the author. The sibling view is frozen at
+session start. Eleven retry counters bound the pipeline, most of them
+protecting one hard-coded step from another.
+
+## The lifecycle
+
+### Three states
+
+| State | Meaning | Leaves it |
+| --- | --- | --- |
+| `running` | a session is live in a job | the session ends: it slept (park), or it stopped (end) |
+| `parked` | no session; the run waits for jobs it launched, for messages, or both | a wake (the same session resumes), or a human ends the PR |
+| `ended` | terminal, with a report | never |
+
+A PR being open is a fact about a run, recorded in `pr_url`, not a state. A
+parked run with a PR is what `in-review` was. `implementing` is `running`;
+`waiting` and `in-review` are `parked`; `concluding` is deleted. The six
+endings stay as they are: merged, rejected, negative result, budget exhausted,
+aborted, stuck. They are how a human reads the board, and every one still
+produces a report.
+
+### One engine: park and wake
+
+A run parks when its session ends with a sleep. A run wakes when the kernel
+has something to deliver: the jobs the session slept on have finished, or a
+message arrived for a run that is not waiting on jobs. A wake resumes the
+same session with everything in its inbox rendered as one data-fenced text.
+That is the whole engine, the same on every backend and in every phase of a
+run: before a PR, with a PR open, after a reviewer writes. The three park
+shapes become one park with a job list that may be empty; the three wake
+paths become one.
+
+### Messages
+
+A message is the unit the kernel delivers. Every message has a source, a
+trust level (everything but the kernel's own budget and clock lines is data,
+never instructions), and an arrival time. The tick writes messages into the
+run's inbox; the wake drains it in arrival order.
+
+| Message | Source | Written by | Delivered |
+| --- | --- | --- | --- |
+| launch result: exit code, bounded tails, declared artifacts | the author's own job | the sweep, when the job is terminal | at the wake the sleep asked for |
+| gate verdict: the paired numbers, the floor, the suite, or an eval error | the kernel's measurement of a submitted tree | the sweep, when the gate jobs are terminal | at the wake |
+| panel verdict: blocking and advisory findings, the transcript | judge sessions | the panel run | at the wake |
+| human comment or review, on the PR or the issue | a person with standing; others as context, never as triggers | the tick's poll | at the next wake |
+| base moved: the digest of what merged and the siblings' numbers | git, main | the tick, once per new base | at the next wake |
+| budget and clock: counts remaining, walltime | the kernel | the wake itself | leads every wake |
+| PR merged or closed | a human, on GitHub | the tick's poll | ends the run; not delivered |
+
+The author's session never sees a raw comment body outside a fence, never
+sees the seed, and never sees a message the kernel did not write into the
+inbox. Advisory findings are delivered like blocking ones; the author decides
+what to do with them. The sibling view is refreshed at every wake, not only
+at start.
+
+Human messages do not interrupt a sleep on jobs. They wait in the inbox and
+arrive with the job results. The author who wants to answer sooner sleeps on
+nothing, which is a checkpoint sleep and costs a sleep like any other. The
+kernel stays out of scheduling.
+
+### The author's moves
+
+| Move | What the kernel does | Rigid part |
+| --- | --- | --- |
+| `launch` | seals the tree, submits a contained job on the contract's lane, records it in the ledger, delivers the result at the wake | containment, placement, metering |
+| `sleep` | parks the run on the launched jobs (possibly none) | the sleep count |
+| `submit` | seals the tree, runs the gate and the panel as jobs, delivers the verdict as a message; an improved verdict publishes | the gate; the publish |
+| `reply` | posts text, as written, on the thread the message came from | standing of the poster; redaction |
+| `end` | ends the run with the author's report and the last verdict as its ending | the report |
+
+`reply` is new. `end` is today's "the session stopped without sleeping",
+given a name and a report; a session that simply stops still ends the run.
+The read-only verbs stay: `status`, `queue`, `history`, `siblings`, `reports`,
+`sync`. The steward has the same moves under its own key, with its own scope.
+
+### Submit, and the one publish
+
+A submit means: measure this sealed tree, and if it is credited, publish it.
+The verdict comes back as a message whatever it says. A gate that says no is
+not a terminal; the author reads the numbers and decides to try again, launch
+more, or end. Today a plain finish's failed gate ends the run and a submitted
+park's failed gate wakes the author; the second is right, and with `end` the
+author can still choose the first.
+
+The publish is the one rigid act after the gate. When no PR exists, the kernel
+opens one from the sealed tree with the number and the author's report. When
+a PR exists, the kernel moves its head to the sealed tree and posts the
+number, after confirming auto-merge is disarmed. Blocking findings at a
+publish open a draft, or keep the PR as it is, and are delivered to the author
+with the verdict. The ledger row moves only when a credited number beats the
+recorded best by the floor; every other number is posted and leaves the row
+alone. A submit whose number is worse than the PR's current one still moves
+the head, with the number stated plainly; the author chose it, the thread
+shows it, and a human merges or not.
+
+### Endings
+
+A run ends when the author ends it, when a human merges or closes its PR,
+when the meter runs out, or when the kernel cannot continue: a crash, a
+tampered workspace, or a wake that made no progress `MAX_WAKE_ATTEMPTS`
+times. Every ending writes the report, seals the line notebook, releases the
+issue claim when no PR exists, and cancels the run's live launches. No other
+path ends a run. In particular, a gate verdict never ends a run by itself,
+and a reviewer's comment never does.
+
+## What stays rigid
+
+| Kept | Why it is the kernel's |
+| --- | --- |
+| the paired measurement, the private seed, the floor, the suite, the cached baseline rule, the zero-change rule (an unchanged tree cannot be credited) | the number must be nobody's claim |
+| scope on the diff before anything is sealed, launched or measured | the out-of-scope edit could be to the ruler |
+| containment, the lane from the contract, `--nice` on launches, always queue, cancel on end | the session cannot hold GPUs or credentials |
+| launch, sleep and GPU-hour counts; refusal on exhaustion with the numbers | the meter is the only bound on spend |
+| the publish: open or move the PR head to the sealed tree, the ledger row rule, disarm before a head moves, never arm when the base moved, humans merge | credit and merge authority |
+| standing: which comments are messages, the bot's own markers, the task label; the issue claim and its release | authorization |
+| leases, the sweep, deadline floors, the stuck cap, the outage latch, the tamper guard, the report on every ending, the line seal at every terminal | liveness and audit |
+
+## What becomes the author's, and what is deleted
+
+| Today | After |
+| --- | --- |
+| an in-scope edit during review is re-measured as the PR candidate [25, 29] | nothing is measured unless submitted |
+| the base-sync ladder: sync, conflict, behind, withheld, superseded, "the numbers above still stand" [25, 26, 30, 31] | one message, base moved; the author merges or not and submits or not |
+| six withhold wordings for a reverted change [29] | the change is never reverted; the author's tree is the author's |
+| abandon a finished re-measure when the head moved [34] | a submit measures the tree the author has; the head moves to it |
+| the panel re-read after a push, its two-revision cap, `finish_attempts` [36, 37] | a submit runs the panel; findings are a message; the sleep count bounds revisions |
+| the kernel re-pins the base and tells the agent to merge; kernel-written conflict prompts [26, 54] | the base-moved message says what happened; no instruction |
+| a submit is refused until a launch has returned [49]; a metered finish without a submit is scored no-improvement [7]; a submit needs a report [50] | the meter and the gate are the constraints; the report is `end`'s and the publish's |
+| a plain finish's failed gate ends the run as negative-result [9] | the verdict is a message; `end` is the author's |
+| advisory findings never reach the author; siblings frozen at start | delivered; refreshed |
+| three comment cursors, `followup_stage`, `panel_wake_*`, `dirty_wake_head`, `extra_update`, `improve_prompt` | one inbox, one cursor, one renderer |
+| the steward's copy of the pipeline; its mission text in kernel code [43–46] | the steward is a role with the same moves; its text is role configuration |
+| `MAX_COMMENTS_PER_WAKE`, `PANEL_WAKE_CAP`, `finish_attempts`, `panel_wake_rounds` | gone; the sleep count is the wake budget |
+
+Out of this pass, and named so nobody reads their absence as a decision: the
+outer loop's choices (which issue, which benchmark next, an issue naming one
+benchmark [39–42]) belong to a planner note; the declared-comparison gate and
+the portfolio ledger stay in `research-loop.md`.
+
+## The record
+
+```
+run_id, target, benchmark, agent_id, issue_number
+state: running | parked | ended        ending, ending_note
+pr_url                                 the fact a PR is open
+session: backend, model, key_file, resume_session_id
+park: jobs (afterany ids), sealed_ref, base_sha, base_branch, deadline
+inbox_cursor                           the last message id delivered
+meter: launches_used, sleeps_used, gpu_hours_used
+wake_attempts                          liveness only
+```
+
+Gone from the record: the three cursors, `followup_stage`, `followup_job_id`,
+`panel_wake_head`, `panel_wake_text`, `panel_wake_rounds`, `dirty_wake_head`,
+the candidate and submitted phases inside `stage`. `auto_blessed_head` stays
+only as long as `merge: auto` does; whether it does is a standing
+contradiction between `architecture.md` and `install.md`, settled elsewhere.
+
+## Open decisions
+
+1. **Interrupting a sleep.** Recommended above: a human message waits for the
+   jobs. The alternative, waking early on a comment, makes the kernel a
+   scheduler and doubles the wake paths.
+2. **The meter in review.** One meter for the run's whole life, topped up by
+   the contract if a target wants generous review time. The alternative is a
+   second budget with its own counters.
+3. **A worse submit on an open PR.** Head moves, number posted, row unchanged.
+4. **`end` as a verb.** Recommended: yes, so a report is asked for at the
+   moment the author decides; a session that simply stops still ends the run
+   with what it has.
+5. **Auto-merge.** `install.md` documents `merge: auto`; `architecture.md`
+   says never on code. Not this pass's to build, but the record shape depends
+   on it.
+
+## Sequencing
+
+Each stage is one PR, reviewed, run from its commit on one fleet before any
+release, and deletes what it replaces.
+
+1. **One inbox, one renderer.** Every inbound message, including the ones
+   delivered today, goes through the inbox and one wake renderer. Advisory
+   findings and a refreshed sibling view ride along. No lifecycle change yet;
+   `extra_update`, `panel_wake_text` and the follow-up preambles go.
+2. **Messages reach a parked author.** `reply` exists. A run with an open PR
+   parks; comments and base moves are inbox messages; the author can launch,
+   reply and sleep in review. The follow-up pipeline no longer runs for
+   comments; it still handles nothing else.
+3. **Submit in review.** The publish moves the PR head; a gate verdict is a
+   message on every path; `end` exists. The submit policies [7, 49, 50] go.
+4. **Three states.** `running`, `parked`, `ended`; the record migrates on
+   read; `followup.py`, the steward's pipeline copy, and the counters are
+   deleted with their tests.
+
+## Standing contradictions this settles
+
+- Launches are submitted at sleep time, not when `launch` is called: kept.
+  Staging is the primitive; the author keeps working after a launch and the
+  jobs start when it sleeps.
+- There is a live channel to a running session, the watcher, for read-only
+  questions. `roles.md`'s "no live channel" is stale.
+- A follow-up's change is not re-measured by the orchestrator; only a submit
+  is measured. `roles.md` and `orchestrator-verify.md` are superseded here.
+- The panel re-read loop after a push is retired; a submit runs the panel.
+- A moved base is told, never forced; the finish's "merge and re-measure
+  both sides" in `roles.md`'s flow is retired.
+- One batch in flight per run is not a rule; launch several, sleep once.

--- a/docs/design/lifecycle.md
+++ b/docs/design/lifecycle.md
@@ -142,6 +142,17 @@ Human messages do not interrupt a sleep on jobs. They wait in the inbox and
 arrive with the job results. The author who wants to answer sooner takes a
 checkpoint sleep. The kernel stays out of scheduling.
 
+The inbox is files: a directory beside the run's record, one file per
+message named by a sequence number, written by temp-and-rename, never
+deleted, outside the workspace so the session cannot forge one. The record
+holds the delivered position. Records, leases and the inbox all sit behind
+one small storage interface (put, list, get, conditional put) with a
+filesystem implementation for Slurm and local compute; a cloud backend gives
+it an object-store implementation and nothing else changes. No messaging
+service is needed: delivery only happens at a wake, which the kernel
+triggers, so nothing waits on a push. A job-completion callback may later
+wake the tick sooner than its cadence; that is a trigger, not a transport.
+
 ### The author's moves
 
 | Move | What the kernel does | Rigid part |

--- a/docs/design/lifecycle.md
+++ b/docs/design/lifecycle.md
@@ -6,9 +6,10 @@ launching jobs are rigid; everything else is the author deciding, through
 tool calls. It absorbs Phase C of `research-loop-buildout.md` and supersedes
 the follow-up sections of `roles.md` and `orchestrator-verify.md`. Built from
 three inventories of the code as of main `8944625` (states and transitions,
-inbound messages and syscalls, standing design rulings); the numbers in
-brackets refer to the kernel-decision list in the first inventory, kept in
-the PR that carries this note.
+inbound messages and syscalls, standing design rulings) and cross-checked by
+an independent read of the note against the code; the numbers in brackets
+refer to the kernel-decision inventory posted on the PR that carries this
+note.
 
 ## The rule
 
@@ -23,12 +24,13 @@ The kernel owns two things because nobody else can be trusted with them:
   queued, cancelled when the run ends.
 
 Around those sit invariants that are not science and are not the author's to
-change: who may send a message and who may merge, isolation of the session,
-crash-proof liveness, a report on every ending, the line notebook sealed at
-every terminal. Everything else is judgment, and judgment belongs to the
-author: what to run, what a result means, whether to answer a reviewer with an
-experiment or a sentence, when to submit, when to stop. Where the kernel makes
-such a call today, that call goes.
+change: who may send a message and who may merge, that a human's commit is
+never overwritten, isolation of the session, crash-proof liveness, a report on
+every ending, the line notebook sealed at every terminal. Everything else is
+judgment, and judgment belongs to the author: what to run, what a result
+means, whether to answer a reviewer with an experiment or a sentence, when to
+submit, when to stop. Where the kernel makes such a call today, that call
+goes.
 
 ## What exists
 
@@ -39,15 +41,16 @@ author-sleep park (the author launched and slept), a candidate park (the
 gate's measures are jobs) and a submitted park (a candidate park the author
 asked for). Each shape has its own wake path with its own decisions.
 
-A run in review does not park. The tick services it on a separate pipeline of
-two thousand lines that reads new comments, resumes the session with a fixed
-prompt, and then decides for it: an in-scope edit is re-measured as the PR's
-new candidate; a number inside the floor leaves the ledger row alone; the row
-is folded into the sealed commit and pushed; a moved base has a ladder of
-sync, conflict, withheld and superseded; a pushed change gets a panel re-read
-with its own revision cap; the steward repeats most of this under another key.
-Reviewers who asked for an ablation got the ablation pushed as the PR head, or
-nothing when the push step failed.
+A run in review does not park in the record's sense. The tick services it on
+a separate pipeline of two thousand lines that reads new comments, resumes
+the session with a fixed prompt, and then decides for it: an in-scope edit is
+re-measured as the PR's new candidate, which on a cluster is a fourth park
+shape kept in `followup_stage`; a number inside the floor leaves the ledger
+row alone; the row is folded into the sealed commit and pushed; a moved base
+has a ladder of sync, conflict, withheld and superseded; a pushed change gets
+a panel re-read with its own revision cap; the steward repeats most of this
+under another key. Reviewers who asked for an ablation got the ablation
+pushed as the PR head or, until this week, nothing when the push step failed.
 
 The inventory counts fifty-six places where the kernel decides something
 about the science or a reviewer's intent. About half are the gate, the meter,
@@ -56,19 +59,25 @@ authorization and merge authority, and stay. The rest cluster in five places:
 | Cluster | Examples | Inventory |
 | --- | --- | --- |
 | review time | re-measure any edit; the base-sync ladder; six withhold wordings; "worse than before, stated plainly"; abandon when the head moved; the panel re-read cap | 25–37 |
-| submit policy | a submit is refused until a launch has returned results; a metered finish without a submit is scored no-improvement, panel only; a submit needs a report | 7, 49, 50 |
+| submit policy | on a metered benchmark a submit is refused until the run has launched; a metered finish without a submit is scored no-improvement, panel only; a submit needs a report | 7, 49, 50 |
 | the finish | blocking findings at a plain finish open a draft; a degraded panel drafts; never arm when the base moved | 13–18 |
 | base moves | the kernel re-pins the base and instructs the agent to merge; conflict and behind prompts written by the kernel | 26, 54 |
 | the outer loop | an issue must name exactly one benchmark; which benchmark to climb next; the steward's mission text | 39, 42, 43 |
 
 Messages reach a session by five channels: the brief at start, the launch
 wake text, an `extra_update` that leads a submitted park's wake, the panel's
-wake text, and the follow-up prompt with its four preambles. Twelve syscalls
-exist. A session has no verb that posts anything to GitHub. A comment cannot
-reach a session parked on jobs. A follow-up session has no syscalls at all.
-Advisory panel findings never reach the author. The sibling view is frozen at
-session start. Eleven retry counters bound the pipeline, most of them
-protecting one hard-coded step from another.
+wake text, and the follow-up prompt with its four preambles. Thirteen verbs
+exist, two of them the judges'. A session has no verb that posts anything to
+GitHub. A comment cannot reach a session parked on jobs. A follow-up session
+has no syscalls at all. Advisory panel findings never reach the author. The
+sibling view is frozen at session start. The wake text and the brief also
+carry research advice (keep experimenting while budget remains, conclude when
+launches are exhausted, ready means measured, one hypothesis one change-set)
+written into kernel code. Eleven retry counters bound the pipeline, most of
+them protecting one hard-coded step from another. Two copies of the first
+publish exist, one for a candidate wake and one for an inline finish, and an
+inline submit drops the sibling launches staged beside it and asks the
+author to stage them again.
 
 ## The lifecycle
 
@@ -94,37 +103,44 @@ has something to deliver: the jobs the session slept on have finished, or a
 message arrived for a run that is not waiting on jobs. A wake resumes the
 same session with everything in its inbox rendered as one data-fenced text.
 That is the whole engine, the same on every backend and in every phase of a
-run: before a PR, with a PR open, after a reviewer writes. The three park
-shapes become one park with a job list that may be empty; the three wake
-paths become one.
+run: before a PR, with a PR open, after a reviewer writes. The four park
+shapes become one park with a job list that may be empty; the wake paths
+become one.
+
+A sleep on no jobs is a checkpoint. It wakes when a message arrives or at the
+checkpoint deadline, whichever comes first, and the wake text says which. A
+parked run with a PR and no jobs waits for messages without a deadline; idle
+waiting spends no wake attempt and cannot end as stuck.
 
 ### Messages
 
 A message is the unit the kernel delivers. Every message has a source, a
-trust level (everything but the kernel's own budget and clock lines is data,
-never instructions), and an arrival time. The tick writes messages into the
-run's inbox; the wake drains it in arrival order.
+thread (the PR when one exists, else the issue the run claimed), a trust
+level (everything but the kernel's own budget and clock lines is data, never
+instructions), and an arrival time. The tick writes messages into the run's
+inbox; the wake drains it in arrival order.
 
 | Message | Source | Written by | Delivered |
 | --- | --- | --- | --- |
 | launch result: exit code, bounded tails, declared artifacts | the author's own job | the sweep, when the job is terminal | at the wake the sleep asked for |
-| gate verdict: the paired numbers, the floor, the suite, or an eval error | the kernel's measurement of a submitted tree | the sweep, when the gate jobs are terminal | at the wake |
+| gate verdict: the paired numbers, the floor, the suite, or an eval error; the sealed tree, the base and the contract it was measured under | the kernel's measurement of a submitted tree | the sweep, when the gate jobs are terminal | at the wake |
 | panel verdict: blocking and advisory findings, the transcript | judge sessions | the panel run | at the wake |
-| human comment or review, on the PR or the issue | a person with standing; others as context, never as triggers | the tick's poll | at the next wake |
+| human comment or review, on the run's thread | a person with standing; others as context, never as triggers | the tick's poll | at the next wake |
 | base moved: the digest of what merged and the siblings' numbers | git, main | the tick, once per new base | at the next wake |
-| budget and clock: counts remaining, walltime | the kernel | the wake itself | leads every wake |
+| budget and clock: counts remaining, the review top-up, walltime | the kernel | the wake itself | leads every wake |
 | PR merged or closed | a human, on GitHub | the tick's poll | ends the run; not delivered |
 
 The author's session never sees a raw comment body outside a fence, never
 sees the seed, and never sees a message the kernel did not write into the
 inbox. Advisory findings are delivered like blocking ones; the author decides
 what to do with them. The sibling view is refreshed at every wake, not only
-at start.
+at start. The inbox keeps a position per GitHub collection, since issue
+comments, reviews and review comments carry independent id sequences, and
+delivers each message once.
 
 Human messages do not interrupt a sleep on jobs. They wait in the inbox and
-arrive with the job results. The author who wants to answer sooner sleeps on
-nothing, which is a checkpoint sleep and costs a sleep like any other. The
-kernel stays out of scheduling.
+arrive with the job results. The author who wants to answer sooner takes a
+checkpoint sleep. The kernel stays out of scheduling.
 
 ### The author's moves
 
@@ -132,55 +148,89 @@ kernel stays out of scheduling.
 | --- | --- | --- |
 | `launch` | seals the tree, submits a contained job on the contract's lane, records it in the ledger, delivers the result at the wake | containment, placement, metering |
 | `sleep` | parks the run on the launched jobs (possibly none) | the sleep count |
-| `submit` | seals the tree, runs the gate and the panel as jobs, delivers the verdict as a message; an improved verdict publishes | the gate; the publish |
+| `submit` | seals the tree, runs the gate and the panel as jobs, delivers the verdict as a message; a credited verdict publishes | the gate; the publish |
 | `reply` | posts text, as written, on the thread the message came from | standing of the poster; redaction |
 | `end` | ends the run with the author's report and the last verdict as its ending | the report |
 
-`reply` is new. `end` is today's "the session stopped without sleeping",
-given a name and a report; a session that simply stops still ends the run.
-The read-only verbs stay: `status`, `queue`, `history`, `siblings`, `reports`,
-`sync`. The steward has the same moves under its own key, with its own scope.
+`reply` and `end` are new. A session that stops without sleeping or
+submitting ends the run with what it has, unmeasured. That is a change: today
+a plain finish is measured by the gate on the tree it left, and can publish.
+Under this note only a submit is measured, on every benchmark, so the author
+always asks for its number. The read-only verbs stay: `status`, `queue`,
+`history`, `siblings`, `reports`, `sync`. The steward has the same moves under
+its own key, with its own scope.
+
+The research advice now written into the wake text and the brief moves to
+the role's instructions, where it can be edited without a kernel change. The
+kernel's wake text states facts: the messages, the counts, the clock.
 
 ### Submit, and the one publish
 
 A submit means: measure this sealed tree, and if it is credited, publish it.
-The verdict comes back as a message whatever it says. A gate that says no is
+The verdict comes back as a message whatever it says, naming the sealed
+tree, the base and the contract it was measured under. A gate that says no is
 not a terminal; the author reads the numbers and decides to try again, launch
 more, or end. Today a plain finish's failed gate ends the run and a submitted
 park's failed gate wakes the author; the second is right, and with `end` the
 author can still choose the first.
 
-The publish is the one rigid act after the gate. When no PR exists, the kernel
-opens one from the sealed tree with the number and the author's report. When
-a PR exists, the kernel moves its head to the sealed tree and posts the
-number, after confirming auto-merge is disarmed. Blocking findings at a
-publish open a draft, or keep the PR as it is, and are delivered to the author
-with the verdict. The ledger row moves only when a credited number beats the
-recorded best by the floor; every other number is posted and leaves the row
-alone. A submit whose number is worse than the PR's current one still moves
-the head, with the number stated plainly; the author chose it, the thread
-shows it, and a human merges or not.
+The publish is the one rigid act after the gate, and there is one of it. When
+no PR exists, the kernel opens one from the sealed tree with the number and
+the author's report. When a PR exists, the kernel moves its head to the
+sealed tree and posts the number, after confirming auto-merge is disarmed.
+The move is a fast-forward only: the sealed tree must contain the PR's
+current head. When a person pushed to the PR since the author last saw it,
+the publish is refused and the fact is delivered as a message; the author
+merges and submits again. A human's commit is never overwritten. The publish
+is also refused when the base's contract no longer defines the benchmark
+with the measurement the verdict was made under; a stale verdict is said,
+not published.
+
+Blocking findings at a publish open a draft, or keep the PR as it is, and are
+delivered to the author with the verdict. The ledger row moves only when a
+credited number beats the recorded best by the floor; every other number is
+posted and leaves the row alone. A submit whose number is worse than the PR's
+current one still moves the head, with the number stated plainly; the author
+chose it, the thread shows it, and a human merges or not.
+
+A steward submit is a ruler change and is measured as one: the full suite
+runs, every sibling's eval is smoke-checked, and the credited number resets
+the baseline instead of competing with it. That is the steward's publish; the
+steward's copy of the review pipeline is not.
+
+### The meter
+
+One meter for the run's whole life: the launch count, the sleep count and the
+GPU-hours the contract sets, spent from the first session to the last. When a
+PR opens the counts get a small top-up the contract names, so review has
+headroom, and every wake states the counts remaining and that the top-up was
+added, so the author can plan for review while still climbing. A reply costs
+nothing. A run that has spent everything can still reply and end.
 
 ### Endings
 
 A run ends when the author ends it, when a human merges or closes its PR,
 when the meter runs out, or when the kernel cannot continue: a crash, a
-tampered workspace, or a wake that made no progress `MAX_WAKE_ATTEMPTS`
-times. Every ending writes the report, seals the line notebook, releases the
-issue claim when no PR exists, and cancels the run's live launches. No other
-path ends a run. In particular, a gate verdict never ends a run by itself,
-and a reviewer's comment never does.
+tampered workspace, or a kernel action that made no progress
+`MAX_WAKE_ATTEMPTS` times, a failed publish retry included. A merge or close
+ends the run at the next tick whatever it is doing: pending jobs are
+cancelled, a session in flight finishes its leg and its publish is refused.
+Every ending writes the report, seals the line notebook, releases the issue
+claim when no PR exists, and cancels the run's live launches. No other path
+ends a run. A gate verdict never ends a run by itself, and a reviewer's
+comment never does.
 
 ## What stays rigid
 
 | Kept | Why it is the kernel's |
 | --- | --- |
-| the paired measurement, the private seed, the floor, the suite, the cached baseline rule, the zero-change rule (an unchanged tree cannot be credited) | the number must be nobody's claim |
+| the paired measurement, the private seed, the floor, the suite, the cached baseline rule, the zero-change rule (an unchanged tree cannot be credited), the verdict bound to its sealed tree, base and contract | the number must be nobody's claim |
 | scope on the diff before anything is sealed, launched or measured | the out-of-scope edit could be to the ruler |
 | containment, the lane from the contract, `--nice` on launches, always queue, cancel on end | the session cannot hold GPUs or credentials |
 | launch, sleep and GPU-hour counts; refusal on exhaustion with the numbers | the meter is the only bound on spend |
-| the publish: open or move the PR head to the sealed tree, the ledger row rule, disarm before a head moves, never arm when the base moved, humans merge | credit and merge authority |
-| standing: which comments are messages, the bot's own markers, the task label; the issue claim and its release | authorization |
+| the publish: open or fast-forward the PR head to the sealed tree, the ledger row rule, disarm before a head moves, never arm when the base moved, refuse when a human pushed or the contract moved, humans merge | credit, merge authority, and nobody's work overwritten |
+| the steward's ruler measurement: full suite, sibling smoke checks, baseline reset | a ruler change must be verified as one |
+| standing: which comments are messages, the bot's own markers, the task label; the issue claim and its release; one delivery per message | authorization and liveness |
 | leases, the sweep, deadline floors, the stuck cap, the outage latch, the tamper guard, the report on every ending, the line seal at every terminal | liveness and audit |
 
 ## What becomes the author's, and what is deleted
@@ -190,15 +240,18 @@ and a reviewer's comment never does.
 | an in-scope edit during review is re-measured as the PR candidate [25, 29] | nothing is measured unless submitted |
 | the base-sync ladder: sync, conflict, behind, withheld, superseded, "the numbers above still stand" [25, 26, 30, 31] | one message, base moved; the author merges or not and submits or not |
 | six withhold wordings for a reverted change [29] | the change is never reverted; the author's tree is the author's |
-| abandon a finished re-measure when the head moved [34] | a submit measures the tree the author has; the head moves to it |
-| the panel re-read after a push, its two-revision cap, `finish_attempts` [36, 37] | a submit runs the panel; findings are a message; the sleep count bounds revisions |
+| abandon a finished re-measure when the head moved [34] | the publish is a fast-forward or a refusal delivered as a message |
+| the panel re-read after a push, its two-revision cap [36, 37] | a submit runs the panel; findings are a message; the sleep count bounds revisions |
+| `finish_attempts` | folds into `wake_attempts`: any kernel retry without progress counts |
 | the kernel re-pins the base and tells the agent to merge; kernel-written conflict prompts [26, 54] | the base-moved message says what happened; no instruction |
-| a submit is refused until a launch has returned [49]; a metered finish without a submit is scored no-improvement [7]; a submit needs a report [50] | the meter and the gate are the constraints; the report is `end`'s and the publish's |
-| a plain finish's failed gate ends the run as negative-result [9] | the verdict is a message; `end` is the author's |
+| a submit is refused until the run has launched [49]; a metered finish without a submit is scored no-improvement [7]; a submit needs a report [50] | the meter and the gate are the constraints; the report is `end`'s and the publish's |
+| a plain finish is measured; its failed gate ends the run as negative-result [9] | only a submit is measured; the verdict is a message; `end` is the author's |
+| research advice in the wake text and the brief | the role's instructions |
 | advisory findings never reach the author; siblings frozen at start | delivered; refreshed |
-| three comment cursors, `followup_stage`, `panel_wake_*`, `dirty_wake_head`, `extra_update`, `improve_prompt` | one inbox, one cursor, one renderer |
-| the steward's copy of the pipeline; its mission text in kernel code [43–46] | the steward is a role with the same moves; its text is role configuration |
-| `MAX_COMMENTS_PER_WAKE`, `PANEL_WAKE_CAP`, `finish_attempts`, `panel_wake_rounds` | gone; the sleep count is the wake budget |
+| two first-publish implementations; an inline submit that drops its sibling launches | one publish; one job-and-wake path on every backend |
+| three cursors as record fields, `followup_stage`, `panel_wake_*`, `dirty_wake_head`, `extra_update`, `improve_prompt` | one inbox with per-collection positions, one renderer |
+| the steward's copy of the pipeline; its mission text in kernel code [43, 45] | the steward is a role with the same moves and its own publish; its text is role configuration |
+| `MAX_COMMENTS_PER_WAKE`, `PANEL_WAKE_CAP`, `finish_attempts`, `panel_wake_rounds` | gone; the sleep count and `wake_attempts` are the bounds |
 
 Out of this pass, and named so nobody reads their absence as a decision: the
 outer loop's choices (which issue, which benchmark next, an issue naming one
@@ -213,51 +266,62 @@ state: running | parked | ended        ending, ending_note
 pr_url                                 the fact a PR is open
 session: backend, model, key_file, resume_session_id
 park: jobs (afterany ids), sealed_ref, base_sha, base_branch, deadline
-inbox_cursor                           the last message id delivered
-meter: launches_used, sleeps_used, gpu_hours_used
+inbox: positions per GitHub collection, last delivered message
+meter: launches_used, sleeps_used, gpu_hours_used, review_topup_added
 wake_attempts                          liveness only
 ```
 
-Gone from the record: the three cursors, `followup_stage`, `followup_job_id`,
-`panel_wake_head`, `panel_wake_text`, `panel_wake_rounds`, `dirty_wake_head`,
-the candidate and submitted phases inside `stage`. `auto_blessed_head` stays
-only as long as `merge: auto` does; whether it does is a standing
-contradiction between `architecture.md` and `install.md`, settled elsewhere.
+Gone from the record: `followup_stage`, `followup_job_id`, `panel_wake_head`,
+`panel_wake_text`, `panel_wake_rounds`, `dirty_wake_head`, the candidate and
+submitted phases inside `stage`. `auto_blessed_head` stays only as long as
+`merge: auto` does.
 
-## Open decisions
+## Decisions
 
-1. **Interrupting a sleep.** Recommended above: a human message waits for the
-   jobs. The alternative, waking early on a comment, makes the kernel a
-   scheduler and doubles the wake paths.
-2. **The meter in review.** One meter for the run's whole life, topped up by
-   the contract if a target wants generous review time. The alternative is a
-   second budget with its own counters.
-3. **A worse submit on an open PR.** Head moves, number posted, row unchanged.
-4. **`end` as a verb.** Recommended: yes, so a report is asked for at the
-   moment the author decides; a session that simply stops still ends the run
-   with what it has.
-5. **Auto-merge.** `install.md` documents `merge: auto`; `architecture.md`
-   says never on code. Not this pass's to build, but the record shape depends
-   on it.
+Settled (Mengye, 2026-09-12):
+
+1. A human message waits for the jobs a run sleeps on; no interrupt.
+2. One meter for the run's life, with a small top-up when the PR opens, stated
+   in every wake.
+3. A worse submit on an open PR moves the head, with the number posted
+   plainly; the ledger row does not move.
+4. `end` is a verb, so a report is asked for at the moment the author
+   decides; a session that simply stops still ends the run with what it has.
+
+Open:
+
+5. **Auto-merge.** `architecture.md` lists "any form of auto-merge on code —
+   never"; `install.md` documents `merge: auto` as an explicit per-repo opt-in
+   under branch protection, and the code implements the opt-in. If the answer
+   is never, the blessing, the arming and the disarm rule leave the record and
+   the publish. Recommendation: keep the opt-in as the install guide states it
+   and correct the architecture sentence; the repo owner turning the dial on
+   is the human decision the principle protects.
 
 ## Sequencing
 
 Each stage is one PR, reviewed, run from its commit on one fleet before any
-release, and deletes what it replaces.
+release, and deletes what it replaces. A fleet never lacks a working path
+between stages.
 
 1. **One inbox, one renderer.** Every inbound message, including the ones
-   delivered today, goes through the inbox and one wake renderer. Advisory
-   findings and a refreshed sibling view ride along. No lifecycle change yet;
-   `extra_update`, `panel_wake_text` and the follow-up preambles go.
+   delivered today, is written to the inbox and rendered by one function;
+   pending blocking findings are read from the inbox from this stage on, so
+   `panel_wake_text` can go. Advisory findings and a refreshed sibling view
+   ride along. No lifecycle change yet.
 2. **Messages reach a parked author.** `reply` exists. A run with an open PR
    parks; comments and base moves are inbox messages; the author can launch,
-   reply and sleep in review. The follow-up pipeline no longer runs for
-   comments; it still handles nothing else.
-3. **Submit in review.** The publish moves the PR head; a gate verdict is a
-   message on every path; `end` exists. The submit policies [7, 49, 50] go.
+   reply and sleep in review. A session that edits code in review still goes
+   through today's re-measure-and-push until the next stage replaces it.
+3. **Submit in review, and `end`.** The publish moves the PR head by
+   fast-forward; a gate verdict is a message on every path; the meter's
+   top-up exists; the submit policies [7, 49, 50] go; the follow-up
+   re-measure path no longer runs.
 4. **Three states.** `running`, `parked`, `ended`; the record migrates on
-   read; `followup.py`, the steward's pipeline copy, and the counters are
-   deleted with their tests.
+   read. This stage lands only when no live record on any fleet carries
+   `followup_stage`; the tick reports the count until it is zero. Then
+   `followup.py`, the steward's pipeline copy, and the counters are deleted
+   with their tests.
 
 ## Standing contradictions this settles
 

--- a/docs/design/lifecycle.md
+++ b/docs/design/lifecycle.md
@@ -145,7 +145,10 @@ checkpoint sleep. The kernel stays out of scheduling.
 The inbox is files: a directory beside the run's record, one file per
 message named by a sequence number, written by temp-and-rename, never
 deleted, outside the workspace so the session cannot forge one. The record
-holds the delivered position. Records, leases and the inbox all sit behind
+holds the delivered position. A message file is durable before any poll
+position advances, and the delivered position advances only after the wake's
+session leg ends, so a wake that dies re-delivers; double delivery is
+harmless, as it is for today's leases. Records, leases and the inbox all sit behind
 one small storage interface (put, list, get, conditional put) with a
 filesystem implementation for Slurm and local compute; a cloud backend gives
 it an object-store implementation and nothing else changes. No messaging
@@ -160,7 +163,7 @@ wake the tick sooner than its cadence; that is a trigger, not a transport.
 | `launch` | seals the tree, submits a contained job on the contract's lane, records it in the ledger, delivers the result at the wake | containment, placement, metering |
 | `sleep` | parks the run on the launched jobs (possibly none) | the sleep count |
 | `submit` | seals the tree, runs the gate and the panel as jobs, delivers the verdict as a message; a credited verdict publishes | the gate; the publish |
-| `reply` | posts text, as written, on the thread the message came from | standing of the poster; redaction |
+| `reply` | posts text on the thread the message came from, with secrets redacted and self-approval scrubbed, as the follow-up's reply is today | standing of the poster; redaction |
 | `end` | ends the run with the author's report and the last verdict as its ending | the report |
 
 `reply` and `end` are new. A session that stops without sleeping or

--- a/docs/design/lifecycle.md
+++ b/docs/design/lifecycle.md
@@ -160,8 +160,8 @@ wake the tick sooner than its cadence; that is a trigger, not a transport.
 
 | Move | What the kernel does | Rigid part |
 | --- | --- | --- |
-| `launch` | seals the tree, submits a contained job on the contract's lane, records it in the ledger, delivers the result at the wake | containment, placement, metering |
-| `sleep` | parks the run on the launched jobs (possibly none) | the sleep count |
+| `launch` | stages a contained job for the contract's lane; the author keeps working | metering |
+| `sleep` | seals the tree, submits the staged jobs, records them in the ledger, parks the run on them (possibly none); the results arrive at the wake | containment, placement, the sleep count |
 | `submit` | seals the tree, runs the gate and the panel as jobs, delivers the verdict as a message; a credited verdict publishes | the gate; the publish |
 | `reply` | posts text on the thread the message came from, with secrets redacted and self-approval scrubbed, as the follow-up's reply is today | standing of the poster; redaction |
 | `end` | ends the run with the author's report and the last verdict as its ending | the report |

--- a/docs/design/research-loop-buildout.md
+++ b/docs/design/research-loop-buildout.md
@@ -162,3 +162,111 @@ against fakes before that.)
 3. **Phase B — submit-for-review as a payload** — LANDED (the orchestrator
    panel-revision loop is retired); suite gate + metric taxonomy still to come.
 4. Parallel/coordination helpers only if recurring author patterns earn them.
+5. **Phase C — in review, the author receives messages** (below): the
+   follow-up pipeline becomes wake messages to the parked author; built in
+   three reviewed stages, the old module deleted in the third.
+
+## Phase C — in review, the author receives messages
+
+**Status: plan (2026-09-12), reviewable before code.** Ruling from Mengye,
+2026-09-12: an in-review run is the author receiving messages and doing
+whatever is necessary. Not hard-coded steps.
+
+### What exists
+
+`followup.py` (2,200 lines) services a run whose PR is open. Each tick it
+reads new comments, resumes the author session with a fixed prompt, and then
+decides on its own what the session's result means. An edit inside scope is
+re-measured as the PR's new candidate; the number moves the ledger row when it
+clears the floor; the row is folded into the sealed commit and pushed; the
+number is posted. A moved base has its own ladder (sync, conflict, withheld,
+superseded). A pushed change gets a panel re-read. The steward lane repeats
+most of this under another key. Every step is the kernel deciding what the
+reviewer wanted. A reviewer who asks for an ablation gets the ablation pushed
+as the PR head, or nothing at all (three finished evaluations went unreported
+in a trial deployment when the kernel's push step failed).
+
+### The design
+
+A message arrives for a run in review: a qualifying comment, a review, a
+panel verdict, the base moving. The kernel delivers it to the parked author
+session as wake text, data-fenced, through the same wake path that delivers
+launch results and gate verdicts today. The author answers with the moves it
+already has in a climb:
+
+- **launch**: run an experiment outside the sandbox, metered and recorded in
+  the ledger; the result comes back at the next wake.
+- **reply**: text, posted on the thread as written.
+- **submit**: this tree is my candidate. The gate measures the sealed tree;
+  on a run in review the PR head moves to that sealed tree and the number is
+  posted with it.
+- **sleep**: park until the next message or the named jobs.
+
+An ablation is a launch and a reply. A requested change is an edit and a
+submit. A moved base is a message that says so; the author merges (or does
+not) and submits. Nothing is re-measured unless the author submits it.
+
+### What the kernel keeps
+
+- The credited number is the kernel's measurement of a submitted tree, never
+  the author's claim.
+- Scope, on the submitted tree.
+- Auto-merge is confirmed disarmed before a PR head moves.
+- The ledger row moves only for a submit that beats the recorded best by the
+  floor; every other number is reported and leaves the row alone.
+- The meter: launches, sleeps, submits. Open question below.
+- Delivery bookkeeping: which comments have been delivered (the cursor), and
+  the one-run-per-PR lease.
+
+### What goes away
+
+The `changed`-detection and automatic re-measure of any edit; the base-sync
+ladder; `_park_remeasure`, `_resume_measure`, `_commit_sealed_tree`,
+`_update_ledger`'s follow-up variant; the panel re-read after a push (a
+submit already runs the panel, Phase B); the steward's copy of the pipeline
+(the steward is a role that receives the same messages under its own key).
+`followup_stage` on the record. `followup.py` and its tests are deleted in the
+PR that lands the replacement; no second implementation of one role.
+
+### State and entry point
+
+A run in review is a parked run: WAITING, woken by messages instead of jobs.
+The wake is the attempt CLI's resume with a message payload; the follow-up
+entry point folds into it. One record shape, one wake path, one terminal.
+
+### Open decisions
+
+1. **Budget.** Review-time launches and sleeps draw on the climb's remaining
+   counts, or on a separate review budget in the contract? Recommendation: the
+   climb's counts, with the contract able to top them up for review; one meter
+   is easier to read in the prompt.
+2. **Who sends messages.** As today: qualifying commenters (member,
+   collaborator, owner; the `outerloop:task` label vouches), the panel, and the
+   base moving. Never the author's own comments.
+3. **A worse submit.** When the author submits a tree whose number is worse
+   than the PR's current one, the head still moves and the number is posted
+   plainly. Recommendation: yes; the author decided, the thread shows it,
+   humans merge. The ledger row does not move.
+4. **Ending.** Unchanged: humans merge or close; a merged PR ends the run
+   merged, a closed one rejected; the steward may close a stale PR.
+
+### Acceptance
+
+A reviewer asks for an ablation on an open PR. The author launches it, sleeps,
+wakes with the result, replies with the numbers, and the PR head does not
+move; the launch is in the ledger. A reviewer asks for a change. The author
+edits, submits, the gate measures, the PR head moves to the sealed tree, and
+the number is on the thread. A base move arrives as a message; the author
+merges and submits, or explains why the PR is superseded.
+
+### Sequencing
+
+Built in stages, each reviewed:
+
+1. Messages reach a parked in-review author: comments delivered as wake text,
+   replies posted as written; launches and sleeps work in review. The old
+   pipeline still handles submits.
+2. Submit on a run in review moves the PR head, with the disarm rule and the
+   ledger rule above.
+3. Delete `followup.py`, its tests, and `followup_stage`; the steward runs on
+   the same path.

--- a/docs/design/research-loop-buildout.md
+++ b/docs/design/research-loop-buildout.md
@@ -162,111 +162,15 @@ against fakes before that.)
 3. **Phase B — submit-for-review as a payload** — LANDED (the orchestrator
    panel-revision loop is retired); suite gate + metric taxonomy still to come.
 4. Parallel/coordination helpers only if recurring author patterns earn them.
-5. **Phase C — in review, the author receives messages** (below): the
-   follow-up pipeline becomes wake messages to the parked author; built in
-   three reviewed stages, the old module deleted in the third.
+5. **Phase C — in review, the author receives messages**: designed in
+   `lifecycle.md`, four reviewed stages, the follow-up module deleted in the
+   last.
 
 ## Phase C — in review, the author receives messages
 
-**Status: plan (2026-09-12), reviewable before code.** Ruling from Mengye,
-2026-09-12: an in-review run is the author receiving messages and doing
-whatever is necessary. Not hard-coded steps.
-
-### What exists
-
-`followup.py` (2,200 lines) services a run whose PR is open. Each tick it
-reads new comments, resumes the author session with a fixed prompt, and then
-decides on its own what the session's result means. An edit inside scope is
-re-measured as the PR's new candidate; the number moves the ledger row when it
-clears the floor; the row is folded into the sealed commit and pushed; the
-number is posted. A moved base has its own ladder (sync, conflict, withheld,
-superseded). A pushed change gets a panel re-read. The steward lane repeats
-most of this under another key. Every step is the kernel deciding what the
-reviewer wanted. A reviewer who asks for an ablation gets the ablation pushed
-as the PR head, or nothing at all (three finished evaluations went unreported
-in a trial deployment when the kernel's push step failed).
-
-### The design
-
-A message arrives for a run in review: a qualifying comment, a review, a
-panel verdict, the base moving. The kernel delivers it to the parked author
-session as wake text, data-fenced, through the same wake path that delivers
-launch results and gate verdicts today. The author answers with the moves it
-already has in a climb:
-
-- **launch**: run an experiment outside the sandbox, metered and recorded in
-  the ledger; the result comes back at the next wake.
-- **reply**: text, posted on the thread as written.
-- **submit**: this tree is my candidate. The gate measures the sealed tree;
-  on a run in review the PR head moves to that sealed tree and the number is
-  posted with it.
-- **sleep**: park until the next message or the named jobs.
-
-An ablation is a launch and a reply. A requested change is an edit and a
-submit. A moved base is a message that says so; the author merges (or does
-not) and submits. Nothing is re-measured unless the author submits it.
-
-### What the kernel keeps
-
-- The credited number is the kernel's measurement of a submitted tree, never
-  the author's claim.
-- Scope, on the submitted tree.
-- Auto-merge is confirmed disarmed before a PR head moves.
-- The ledger row moves only for a submit that beats the recorded best by the
-  floor; every other number is reported and leaves the row alone.
-- The meter: launches, sleeps, submits. Open question below.
-- Delivery bookkeeping: which comments have been delivered (the cursor), and
-  the one-run-per-PR lease.
-
-### What goes away
-
-The `changed`-detection and automatic re-measure of any edit; the base-sync
-ladder; `_park_remeasure`, `_resume_measure`, `_commit_sealed_tree`,
-`_update_ledger`'s follow-up variant; the panel re-read after a push (a
-submit already runs the panel, Phase B); the steward's copy of the pipeline
-(the steward is a role that receives the same messages under its own key).
-`followup_stage` on the record. `followup.py` and its tests are deleted in the
-PR that lands the replacement; no second implementation of one role.
-
-### State and entry point
-
-A run in review is a parked run: WAITING, woken by messages instead of jobs.
-The wake is the attempt CLI's resume with a message payload; the follow-up
-entry point folds into it. One record shape, one wake path, one terminal.
-
-### Open decisions
-
-1. **Budget.** Review-time launches and sleeps draw on the climb's remaining
-   counts, or on a separate review budget in the contract? Recommendation: the
-   climb's counts, with the contract able to top them up for review; one meter
-   is easier to read in the prompt.
-2. **Who sends messages.** As today: qualifying commenters (member,
-   collaborator, owner; the `outerloop:task` label vouches), the panel, and the
-   base moving. Never the author's own comments.
-3. **A worse submit.** When the author submits a tree whose number is worse
-   than the PR's current one, the head still moves and the number is posted
-   plainly. Recommendation: yes; the author decided, the thread shows it,
-   humans merge. The ledger row does not move.
-4. **Ending.** Unchanged: humans merge or close; a merged PR ends the run
-   merged, a closed one rejected; the steward may close a stale PR.
-
-### Acceptance
-
-A reviewer asks for an ablation on an open PR. The author launches it, sleeps,
-wakes with the result, replies with the numbers, and the PR head does not
-move; the launch is in the ledger. A reviewer asks for a change. The author
-edits, submits, the gate measures, the PR head moves to the sealed tree, and
-the number is on the thread. A base move arrives as a message; the author
-merges and submits, or explains why the PR is superseded.
-
-### Sequencing
-
-Built in stages, each reviewed:
-
-1. Messages reach a parked in-review author: comments delivered as wake text,
-   replies posted as written; launches and sleeps work in review. The old
-   pipeline still handles submits.
-2. Submit on a run in review moves the PR head, with the disarm rule and the
-   ledger rule above.
-3. Delete `followup.py`, its tests, and `followup_stage`; the steward runs on
-   the same path.
+**Status: absorbed into `lifecycle.md` (2026-09-12).** The ruling stands: an
+in-review run is the author receiving messages and doing whatever is
+necessary, not hard-coded steps. The lifecycle note carries the design: three
+states, one park-and-wake engine, the inbox and its message kinds, the
+author's moves (launch, sleep, submit, reply, end), what stays rigid, what is
+deleted, the open decisions and the four-stage sequencing.


### PR DESCRIPTION
Design only, for review before code. Rule (Mengye, 2026-09-12): benchmark verification and launching jobs are rigid; everything else is the author deciding through tool calls, and the lifecycle is message-based, not hard-coded steps.

`docs/design/lifecycle.md`: what exists (five states, three park shapes, a separate two-thousand-line review pipeline, fifty-six kernel decisions about science or intent, eleven retry counters, five message channels, no reply verb, no comment reaching a parked session); the lifecycle after (three states, one park-and-wake engine, an inbox with seven message kinds and one renderer, five author moves, one publish, endings only by the author, a human, the meter, or a kernel failure); what stays rigid and why; a line-by-line table of what becomes the author's and what is deleted; the record shape; five open decisions; four reviewed stages; and the standing doc contradictions this settles.

Phase C in `research-loop-buildout.md` is reduced to a pointer. The kernel-decision inventory the note's bracketed numbers refer to is posted as a comment on this PR.